### PR TITLE
Fix: stale my/ paths in skill docs (bulk migration)

### DIFF
--- a/solutions/ess-maker-skills/.github/prompts/connect.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/connect.prompt.md
@@ -26,5 +26,5 @@ Rules:
    situation, stay silent and proceed to the next action.
 
 After reading SKILL.md, your first action is to check for
-`my/connect/tasks.md`. If starting fresh, your first message to the user
+`.local/connect/tasks.md`. If starting fresh, your first message to the user
 is the checklist table from the Fresh Start section.

--- a/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
@@ -31,5 +31,5 @@ Rules:
    situation, stay silent and proceed to the next action.
 
 After reading SKILL.md, your first action is to check for
-`my/onboarding/tasks.md`. If starting fresh, your first message to the user
+`workspace/onboarding/tasks.md`. If starting fresh, your first message to the user
 is the checklist table from the Fresh Start section.

--- a/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
+++ b/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
@@ -198,7 +198,7 @@ Runner attributes available to checks (set up by `cli.py`):
 | `runner.graph` | `GraphClient \| None` | Microsoft Graph client |
 | `runner.pp_admin` | `PowerPlatformAdminClient \| None` | BAP admin client |
 | `runner.pva` | `PVAClient \| None` | Island Gateway client |
-| `runner.config` | `dict` | Parsed `my/config.json` |
+| `runner.config` | `dict` | Parsed `.local/config.json` |
 
 Minimal example:
 
@@ -294,7 +294,7 @@ and do the per-tier verification.
 5. **Follow existing client patterns.** New API integrations should follow the
    same structure as `graph_client.py` / `pp_admin_client.py` / `pva_client.py`:
    - Class with `authenticate()` method
-   - Uses shared MSAL token cache at `my/.token_cache.bin`
+   - Uses shared MSAL token cache at `.local/.token_cache.bin`
    - Initialized in `cli.py`, attached to `runner`
    - Gracefully skips if auth fails (print warning, set to None)
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
@@ -52,7 +52,7 @@ class PVAClient:
         """Acquire a PVA access token and discover gateway URL."""
         authority = f"https://login.microsoftonline.com/{self.tenant_id}"
         cache = msal.SerializableTokenCache()
-        cache_path = os.path.join("my", ".token_cache.bin")
+        cache_path = os.path.join(".local", ".token_cache.bin")
 
         if os.path.exists(cache_path):
             with open(cache_path, "r") as f:

--- a/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pva_client.py
@@ -90,7 +90,7 @@ class PVAClient:
             )
 
         if cache.has_state_changed:
-            os.makedirs("my", exist_ok=True)
+            os.makedirs(".local", exist_ok=True)
             with open(cache_path, "w") as f:
                 f.write(cache.serialize())
 

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/permissions-required.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/permissions-required.md
@@ -65,11 +65,11 @@ Used for: the 17 workflow tests (WD-WF-001 through WD-WF-017).
 1. **Environment variables** — if already set (e.g., from a CI pipeline)
 2. **`.vscode/mcp.json`** — base URL and tenant are read directly (they're
    not secrets). Username/password use `${input:...}` so they can't be read.
-3. **`my/config.json`** → `connections.Workday` — tenant and base URL from
+3. **`.local/config.json`** → `connections.Workday` — tenant and base URL from
    the `/connect workday` setup
 4. **Interactive prompt** — if creds still missing, prompts for ISU username
    and password at runtime. **Never saved to disk.**
-5. **`my/config.json`** → `workdayTestEmployeeId` — cached after first prompt
+5. **`.local/config.json`** → `workdayTestEmployeeId` — cached after first prompt
    so you only enter it once
 
 Environment variables needed (if not auto-resolved):

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/remediation-guide.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/remediation-guide.md
@@ -44,7 +44,7 @@ verification.
 ### ENV-001: Environment not found
 **Root cause:** Environment ID couldn't be derived, or user lacks admin access.
 **Fix:**
-1. Confirm the Dataverse URL in `my/config.json` is correct
+1. Confirm the Dataverse URL in `.local/config.json` is correct
 2. Ensure you have Environment Admin or PP Admin role
 3. Re-run `/setup` if the URL is wrong
 **Verify:** Re-run `/flightcheck --scope environment`

--- a/solutions/ess-maker-skills/src/skills/cleanup/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/cleanup/SKILL.md
@@ -14,11 +14,11 @@ This skill scans a cloned ESS agent for compile errors and walks the user throug
 
 ## Step 1: Read Config
 
-Read `my/config.json` to get the agent details:
+Read `.local/config.json` to get the agent details:
 - `agent.folder` — the name of the cloned agent folder (e.g., `Employee Self-Service HR`)
 - `agent.slug` — the slugified name (e.g., `employee-self-service-hr`)
 
-If `my/config.json` doesn't exist or doesn't have `agent.folder`, tell the user: "I can't find your agent configuration. Run `/setup` first." Then STOP.
+If `.local/config.json` doesn't exist or doesn't have `agent.folder`, tell the user: "I can't find your agent configuration. Run `/setup` first." Then STOP.
 
 ## Step 2: Quick Scan (before checkpoint)
 
@@ -73,7 +73,7 @@ After scanning, group the errors into these categories:
 ### Category 3: Missing Dialog Reference
 **Error message**: `Dialog with id '{schema}.topic.{name}' not found`
 **What it means**: The topic references another topic using a `BeginDialog` action, but the schema name in the reference is wrong. Common cause: truncated schema name (e.g., `msdyn_copilotforemployeeselfservice` instead of `msdyn_copilotforemployeeselfservicehr`).
-**Fix**: Look at the incorrect dialog reference. Read `my/config.json` to get the correct `agent.schemaName`. Replace the wrong schema prefix with the correct one. For example, if the error says `msdyn_copilotforemployeeselfservice.topic.WorkdayManagerCheck` and the correct schemaName is `msdyn_copilotforemployeeselfservicehr`, replace `msdyn_copilotforemployeeselfservice` with `msdyn_copilotforemployeeselfservicehr` in the file.
+**Fix**: Look at the incorrect dialog reference. Read `.local/config.json` to get the correct `agent.schemaName`. Replace the wrong schema prefix with the correct one. For example, if the error says `msdyn_copilotforemployeeselfservice.topic.WorkdayManagerCheck` and the correct schemaName is `msdyn_copilotforemployeeselfservicehr`, replace `msdyn_copilotforemployeeselfservice` with `msdyn_copilotforemployeeselfservicehr` in the file.
 
 ### Unknown Errors
 If you find errors that don't match any of the above categories, list them separately and tell the user: "I found some errors I don't have an automatic fix for. Here's what they are:" Then list them and suggest the user check the Copilot Studio documentation.

--- a/solutions/ess-maker-skills/src/skills/connect/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/connect/SKILL.md
@@ -15,7 +15,7 @@ pass it to step1 as PRE_SELECTED_INTEGRATION. Step1 will skip the
 
 Read `src/skills/connect/step1.md` and follow it.
 
