### PR TITLE
Drop main2 from workflow triggers (closes #27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "main2" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "main2" ]
+    branches: [ "main" ]
 
 jobs:
   lint:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "main2" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "main2" ]
+    branches: [ "main" ]
   schedule:
     - cron: '30 5 * * 1'
 

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - main
-      - main2
     paths:
       - .github/labels.yml
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ If your change touches a Copilot Chat command (`/create`, `/update`, `/flightche
 
 ### 3. CodeQL
 
-CodeQL runs on every PR via the workflow seeded on `main2` (see the [repo's CodeQL alerts](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/security/code-scanning) for current state). Wait for the check to pass. If CodeQL flags an issue, address it or document why it is a false positive in the PR description. The kit's own `codeql.yml` will be re-introduced as part of the post-rename CI consolidation tracked in [#27](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/issues/27); link the path-relative file once it lands.
+CodeQL runs on every PR. See the [repo's CodeQL alerts](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/security/code-scanning) for current state. Wait for the check to pass. If CodeQL flags an issue, address it or document why it is a false positive in the PR description.
 
 ### 4. CLA bot
 

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -4,8 +4,6 @@ Customize your Employee Self-Service (ESS) agent using GitHub Copilot in VS Code
 
 > **This repo is intended as an example or learning tool.** It demonstrates how to customize Employee Self-Service (ESS) agents using GitHub Copilot in VS Code. It is not a Microsoft product or a supported service. See [SUPPORT.md](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/blob/main/SUPPORT.md) for the support model and [SECURITY.md](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/blob/main/SECURITY.md) for reporting security issues.
 
-> **About this README.** This document describes the complete kit. While the modular review (PRs #1-#10) is in flight, some features below land in subsequent PRs of the stack and may not be available on `main2` yet.
-
 ## Why This Kit
 
 Building and customizing an ESS agent means working across topic YAML, Power Automate workflow schemas, ServiceNow/Workday connector patterns, adaptive card JSON, and Dataverse template configurations. The ESS Maker Kit packages all of that domain knowledge into a VS Code workspace so GitHub Copilot can do the heavy lifting — you describe the scenario, and the agent builds it.


### PR DESCRIPTION
Closes #27.

Post-cutover cleanup. `main2` was renamed to `main` today (2026-05-08); the trigger references in these workflows are now dead branches and only add noise.

## Files changed
- `.github/workflows/ci.yml` - drop `main2` from push and pull_request triggers (2 occurrences)
- `.github/workflows/codeql.yml` - same (2 occurrences)
- `.github/workflows/label-sync.yml` - drop `main2` from push trigger branches list

## Verification
- Zero remaining `main2` references in `.github/` after this PR.
- All current open PRs target either `main` (the new monorepo trunk) or `main-pre-cutover` (the snapshot of the old layout).
