### PR TITLE
Add CONFIG-013: Knowledge source crawl/index readiness check [reposted from #57]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,3 +89,7 @@ CodeQL runs on every PR via the workflow seeded on `main2` (see the [repo's Code
 ### 4. CLA bot
 
 The Microsoft CLA bot will comment on your PR if you are an external contributor. You must accept the CLA before the PR can be merged.
+
+### 5. Code quality
+
+- **No fabricated URLs.** Every URL in code (doc links, remediation messages, comments, README references) must point to a page you have confirmed exists. See [`.github/copilot-instructions.md`](.github/copilot-instructions.md#no-fabricated-urls) → "No fabricated URLs" for the verification rule.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,4 +92,4 @@ The Microsoft CLA bot will comment on your PR if you are an external contributor
 
 ### 5. Code quality
 
-- **No fabricated URLs.** Every URL in code (doc links, remediation messages, comments, README references) must point to a page you have confirmed exists. See [`.github/copilot-instructions.md`](.github/copilot-instructions.md#no-fabricated-urls) → "No fabricated URLs" for the verification rule.
+- **No fabricated URLs.** Every URL in code (doc links, remediation messages, comments, README references) must point to a page you have confirmed exists. See [solutions/ess-maker-skills/.github/copilot-instructions.md#no-fabricated-urls](solutions/ess-maker-skills/.github/copilot-instructions.md#no-fabricated-urls) for the verification rule.

--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -325,6 +325,45 @@ partial workflow.
 3. **Test in Copilot Studio**: Open [Copilot Studio](https://copilotstudio.microsoft.com/) to test conversations
 4. **Publish**: Publish the agent in the Copilot Studio portal to make changes live
 
+## Code Quality Rules
+
+### No fabricated URLs
+
+**NEVER invent, guess, or hallucinate URLs.** Every URL in code (doc_link fields,
+remediation messages, comments, README references) must point to a page you have
+confirmed exists. Verify by ANY of:
+
+- Finding the same URL already cited elsewhere in the repo (`git grep` / repo search)
+- Fetching the URL over HTTP and confirming a 2xx response (if your tooling supports it)
+- Pulling the page from an official Microsoft Learn / Docs reference you already trust
+
+Pick whichever is available — the rule is "don't ship unverified URLs", not "use a
+specific verification tool".
+
+**If no verified URL exists for a given concept:**
+
+1. Use the `DOC_BASE` constant already defined in the file (if applicable) but
+   do NOT append a made-up path segment.
+2. Add a `# TODO: create doc page` comment next to the empty/placeholder link.
+3. In your PR description or commit message, note that a documentation page is
+   needed. Specify:
+   - The URL path where the page should live (following existing URL patterns)
+   - A 1–2 sentence description of what content the page should contain
+   - Who should create it (e.g., "docs team" or "PM")
+
+**Example (good):**
+```python
+doc_link="",  # TODO: create doc page at /manage-knowledge-sources covering crawl status troubleshooting
+```
+
+**Example (bad):**
+```python
+doc_link=f"{DOC_BASE}/manage-knowledge-sources",  # this page doesn't exist!
+```
+
+This rule exists because fabricated links erode customer trust and create
+support burden when they 404. A missing link is always better than a broken one.
+
 ## User Config
 
 The file `.local/config.json` stores the user's setup state and agent details:

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
@@ -385,7 +385,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
             remediation=(
                 "Publish the agent in Copilot Studio to provision missing sources, "
                 "or remove the local file if it should not exist. Identify mismatched "
-                "sources by comparing filenames in my/agents/{slug}/knowledge/ against "
+                "sources by comparing filenames in workspace/agents/{slug}/knowledge/ against "
                 "Copilot Studio → Knowledge."
             ),
         ))

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
@@ -335,7 +335,7 @@ def _check_knowledge_sources(agent_path: Path, label: str, runner=None) -> list[
     if runner and hasattr(runner, "config"):
         bot_id = runner.config.get("agent", {}).get("botId")
 
-    if not pva or not hasattr(pva, "is_configured") or not pva.is_configured or not bot_id:
+    if not pva or not pva.is_configured or not bot_id:
         results.append(CheckResult(
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
@@ -58,12 +58,12 @@ def run_local_file_checks(runner) -> list[CheckResult]:
     # Run checks for each agent
     for agent_path in sorted(agent_folders):
         agent_name = agent_path.name
-        results.extend(_check_single_agent(agent_path, agent_name))
+        results.extend(_check_single_agent(agent_path, agent_name, runner))
 
     return results
 
 
-def _check_single_agent(agent_path: Path, agent_name: str) -> list[CheckResult]:
+def _check_single_agent(agent_path: Path, agent_name: str, runner=None) -> list[CheckResult]:
     """Run all local file checks for a single agent."""
     results: list[CheckResult] = []
 
@@ -84,6 +84,9 @@ def _check_single_agent(agent_path: Path, agent_name: str) -> list[CheckResult]:
 
     # ---- Template configs ----
     results.extend(_check_template_configs(agent_path, label))
+
+    # ---- Knowledge source readiness ----
+    results.extend(_check_knowledge_sources(agent_path, label, runner))
 
     return results
 
@@ -287,3 +290,199 @@ def _check_template_configs(agent_path: Path, label: str) -> list[CheckResult]:
     ))
 
     return results
+
+
+# Knowledge source crawl readiness statuses (the `status` field on the API response).
+# These represent the indexing lifecycle, distinct from the lifecycle `state` field.
+_READY_STATUSES = {"completed", "indexed", "ready", "succeeded"}
+# Statuses that indicate the source is not yet ready for deployment.
+_NOT_READY_STATUSES = {"pending", "crawling", "queued", "provisioning", "failed", "error"}
+
+
+def _check_knowledge_sources(agent_path: Path, label: str, runner=None) -> list[CheckResult]:
+    """
+    CONFIG-013: Verify that all configured knowledge sources have completed
+    their initial crawl and are fully indexed.
+
+    Uses the Copilot Studio Island Gateway API to get live status when available,
+    otherwise falls back to local file validation only.
+    """
+    results = []
+    knowledge_dir = agent_path / "knowledge"
+
+    if not knowledge_dir.exists():
+        results.append(CheckResult(
+            checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description=f"{label}: Knowledge source readiness",
+            result="No knowledge directory found — no sources configured",
+        ))
+        return results
+
+    knowledge_files = list(knowledge_dir.glob("*.mcs.yml"))
+    if not knowledge_files:
+        results.append(CheckResult(
+            checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description=f"{label}: Knowledge source readiness",
+            result="No knowledge source files found",
+        ))
+        return results
+
+    # Require the Island Gateway API for live status
+    pva = getattr(runner, "pva", None) if runner else None
+    bot_id = None
+    if runner and hasattr(runner, "config"):
+        bot_id = runner.config.get("agent", {}).get("botId")
+
+    if not pva or not hasattr(pva, "is_configured") or not pva.is_configured or not bot_id:
+        results.append(CheckResult(
+            checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description=f"{label}: Knowledge source readiness",
+            result="Cannot verify — Copilot Studio API authentication required",
+        ))
+        return results
+
+    return _check_knowledge_sources_via_gateway(pva, bot_id, knowledge_files, label)
+
+
+def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list, label: str) -> list[CheckResult]:
+    """Check knowledge source status using the Island Gateway API.
+
+    Note on local-to-remote matching: the local filename is derived from the
+    Dataverse `botcomponents.name` field, while the Island Gateway returns
+    `displayName` (which for SharePoint sources is the site URL, not a stable
+    identifier). There is no reliable join key to match individual files to
+    components, so we use a count comparison plus per-remote status check.
+    """
+    results = []
+
+    try:
+        sources = pva.get_knowledge_sources(bot_id)
+    except Exception as e:
+        results.append(CheckResult(
+            checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description=f"{label}: Knowledge source crawl status",
+            result=f"Could not query Copilot Studio API: {e}",
+            remediation="Check authentication and retry. Verify status manually in Copilot Studio → Knowledge.",
+        ))
+        return results
+
+    # Count comparison: warn if local files outnumber remote components.
+    # This catches the case where a local source was never published (false PASSED
+    # in the previous implementation when local>0 and remote=0 only).
+    if len(knowledge_files) > len(sources):
+        results.append(CheckResult(
+            checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description=f"{label}: Local/remote knowledge source count mismatch",
+            result=(
+                f"{len(knowledge_files)} local knowledge file(s) but only {len(sources)} "
+                "component(s) returned from Copilot Studio. Some sources may not be published."
+            ),
+            remediation=(
+                "Publish the agent in Copilot Studio to provision missing sources, "
+                "or remove the local file if it should not exist. Identify mismatched "
+                "sources by comparing filenames in my/agents/{slug}/knowledge/ against "
+                "Copilot Studio → Knowledge."
+            ),
+        ))
+
+    if not sources:
+        # No remote sources at all — nothing more to check beyond the count warning above.
+        return results
+
+    all_ready = True
+    for source in sources:
+        name = source.get("displayName", "Unknown")
+        # `status` is the crawl/index readiness signal we want.
+        # `state` is lifecycle (Active/Inactive/Provisioning/etc.) and does NOT
+        # tell us whether indexing finished. Falling back to `state` here would
+        # be a false-pass: an Active-but-still-crawling source could be PASSED.
+        crawl_status = (source.get("status") or "").strip().lower()
+        lifecycle_state = (source.get("state") or "").strip().lower()
+        source_kind = ""
+        config = source.get("configuration", {})
+        if config:
+            src = config.get("source", {})
+            source_kind = src.get("$kind", "")
+
+        # Determine source type for display
+        source_type = _format_source_type(source_kind)
+
+        if crawl_status in _READY_STATUSES:
+            results.append(CheckResult(
+                checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+                priority=Priority.HIGH.value, status=Status.PASSED.value,
+                description=f"{label}: '{name}' ({source_type})",
+                result=f"Status: {crawl_status} — indexed and ready",
+            ))
+        elif crawl_status in _NOT_READY_STATUSES:
+            all_ready = False
+            results.append(CheckResult(
+                checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+                priority=Priority.HIGH.value, status=Status.FAILED.value,
+                description=f"{label}: '{name}' ({source_type})",
+                result=f"Status: {crawl_status} — not ready for deployment",
+                remediation=(
+                    f"Knowledge source '{name}' has not completed indexing. "
+                    "Wait for the crawl to finish, or check for errors in "
+                    "Copilot Studio → Knowledge."
+                ),
+            ))
+        elif crawl_status:
+            # Unknown status string, but the API DID return a status field.
+            # WARNING with the raw value so we learn the new status over time.
+            all_ready = False
+            results.append(CheckResult(
+                checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+                priority=Priority.HIGH.value, status=Status.WARNING.value,
+                description=f"{label}: '{name}' ({source_type})",
+                result=f"Unknown crawl status: {crawl_status}",
+                remediation=(
+                    "Verify in Copilot Studio → Knowledge whether the source has "
+                    "finished indexing. File an issue so this status string can be "
+                    "added to the readiness allowlist."
+                ),
+            ))
+        else:
+            # No `status` returned at all — we only have lifecycle `state`.
+            # That is NOT proof of indexing; surface as WARNING, not PASSED.
+            all_ready = False
+            results.append(CheckResult(
+                checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+                priority=Priority.HIGH.value, status=Status.WARNING.value,
+                description=f"{label}: '{name}' ({source_type})",
+                result=(
+                    f"Crawl readiness unknown (lifecycle state={lifecycle_state or 'unknown'}). "
+                    "API did not return a `status` field for this source."
+                ),
+                remediation=(
+                    "Verify in Copilot Studio → Knowledge whether the source has "
+                    "finished indexing before deploying."
+                ),
+            ))
+
+    if all_ready and sources and len(knowledge_files) <= len(sources):
+        results.append(CheckResult(
+            checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
+            priority=Priority.HIGH.value, status=Status.PASSED.value,
+            description=f"{label}: All knowledge sources indexed",
+            result=f"{len(sources)} knowledge source(s) fully indexed and ready",
+        ))
+
+    return results
+
+
+def _format_source_type(source_kind: str) -> str:
+    """Convert a $kind value to a human-readable source type."""
+    mapping = {
+        "SharePointSearchSource": "SharePoint",
+        "GraphConnectorSearchSource": "Graph Connector",
+        "FileSource": "File Upload",
+        "WebSearchSource": "Web",
+        "DataverseSource": "Dataverse",
+    }
+    return mapping.get(source_kind, source_kind or "Unknown")

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -31,6 +31,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from flightcheck.runner import FlightCheckRunner, save_results, Status
 from flightcheck.graph_client import GraphClient
 from flightcheck.pp_admin_client import PPAdminClient, derive_environment_id
+from flightcheck.pva_client import PVAClient
 
 # Check modules
 from flightcheck.checks.prerequisites import run_prerequisites_checks
@@ -154,6 +155,28 @@ def main():
         print(f"  Power Platform: WARNING — {e}")
         print("  (Some checks will be skipped)")
 
+    # Gate PVA (Copilot Studio Island Gateway) auth on scope.
+    # Only CONFIG-013 needs PVA today, and it lives in run_local_file_checks.
+    # Authenticating unconditionally would prompt for a second interactive login
+    # on scopes like --scope prerequisites that don't need it.
+    pva = None
+    if args.scope in ("full", "local"):
+        print("Authenticating to Copilot Studio (Island Gateway)...")
+        pva = PVAClient(tenant_id, env_url)
+        try:
+            pva.authenticate()
+            if pva.is_configured:
+                print("  Copilot Studio: OK")
+            else:
+                print("  Copilot Studio: WARNING — Could not discover gateway URL")
+                print("  (Knowledge source status check will use local-only validation)")
+        except Exception as e:
+            print(f"  Copilot Studio: WARNING — {e}")
+            print("  (Knowledge source status check will use local-only validation)")
+            pva = None
+    else:
+        print("Skipping Copilot Studio auth (not required for this scope).")
+
     # --- Build runner ---
     runner = FlightCheckRunner(scope=args.scope)
     runner.config = config
@@ -162,6 +185,7 @@ def main():
     runner.env_id = env_id
     runner.graph = graph
     runner.pp_admin = pp_admin
+    runner.pva = pva
 
     # Register checks based on scope
     if args.scope == "full":

--- a/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
@@ -1,0 +1,197 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Copilot Kit — PVA (Island Gateway) Client
+
+Provides authenticated access to the Copilot Studio Island Gateway API
+for reading bot component status (including knowledge source crawl/index status).
+
+Authentication uses the same MSAL cache as auth.py / graph_client.py.
+"""
+
+import os
+import sys
+
+try:
+    import msal
+except ImportError:
+    print("ERROR: 'msal' package not found. Run: pip install msal")
+    sys.exit(1)
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' package not found. Run: pip install requests")
+    sys.exit(1)
+
+
+CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"
+
+# PVA app ID — used as the token audience for the Island Gateway API
+PVA_SCOPE = "96ff4394-9197-43aa-b393-6a41652e21f8/.default"
+
+# BAP API for discovering the gateway URL
+BAP_SCOPE = "https://api.bap.microsoft.com/.default"
+BAP_BASE = "https://api.bap.microsoft.com"
+
+
+class PVAClient:
+    """Copilot Studio Island Gateway API client."""
+
+    def __init__(self, tenant_id: str, env_url: str):
+        self.tenant_id = tenant_id
+        self.env_url = env_url
+        self._pva_token: str | None = None
+        self._gateway_url: str | None = None
+        self._bap_env_id: str | None = None
+
+    def authenticate(self) -> str:
+        """Acquire a PVA access token and discover gateway URL."""
+        authority = f"https://login.microsoftonline.com/{self.tenant_id}"
+        cache = msal.SerializableTokenCache()
+        cache_path = os.path.join("my", ".token_cache.bin")
+
+        if os.path.exists(cache_path):
+            with open(cache_path, "r") as f:
+                cache.deserialize(f.read())
+
+        app = msal.PublicClientApplication(
+            CLIENT_ID, authority=authority, token_cache=cache
+        )
+
+        # Get PVA token
+        accounts = app.get_accounts()
+        result = None
+        if accounts:
+            result = app.acquire_token_silent([PVA_SCOPE], account=accounts[0])
+
+        if not result or "access_token" not in result:
+            print("Opening browser for PVA sign-in...")
+            result = app.acquire_token_interactive(
+                [PVA_SCOPE], prompt="select_account"
+            )
+
+        if "access_token" not in result:
+            error = result.get("error_description", result.get("error", "Unknown"))
+            raise RuntimeError(f"PVA auth failed: {error}")
+
+        self._pva_token = result["access_token"]
+
+        # Get BAP token for gateway discovery
+        bap_result = None
+        if accounts:
+            bap_result = app.acquire_token_silent([BAP_SCOPE], account=accounts[0])
+        if not bap_result or "access_token" not in bap_result:
+            bap_result = app.acquire_token_interactive(
+                [BAP_SCOPE], prompt="select_account"
+            )
+
+        if cache.has_state_changed:
+            os.makedirs("my", exist_ok=True)
+            with open(cache_path, "w") as f:
+                f.write(cache.serialize())
+
+        # Discover gateway URL from BAP
+        if bap_result and "access_token" in bap_result:
+            self._discover_gateway(bap_result["access_token"])
+
+        return self._pva_token
+
+    def _discover_gateway(self, bap_token: str):
+        """Find the PVA gateway URL and BAP environment ID for this environment.
+
+        Raises:
+            RuntimeError: when the BAP environment list cannot be fetched, or
+                when no environment matches the configured Dataverse URL. The
+                caller surfaces this as a WARNING with the actual reason.
+        """
+        headers = {"Authorization": f"Bearer {bap_token}", "Accept": "application/json"}
+
+        # List environments and find the one matching our Dataverse URL.
+        # Try admin endpoint first, fall back to non-admin on 401/403.
+        url = (
+            f"{BAP_BASE}/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments"
+            "?api-version=2021-04-01"
+        )
+        try:
+            resp = requests.get(url, headers=headers, timeout=30)
+            if resp.status_code in (401, 403):
+                url = (
+                    f"{BAP_BASE}/providers/Microsoft.BusinessAppPlatform/environments"
+                    "?api-version=2021-04-01"
+                )
+                resp = requests.get(url, headers=headers, timeout=30)
+        except requests.RequestException as e:
+            raise RuntimeError(f"BAP environments request failed: {e}") from e
+
+        if not resp.ok:
+            raise RuntimeError(
+                f"BAP environments returned {resp.status_code}: {resp.text[:200]}"
+            )
+
+        # Extract the org name from our env_url for matching
+        # e.g., "https://orgb78b4a3b.crm.dynamics.com" → "orgb78b4a3b"
+        org_match = self.env_url.split("//")[1].split(".")[0] if "//" in self.env_url else ""
+
+        envs = resp.json().get("value", [])
+        for env in envs:
+            props = env.get("properties", {})
+            linked = props.get("linkedEnvironmentMetadata", {})
+            instance_url = linked.get("instanceUrl", "")
+            if org_match and org_match in instance_url:
+                self._bap_env_id = env.get("name")
+                runtime = props.get("runtimeEndpoints", {})
+                self._gateway_url = runtime.get("microsoft.PowerVirtualAgents")
+                return
+
+        raise RuntimeError(
+            f"No BAP environment matched Dataverse org '{org_match}'. "
+            "User may not have access to this environment, or the environment "
+            "type is not Copilot Studio-enabled."
+        )
+
+    @property
+    def is_configured(self) -> bool:
+        """True if gateway URL and BAP env ID were discovered."""
+        return bool(self._pva_token and self._gateway_url and self._bap_env_id)
+
+    def get_knowledge_sources(self, bot_id: str) -> list[dict]:
+        """
+        Fetch knowledge source components from the Island Gateway API.
+
+        Returns a list of KnowledgeSourceComponent dicts with fields:
+        - displayName, id, state, status, configuration, etc.
+        """
+        if not self.is_configured:
+            return []
+
+        url = (
+            f"{self._gateway_url}/api/botmanagement/v1"
+            f"/environments/{self._bap_env_id}"
+            f"/bots/{bot_id}/content/botcomponents"
+        )
+        headers = {
+            "Authorization": f"Bearer {self._pva_token}",
+            "Content-Type": "application/json",
+            "x-ms-client-tenant-id": self.tenant_id,
+            "x-cci-tenantid": self.tenant_id,
+            "x-cci-bapenvironmentid": self._bap_env_id,
+            "x-cci-cdsbotid": bot_id,
+        }
+
+        resp = requests.post(url, headers=headers, json={}, timeout=60)
+        if not resp.ok:
+            raise RuntimeError(
+                f"Island Gateway returned {resp.status_code}: {resp.text[:200]}"
+            )
+        data = resp.json()
+
+        # Extract KnowledgeSourceComponent entries
+        knowledge_sources = []
+        for change in data.get("botComponentChanges", []):
+            comp = change.get("component", {})
+            if comp.get("$kind") == "KnowledgeSourceComponent":
+                knowledge_sources.append(comp)
+
+        return knowledge_sources

--- a/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
@@ -12,6 +12,7 @@ Authentication uses the same MSAL cache as auth.py / graph_client.py.
 
 import os
 import sys
+from urllib.parse import urlparse
 
 try:
     import msal
@@ -140,7 +141,9 @@ class PVAClient:
             props = env.get("properties", {})
             linked = props.get("linkedEnvironmentMetadata", {})
             instance_url = linked.get("instanceUrl", "")
-            if org_match and org_match in instance_url:
+            instance_host = (urlparse(instance_url).hostname or "").lower()
+            # Match on hostname prefix + "." so "org123" doesn't match "org1234contoso".
+            if org_match and instance_host.startswith(org_match.lower() + "."):
                 self._bap_env_id = env.get("name")
                 runtime = props.get("runtimeEndpoints", {})
                 self._gateway_url = runtime.get("microsoft.PowerVirtualAgents")

--- a/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
@@ -28,7 +28,8 @@ except ImportError:
 
 CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"
 
-# PVA app ID — used as the token audience for the Island Gateway API
+# 96ff4394-9197-43aa-b393-6a41652e21f8 is the well-known Power Virtual Agents
+# first-party app ID, used as the token audience for the Island Gateway API.
 PVA_SCOPE = "96ff4394-9197-43aa-b393-6a41652e21f8/.default"
 
 # BAP API for discovering the gateway URL


### PR DESCRIPTION
Reposts #57 (Graham's CONFIG-013 + PVAClient) onto the new main after today's cutover.

## What changed vs original

PR #57 touched files at both root (CONTRIBUTING.md) and under what was scripts/ (now solutions/ess-maker-skills/scripts/). Used a split-patch approach to translate paths correctly:
- CONTRIBUTING.md stays at root.
- .github/copilot-instructions.md addition -> solutions/ess-maker-skills/.github/copilot-instructions.md
- scripts/flightcheck/{checks/local_files.py, cli.py, pva_client.py} -> solutions/ess-maker-skills/scripts/flightcheck/...
- Both root patch (--apply --3way) and solution patch (--apply --3way --directory=solutions/ess-maker-skills/) applied cleanly.
- Authorship preserved via Co-authored-by trailer on the squash commit.

## Fixup commit added on this branch

PR #57's CONTRIBUTING.md addition cross-referenced .github/copilot-instructions.md#no-fabricated-urls, which was correct pre-cutover but is now broken (file lives at solutions/ess-maker-skills/.github/copilot-instructions.md). Added a fixup commit updating the link target.

## Round-1 follow-up still open

John flagged three items in his round-1 review on #57:
- pva_client.py:32 - GUID 96ff4394-9197-43aa-b393-6a41652e21f8 needs a naming comment (well-known PVA resource ID).
- pva_client.py:142 - substring match on org name is fragile (org123 will match org1234contoso).
- local_files.py:338 - hasattr(pva, 'is_configured') guard is defensive but unnecessary.

Recommend addressing in fixup commits on this branch before merge.

Closes #57.

Co-authored-by: Graham McMynn <grahamc@microsoft.com>