-(Step 1 asks which integration. It checks `my/connect/{integration}/tasks.md`
+(Step 1 asks which integration. It checks `.local/connect/{integration}/tasks.md`
 for existing state — completed, in-progress, or fresh. Then it dispatches to
 the integration-specific step files.)
 
@@ -27,8 +27,8 @@ Each integration has its own folder with its own tasks.md and step files:
 
 - **ServiceNow**: `src/skills/connect/servicenow/`
   - Tasks template: `src/skills/connect/servicenow/tasks.md`
-  - State file: `my/connect/servicenow/tasks.md`
-  - Config file: `my/connect/servicenow/config.json`
+  - State file: `.local/connect/servicenow/tasks.md`
+  - Config file: `.local/connect/servicenow/config.json`
   - Step 1: `step1.md` — instance info, MCP setup, connectivity check
   - Step 2 (Entra): `step2-entra.md` — create Entra app registration for user login
   - Step 2 (Certificate): `step2-certificate.md` — create two Entra apps + OIDC + system user
@@ -41,8 +41,8 @@ Each integration has its own folder with its own tasks.md and step files:
 
 - **Workday**: `src/skills/connect/workday/`
   - Tasks template: `src/skills/connect/workday/tasks.md`
-  - State file: `my/connect/workday/tasks.md`
-  - Config file: `my/connect/workday/config.json`
+  - State file: `.local/connect/workday/tasks.md`
+  - Config file: `.local/connect/workday/config.json`
   - Step 1: `step1.md` — gather info, MCP setup, connectivity check, detect existing state (Entra app, extension pack, RaaS report)
   - Step 2: `step2.md` — Entra SSO setup (mandatory), ISU accounts, security groups, auth policies, API client, domain permissions, RaaS report
   - Step 3: `step3.md` — extension pack install (or diagnose existing), connection setup (3 different auth types), post-install verification, topic redirect auto-push, end-to-end test

--- a/solutions/ess-maker-skills/src/skills/connect/azure/app-registration.md
+++ b/solutions/ess-maker-skills/src/skills/connect/azure/app-registration.md
@@ -126,7 +126,7 @@ Stop here. Do not proceed.
 For any other error, retry once. If still fails, show the error and stop.
 
 **Immediately save APP_CLIENT_ID and APP_OBJECT_ID** to
-`my/connect/servicenow/config.json` under the relevant auth section
+`.local/connect/servicenow/config.json` under the relevant auth section
 (e.g., `entra.appClientId`, `entra.appObjectId`). This preserves state
 if the session breaks before the calling file's final config save.
 

--- a/solutions/ess-maker-skills/src/skills/connect/azure/login.md
+++ b/solutions/ess-maker-skills/src/skills/connect/azure/login.md
@@ -80,7 +80,7 @@ az account show --query tenantId -o tsv
 
 ## A.4 — Sign in with device code
 
-**Track attempts.** Read `my/.azure-login-attempts.json` if it exists.
+**Track attempts.** Read `.local/.azure-login-attempts.json` if it exists.
 If it does not exist, treat the current attempt count as `0`. Increment
 the counter and write it back:
 
@@ -104,7 +104,7 @@ Talk to your tenant admin and then run `/connect` again to retry.
 
 **End message.**
 
-Delete `my/.azure-login-attempts.json` so the next `/connect` run
+Delete `.local/.azure-login-attempts.json` so the next `/connect` run
 starts a fresh count, then stop here. Do not proceed.
 
 Otherwise, run this command in the terminal using `run_in_terminal`
@@ -168,7 +168,7 @@ az account show --query tenantId -o tsv
 Compare the output to TENANT_ID (case-insensitive).
 
 **If they match**: Azure login is complete. Delete
-`my/.azure-login-attempts.json` (success — clear the counter). Return
+`.local/.azure-login-attempts.json` (success — clear the counter). Return
 TENANT_ID to the calling file.
 
 **If they don't match**:
@@ -192,7 +192,7 @@ Go back to A.4 and retry.
 
 **If `az account show` fails** (not logged in):
 
-Read `my/.azure-login-attempts.json` to determine the current attempt
+Read `.local/.azure-login-attempts.json` to determine the current attempt
 count. If `attempts < 2`:
 
 **Message:**
@@ -218,7 +218,7 @@ Having trouble with the device-code sign-in. Let's try it manually:
 **End message.**
 
 **Bump the counter before waiting on the user.** Write
-`my/.azure-login-attempts.json`:
+`.local/.azure-login-attempts.json`:
 
 ```
 { "tenantId": "{TENANT_ID}", "attempts": 3 }
@@ -249,5 +249,5 @@ Talk to your tenant admin and try `/connect` again once resolved.
 
 **End message.**
 
-Delete `my/.azure-login-attempts.json` so the next `/connect` run
+Delete `.local/.azure-login-attempts.json` so the next `/connect` run
 starts clean. Stop. Do NOT route back into A.4 or the manual flow.

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step1.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step1.md
@@ -138,7 +138,7 @@ No action needed. Proceed to 1.3.
 
 ## 1.3 — Save config
 
-Write `my/connect/servicenow/config.json`:
+Write `.local/connect/servicenow/config.json`:
 
 ```json
 {
@@ -245,7 +245,7 @@ query_table(table="sys_user", query="user_name=admin", fields="sys_id,user_name,
 
 **If the query succeeds** (returns at least one record):
 
-Update `my/connect/servicenow/tasks.md` — change step 1 from
+Update `.local/connect/servicenow/tasks.md` — change step 1 from
 `- [ ]` to `- [x]`.
 
 **Message:**
@@ -286,7 +286,7 @@ Route by SNOW_AUTH for the Power Platform connector:
   Read `src/skills/connect/servicenow/step2-oauth2.md` and follow it.
 
 - If SNOW_AUTH is `basic`:
-  Update step 2 from `- [ ]` to `- [x]` in `my/connect/servicenow/tasks.md`.
+  Update step 2 from `- [ ]` to `- [x]` in `.local/connect/servicenow/tasks.md`.
   Read `src/skills/connect/servicenow/step3-basic.md` and follow it.
 
 When the Power Platform flow completes (step 4 finishes), check

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-certificate.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-certificate.md
@@ -10,7 +10,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 display text like "APP_A_CLIENT_ID = ..." or "OIDC_ENTITY_SYS_ID = ..." in
 chat. The user should only see Message blocks and tool output tables.
 
-Read `my/connect/servicenow/config.json` for INSTANCE_NAME.
+Read `.local/connect/servicenow/config.json` for INSTANCE_NAME.
 
 **Do NOT ask the user any questions or show any messages before reading
 login.md in section 2.1.** Go directly to 2.1.
@@ -41,7 +41,7 @@ When it completes, you will have APP_A_CLIENT_ID, APP_A_OBJECT_ID,
 and SCOPE_GUID.
 
 **Immediately save APP_A_CLIENT_ID and APP_A_OBJECT_ID** to
-`my/connect/servicenow/config.json` under `certificate.appAClientId`
+`.local/connect/servicenow/config.json` under `certificate.appAClientId`
 and `certificate.appAObjectId`.
 
 The certificate auth docs require an additional `aud` optional claim
@@ -142,11 +142,11 @@ From the terminal output, extract:
 - The thumbprint → save as CERT_THUMBPRINT
 
 **Save CERT_PFX_PATH, CERT_CER_PATH, and CERT_THUMBPRINT** to
-`my/connect/servicenow/config.json` under `certificate.certPfxPath`,
+`.local/connect/servicenow/config.json` under `certificate.certPfxPath`,
 `certificate.certCerPath`, and `certificate.certThumbprint`.
 
 **Do NOT write CERT_PASSWORD to disk.** The PFX password is a reusable
-credential — persisting it to `my/connect/servicenow/config.json` would
+credential — persisting it to `.local/connect/servicenow/config.json` would
 leave it sitting in the workspace even after the session ends. Keep it
 in session memory for the rest of this flow. If the session breaks,
 resume code in step3-certificate.md will re-prompt the user.
@@ -216,7 +216,7 @@ Extract the CER path from the output → save as CERT_CER_PATH.
 .cer file path directly.
 
 **Save CERT_PFX_PATH and CERT_CER_PATH** to
-`my/connect/servicenow/config.json` under `certificate.certPfxPath`
+`.local/connect/servicenow/config.json` under `certificate.certPfxPath`
 and `certificate.certCerPath`. Compute and save CERT_THUMBPRINT to
 `certificate.certThumbprint` (use
 `(Get-PfxCertificate -FilePath '{CERT_PFX_PATH}').Thumbprint` if not
@@ -338,7 +338,7 @@ Stop here. Do not proceed.
 For any other error, retry once. If still fails, show the error and stop.
 
 **Immediately save APP_B_CLIENT_ID and APP_B_OBJECT_ID** to
-`my/connect/servicenow/config.json` under `certificate.appBClientId`
+`.local/connect/servicenow/config.json` under `certificate.appBClientId`
 and `certificate.appBObjectId`.
 
 ---
@@ -425,7 +425,7 @@ Save the output as APP_B_SP_OBJECT_ID.
 For any other error, retry once, then show the error and stop.
 
 **Immediately save APP_B_SP_OBJECT_ID** to
-`my/connect/servicenow/config.json` under
+`.local/connect/servicenow/config.json` under
 `certificate.appBSpObjectId`.
 
 ---
@@ -562,7 +562,7 @@ Replace `{TENANT_ID}` with the actual value.
 Extract `sys_id` from the response → save as OIDC_CONFIG_SYS_ID.
 
 **Immediately save OIDC_CONFIG_SYS_ID** to
-`my/connect/servicenow/config.json` under
+`.local/connect/servicenow/config.json` under
 `certificate.oidcConfigSysId`.
 
 **If create returns 403**: fall back to querying for the built-in
@@ -677,7 +677,7 @@ Replace `{APP_B_SP_OBJECT_ID}` with the actual value.
 Save the `sys_id` from the response as CREATED_SVC_USER_SYS_ID.
 
 **Immediately save CREATED_SVC_USER_SYS_ID** to
-`my/connect/servicenow/config.json` under
+`.local/connect/servicenow/config.json` under
 `certificate.createdSvcUserSysId`. This ensures the created user is
 tracked for cleanup if later steps fail.
 
@@ -715,7 +715,7 @@ Wait for the user. Then proceed to 2.11.
 
 ## 2.11 — Save config and display results
 
-Update `my/connect/servicenow/config.json` — add a `certificate` object
+Update `.local/connect/servicenow/config.json` — add a `certificate` object
 (merge with any fields already saved in earlier steps):
 
 ```json
@@ -752,7 +752,7 @@ also add:
 }
 ```
 
-Update `my/connect/servicenow/tasks.md` — change step 2 from
+Update `.local/connect/servicenow/tasks.md` — change step 2 from
 `- [ ]` to `- [x]`.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-entra.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-entra.md
@@ -9,7 +9,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 display text like "APP_CLIENT_ID = ..." or "OIDC_ENTITY_SYS_ID = ..." in
 chat. The user should only see Message blocks and tool output tables.
 
-Read `my/connect/servicenow/config.json` for INSTANCE_NAME.
+Read `.local/connect/servicenow/config.json` for INSTANCE_NAME.
 
 **Do NOT ask the user any questions or show any messages before reading
 login.md in section 2.1.** Go directly to 2.1.
@@ -110,7 +110,7 @@ create_record(table="sys_user", data="{\"user_name\": \"{ENTRA_UPN}\", \"email\"
 Save the `sys_id` from the response as CREATED_USER_SYS_ID.
 
 **Immediately save CREATED_USER_SYS_ID** to
-`my/connect/servicenow/config.json` under `entra.createdUserSysId`.
+`.local/connect/servicenow/config.json` under `entra.createdUserSysId`.
 This ensures the created user is tracked for cleanup if later steps fail.
 
 **Message (do NOT wait for user response — continue immediately):**
@@ -293,7 +293,7 @@ and tell the user to link them manually in ServiceNow admin.
 
 ## 2.7 — Save config and display results
 
-Update `my/connect/servicenow/config.json` — add an `entra` object:
+Update `.local/connect/servicenow/config.json` — add an `entra` object:
 
 ```json
 {
@@ -318,7 +318,7 @@ If CREATED_USER_SYS_ID was set (user was created in step 2.3), also add:
 }
 ```
 
-Update `my/connect/servicenow/tasks.md` — change step 2 from
+Update `.local/connect/servicenow/tasks.md` — change step 2 from
 `- [ ]` to `- [x]`.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-graph.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-graph.md
@@ -14,7 +14,7 @@ chat. The user should only see Message blocks and tool output tables.
 **Do NOT ask the user any questions before reading azure/login.md in
 section 2.1.** Go directly to 2.1.
 
-Read `my/connect/servicenow/config.json` for INSTANCE_NAME and TENANT_ID
+Read `.local/connect/servicenow/config.json` for INSTANCE_NAME and TENANT_ID
 (if already captured from an earlier Entra login). If TENANT_ID is not
 in config, section 2.1 will collect it.
 
@@ -177,7 +177,7 @@ Note the **v2.0** endpoint — this differs from the Power Platform path.
 Extract `sys_id` from the response → save as OIDC_ENTITY_SYS_ID.
 
 **Immediately save OIDC_ENTITY_SYS_ID** to
-`my/connect/servicenow/config.json` under `graph.oidcEntitySysId`.
+`.local/connect/servicenow/config.json` under `graph.oidcEntitySysId`.
 
 **If the call fails**: retry once. If still fails, show the error and
 suggest manual creation in ServiceNow admin.
@@ -222,7 +222,7 @@ create_record(table="oidc_provider_configuration", data="{\"name\": \"Microsoft 
 Extract `sys_id` from the response → save as OIDC_CONFIG_SYS_ID.
 
 **Immediately save OIDC_CONFIG_SYS_ID** to
-`my/connect/servicenow/config.json` under `graph.oidcConfigSysId`.
+`.local/connect/servicenow/config.json` under `graph.oidcConfigSysId`.
 
 **If create returns 403**: fall back to querying for the built-in
 "Azure AD" config and updating it:
@@ -281,7 +281,7 @@ create_record(table="sys_user", data="{\"user_name\": \"{SP_OBJECT_ID}\", \"firs
 Extract `sys_id` from the response → save as GRAPH_USER_SYS_ID.
 
 **Immediately save GRAPH_USER_SYS_ID** to
-`my/connect/servicenow/config.json` under `graph.userSysId`.
+`.local/connect/servicenow/config.json` under `graph.userSysId`.
 
 ---
 
@@ -573,7 +573,7 @@ manually in ServiceNow:
 
 ## 2.9 — Save config and display results
 
-Update `my/connect/servicenow/config.json` — add or update the `graph`
+Update `.local/connect/servicenow/config.json` — add or update the `graph`
 object. Some fields may already be saved from incremental saves above;
 ensure all fields are present:
 

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-oauth2.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step2-oauth2.md
@@ -8,7 +8,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "REDIRECT_URL = ..." or "CLIENT_SECRET = ..." in chat.
 
-Read `my/connect/servicenow/config.json` for INSTANCE_NAME.
+Read `.local/connect/servicenow/config.json` for INSTANCE_NAME.
 
 ---
 
@@ -198,7 +198,7 @@ If this call fails, log the error but continue — it's not blocking.
 
 ## 2.5 — Save config and display results
 
-Update `my/connect/servicenow/config.json` — add an `oauth` object:
+Update `.local/connect/servicenow/config.json` — add an `oauth` object:
 
 ```json
 {
@@ -212,7 +212,7 @@ Update `my/connect/servicenow/config.json` — add an `oauth` object:
 
 Do NOT store the client secret in config.json.
 
-Update `my/connect/servicenow/tasks.md` — change step 2 from
+Update `.local/connect/servicenow/tasks.md` — change step 2 from
 `- [ ]` to `- [x]`.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-basic.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-basic.md
@@ -8,7 +8,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "INSTANCE_NAME = ..." or "PACK_NAME = ..." in chat.
 
-Read `my/connect/servicenow/config.json` to restore INSTANCE_NAME and
+Read `.local/connect/servicenow/config.json` to restore INSTANCE_NAME and
 SNOW_USAGE (from `usage`).
 
 ---
@@ -108,10 +108,10 @@ Go back to section 3.2 with CURRENT_PACK set to `hrsd`.
 
 **Otherwise (single pack, or second pack just finished):**
 
-Update `my/connect/servicenow/tasks.md` — change step 3 from
+Update `.local/connect/servicenow/tasks.md` — change step 3 from
 `- [ ]` to `- [x]`.
 
-Update `my/connect/servicenow/config.json` — set the status of each
+Update `.local/connect/servicenow/config.json` — set the status of each
 installed pack from `"pending"` to `"installed"` in the `packs` object.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-certificate.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-certificate.md
@@ -9,7 +9,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "INSTANCE_NAME = ..." or "PACK_NAME = ..." in chat.
 
-Read `my/connect/servicenow/config.json` to restore INSTANCE_NAME,
+Read `.local/connect/servicenow/config.json` to restore INSTANCE_NAME,
 SNOW_USAGE (from `usage`), TENANT_ID (from `certificate.tenantId`),
 APP_A_CLIENT_ID (from `certificate.appAClientId`),
 APP_B_CLIENT_ID (from `certificate.appBClientId`), and
@@ -30,7 +30,7 @@ Otherwise (this is a resumed session), prompt for it now via
 ```
 
 Save the answer as CERT_PASSWORD (session memory only — do not write
-to `my/connect/servicenow/config.json`).
+to `.local/connect/servicenow/config.json`).
 
 ---
 
@@ -214,10 +214,10 @@ Go back to section 3.2 with CURRENT_PACK set to `hrsd`.
 
 **Otherwise (single pack, or second pack just finished):**
 
-Update `my/connect/servicenow/tasks.md` — change step 3 from
+Update `.local/connect/servicenow/tasks.md` — change step 3 from
 `- [ ]` to `- [x]`.
 
-Update `my/connect/servicenow/config.json` — set the status of each
+Update `.local/connect/servicenow/config.json` — set the status of each
 installed pack from `"pending"` to `"installed"` in the `packs` object.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-entra.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-entra.md
@@ -8,7 +8,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "INSTANCE_NAME = ..." or "PACK_NAME = ..." in chat.
 
-Read `my/connect/servicenow/config.json` to restore INSTANCE_NAME,
+Read `.local/connect/servicenow/config.json` to restore INSTANCE_NAME,
 SNOW_USAGE (from `usage`), and APP_CLIENT_ID (from `entra.appClientId`).
 
 ---
@@ -110,10 +110,10 @@ Go back to section 3.2 with CURRENT_PACK set to `hrsd`.
 
 **Otherwise (single pack, or second pack just finished):**
 
-Update `my/connect/servicenow/tasks.md` — change step 3 from
+Update `.local/connect/servicenow/tasks.md` — change step 3 from
 `- [ ]` to `- [x]`.
 
-Update `my/connect/servicenow/config.json` — set the status of each
+Update `.local/connect/servicenow/config.json` — set the status of each
 installed pack from `"pending"` to `"installed"` in the `packs` object.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-graph.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-graph.md
@@ -10,7 +10,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 
 **Do NOT show internal variable names or assignments to the user.**
 
-Read `my/connect/servicenow/config.json` for INSTANCE_NAME.
+Read `.local/connect/servicenow/config.json` for INSTANCE_NAME.
 
 ---
 
@@ -128,7 +128,7 @@ Wait for the user.
 
 ## 3.4 — Complete
 
-Update `my/connect/servicenow/config.json` — set
+Update `.local/connect/servicenow/config.json` — set
 `"graph"."status"` to `"connected"`.
 
 **Message:**
@@ -141,7 +141,7 @@ employee questions. The connector will sync articles automatically
 
 **End message.**
 
-Check `my/connect/servicenow/config.json` for `connectorType`. If it
+Check `.local/connect/servicenow/config.json` for `connectorType`. If it
 is `both` AND the Power Platform connector was already set up before
 this flow, stop here — everything is done.
 

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-oauth2.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step3-oauth2.md
@@ -8,7 +8,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "CLIENT_ID = ..." or "PACK_NAME = ..." in chat.
 
-Read `my/connect/servicenow/config.json` to restore INSTANCE_NAME,
+Read `.local/connect/servicenow/config.json` to restore INSTANCE_NAME,
 SNOW_USAGE (from `usage`), CLIENT_ID (from `oauth.clientId`).
 
 The CLIENT_SECRET should still be in memory from step 2. If the agent
@@ -92,10 +92,10 @@ Wait for the user to paste the URL. Save it as CORRECT_REDIRECT.
 Call the ServiceNow MCP `update_record` tool to fix the redirect URL:
 
 - `table`: `"oauth_entity"`
-- `sys_id`: read from `my/connect/servicenow/config.json` at `oauth.sysId`
+- `sys_id`: read from `.local/connect/servicenow/config.json` at `oauth.sysId`
 - `data`: `"{\"redirect_url\": \"{CORRECT_REDIRECT}\"}"`
 
-Update `my/connect/servicenow/config.json` — set `oauth.redirectUrl` to
+Update `.local/connect/servicenow/config.json` — set `oauth.redirectUrl` to
 CORRECT_REDIRECT.
 
 **Message:**
@@ -152,10 +152,10 @@ Go back to section 3.2 with CURRENT_PACK set to `hrsd`.
 
 **Otherwise (single pack, or second pack just finished):**
 
-Update `my/connect/servicenow/tasks.md` — change step 3 from
+Update `.local/connect/servicenow/tasks.md` — change step 3 from
 `- [ ]` to `- [x]`.
 
-Update `my/connect/servicenow/config.json` — set the status of each
+Update `.local/connect/servicenow/config.json` — set the status of each
 installed pack from `"pending"` to `"installed"` in the `packs` object.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step4.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step4.md
@@ -6,8 +6,8 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "ENV_URL = ..." or "BOT_ID = ..." in chat.
 
-Read `my/connect/servicenow/config.json` for INSTANCE_NAME, SNOW_USAGE, etc.
-Read `my/config.json` for the agent details (dataverseEndpoint, agent.botId,
+Read `.local/connect/servicenow/config.json` for INSTANCE_NAME, SNOW_USAGE, etc.
+Read `.local/config.json` for the agent details (dataverseEndpoint, agent.botId,
 agent.name, agent.schemaName, agent.isManaged).
 
 ---
@@ -21,7 +21,7 @@ This takes about 10–20 seconds...
 
 **End message.**
 
-Read `my/config.json` to get the agent details. Set:
+Read `.local/config.json` to get the agent details. Set:
 - ENV_URL = `dataverseEndpoint`
 - BOT_ID = `agent.botId`
 - BOT_NAME = `agent.name`
@@ -44,12 +44,12 @@ Wait for the script to complete. Check the output for:
 
 ### If template configs > 0 AND new ServiceNow topics are visible
 
-Update `my/connect/servicenow/tasks.md` — change step 4 from
+Update `.local/connect/servicenow/tasks.md` — change step 4 from
 `- [ ]` to `- [x]`.
 
-Update `my/connect/servicenow/config.json` — set `"status": "connected"`.
+Update `.local/connect/servicenow/config.json` — set `"status": "connected"`.
 
-Update `my/config.json` — add or update a `connections` object:
+Update `.local/config.json` — add or update a `connections` object:
 
 ```json
 {

--- a/solutions/ess-maker-skills/src/skills/connect/step1.md
+++ b/solutions/ess-maker-skills/src/skills/connect/step1.md
@@ -7,7 +7,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 
 ## 1.1 — Check what's already connected
 
-Check which folders exist under `my/connect/`. For each folder that has a
+Check which folders exist under `.local/connect/`. For each folder that has a
 `tasks.md` where all items are checked, that integration is connected.
 
 Build a list of connected integrations (if any).
@@ -52,11 +52,11 @@ Wait for the user to respond.
 
 ### If the user chose ServiceNow (1 or "servicenow")
 
-Check if `my/connect/servicenow/tasks.md` exists.
+Check if `.local/connect/servicenow/tasks.md` exists.
 
 **If it exists and all items are checked:**
 
-Read `my/connect/servicenow/config.json` to get the current `authType`.
+Read `.local/connect/servicenow/config.json` to get the current `authType`.
 Map it to a display name:
 - `entra` → "Entra ID (interactive sign-in)"
 - `certificate` → "Certificate (service-to-service)"
@@ -101,14 +101,14 @@ Map the answer to SNOW_AUTH using the same rules as
 `src/skills/connect/servicenow/step1.md` section 1.1 (the per-product
 step1, NOT this top-level routing file).
 
-Update `my/connect/servicenow/config.json` — set `authType` to the new
+Update `.local/connect/servicenow/config.json` — set `authType` to the new
 value. Set `status` to `"in-progress"`. Reset all pack statuses in
 `packs` from `"installed"` to `"pending"`.
 
-Update `my/connect/servicenow/tasks.md` — reset steps 2, 3, and 4 from
+Update `.local/connect/servicenow/tasks.md` — reset steps 2, 3, and 4 from
 `- [x]` to `- [ ]`.
 
-Update `my/config.json` — remove the `connections.ServiceNow` entry (it
+Update `.local/config.json` — remove the `connections.ServiceNow` entry (it
 will be re-created by step 4 with the new auth type after verification).
 
 **Message:**
@@ -124,7 +124,7 @@ Switching to **{new auth display name}**. Picking up from step 2.
 
 **End message.**
 
-Read `my/connect/servicenow/config.json` to restore INSTANCE_NAME and
+Read `.local/connect/servicenow/config.json` to restore INSTANCE_NAME and
 other values. Then route by the new SNOW_AUTH:
 
 - If `entra` → read `src/skills/connect/servicenow/step2-entra.md`
@@ -135,12 +135,12 @@ other values. Then route by the new SNOW_AUTH:
 
 **If the user chose 3 (reconnect from scratch):**
 
-Reset `my/connect/servicenow/tasks.md` — all steps to `- [ ]`.
+Reset `.local/connect/servicenow/tasks.md` — all steps to `- [ ]`.
 
-Delete `my/connect/servicenow/config.json`.
+Delete `.local/connect/servicenow/config.json`.
 
 Copy `src/skills/connect/servicenow/tasks.md` to
-`my/connect/servicenow/tasks.md`.
+`.local/connect/servicenow/tasks.md`.
 
 **Message:**
 
@@ -159,10 +159,10 @@ Now read `src/skills/connect/servicenow/step1.md` and follow it.
 
 **If it exists and some items are unchecked:**
 
-Show the checklist from `my/connect/servicenow/tasks.md` (✅ for checked,
+Show the checklist from `.local/connect/servicenow/tasks.md` (✅ for checked,
 ⬜ for unchecked) followed by "Picking up where we left off."
 
-Read `my/connect/servicenow/config.json` to restore saved values
+Read `.local/connect/servicenow/config.json` to restore saved values
 (INSTANCE_NAME, SNOW_USAGE, SNOW_AUTH, etc.). Then find the first unchecked
 step and route as follows:
 
@@ -184,7 +184,7 @@ step and route as follows:
 **If it does not exist:**
 
 Copy `src/skills/connect/servicenow/tasks.md` to
-`my/connect/servicenow/tasks.md`.
+`.local/connect/servicenow/tasks.md`.
 
 **Message:**
 
@@ -203,11 +203,11 @@ Now read `src/skills/connect/servicenow/step1.md` and follow it.
 
 ### If the user chose Workday (2 or "workday")
 
-Check if `my/connect/workday/tasks.md` exists.
+Check if `.local/connect/workday/tasks.md` exists.
 
 **If it exists and all items are checked:**
 
-Read `my/connect/workday/config.json` to get the current tenant name.
+Read `.local/connect/workday/config.json` to get the current tenant name.
 
 **Message:**
 
@@ -224,12 +224,12 @@ Wait for the user.
 
 **If the user chose 2 (reconnect):**
 
-Reset `my/connect/workday/tasks.md` — all steps to `- [ ]`.
+Reset `.local/connect/workday/tasks.md` — all steps to `- [ ]`.
 
-Delete `my/connect/workday/config.json`.
+Delete `.local/connect/workday/config.json`.
 
 Copy `src/skills/connect/workday/tasks.md` to
-`my/connect/workday/tasks.md`.
+`.local/connect/workday/tasks.md`.
 
 **Message:**
 
@@ -247,10 +247,10 @@ Now read `src/skills/connect/workday/step1.md` and follow it.
 
 **If it exists and some items are unchecked:**
 
-Show the checklist from `my/connect/workday/tasks.md` (✅ for checked,
+Show the checklist from `.local/connect/workday/tasks.md` (✅ for checked,
 ⬜ for unchecked) followed by "Picking up where we left off."
 
-Read `my/connect/workday/config.json` to restore saved values. Then
+Read `.local/connect/workday/config.json` to restore saved values. Then
 find the first unchecked step and route:
 
 - **Step 1 unchecked** → read `src/skills/connect/workday/step1.md`
@@ -260,7 +260,7 @@ find the first unchecked step and route:
 **If it does not exist:**
 
 Copy `src/skills/connect/workday/tasks.md` to
-`my/connect/workday/tasks.md`.
+`.local/connect/workday/tasks.md`.
 
 **Message:**
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
@@ -76,7 +76,7 @@ If pip fails, try `python -m pip install -r src/mcp/workday/requirements.txt`.
 
 ## 1.3 — Save initial config
 
-Write `my/connect/workday/config.json`:
+Write `.local/connect/workday/config.json`:
 
 ```json
 {
@@ -300,7 +300,7 @@ Save as WD_OAUTH_TOKEN_URL.
 
 ### 1.7e — Update config with discovered state
 
-Update `my/connect/workday/config.json` — merge all discovered values:
+Update `.local/connect/workday/config.json` — merge all discovered values:
 
 ```json
 {
@@ -325,7 +325,7 @@ Update `my/connect/workday/config.json` — merge all discovered values:
 
 ## 1.8 — Show status and proceed
 
-Update `my/connect/workday/tasks.md` — change step 1 from
+Update `.local/connect/workday/tasks.md` — change step 1 from
 `- [ ]` to `- [x]`.
 
 Build a status summary from the detected state.

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
@@ -6,7 +6,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "DOMAIN_NAME = ..." or "TENANT_NAME = ..." in chat.
 
-Read `my/connect/workday/config.json` for ALL values — WD_BASE_URL (baseUrl),
+Read `.local/connect/workday/config.json` for ALL values — WD_BASE_URL (baseUrl),
 WD_TENANT (tenant), WD_TOKEN_HOST (tokenHost), DOMAIN_NAME (domainName),
 TENANT_ID (tenantId), WD_ENTRA_APP_ID (entraAppId),
 WD_ENTRA_APP_ID_URI (entraAppIdUri), WD_OAUTH_TOKEN_URL (oauthTokenUrl),
@@ -69,7 +69,7 @@ scenarios (compensation, time off requests, contact updates).
 
 ### 2.1a — Check if Entra app already exists
 
-Read `my/connect/workday/config.json`. If `entraSSO` is `true` and
+Read `.local/connect/workday/config.json`. If `entraSSO` is `true` and
 `entraAppId` is set, an Entra app was already found in step 1.
 
 **If ENTRA_SSO_EXISTS is true:**
@@ -269,7 +269,7 @@ Type **done** when complete.
 
 Wait for the user.
 
-Update `my/connect/workday/config.json`:
+Update `.local/connect/workday/config.json`:
 ```json
 {
   "entraSSO": true,
@@ -410,13 +410,13 @@ which will verify authentication actually works.
 
 **Hold ISU_WQL_PASSWORD and ISU_GENERIC_PASSWORD in session memory only**
 for use in step 3 connection setup. Do NOT write them to
-`my/connect/workday/config.json` - ISU credentials are full reusable
+`.local/connect/workday/config.json` - ISU credentials are full reusable
 Workday user accounts (worse risk profile than the cert PFX passphrase
-in `step2-certificate.md`, which we also keep off disk), and `my/` is a
+in `step2-certificate.md`, which we also keep off disk), and `.local/` is a
 working directory contributors share, debug from, and occasionally
 commit by accident. The Power Platform connection ref encrypts and
 stores them server-side once step 3 wires the connections, so the
-on-disk copy in `my/` would be a duplicate worth eliminating.
+on-disk copy in `.local/` would be a duplicate worth eliminating.
 
 If the user comes back to step 3 in a new session and the passwords
 are gone from session memory, re-prompt for them at that point.
@@ -473,7 +473,7 @@ Wait for the user. Proceed to Task 4.
 
 ## Task 4: Register API Client
 
-Check `my/connect/workday/config.json` for `oauthClientId`. If it's
+Check `.local/connect/workday/config.json` for `oauthClientId`. If it's
 already set (discovered or saved previously), skip to the save step.
 
 **Message:**
@@ -541,7 +541,7 @@ Use the `vscode_askQuestions` tool:
 
 Save as OAUTH_CLIENT_ID.
 
-Update `my/connect/workday/config.json`:
+Update `.local/connect/workday/config.json`:
 ```json
 {
   "oauthClientId": "{OAUTH_CLIENT_ID}",
@@ -676,7 +676,7 @@ retry.
 
 ## Task 6: WD_User_Context RaaS Report
 
-Check `my/connect/workday/config.json`. If `raasReportExists` is `true`,
+Check `.local/connect/workday/config.json`. If `raasReportExists` is `true`,
 the report was already detected in step 1.
 
 **If report exists:**
@@ -946,7 +946,7 @@ Wait for the user on retry. Re-run `get_user_context`.
 
 ## 2.7 — Complete step 2
 
-Update `my/connect/workday/tasks.md` — change step 2 from
+Update `.local/connect/workday/tasks.md` — change step 2 from
 `- [ ]` to `- [x]`.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
@@ -6,8 +6,8 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 **Do NOT show internal variable names or assignments to the user.** Never
 display text like "ENV_URL = ..." or "BOT_ID = ..." in chat.
 
-Read `my/connect/workday/config.json` for ALL values.
-Read `my/config.json` for agent details (dataverseEndpoint, agent.botId,
+Read `.local/connect/workday/config.json` for ALL values.
+Read `.local/config.json` for agent details (dataverseEndpoint, agent.botId,
 agent.name, agent.schemaName, agent.isManaged).
 
 **CRITICAL RULES (from retro):**
@@ -31,7 +31,7 @@ agent.name, agent.schemaName, agent.isManaged).
 
 ## 3.1 — Check if extension pack is already installed
 
-Read `my/connect/workday/config.json` for `extensionInstalled`.
+Read `.local/connect/workday/config.json` for `extensionInstalled`.
 
 If step 1 already detected connection references exist, the extension
 pack is installed. Skip to section 3.5 (diagnose/fix existing install).
@@ -48,7 +48,7 @@ Preparing your agent for the Workday extension...
 
 **End message.**
 
-Read `my/config.json` to get agent details. Run:
+Read `.local/config.json` to get agent details. Run:
 
 ```
 python scripts/fetch_and_setup.py --url "{ENV_URL}" --bot-id "{BOT_ID}" --name "{BOT_NAME}" --schema "{SCHEMA_NAME}" {--managed if IS_MANAGED}
@@ -277,7 +277,7 @@ Wait for the user.
 Read the agent's `user-context-setup.mcs.yml` file:
 
 ```
-my/agents/{slug}/topics/user-context-setup.mcs.yml
+workspace/agents/{slug}/topics/user-context-setup.mcs.yml
 ```
 
 Check if it already contains a `BeginDialog` action pointing to
@@ -433,11 +433,11 @@ and verify the full permission list.
 
 ## 3.7 — Complete
 
-Update `my/connect/workday/tasks.md` — change step 3 to `- [x]`.
+Update `.local/connect/workday/tasks.md` — change step 3 to `- [x]`.
 
-Update `my/connect/workday/config.json` — set `"status": "connected"`.
+Update `.local/connect/workday/config.json` — set `"status": "connected"`.
 
-Update `my/config.json` — add or merge:
+Update `.local/config.json` — add or merge:
 
 ```json
 {

--- a/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
@@ -7,7 +7,7 @@ via Dataverse. Test cases are stored as `botcomponent` records with
 
 ## Rules
 
-- ALWAYS read `my/config.json` to get the agent folder name and slug.
+- ALWAYS read `.local/config.json` to get the agent folder name and slug.
 - ALWAYS read all topic files in the agent folder to understand what the agent does before generating tests.
 - Write evaluation files to `{agent.folder}/evaluations/` as `.mcs.yml` YAML files.
 - Use the existing starter test sets in `src/examples/ess-samples/ESSEvaluationSamples/StarterTestSets/` as exemplar patterns for each test category.
@@ -18,7 +18,7 @@ via Dataverse. Test cases are stored as `botcomponent` records with
 
 ## Step 1: Read Agent Context
 
-1. Read `my/config.json` to get `agent.folder` and `agent.slug`.
+1. Read `.local/config.json` to get `agent.folder` and `agent.slug`.
 2. Read ALL topic files in `{agent.folder}/topics/` — every `.mcs.yml` file.
 3. Classify each topic:
 

--- a/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
@@ -6,7 +6,7 @@ locally AND pushing the deletion to the live environment via push.
 
 ## CRITICAL — Local Files Are a Working Copy
 
-The files in `my/agents/{slug}/evaluations/` are a **working copy**. Deleting
+The files in `workspace/agents/{slug}/evaluations/` are a **working copy**. Deleting
 a local file is NOT the same as deleting the test case from the live agent.
 You MUST push the deletion via `push.py`. **NEVER stop after deleting only
 the local file.**
@@ -20,7 +20,7 @@ children first, then the parent. Do NOT push partial deletions.
 
 ## Rules
 
-- ALWAYS read `my/config.json` to get the agent folder, slug, and schema name.
+- ALWAYS read `.local/config.json` to get the agent folder, slug, and schema name.
 - ALWAYS checkpoint before deleting anything.
 - ALWAYS push the deletion to Copilot Studio after removing files.
 - NEVER delete a file without confirming with the user first.
@@ -28,7 +28,7 @@ children first, then the parent. Do NOT push partial deletions.
 
 ## Step 1: Identify What to Delete
 
-Read `my/config.json` to get `agent.folder`.
+Read `.local/config.json` to get `agent.folder`.
 
 List files in `{agent.folder}/evaluations/`. Read the `.component-map.json`
 to understand parent→child relationships (entries with

--- a/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
@@ -6,7 +6,7 @@ files AND pushing changes to Copilot Studio via push.
 
 ## CRITICAL — Local Files Are a Working Copy
 
-The files in `my/agents/{slug}/evaluations/` are a **working copy** of the
+The files in `workspace/agents/{slug}/evaluations/` are a **working copy** of the
 evaluation test sets deployed in Copilot Studio. Editing a local file is NOT
 the same as updating the live test case. You MUST push the changes via
 `push.py` for them to take effect. **NEVER stop after editing only the local
@@ -14,14 +14,14 @@ file.**
 
 ## Rules
 
-- ALWAYS read `my/config.json` to get the agent folder, slug, and schema name.
+- ALWAYS read `.local/config.json` to get the agent folder, slug, and schema name.
 - ALWAYS checkpoint before making changes.
 - ALWAYS push changes to Copilot Studio after editing.
 - **TRACK PROGRESS**: Use the todo list tool to track your progress.
 
 ## Step 1: Identify the Test Set / Test Cases
 
-Read `my/config.json` to get `agent.folder`.
+Read `.local/config.json` to get `agent.folder`.
 
 List all files in `{agent.folder}/evaluations/`. Two kinds exist:
 

--- a/solutions/ess-maker-skills/src/skills/flightcheck/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/flightcheck/SKILL.md
@@ -11,7 +11,7 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 
 ## Start
 
-Read `my/config.json` to confirm setup is complete and get the agent context.
+Read `.local/config.json` to confirm setup is complete and get the agent context.
 
 If setup is not complete, show:
 
@@ -77,14 +77,14 @@ Then open the HTML report in the user's default browser. Use Python to
 handle paths with spaces correctly:
 
 ```
-python -c "import webbrowser, os; webbrowser.open('file:///' + os.path.abspath('my/flightcheck/report.html').replace(os.sep, '/'))"
+python -c "import webbrowser, os; webbrowser.open('file:///' + os.path.abspath('workspace/flightcheck/report.html').replace(os.sep, '/'))"
 ```
 
 ---
 
 ## Step 3: Read results and present findings
 
-Read `my/flightcheck/results.json`. Build the output below using the data.
+Read `workspace/flightcheck/results.json`. Build the output below using the data.
 You MUST follow this exact format every time. Do not improvise, add prose
 between sections, or skip any section.
 
@@ -103,7 +103,7 @@ Always show this first:
 | ℹ️ Not Configured | {not_configured} |
 | **Total** | **{total}** |
 
-*Completed in {duration_secs}s — [View full report](my/flightcheck/report.html)*
+*Completed in {duration_secs}s — [View full report](workspace/flightcheck/report.html)*
 ```
 
 Where VERDICT_EMOJI and VERDICT_TEXT are:
@@ -212,7 +212,7 @@ python scripts/flightcheck/cli.py --scope {SCOPE}
 Open the updated report:
 
 ```
-Start-Process "my/flightcheck/report.html"
+Start-Process "workspace/flightcheck/report.html"
 ```
 
 Then present the new results using the same format (3a → 3b → 3c).

--- a/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
@@ -8,10 +8,10 @@ or what files you are reading.
 
 ## Start
 
-Read `my/onboarding/tasks.md`.
+Read `workspace/onboarding/tasks.md`.
 
 If the file does not exist, copy `src/skills/onboarding/tasks.md` to
-`my/onboarding/tasks.md` and go to Fresh Start below.
+`workspace/onboarding/tasks.md` and go to Fresh Start below.
 
 If the file exists but mentions "Copilot Studio extension", "Clone agent", or
 "PAC CLI", delete it, re-copy from `src/skills/onboarding/tasks.md`, and show:

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
@@ -70,7 +70,7 @@ Find the line starting with `SELECTED_AGENT_JSON:` in the output. Parse the
 JSON after the colon to get BOT_ID (`botid`), BOT_NAME (`name`),
 SCHEMA_NAME (`schemaname`), and IS_MANAGED (`ismanaged`).
 
-Update `my/onboarding/tasks.md` — change both step 1 and step 2 from
+Update `workspace/onboarding/tasks.md` — change both step 1 and step 2 from
 `- [ ]` to `- [x]`.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/onboarding/step2.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step2.md
@@ -29,7 +29,7 @@ and runs setup.py automatically. No MCP queries needed.
 If the script fails with an auth error, tell the user to check they selected
 the correct account with access to the environment, and re-run the command.
 
-When the script completes successfully, update `my/onboarding/tasks.md` —
+When the script completes successfully, update `workspace/onboarding/tasks.md` —
 change step 3 from `- [ ]` to `- [x]`.
 
 **Message:**
@@ -73,7 +73,7 @@ Wait for the user to respond.
 
 ## 2.3 — Finish
 
-Update `my/onboarding/tasks.md` — change step 4 from `- [ ]` to `- [x]`.
+Update `workspace/onboarding/tasks.md` — change step 4 from `- [ ]` to `- [x]`.
 
 **Message:**
 

--- a/solutions/ess-maker-skills/src/skills/onboarding/step3-flightcheck.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step3-flightcheck.md
@@ -27,7 +27,7 @@ Use the `vscode_askQuestions` tool:
 
 **If they choose "Skip":**
 
-Do NOT update `my/onboarding/tasks.md`. Step 5 stays unchecked so
+Do NOT update `workspace/onboarding/tasks.md`. Step 5 stays unchecked so
 `/setup` will offer the readiness check again on the next run.
 
 **Message:**
@@ -61,13 +61,13 @@ python scripts/flightcheck/cli.py --scope full
 
 Wait for the script to finish.
 
-Update `my/onboarding/tasks.md` — change step 5 from `- [ ]` to `- [x]`.
+Update `workspace/onboarding/tasks.md` — change step 5 from `- [ ]` to `- [x]`.
 
 ---
 
 ## 3.3 — Present results
 
-Read `my/flightcheck/results.json`. Present the results using the same
+Read `workspace/flightcheck/results.json`. Present the results using the same
 format as `src/skills/flightcheck/SKILL.md` Step 3 (summary banner →
 category breakdown table → issues table → next steps). Follow that format
 exactly.

--- a/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
@@ -6,7 +6,7 @@ This skill guides the user through creating a new Copilot Studio topic.
 
 - Do NOT run terminal commands or scripts. Use built-in file reading and writing tools only.
 - ALWAYS read existing topic files in the user's agent folder (`{agent.folder}/topics/`) as schema examples before generating any YAML.
-- ALWAYS read `my/config.json` to get the agent folder name and schema name.
+- ALWAYS read `.local/config.json` to get the agent folder name and schema name.
 - Write the new topic file to `{agent.folder}/topics/{TopicName}.mcs.yml`.
 - After writing the file, check for errors using the diagnostics tool on the new file.
 - **TEMPLATE CONFIG IS THE DEFAULT**: For any scenario that calls ServiceNow or Workday, use the **Template Config + Shared Flow** pattern. This is the official ESS extensibility pattern. The topic calls the existing shared system topic (e.g., `ServiceNowHRSDSystemGetCommonExecution`), which invokes the shared orchestrator flow. Do NOT create standalone cloud flows for these connectors.
@@ -113,11 +113,11 @@ For any scenario that involves data collection + external system calls, think th
 
 ## Step 4: Check for Existing Patterns
 
-Read the agent snapshot at `my/agents/{agent.slug}/topics.md` to see if similar topics already exist. If a similar pattern exists:
+Read the agent snapshot at `workspace/agents/{agent.slug}/topics.md` to see if similar topics already exist. If a similar pattern exists:
 - Tell the user: "I found a similar topic ({name}) that does {X}. I'll use its pattern as a reference."
 - Read the existing topic file to understand the action chain.
 
-If the topic calls a workflow, check `my/agents/{agent.slug}/workflows.md` to see if a suitable workflow already exists. If not, tell the user they'll also need a workflow and offer to create one after the topic.
+If the topic calls a workflow, check `workspace/agents/{agent.slug}/workflows.md` to see if a suitable workflow already exists. If not, tell the user they'll also need a workflow and offer to create one after the topic.
 
 ## Step 5: Generate the Topic YAML
 
@@ -162,7 +162,7 @@ The topic calls the shared system topic, which looks up a template config by
 topic to work. **Create it before writing the topic file.**
 
 1. **Try to use the Dataverse MCP** regardless of what `templateConfigsDiscovered`
-   says in `my/config.json`. The flag may be stale. Search for Dataverse tools
+   says in `.local/config.json`. The flag may be stale. Search for Dataverse tools
    by calling `tool_search_tool_regex` with pattern `dataverse|Dataverse`.
    If tools are found, proceed with automated creation. If no tools are found,
    fall back to manual instructions (see "Manual Fallback" below).
@@ -206,7 +206,7 @@ its steps. The user should not have to manage the dependency chain manually.
 
 ### 6.3 — Write the topic file
 
-1. Read `my/config.json` to get `agent.folder`.
+1. Read `.local/config.json` to get `agent.folder`.
 2. Write the topic file to `{agent.folder}/topics/{filename}.mcs.yml`.
 
 ### 6.4 — Scan for errors

--- a/solutions/ess-maker-skills/src/skills/topics/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/delete/SKILL.md
@@ -6,7 +6,7 @@ environment via push.
 
 ## CRITICAL — Local Files Are a Working Copy
 
-The files in `my/agents/{slug}/` are a **working copy** of what's deployed in
+The files in `workspace/agents/{slug}/` are a **working copy** of what's deployed in
 Copilot Studio. Deleting a local file is NOT the same as deleting the topic
 from the live agent. You MUST push the deletion to Copilot Studio via
 `push.py` for it to take effect. **NEVER stop after deleting only the local
@@ -14,7 +14,7 @@ file.**
 
 ## Rules
 
-- ALWAYS read `my/config.json` to get the agent folder, slug, and schema name.
+- ALWAYS read `.local/config.json` to get the agent folder, slug, and schema name.
 - ALWAYS checkpoint before deleting anything.
 - ALWAYS push the deletion to Copilot Studio after removing the local file.
 - NEVER delete a file without confirming with the user first.
@@ -23,7 +23,7 @@ file.**
 
 ## Step 1: Identify the Topic
 
-Read `my/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `agent.folder` and `agent.slug`.
 
 If the user named a specific topic, find the matching file in
 `{agent.folder}/topics/`. Match by:

--- a/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
@@ -6,14 +6,14 @@ live environment via push.
 
 ## CRITICAL — Local Files Are a Working Copy
 
-The files in `my/agents/{slug}/` are a **working copy** of what's deployed in
+The files in `workspace/agents/{slug}/` are a **working copy** of what's deployed in
 Copilot Studio. Editing a local file is NOT the same as updating the live
 topic. You MUST push the changes to Copilot Studio via `push.py` for them to
 take effect. **NEVER stop after editing only the local file.**
 
 ## Rules
 
-- ALWAYS read `my/config.json` to get the agent folder, slug, and schema name.
+- ALWAYS read `.local/config.json` to get the agent folder, slug, and schema name.
 - ALWAYS read existing topic files in the user's agent folder as schema examples before editing any YAML.
 - ALWAYS checkpoint before making changes.
 - ALWAYS push changes to Copilot Studio after editing.
@@ -23,7 +23,7 @@ take effect. **NEVER stop after editing only the local file.**
 
 ## Step 1: Identify the Topic
 
-Read `my/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `agent.folder` and `agent.slug`.
 
 If the user named a specific topic, find the matching file in
 `{agent.folder}/topics/`. Match by filename, `componentName`, trigger phrases,

--- a/solutions/ess-maker-skills/src/skills/troubleshoot/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/troubleshoot/SKILL.md
@@ -13,7 +13,7 @@ checkpoint required.
 - **Before starting diagnosis**, suggest running `/flightcheck` first if the
   user hasn't recently. FlightCheck's automated checks often surface the root
   cause faster than manual walkthrough. If the user says they already ran it,
-  ask them to share the results from `my/flightcheck/results.json`.
+  ask them to share the results from `workspace/flightcheck/results.json`.
 - Track progress with todos if the diagnosis spans multiple configs.
 - Always read the relevant reference doc BEFORE presenting guidance — do not
   guess or paraphrase from memory.
@@ -26,7 +26,7 @@ checkpoint required.
 
 ## Step 1: Identify the Integration and Read Config
 
-Read `my/config.json` to determine:
+Read `.local/config.json` to determine:
 - Which agent is active (the `agent.folder` field)
 - Which integrations are configured
 

--- a/solutions/ess-maker-skills/src/skills/workflows/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/workflows/create/SKILL.md
@@ -27,7 +27,7 @@ Then read `src/skills/topics/create/SKILL.md` and follow the template config pat
 - Do NOT run terminal commands or scripts. Use built-in file reading and writing tools only.
 - ALWAYS read existing workflow files in the user's agent folder (`{agent.folder}/workflows/`) as schema examples before generating any workflow JSON.
 - ALWAYS read the agent's `connectionreferences.mcs.yml` to understand connector wiring.
-- ALWAYS read `my/config.json` to get the agent folder name.
+- ALWAYS read `.local/config.json` to get the agent folder name.
 - Create the workflow in a new folder: `{agent.folder}/workflows/{WorkflowName}-{GUID}/`
 - Write both `metadata.yml` and `workflow.json` into that folder.
 - After writing, check for errors using the diagnostics tool.
@@ -45,10 +45,10 @@ From their response, determine:
 
 ## Step 2: Check Existing Workflows
 
-Read `my/agents/{agent.slug}/workflows.md` to see if a suitable workflow already exists. If the agent already has a workflow that does something similar, tell the user:
+Read `workspace/agents/{agent.slug}/workflows.md` to see if a suitable workflow already exists. If the agent already has a workflow that does something similar, tell the user:
 - "Your agent already has a workflow called '{name}' that {does X}. Would you like to use that one, or create a new one?"
 
-Also check `my/agents/{agent.slug}/connections.md` to see which connectors are already configured. If the needed connector isn't available, tell the user they'll need to add it through the Copilot Studio portal first.
+Also check `workspace/agents/{agent.slug}/connections.md` to see which connectors are already configured. If the needed connector isn't available, tell the user they'll need to add it through the Copilot Studio portal first.
 
 ## Step 3: Generate the Workflow
 
@@ -76,7 +76,7 @@ isTransacted: true
 
 ### workflow.json
 Customize the template by:
-1. Setting the correct `connectionReferences` — match the `connectionReferenceLogicalName` to a value from `my/agents/{agent.slug}/connections.md`
+1. Setting the correct `connectionReferences` — match the `connectionReferenceLogicalName` to a value from `workspace/agents/{agent.slug}/connections.md`
 2. Defining trigger inputs — what the topic will pass to the workflow
 3. Adding the correct connector action — use the right `operationId` for the task
 4. Defining the response outputs — what data goes back to the topic

--- a/solutions/ess-maker-skills/src/skills/workflows/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/workflows/delete/SKILL.md
@@ -6,7 +6,7 @@ workflow both locally AND from the live environment via push.
 
 ## CRITICAL — Local Files Are a Working Copy
 
-The files in `my/agents/{slug}/` are a **working copy** of what's deployed in
+The files in `workspace/agents/{slug}/` are a **working copy** of what's deployed in
 Copilot Studio. Deleting local files is NOT the same as deleting the workflow
 from the live agent. You MUST push the deletion to Copilot Studio via
 `push.py` for it to take effect. **NEVER stop after deleting only the local
@@ -14,7 +14,7 @@ files.**
 
 ## Rules
 
-- ALWAYS read `my/config.json` to get the agent folder, slug, and schema name.
+- ALWAYS read `.local/config.json` to get the agent folder, slug, and schema name.
 - ALWAYS checkpoint before deleting anything.
 - ALWAYS push the deletion to Copilot Studio after removing local files.
 - NEVER delete without confirming with the user first.
@@ -24,7 +24,7 @@ files.**
 
 ## Step 1: Identify the Workflow
 
-Read `my/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `agent.folder` and `agent.slug`.
 
 List the workflow folders in `{agent.folder}/workflows/`. Each workflow is a
 folder containing `metadata.yml` and `workflow.json`.

--- a/solutions/ess-maker-skills/src/skills/workflows/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/workflows/update/SKILL.md
@@ -6,14 +6,14 @@ local working copy AND pushing the change to the live environment via push.
 
 ## CRITICAL — Local Files Are a Working Copy
 
-The files in `my/agents/{slug}/` are a **working copy** of what's deployed in
+The files in `workspace/agents/{slug}/` are a **working copy** of what's deployed in
 Copilot Studio. Editing a local file is NOT the same as updating the live
 workflow. You MUST push the changes to Copilot Studio via `push.py` for them
 to take effect. **NEVER stop after editing only the local file.**
 
 ## Rules
 
-- ALWAYS read `my/config.json` to get the agent folder, slug, and schema name.
+- ALWAYS read `.local/config.json` to get the agent folder, slug, and schema name.
 - ALWAYS read existing workflow files in the user's agent folder as schema examples before editing JSON.
 - ALWAYS read the agent's `connectionreferences.mcs.yml` to verify connectors.
 - ALWAYS checkpoint before making changes.
@@ -22,7 +22,7 @@ to take effect. **NEVER stop after editing only the local file.**
 
 ## Step 1: Identify the Workflow
 
-Read `my/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `agent.folder` and `agent.slug`.
 
 List workflow folders in `{agent.folder}/workflows/`. Each contains
 `metadata.yml` and `workflow.json`.


### PR DESCRIPTION
## Description

Migrates 159 stale `my/` path references across 40 files to the new convention established in PR #2 and reinforced by John in PRs #16, #17, #18, #19, #54, #61, #62, #63: `my/` is dead, replaced by `workspace/` (user-edited content) and `.local/` (kit bookkeeping).

The Python scripts (`auth.py`, `setup.py`, `checkpoint.py`, `flightcheck/cli.py`, every flightcheck check) were migrated correctly during the SFI cutover. The skill docs that the LLM reads at task time were not. This produces a class of silent failure: the LLM is told to write to `my/connect/servicenow/config.json` while `auth.py` reads from `.local/connect/servicenow/config.json` -- the same defect John flagged on PR #54, scaled to 30+ more files.

## Mapping applied (mechanical, ordered to avoid prefix collisions)

| Old path | New path | Reason |
|---|---|---|
| `my/agents/` | `workspace/agents/` | User-edited |
| `my/onboarding/` | `workspace/onboarding/` | User-visible state |
| `my/flightcheck/` | `workspace/flightcheck/` | User-visible reports |
| `my/tests/` | `workspace/tests/` | User-visible test sets |
| `my/connect/` | `.local/connect/` | Kit bookkeeping |
| `my/config.json` | `.local/config.json` | Kit bookkeeping |
| `my/.token_cache.bin` | `.local/.token_cache.bin` | Kit bookkeeping |
| `my/.azure-login-attempts.json` | `.local/.azure-login-attempts.json` | Kit bookkeeping |

## Files touched (39 docs + 1 runtime)

- `.github/prompts/{connect,setup}.prompt.md`
- `scripts/flightcheck/AGENTS.md` -- carries over from PR #61 follow-up
- `scripts/flightcheck/pva_client.py:55` -- runtime fix; aligns with `auth.py:127`, `graph_client.py:78`, `pp_admin_client.py:71`
- `src/reference/ess-docs/flightcheck/{permissions-required,remediation-guide}.md`
- `src/skills/cleanup/SKILL.md`
- `src/skills/connect/{SKILL.md,step1.md}`
- `src/skills/connect/azure/{app-registration,login}.md`
- `src/skills/connect/servicenow/` -- 11 files
- `src/skills/connect/workday/{step1,step2,step3}.md`
- `src/skills/evaluations/{create,delete,update}/SKILL.md`
- `src/skills/flightcheck/SKILL.md`
- `src/skills/onboarding/{SKILL.md,step1b,step2,step3-flightcheck}.md`
- `src/skills/topics/{create,delete,update}/SKILL.md`
- `src/skills/troubleshoot/SKILL.md`
- `src/skills/workflows/{create,delete,update}/SKILL.md`

## Not changed (intentional)

- `scripts/auth.py:44` -- historical comment referencing the migration itself; accurate as-is
- `scripts/flightcheck/checks/local_files.py:342` -- same
- `src/examples/ess-samples/` -- vendored upstream sample content

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Testing

- `ruff check scripts/ src/mcp/` -- passes locally
- `python -m compileall -q scripts/ src/mcp/` -- passes locally
- Diff is one-for-one substitutions: 159 insertions, 159 deletions across 40 files; reviewer can verify by spot-checking that every `-` line and corresponding `+` line differ only in the path mapping above

## Checklist

- [x] My code follows the existing style
- [x] I have added/updated tests where applicable (n/a -- no test suite for skill markdown)
- [x] I have updated documentation as needed
