### PR TITLE
Restore sync_docs.py + sync_samples.py under new monorepo layout

### DIFF
--- a/solutions/ess-maker-skills/scripts/sync_docs.py
+++ b/solutions/ess-maker-skills/scripts/sync_docs.py
@@ -1,0 +1,181 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Maker Kit - Sync Official ESS Docs
+
+Fetches the latest Employee Self-Service documentation from the
+MicrosoftDocs/microsoft-365-docs repo and saves cleaned markdown
+files to src/reference/ess-docs/.
+
+Must be run from solutions/ess-maker-skills/ (paths are relative).
+
+Usage:
+    cd solutions/ess-maker-skills
+    python scripts/sync_docs.py          - Fetch all docs
+    python scripts/sync_docs.py --force  - Re-download even if files exist
+
+Source: https://github.com/MicrosoftDocs/microsoft-365-docs/tree/public/copilot/employee-self-service
+"""
+
+import os
+import re
+import sys
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' package not found. Run: pip install requests")
+    sys.exit(1)
+
+REPO = "MicrosoftDocs/microsoft-365-docs"
+BRANCH = "public"
+SOURCE_PATH = "copilot/employee-self-service"
+RAW_BASE = f"https://raw.githubusercontent.com/{REPO}/{BRANCH}/{SOURCE_PATH}"
+API_URL = f"https://api.github.com/repos/{REPO}/contents/{SOURCE_PATH}?ref={BRANCH}"
+
+OUTPUT_DIR = os.path.join("src", "reference", "ess-docs")
+
+# Organize files into subdirectories by prefix/topic
+CATEGORY_MAP = {
+    "integrations": [
+        "servicenow", "workday", "sap", "sharepoint-filtering",
+    ],
+    "deployment": [
+        "deploy-overview-alm", "deployment-checklist", "prerequisites",
+        "prepare", "publish", "install",
+    ],
+    "operations": [
+        "evaluations", "usage-analytics", "auditing-logging",
+        "known-issues-limitations", "feedback",
+    ],
+    "customization": [
+        "customize", "agent-handoff", "design-best-practices",
+        "emotional-quotient-ambiguity", "employee-self-service-multilingual",
+        "optimization-sharepoint", "sharepoint-filtering",
+    ],
+}
+
+SKIP_FILES = {"TOC.yml"}
+SKIP_DIRS = {"media"}
+
+
+def categorize(filename):
+    """Determine which subdirectory a file belongs in."""
+    base = filename.replace(".md", "")
+    for category, prefixes in CATEGORY_MAP.items():
+        for prefix in prefixes:
+            if base.startswith(prefix):
+                return category
+    return ""  # root level
+
+
+def strip_frontmatter(content):
+    """Remove YAML frontmatter (--- delimited) from markdown."""
+    if content.startswith("---"):
+        end = content.find("---", 3)
+        if end != -1:
+            content = content[end + 3:].lstrip("\n")
+    return content
+
+
+def clean_content(content):
+    """Strip frontmatter and clean up MS Learn-specific markup."""
+    content = strip_frontmatter(content)
+
+    # Remove MS Learn include references like [!INCLUDE [...](...)]
+    content = re.sub(r'\[!INCLUDE\s*\[.*?\]\(.*?\)\]', '', content)
+
+    # Remove zone pivot markers
+    content = re.sub(r'::: ?zone .*?\n', '', content)
+    content = re.sub(r'::: ?zone-end\n?', '', content)
+
+    # Clean up image references to just show alt text
+    # :::image ... alt-text="..." ... :::  ΓåÆ  [Image: alt-text]
+    content = re.sub(
+        r':::image[^:]*?alt-text="([^"]*)"[^:]*?:::',
+        r'[Image: \1]',
+        content
+    )
+
+    # Remove multiple consecutive blank lines
+    content = re.sub(r'\n{3,}', '\n\n', content)
+
+    return content.strip() + "\n"
+
+
+def fetch_file_list():
+    """Get list of files from GitHub API."""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    # Check for GH token to avoid rate limits
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    resp = requests.get(API_URL, headers=headers, timeout=30)
+    if resp.status_code == 403:
+        print("ERROR: GitHub API rate limit hit. Set GITHUB_TOKEN env var.")
+        sys.exit(1)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_raw_file(filename):
+    """Download a single file from raw.githubusercontent.com."""
+    url = f"{RAW_BASE}/{filename}"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
+
+def main():
+    force = "--force" in sys.argv
+
+    print(f"Fetching file list from {SOURCE_PATH}...")
+    items = fetch_file_list()
+
+    md_files = [
+        item["name"] for item in items
+        if item["type"] == "file"
+        and item["name"].endswith(".md")
+        and item["name"] not in SKIP_FILES
+    ]
+
+    print(f"Found {len(md_files)} markdown files.\n")
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    created = 0
+    skipped = 0
+
+    for filename in sorted(md_files):
+        category = categorize(filename)
+        if category:
+            dest_dir = os.path.join(OUTPUT_DIR, category)
+        else:
+            dest_dir = OUTPUT_DIR
+
+        os.makedirs(dest_dir, exist_ok=True)
+        dest_path = os.path.join(dest_dir, filename)
+
+        if os.path.exists(dest_path) and not force:
+            print(f"  SKIP {dest_path} (exists, use --force to overwrite)")
+            skipped += 1
+            continue
+
+        print(f"  Fetching {filename}...", end=" ")
+        try:
+            raw = fetch_raw_file(filename)
+            cleaned = clean_content(raw)
+            with open(dest_path, "w", encoding="utf-8") as f:
+                f.write(cleaned)
+            print(f"ΓåÆ {dest_path}")
+            created += 1
+        except Exception as e:
+            print(f"FAILED: {e}")
+
+    print(f"\nDone. {created} files written, {skipped} skipped.")
+    print(f"Output: {OUTPUT_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/sync_docs.py
+++ b/solutions/ess-maker-skills/scripts/sync_docs.py
@@ -52,12 +52,11 @@ CATEGORY_MAP = {
     "customization": [
         "customize", "agent-handoff", "design-best-practices",
         "emotional-quotient-ambiguity", "employee-self-service-multilingual",
-        "optimization-sharepoint", "sharepoint-filtering",
+        "optimization-sharepoint",
     ],
 }
 
 SKIP_FILES = {"TOC.yml"}
-SKIP_DIRS = {"media"}
 
 
 def categorize(filename):
@@ -91,7 +90,7 @@ def clean_content(content):
     content = re.sub(r'::: ?zone-end\n?', '', content)
 
     # Clean up image references to just show alt text
-    # :::image ... alt-text="..." ... :::  ΓåÆ  [Image: alt-text]
+    # :::image ... alt-text="..." ... :::  ->  [Image: alt-text]
     content = re.sub(
         r':::image[^:]*?alt-text="([^"]*)"[^:]*?:::',
         r'[Image: \1]',
@@ -104,15 +103,18 @@ def clean_content(content):
     return content.strip() + "\n"
 
 
-def fetch_file_list():
-    """Get list of files from GitHub API."""
+def get_headers():
+    """Build GitHub API headers, with optional auth token to avoid rate limits."""
     headers = {"Accept": "application/vnd.github.v3+json"}
-    # Check for GH token to avoid rate limits
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
     if token:
         headers["Authorization"] = f"token {token}"
+    return headers
 
-    resp = requests.get(API_URL, headers=headers, timeout=30)
+
+def fetch_file_list():
+    """Get list of files from GitHub API."""
+    resp = requests.get(API_URL, headers=get_headers(), timeout=30)
     if resp.status_code == 403:
         print("ERROR: GitHub API rate limit hit. Set GITHUB_TOKEN env var.")
         sys.exit(1)
@@ -123,7 +125,7 @@ def fetch_file_list():
 def fetch_raw_file(filename):
     """Download a single file from raw.githubusercontent.com."""
     url = f"{RAW_BASE}/{filename}"
-    resp = requests.get(url, timeout=30)
+    resp = requests.get(url, headers=get_headers(), timeout=30)
     resp.raise_for_status()
     return resp.text
 
@@ -168,7 +170,7 @@ def main():
             cleaned = clean_content(raw)
             with open(dest_path, "w", encoding="utf-8") as f:
                 f.write(cleaned)
-            print(f"ΓåÆ {dest_path}")
+            print(f"-> {dest_path}")
             created += 1
         except Exception as e:
             print(f"FAILED: {e}")

--- a/solutions/ess-maker-skills/scripts/sync_samples.py
+++ b/solutions/ess-maker-skills/scripts/sync_samples.py
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Maker Kit - Sync Official ESS Samples
+
+Fetches the latest Employee Self-Service samples from the
+microsoft/CopilotStudioSamples repo and saves them to
+src/examples/ess-samples/.
+
+Must be run from solutions/ess-maker-skills/ (paths are relative).
+
+Usage:
+    cd solutions/ess-maker-skills
+    python scripts/sync_samples.py          - Fetch all samples
+    python scripts/sync_samples.py --force  - Re-download even if files exist
+
+Source: https://github.com/microsoft/CopilotStudioSamples/tree/main/EmployeeSelfServiceAgent
+"""
+
+import os
+import re
+import sys
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' package not found. Run: pip install requests")
+    sys.exit(1)
+
+REPO = "microsoft/CopilotStudioSamples"
+BRANCH = "main"
+SOURCE_PATH = "EmployeeSelfServiceAgent"
+API_BASE = f"https://api.github.com/repos/{REPO}/contents"
+RAW_BASE = f"https://raw.githubusercontent.com/{REPO}/{BRANCH}"
+
+OUTPUT_DIR = os.path.join("src", "examples", "ess-samples")
+
+# The new monorepo layout (post-cutover, May 2026) preserves the upstream
+# PascalCase folder names verbatim (Workday/EmployeeScenarios,
+# ServiceNow/CatalogScenarios, ESSEvaluationSamples/StarterTestSets, etc.),
+# so no path translation is needed. Kept the helper as identity for
+# backward compat with callers below.
+
+
+def rename_upstream_path(rel_path):
+    """Identity passthrough. New layout matches upstream PascalCase verbatim."""
+    return rel_path.replace("\\", "/")
+
+SKIP_FILES = {".gitignore", "LICENSE"}
+# Skip media/image files ΓÇö not useful for agent context
+SKIP_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico"}
+
+
+def get_headers():
+    """Build GitHub API headers, with optional auth token."""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def list_contents(path):
+    """List contents of a GitHub directory. Returns list of items."""
+    url = f"{API_BASE}/{path}?ref={BRANCH}"
+    resp = requests.get(url, headers=get_headers(), timeout=30)
+    if resp.status_code == 403:
+        print("ERROR: GitHub API rate limit hit. Set GITHUB_TOKEN env var.")
+        sys.exit(1)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_raw_file(github_path):
+    """Download a file from raw.githubusercontent.com."""
+    url = f"{RAW_BASE}/{github_path}"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
+
+def strip_frontmatter(content):
+    """Remove YAML frontmatter (--- delimited) from markdown."""
+    if content.startswith("---"):
+        end = content.find("---", 3)
+        if end != -1:
+            content = content[end + 3:].lstrip("\n")
+    return content
+
+
+def clean_markdown(content):
+    """Strip frontmatter from markdown files."""
+    content = strip_frontmatter(content)
+    # Remove multiple consecutive blank lines
+    content = re.sub(r'\n{3,}', '\n\n', content)
+    return content.strip() + "\n"
+
+
+def walk_and_fetch(github_path, local_base, force=False):
+    """Recursively walk a GitHub directory and download all files."""
+    created = 0
+    skipped = 0
+
+    items = list_contents(github_path)
+
+    for item in sorted(items, key=lambda x: x["name"]):
+        name = item["name"]
+        item_type = item["type"]
+        item_path = item["path"]  # full path in repo
+
+        # Compute local destination relative to SOURCE_PATH, applying renames
+        rel_path = item_path[len(SOURCE_PATH):].lstrip("/")
+        local_rel = rename_upstream_path(rel_path)
+        local_path = os.path.join(local_base, local_rel.replace("/", os.sep))
+
+        if item_type == "dir":
+            # Recurse into subdirectory
+            c, s = walk_and_fetch(item_path, local_base, force)
+            created += c
+            skipped += s
+
+        elif item_type == "file":
+            # Skip unwanted files
+            if name in SKIP_FILES:
+                continue
+            ext = os.path.splitext(name)[1].lower()
+            if ext in SKIP_EXTENSIONS:
+                continue
+
+            # Check if already exists
+            if os.path.exists(local_path) and not force:
+                print(f"  SKIP {local_path} (exists)")
+                skipped += 1
+                continue
+
+            print(f"  Fetching {rel_path}...", end=" ")
+            try:
+                raw = fetch_raw_file(item_path)
+
+                # Clean markdown files
+                if name.endswith(".md"):
+                    raw = clean_markdown(raw)
+
+                os.makedirs(os.path.dirname(local_path), exist_ok=True)
+                with open(local_path, "w", encoding="utf-8") as f:
+                    f.write(raw)
+                print(f"ΓåÆ {local_path}")
+                created += 1
+            except Exception as e:
+                print(f"FAILED: {e}")
+
+    return created, skipped
+
+
+def main():
+    force = "--force" in sys.argv
+
+    print(f"Fetching ESS samples from {REPO}/{SOURCE_PATH}...")
+    print(f"Output: {OUTPUT_DIR}/\n")
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    created, skipped = walk_and_fetch(SOURCE_PATH, OUTPUT_DIR, force)
+
+    print(f"\nDone. {created} files written, {skipped} skipped.")
+    print(f"Output: {OUTPUT_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/sync_samples.py
+++ b/solutions/ess-maker-skills/scripts/sync_samples.py
@@ -48,7 +48,7 @@ def rename_upstream_path(rel_path):
     return rel_path.replace("\\", "/")
 
 SKIP_FILES = {".gitignore", "LICENSE"}
-# Skip media/image files ΓÇö not useful for agent context
+# Skip media/image files - not useful for agent context
 SKIP_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico"}
 
 
@@ -75,7 +75,7 @@ def list_contents(path):
 def fetch_raw_file(github_path):
     """Download a file from raw.githubusercontent.com."""
     url = f"{RAW_BASE}/{github_path}"
-    resp = requests.get(url, timeout=30)
+    resp = requests.get(url, headers=get_headers(), timeout=30)
     resp.raise_for_status()
     return resp.text
 
@@ -145,7 +145,7 @@ def walk_and_fetch(github_path, local_base, force=False):
                 os.makedirs(os.path.dirname(local_path), exist_ok=True)
                 with open(local_path, "w", encoding="utf-8") as f:
                     f.write(raw)
-                print(f"ΓåÆ {local_path}")
+                print(f"-> {local_path}")
                 created += 1
             except Exception as e:
                 print(f"FAILED: {e}")


### PR DESCRIPTION
Restores `sync_docs.py` and `sync_samples.py` under the new monorepo layout.

## Background

Both scripts existed at `scripts/` on legacy `main` and were dropped during the SFI re-review on the empty `main2` baseline. Sanity-diffing the post-cutover `main` against the snapshot `main-pre-cutover` flagged them as the only real content gap.

## What changed

- **sync_docs.py** - identical to legacy main except for the docstring (paths are relative; must be run from `solutions/ess-maker-skills/`).
- **sync_samples.py** - two updates required by the new layout:
  1. `OUTPUT_DIR` changes from `src/samples/` to `src/examples/ess-samples/`.
  2. The `PATH_RENAMES` translation table is removed. The new monorepo preserves upstream `microsoft/CopilotStudioSamples` PascalCase folder names verbatim (`Workday/EmployeeScenarios`, `ServiceNow/CatalogScenarios`, `ESSEvaluationSamples/StarterTestSets`), so the translation is now identity. `rename_upstream_path()` kept as a no-op pass-through for backward compat with internal callers.

## Verification

- `python -m py_compile` clean on both files.
- `python -m ruff check` clean on both files.
- Manual run not done in this PR; recommend running `python scripts/sync_docs.py --force` and `python scripts/sync_samples.py --force` once after merge to refresh against current upstream and confirm zero net diff (the vendored content already shipped via PR #9 / PR #10).
