### PR TITLE
Rebrand: outside-repo "Employee Self-Service Agent Developer Kit", inside-repo "ESS Maker Kit"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,23 +3,23 @@
 
 # Default reviewers for any path not explicitly matched.
 #
-# TODO: Replace @microsoft/ess-copilot-kit-maintainers with the actual GitHub
-# team that owns this kit. Created as a stub so review routing is automatic
-# from PR #12 onward; the team can be fanned out per area as ownership
-# crystallizes.
+# TODO: Replace @microsoft/ess-developer-kit-maintainers with the actual
+# GitHub team that owns this kit. Created as a stub so review routing is
+# automatic from PR #12 onward; the team can be fanned out per area as
+# ownership crystallizes.
 
-*                                                                @microsoft/ess-copilot-kit-maintainers
+*                                                                @microsoft/ess-developer-kit-maintainers
 
 # Repo infrastructure (CI, CodeQL, Dependabot, issue templates, this file)
-/.github/                                                        @microsoft/ess-copilot-kit-maintainers
+/.github/                                                        @microsoft/ess-developer-kit-maintainers
 
 # Per-area owners (per-solution layout - kept aligned with PR #2's structure)
-/solutions/ess-maker-skills/scripts/                             @microsoft/ess-copilot-kit-maintainers
-/solutions/ess-maker-skills/src/skills/                          @microsoft/ess-copilot-kit-maintainers
-/solutions/ess-maker-skills/src/mcp/servicenow/                  @microsoft/ess-copilot-kit-maintainers
-/solutions/ess-maker-skills/src/mcp/workday/                     @microsoft/ess-copilot-kit-maintainers
-/solutions/ess-maker-skills/.github/copilot-instructions.md      @microsoft/ess-copilot-kit-maintainers
+/solutions/ess-maker-skills/scripts/                             @microsoft/ess-developer-kit-maintainers
+/solutions/ess-maker-skills/src/skills/                          @microsoft/ess-developer-kit-maintainers
+/solutions/ess-maker-skills/src/mcp/servicenow/                  @microsoft/ess-developer-kit-maintainers
+/solutions/ess-maker-skills/src/mcp/workday/                     @microsoft/ess-developer-kit-maintainers
+/solutions/ess-maker-skills/.github/copilot-instructions.md      @microsoft/ess-developer-kit-maintainers
 
 # Reference content + samples (lower review velocity)
-/solutions/ess-maker-skills/src/reference/                       @microsoft/ess-copilot-kit-maintainers
-/samples/                                                        @microsoft/ess-copilot-kit-maintainers
+/solutions/ess-maker-skills/src/reference/                       @microsoft/ess-developer-kit-maintainers
+/samples/                                                        @microsoft/ess-developer-kit-maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a bug or unexpected behavior in the ESS Copilot Kit
+description: Report a bug or unexpected behavior in the ESS Maker Kit
 title: "[Bug]: "
 labels: ["bug", "needs-triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest a new feature or improvement for the ESS Copilot Kit
+description: Suggest a new feature or improvement for the ESS Maker Kit
 title: "[Feature]: "
 labels: ["enhancement", "needs-triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,5 +1,5 @@
 name: Question / help
-description: Ask a question about how to use the ESS Copilot Kit
+description: Ask a question about how to use the ESS Maker Kit
 title: "[Question]: "
 labels: ["question", "needs-triage"]
 body:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESS Copilot Kit
+# Employee Self-Service Agent Developer Kit
 
 A monorepo of solutions, samples, and tooling for the Microsoft Employee Self-Service (ESS) agent built on Microsoft Copilot Studio.
 

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -1,6 +1,6 @@
 # Solutions
 
-This folder contains the individual solutions in the Employee Self-Service Agent Toolkit monorepo.
+This folder contains the individual solutions in the Employee Self-Service Agent Developer Kit monorepo.
 
 A **solution** is a self-contained, customer-runnable artifact: a VS Code workspace, a CLI, an evaluation harness, etc. Each solution lives in its own subfolder with its own README, dependencies, and license header. Solutions are independently versioned and installable.
 

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -1,4 +1,4 @@
-# ESS Copilot Kit
+# ESS Maker Kit
 
 Customize your Employee Self-Service (ESS) agent using GitHub Copilot in VS Code — no deep platform knowledge required. Describe what you need in plain English and the kit generates topic YAML, workflow JSON, adaptive cards, and integration configurations for you.
 
@@ -8,7 +8,7 @@ Customize your Employee Self-Service (ESS) agent using GitHub Copilot in VS Code
 
 ## Why This Kit
 
-Building and customizing an ESS agent means working across topic YAML, Power Automate workflow schemas, ServiceNow/Workday connector patterns, adaptive card JSON, and Dataverse template configurations. The ESS Copilot Kit packages all of that domain knowledge into a VS Code workspace so GitHub Copilot can do the heavy lifting — you describe the scenario, and the agent builds it.
+Building and customizing an ESS agent means working across topic YAML, Power Automate workflow schemas, ServiceNow/Workday connector patterns, adaptive card JSON, and Dataverse template configurations. The ESS Maker Kit packages all of that domain knowledge into a VS Code workspace so GitHub Copilot can do the heavy lifting — you describe the scenario, and the agent builds it.
 
 ---
 


### PR DESCRIPTION
Naming policy locked with @saengland: outside the inner solution (repo identity files) uses the full repo name **"Employee Self-Service Agent Developer Kit"**; inside the inner solution (the product surface customers interact with) uses **"ESS Maker Kit"**.

**Outside (repo identity)**
- `README.md` H1 header
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,question}.yml` descriptions

**Inside (the product)**
- `solutions/ess-maker-skills/README.md` H1 header + body reference

Drops the prior "ESS Copilot Kit" label that was provisional. The "Copilot Kit" term carries an unrelated-OSS-project confusion risk (`copilotkit/copilotkit`) that the new split avoids.

Companion rebrand commits land in the open `review/*` PRs that introduce new files using the old label (slice PRs #3, #4, #6, #8 - inventory in the PR #29 thread).

Tracker: #10
Addresses naming concern raised in [PR #29 review](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/pull/29#pullrequestreview-4231313967) by @johnguy0.