### PR TITLE
ci: lint only the Python paths that exist on the branch (unblocks PRs #29-#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,21 +25,31 @@ jobs:
     - name: Install ruff
       run: pip install ruff
 
-    - name: Check for Python source files
-      id: check_python
+    - name: Discover Python source paths
+      id: discover
       run: |
-        if find solutions/ess-maker-skills/scripts solutions/ess-maker-skills/src/mcp -type f -name "*.py" 2>/dev/null | grep -q .; then
+        candidates="solutions/ess-maker-skills/scripts solutions/ess-maker-skills/src/mcp"
+        paths=""
+        for d in $candidates; do
+          if [ -d "$d" ] && find "$d" -type f -name "*.py" 2>/dev/null | grep -q .; then
+            paths="$paths $d"
+          fi
+        done
+        paths=$(echo "$paths" | xargs)
+        echo "paths=$paths" >> "$GITHUB_OUTPUT"
+        if [ -n "$paths" ]; then
           echo "has_python=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Linting Python in: $paths"
         else
           echo "has_python=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::No Python files in this branch under solutions/ess-maker-skills/scripts/ or src/mcp/ - skipping lint and syntax check. (Expected on review/01-skeleton + review/02-solutions-layout; the Python lands in PR #3-#5.)"
+          echo "::notice::No Python files under $candidates - skipping lint and syntax check. (Expected on branches that don't yet include Python sources.)"
         fi
 
     - name: Lint with ruff
-      if: steps.check_python.outputs.has_python == 'true'
-      run: ruff check solutions/ess-maker-skills/scripts/ solutions/ess-maker-skills/src/mcp/ --output-format=github
+      if: steps.discover.outputs.has_python == 'true'
+      run: ruff check ${{ steps.discover.outputs.paths }} --output-format=github
 
     - name: Check Python syntax
-      if: steps.check_python.outputs.has_python == 'true'
+      if: steps.discover.outputs.has_python == 'true'
       run: |
-        python -m compileall -q solutions/ess-maker-skills/scripts/ solutions/ess-maker-skills/src/mcp/
+        python -m compileall -q ${{ steps.discover.outputs.paths }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,18 @@ jobs:
           echo "::notice::Linting Python in: $paths"
         else
           echo "has_python=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::No Python files under $candidates - skipping lint and syntax check. (Expected on branches that don't yet include Python sources.)"
+          echo "::notice::No Python files under $candidates - skipping lint and syntax check. (Expected on branches that don't yet include Python sources; the slice PRs #29/#30/#31 add them.)"
         fi
 
     - name: Lint with ruff
       if: steps.discover.outputs.has_python == 'true'
-      run: ruff check ${{ steps.discover.outputs.paths }} --output-format=github
+      env:
+        PATHS: ${{ steps.discover.outputs.paths }}
+      run: ruff check $PATHS --output-format=github
 
     - name: Check Python syntax
       if: steps.discover.outputs.has_python == 'true'
+      env:
+        PATHS: ${{ steps.discover.outputs.paths }}
       run: |
-        python -m compileall -q ${{ steps.discover.outputs.paths }}
+        python -m compileall -q $PATHS


### PR DESCRIPTION
## Why
The current `Lint Python` job in `.github/workflows/ci.yml` hard-codes both `solutions/ess-maker-skills/scripts/` AND `solutions/ess-maker-skills/src/mcp/` as args to ruff and `compileall`. Ruff returns `E902 No such file or directory` whenever either path is absent, which is the case on every per-PR review branch:

| PR | Python paths present | Lint result on main2 today |
|---|---|---|
| [#29](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/pull/29) review/03-scripts | `scripts/` only | FAIL (`E902` on `src/mcp`) |
| [#30](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/pull/30) review/04-mcp-workday | `scripts/` + `src/mcp/workday/` | FAIL (gate expects both legs) |
| [#31](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/pull/31) review/05-mcp-servicenow | `scripts/` + `src/mcp/servicenow/` | FAIL (same shape) |

This is a workflow bug, not a code bug on any of those PRs.

## Change
Replace the binary `has_python` gate with a `discover` step that walks each candidate path, adds it to the output ONLY if it exists AND contains `.py` files, and feeds the resolved list to ruff and `compileall`.

`scripts/` and `src/mcp/` remain the only candidate directories - this PR doesn't expand the lint surface, it just stops hard-coding paths that aren't on the branch.

## Verification
- This PR's own CI run is the first signal (no Python under either candidate at the main2 root yet -> the discover step will report `has_python=false` and skip).
- After merge, I'll rerun CI on PR #29 / #30 / #31 to confirm green.

## Follow-up
Once main2 has this fix, I'll merge it into the three review branches and confirm `Lint Python` flips to SUCCESS on each.