### PR TITLE
add /provision skill

### DIFF
--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -21,11 +21,14 @@ Respond with ONLY this exact message and nothing else:
 
 **The ONLY exception**: If the user typed `/setup` or explicitly asked to run
 setup, proceed with setup — read `src/skills/onboarding/SKILL.md` and follow it.
+If the user typed `/provision`, proceed with provisioning — read
+`src/skills/provision/SKILL.md` and follow it. `/provision` does not require
+prior `/setup` because it installs the agent that `/setup` would later extract.
 
 **This gate applies to ALL user messages** — including "hello", "hi", "help",
 "what can you do", "I need a topic", "create a workflow", or any other request.
-If config doesn't exist or setup isn't complete, and the user didn't say `/setup`,
-show ONLY the welcome message above. No other text. No capabilities list. No greeting.
+If config doesn't exist or setup isn't complete, and the user didn't say `/setup`
+or `/provision`, show ONLY the welcome message above. No other text. No capabilities list. No greeting.
 
 ### If `.local/config.json` exists AND `setup` is `"complete"`:
 

--- a/solutions/ess-maker-skills/.github/prompts/provision.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/provision.prompt.md
@@ -1,0 +1,29 @@
+---
+agent: agent
+description: "Provision a Power Platform env with ESS base + ISV extension, end to end"
+---
+
+# Provision
+
+**No setup prerequisite.** Unlike `/connect` or `/flightcheck`, this command
+does NOT require `/setup` to have been run first. `/provision` installs the
+agent that `/setup` would later extract.
+
+You are a script executor. Read `src/skills/provision/SKILL.md` (the
+orchestrator) and follow it. It will tell you which step file to read next.
+Each step file contains pre-written messages between **Message:** and
+**End message.** markers.
+
+Rules:
+1. Show Message block text to the user EXACTLY as written. Do not rephrase.
+2. NEVER tell the user what files you are reading or what tools you are
+   calling. The user must never see "Read SKILL.md" or "Calling tool" or
+   file names or line numbers. If they see any of that, you have failed.
+3. The ONLY text the user sees is Message blocks and tool/script output tables.
+4. Do not compose your own messages. If there is no Message block for a
+   situation, stay silent and proceed to the next action.
+5. Never echo values read from `.local/.env` back to chat. Treat them as
+   sensitive even though the file is gitignored.
+
+After reading SKILL.md, your first action is to load `.local/.env` (if
+present) and parse it per SKILL.md Step 0. Then walk through Steps 1-5.

--- a/solutions/ess-maker-skills/.gitignore
+++ b/solutions/ess-maker-skills/.gitignore
@@ -8,3 +8,9 @@ workspace/**
 .local/**
 !.local/
 !.local/.gitkeep
+
+# my/ holds skill-internal state (per-skill config and tasks.md). Used by
+# /connect, /provision, etc. for resumable run state. Never committed.
+my/**
+!my/
+!my/.gitkeep

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -127,6 +127,75 @@ python scripts/flightcheck/cli.py --scope full
 | `workday` | Workday connections, flows, env vars, and SOAP workflow tests |
 | `local` | Agent files only — no API calls |
 | `prerequisites` | Licenses and roles only |
+| `provision` | Smoke test for the `/provision` skill — env, external systems, Workday |
+
+---
+
+### 🚀 `/provision` — One-Command Environment Provisioning
+
+End-to-end provisioning of a fresh Power Platform environment with ESS base, Workday ISV, connections, and configured topic. Targets internal dev work in EmployeeHub today; extends to other tenants with `.env` configuration.
+
+What `/provision ess with workday` does:
+
+1. Creates a new Power Platform env via PAC CLI (Developer type, configurable ring: Preprod or Prod)
+2. Installs the ESS HR or ESS IT base agent from AppSource via `pac application install`
+3. Installs the Workday HCM extension (`msdyn_EssHRWorkday` or `msdyn_EssITWorkday`)
+4. Creates the Workday SOAP and Dataverse connections programmatically via the Power Platform Connectivity API (per-env REST endpoint)
+5. Prompts the user to complete the OAuth handshake for both connections in the Power Apps maker portal (one click each)
+6. Binds solution-level connection references in Dataverse
+7. Enables the Workday flows via Dataverse workflow activation
+8. Guides the user through manual Copilot Studio flow wiring and connection parameter sharing
+9. PATCHes the `[Admin] - User Context - Setup` topic to redirect to `WorkdaySystemGetUserContextV2`
+10. Verifies all provision tasks completed via checklist review
+
+Wall-clock: ~7 minutes of automation plus ~2-3 minutes of manual steps (connection sign-in + Copilot Studio flow wiring). Compared to the manual flow it replaces (~30 minutes of error-prone clicking).
+
+#### One-time setup (per tenant)
+
+To use `/provision` in any tenant, register a custom Entra app once and grant it the right delegated permissions.
+
+**Steps (one-time per tenant):**
+
+1. Sign in to [Azure portal](https://portal.azure.com) → **Microsoft Entra ID** → **App registrations** → **+ New registration**.
+2. Name it (e.g. `ESS-DevKit-Provision-Client`). Single tenant. No redirect URI yet.
+3. Open the new app → **Authentication** → **+ Add a platform** → **Mobile and desktop applications** → add redirect URI `http://localhost`.
+4. **Authentication** → scroll down → **Advanced settings** → set **Allow public client flows** to **Yes** → **Save**.
+5. **API permissions** → **+ Add a permission** → **APIs my organization uses**. Add each of these as **Delegated**, then **Grant admin consent**:
+   - **Power Platform API** (App ID `8578e004-a5c6-46e7-913e-12f58912df43`) — for Prod-ring usage
+     - `Connectivity.Connections.Read`
+     - `Connectivity.Connections.ReadWrite`
+     - `Connectivity.Connectors.Read`
+   - **Power Platform API (preprod)** (App ID `0ddb742a-e7dc-4899-a31e-80e797ec7144`) — for Preprod-ring usage. Same permissions as above.
+   - **Microsoft Graph** — `User.Read`
+6. Copy the **Application (client) ID** from the Overview blade.
+7. In `.local/.env` add:
+   ```text
+   ESS_DEVKIT_EMPHUB_CLIENT_ID=<your-app-client-id>
+   ```
+
+Also one-time per ring:
+
+- Install PAC CLI: `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` (or use the Windows MSI at https://aka.ms/PowerAppsCLI).
+- Create a PAC auth profile per ring:
+  - Preprod (PPE): `pac auth create --cloud Preprod --deviceCode`
+  - Prod: `pac auth create --cloud Public --deviceCode`
+
+#### Usage
+
+```
+/provision ess with workday
+```
+
+The skill asks for persona (HR or IT), ring (Preprod or Prod), and env name, then runs the full flow. State is persisted under `my/provision/{env-name}/` so a failed run can resume.
+
+#### Reference: EmployeeHub tenant setup
+
+The ESS team's `EmployeeHub.onmicrosoft.com` tenant already has this app registered. The client ID lives in the team's `.env` template. New team members just need:
+
+1. `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` + `pac auth create --cloud Preprod --deviceCode`
+2. Copy the team's `.local/.env` template into their kit folder
+3. Be granted access to the EmployeeHub PPE tenant by the team admin
+4. Run `/provision ess with workday`
 
 ---
 

--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -18,20 +18,20 @@ from urllib.parse import quote
 try:
     import msal
 except ImportError:
-    print("ERROR: 'msal' package not found. Run: pip install msal")
+    print("ERROR: 'msal' package not found. Run: pip install msal", file=sys.stderr)
     sys.exit(1)
 
 try:
     import requests
 except ImportError:
-    print("ERROR: 'requests' package not found. Run: pip install requests")
+    print("ERROR: 'requests' package not found. Run: pip install requests", file=sys.stderr)
     sys.exit(1)
 
 try:
     from urllib3.util.retry import Retry
     from requests.adapters import HTTPAdapter
 except ImportError:
-    print("ERROR: 'urllib3' / 'requests' not found. Run: pip install requests")
+    print("ERROR: 'urllib3' / 'requests' not found. Run: pip install requests", file=sys.stderr)
     sys.exit(1)
 
 
@@ -141,8 +141,8 @@ def authenticate(env_url):
         result = app.acquire_token_silent([scope], account=accounts[0])
 
     if not result or "access_token" not in result:
-        print(f"Opening browser for sign-in (tenant: {tenant})...")
-        print("Please select the account that has access to this environment.")
+        print(f"Opening browser for sign-in (tenant: {tenant})...", file=sys.stderr)
+        print("Please select the account that has access to this environment.", file=sys.stderr)
         result = app.acquire_token_interactive(
             [scope], prompt="select_account"
         )
@@ -151,8 +151,8 @@ def authenticate(env_url):
         # Don't echo error_description - it can include tenant IDs and
         # internal flow details (CWE-209).
         error = result.get("error", "unknown_error")
-        print(f"ERROR: Authentication failed ({error}).")
-        print("Verify you have access to this environment and try again.")
+        print(f"ERROR: Authentication failed ({error}).", file=sys.stderr)
+        print("Verify you have access to this environment and try again.", file=sys.stderr)
         sys.exit(1)
 
     # Persist cache with strict 0o600 permissions on POSIX. The cache holds
@@ -209,11 +209,11 @@ def query_all(env_url, token, entity_set, select, filter_expr=None):
         all_records.extend(records)
         url = data.get("@odata.nextLink")
         if page == 1:
-            print(f"  Page {page}: {len(records)} records", end="")
+            print(f"  Page {page}: {len(records)} records", end="", file=sys.stderr)
         elif records:
-            print(f" → Page {page}: {len(records)}", end="")
+            print(f" | Page {page}: {len(records)}", end="", file=sys.stderr)
 
-    print(f" → Total: {len(all_records)}")
+    print(f" | Total: {len(all_records)}", file=sys.stderr)
     return all_records
 
 
@@ -282,7 +282,7 @@ def load_config():
     """
     config_path = os.path.join(LOCAL_STATE_DIR, "config.json")
     if not os.path.exists(config_path):
-        print(f"ERROR: {config_path} not found. Run /setup first.")
+        print(f"ERROR: {config_path} not found. Run /setup first.", file=sys.stderr)
         sys.exit(1)
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = json.load(f)
@@ -290,7 +290,8 @@ def load_config():
     if ver != EXPECTED_CONFIG_VERSION:
         print(
             f"ERROR: {config_path} is schema v{ver}, expected "
-            f"v{EXPECTED_CONFIG_VERSION}. Run `/setup --refresh` to migrate."
+            f"v{EXPECTED_CONFIG_VERSION}. Run `/setup --refresh` to migrate.",
+            file=sys.stderr,
         )
         sys.exit(1)
     return cfg

--- a/solutions/ess-maker-skills/scripts/bind_connection_refs.py
+++ b/solutions/ess-maker-skills/scripts/bind_connection_refs.py
@@ -1,0 +1,222 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Bind Connection References to Connections
+
+PATCHes Dataverse connectionreference rows to point at connections created
+by create_connection.py. Required after every ISV solution install so flows
+can use the connections at runtime.
+
+Usage:
+    python scripts/bind_connection_refs.py \\
+        --env-id <guid> --env-url <url> \\
+        --workday-connection <guid> --dataverse-connection <guid>
+
+    python scripts/bind_connection_refs.py --env-id <guid> --env-url <url> \\
+        --mapping bindings.json   # {"workday": "<guid>", "dataverse": "<guid>"}
+
+Exit codes: 0 success, 1 auth, 2 PATCH failed, 3 unexpected.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: requests required. Run: pip install -r scripts/requirements.txt", file=sys.stderr)
+    sys.exit(3)
+
+from auth import authenticate, query_all
+
+
+# Purpose key -> connector unique names (exact match on last path segment
+# of connectorid, e.g. "/providers/Microsoft.PowerApps/apis/shared_workdaysoap").
+CONNECTOR_UNIQUE_NAMES = {
+    "workday": {"shared_workdaysoap"},
+    "dataverse": {"shared_commondataserviceforapps", "shared_commondataservice"},
+    "servicenow": {"shared_service-now", "shared_servicenowhrservicedelivery"},
+    "successfactors": {"shared_sapsuccessfactors"},
+}
+
+
+def _connector_unique_name(connectorid):
+    """Extract the trailing unique name from a connectorid URL or raw name."""
+    if not connectorid:
+        return ""
+    return connectorid.rstrip("/").rsplit("/", 1)[-1].lower()
+
+
+def classify_connection_refs(refs):
+    """Group connection refs by purpose key via exact connector unique-name match."""
+    grouped = {}
+    for ref in refs:
+        unique_name = _connector_unique_name(ref.get("connectorid"))
+        for key, names in CONNECTOR_UNIQUE_NAMES.items():
+            if unique_name in names:
+                grouped.setdefault(key, []).append(ref)
+                break
+    return grouped
+
+
+def patch_connection_ref(env_url, token, ref_id, connection_id):
+    """PATCH a connectionreference to bind it to a connection."""
+    url = f"{env_url.rstrip('/')}/api/data/v9.2/connectionreferences({ref_id})"
+    body = {"connectionid": connection_id}
+    resp = requests.patch(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "If-Match": "*",
+            "OData-MaxVersion": "4.0",
+            "OData-Version": "4.0",
+        },
+        json=body,
+        timeout=30,
+    )
+    return resp
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bind connection references to existing connections in a Power Platform env")
+    parser.add_argument("--env-id", required=True, help="Env GUID (recorded in output JSON for downstream correlation)")
+    parser.add_argument("--env-url", required=True, help="Dataverse env URL, e.g. https://orgxyz.crm.dynamics.com")
+    parser.add_argument("--workday-connection", help="Workday connection GUID")
+    parser.add_argument("--dataverse-connection", help="Dataverse connection GUID")
+    parser.add_argument("--mapping", help="JSON file with {purpose-key: connection-guid} mapping (overrides --*-connection flags)")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing connection binding without asking. Default is to skip refs that are already bound to a different connection.")
+    args = parser.parse_args()
+
+    # Build the connection mapping.
+    mapping = {}
+    if args.mapping:
+        with open(args.mapping, "r", encoding="utf-8") as f:
+            mapping = json.load(f)
+    else:
+        if args.workday_connection:
+            mapping["workday"] = args.workday_connection
+        if args.dataverse_connection:
+            mapping["dataverse"] = args.dataverse_connection
+
+    if not mapping:
+        print("ERROR: no connection bindings specified. Use --workday-connection / --dataverse-connection or --mapping.", file=sys.stderr)
+        sys.exit(2)
+
+    token = authenticate(args.env_url)
+
+    # Query ESS / Workday ISV connection refs only (by logical name prefix).
+    ess_filter = (
+        "startswith(connectionreferencelogicalname,'msdyn_ess') "
+        "or startswith(connectionreferencelogicalname,'msdyn_copilotforemployeeselfservice') "
+        "or startswith(connectionreferencelogicalname,'new_sharedworkdaysoap') "
+        "or startswith(connectionreferencelogicalname,'msviess_shared')"
+    )
+    refs = query_all(
+        args.env_url,
+        token,
+        "connectionreferences",
+        "connectionreferenceid,connectionreferencelogicalname,connectionreferencedisplayname,connectorid,statuscode,connectionid",
+        ess_filter,
+    )
+    print(f"Discovered {len(refs)} connection references in env", file=sys.stderr)
+
+    grouped = classify_connection_refs(refs)
+
+    results = []
+    failures = []
+
+    for purpose_key, connection_id in mapping.items():
+        candidate_refs = grouped.get(purpose_key, [])
+        if not candidate_refs:
+            # Expected for some ISVs (e.g. Workday has no Dataverse ref).
+            results.append({
+                "purpose": purpose_key,
+                "connectionId": connection_id,
+                "status": "no-refs-in-solution",
+                "reason": f"no connection refs found matching connector(s): {CONNECTOR_UNIQUE_NAMES.get(purpose_key, {purpose_key})}",
+            })
+            continue
+
+        for ref in candidate_refs:
+            ref_id = ref.get("connectionreferenceid")
+            ref_name = ref.get("connectionreferencelogicalname", "")
+            existing = ref.get("connectionid")
+
+            # Idempotency: skip if already bound to the target; require --force for different.
+            if existing:
+                existing_lower = str(existing).replace("-", "").lower()
+                target_lower = str(connection_id).replace("-", "").lower()
+                if existing_lower == target_lower:
+                    print(f"Skipping {ref_name}: already bound to target connection.", file=sys.stderr)
+                    results.append({
+                        "purpose": purpose_key,
+                        "refId": ref_id,
+                        "refLogicalName": ref_name,
+                        "connectionId": connection_id,
+                        "status": "already-bound",
+                    })
+                    continue
+                if not args.force:
+                    print(f"Skipping {ref_name}: already bound to a different connection ({existing}). Use --force to overwrite.", file=sys.stderr)
+                    results.append({
+                        "purpose": purpose_key,
+                        "refId": ref_id,
+                        "refLogicalName": ref_name,
+                        "connectionId": connection_id,
+                        "currentConnectionId": existing,
+                        "status": "skipped-already-bound",
+                    })
+                    continue
+
+            print(f"Binding {ref_name} -> connection {connection_id}", file=sys.stderr)
+            resp = patch_connection_ref(args.env_url, token, ref_id, connection_id)
+
+            if resp.status_code in (200, 204):
+                results.append({
+                    "purpose": purpose_key,
+                    "refId": ref_id,
+                    "refLogicalName": ref_name,
+                    "connectionId": connection_id,
+                    "status": "bound",
+                })
+            else:
+                results.append({
+                    "purpose": purpose_key,
+                    "refId": ref_id,
+                    "refLogicalName": ref_name,
+                    "connectionId": connection_id,
+                    "status": f"failed: {resp.status_code}",
+                    "body": resp.text[:400],
+                })
+                failures.append({
+                    "purpose": purpose_key,
+                    "refId": ref_id,
+                    "refLogicalName": ref_name,
+                    "connectionId": connection_id,
+                    "reason": f"PATCH returned {resp.status_code}: {resp.text[:200]}",
+                })
+
+    output = {
+        "envId": args.env_id,
+        "envUrl": args.env_url,
+        "totalRefsInEnv": len(refs),
+        "bindings": results,
+        "failures": failures,
+    }
+    print(json.dumps(output, indent=2))
+
+    # "already-bound" to target is OK; "skipped-already-bound" to a different
+    # connection means the caller's intent was not fulfilled.
+    incomplete = [r for r in results if r.get("status") == "skipped-already-bound"]
+    sys.exit(0 if not failures and not incomplete else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/create_connection.py
+++ b/solutions/ess-maker-skills/scripts/create_connection.py
@@ -1,0 +1,262 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Power Platform Connection Creator
+
+PUTs a new connection via the per-environment Connectivity API.
+
+OAuth-mode connections come back Unauthenticated — the user must complete
+sign-in in the maker portal (the connector's own Entra app handles the
+SAML federation to Workday). See step3.md "Auth-mode decision".
+
+Usage:
+    python scripts/create_connection.py \\
+        --env-id <guid> --env-url <url> --connector shared_workdaysoap
+    python scripts/create_connection.py \\
+        --env-id <guid> --env-url <url> --connector shared_commondataserviceforapps
+
+Exit codes: 0 success, 1 auth, 2 client error (4xx), 3 unexpected.
+"""
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' required. Run: pip install -r scripts/requirements.txt", file=sys.stderr)
+    sys.exit(3)
+
+from auth import discover_tenant
+from pp_helpers import (
+    SCOPES_BY_RING,
+    acquire_browser_token,
+    load_env_file,
+    lookup_env,
+    per_env_host,
+    short_connector_name,
+)
+
+
+API_VERSION = "1"
+
+
+def build_workday_params(env_map):
+    """Construct connectionParametersSet.values for shared_workdaysoap `oauth` mode."""
+    required = [
+        "WORKDAY_BASE_URL",
+        "WORKDAY_TENANT",
+        "WORKDAY_OAUTH_TOKEN_URL",
+        "WORKDAY_OAUTH_CLIENT_ID",
+        "WORKDAY_ENTRA_APP_ID_URI",
+    ]
+    resolved = {}
+    missing = []
+    for key in required:
+        v = lookup_env(env_map, key)
+        if v:
+            resolved[key] = v
+        else:
+            missing.append(key)
+
+    if missing:
+        print(
+            f"ERROR: missing required Workday values from .env: {', '.join(missing)}\n"
+            f"Accepted aliases per key are listed in SKILL.md Step 0.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    values = {
+        "token:ResourceUri": {"value": resolved["WORKDAY_ENTRA_APP_ID_URI"]},
+        "token:WorkdayTokenUri": {"value": resolved["WORKDAY_OAUTH_TOKEN_URL"]},
+        "token:WorkdayClientId": {"value": resolved["WORKDAY_OAUTH_CLIENT_ID"]},
+        "baseUri": {"value": resolved["WORKDAY_BASE_URL"]},
+        "tenantName": {"value": resolved["WORKDAY_TENANT"]},
+    }
+
+    rest_url = lookup_env(env_map, "WORKDAY_REST_URL")
+    if rest_url:
+        values["restBaseUri"] = {"value": rest_url}
+
+    return values
+
+
+
+def build_request_body(connector, auth_mode, display_name, env_id, values):
+    """Construct the PUT request body for the Power Platform connections API."""
+    body = {
+        "properties": {
+            "apiId": f"/providers/Microsoft.PowerApps/apis/{connector}",
+            "displayName": display_name,
+            "environment": {
+                "id": f"/providers/Microsoft.PowerApps/environments/{env_id}",
+                "name": env_id,
+            },
+        }
+    }
+    if values:
+        body["properties"]["connectionParametersSet"] = {
+            "name": auth_mode,
+            "values": values,
+        }
+    return body
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a Power Platform connection via the connectivity REST API")
+    parser.add_argument("--env-id", required=True, help="Target environment GUID (for the per-env host)")
+    parser.add_argument("--env-url", required=True, help="Dataverse env URL (used for tenant discovery)")
+    parser.add_argument("--connector", required=True, help="Connector unique name, e.g. shared_workdaysoap")
+    parser.add_argument("--ring", default="preprod", choices=list(SCOPES_BY_RING.keys()), help="Power Platform ring (preprod or prod). Drives scope and per-env host.")
+    parser.add_argument("--auth-mode", default="oauth", help="Auth mode key (oauth | basic | oauth2generic | oauthapim). Default: oauth")
+    parser.add_argument("--display-name", help="Connection display name. Default: derived from connector name.")
+    parser.add_argument("--connection-id", help="Override the generated connection GUID")
+    parser.add_argument("--params-file", help="JSON file with connectionParametersSet.values (overrides .env auto-resolution)")
+    parser.add_argument("--env-file", default=".local/.env", help="Path to .env file (default: .local/.env)")
+    parser.add_argument("--client-id", help="Custom Entra app client ID. If omitted, read from .env as ESS_DEVKIT_EMPHUB_CLIENT_ID.")
+    parser.add_argument("--tenant", help="Entra tenant (GUID or domain). If omitted, discovered from --env-url.")
+    parser.add_argument("--scope", help="OAuth scope. If omitted, derived from --ring.")
+    args = parser.parse_args()
+
+    # Load .env once for both connection params and client-id lookup.
+    env_map = load_env_file(args.env_file)
+
+
+    # Resolve client_id: --client-id > .env > error.
+    client_id = args.client_id or lookup_env(env_map, "ESS_DEVKIT_EMPHUB_CLIENT_ID")
+    if not client_id:
+        print(
+            "ERROR: no client ID for the ESS Dev Kit custom Entra app.\n"
+            "Set ESS_DEVKIT_EMPHUB_CLIENT_ID in .local/.env, or pass --client-id.\n"
+            "See README for app registration steps.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Resolve tenant: --tenant > discover from env_url.
+    tenant = args.tenant or discover_tenant(args.env_url)
+    if not tenant or tenant == "organizations":
+        print(
+            "ERROR: could not discover tenant from env URL. Pass --tenant explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Resolve scope: --scope > ring default.
+    scope = args.scope or SCOPES_BY_RING[args.ring]
+
+    # _warmup: cache the token and exit. Used by step1.md to front-load auth.
+    if args.connector == "_warmup":
+        token = acquire_browser_token(client_id, tenant, scope)
+        print(json.dumps({"status": "ok", "scope": scope, "connector": "_warmup"}))
+        sys.exit(0)
+
+    # Resolve connection parameters.
+    if args.params_file:
+        with open(args.params_file, "r", encoding="utf-8") as f:
+            values = json.load(f)
+    elif args.connector == "shared_workdaysoap":
+        values = build_workday_params(env_map)
+    elif args.connector == "shared_commondataserviceforapps":
+        # Dataverse: no parameters needed; auth is purely via the bearer flow.
+        values = {}
+    else:
+        print(
+            f"ERROR: no automatic param-resolution for connector '{args.connector}'.\n"
+            f"Pass --params-file with a JSON document shaped like:\n"
+            f"  {{\"paramName\": {{\"value\": \"...\"}}, ...}}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Strip dashes for consistent URL path; uuid4().hex is already dash-free.
+    if args.connection_id:
+        connection_id = args.connection_id.replace("-", "").lower()
+    else:
+        connection_id = uuid.uuid4().hex
+
+    # Timestamp in display name so re-runs are uniquely identifiable.
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    display_name = args.display_name or f"{short_connector_name(args.connector)}_{args.auth_mode}_{timestamp}"
+
+    # Acquire token (browser-based interactive with caching).
+    token = acquire_browser_token(client_id, tenant, scope)
+
+    # Build URL + body.
+    host = per_env_host(args.env_id, args.ring)
+    url = (
+        f"https://{host}/connectivity/connectors/{args.connector}"
+        f"/connections/{connection_id}?api-version={API_VERSION}"
+    )
+    body = build_request_body(args.connector, args.auth_mode, display_name, args.env_id, values)
+
+    print(f"PUT {url}", file=sys.stderr)
+
+    try:
+        resp = requests.put(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            json=body,
+            timeout=30,
+        )
+    except Exception as e:
+        print(f"ERROR: request failed: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    if resp.status_code in (200, 201):
+        try:
+            data = resp.json()
+        except Exception:
+            data = {}
+        props = data.get("properties", {})
+        statuses = props.get("statuses", [])
+
+        # Prefer the token-target status (most informative for oauth connections).
+        status_summary = "Unknown"
+        target = None
+        for s in statuses:
+            if s.get("target") == "token":
+                status_summary = s.get("status", "Unknown")
+                target = "token"
+                break
+        else:
+            if statuses:
+                status_summary = statuses[0].get("status", "Unknown")
+                target = statuses[0].get("target")
+
+        out = {
+            "connectionId": connection_id,
+            "connectionUrl": url.split("?")[0],
+            "connector": args.connector,
+            "envId": args.env_id,
+            "displayName": display_name,
+            "status": status_summary,
+            "statusTarget": target,
+        }
+        print(json.dumps(out, indent=2))
+        sys.exit(0)
+    elif resp.status_code == 401:
+        print(f"ERROR: 401 auth rejected by API. Body: {resp.text[:500]}", file=sys.stderr)
+        sys.exit(1)
+    elif 400 <= resp.status_code < 500:
+        print(f"ERROR: PUT {resp.status_code}: {resp.text[:800]}", file=sys.stderr)
+        sys.exit(2)
+    else:
+        print(f"ERROR: PUT {resp.status_code}: {resp.text[:800]}", file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/create_env.py
+++ b/solutions/ess-maker-skills/scripts/create_env.py
@@ -1,0 +1,317 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Power Platform Environment Creator (PAC CLI wrapper)
+
+Wraps `pac admin create` with capacity pre-checks and argument validation.
+
+Usage:
+    python scripts/create_env.py --ring preprod --name essdev-foo-wd-20260511
+    python scripts/create_env.py --ring prod --name myorg-test --type Developer
+
+Exit codes: 0 success, 1 auth/tool, 2 capacity/naming, 3 unexpected.
+"""
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys  # noqa: E402  (sys imported before re-use in module-level regex)
+
+
+# Ring -> PAC --cloud flag mapping.
+# PAC's cloud names: Preprod (PPE) and Public (Prod).
+CLOUD_FOR_RING = {
+    "preprod": "Preprod",
+    "prod": "Public",
+}
+
+
+def _run(cmd, capture=True, timeout=1800):
+    """Run a shell command, return (returncode, stdout, stderr).
+
+    shell=True on Windows because pac is a .CMD batch file. Caller must
+    validate all argv values before calling (see _VALID_*_RE patterns).
+    """
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=capture,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            shell=(sys.platform == "win32"),
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        return 124, "", f"subprocess timed out after {timeout}s: {e}"
+    return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+
+# Allowlists for shell-passed arguments (defense against injection via shell=True).
+_VALID_ENV_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+_VALID_REGION_RE = re.compile(r"^[a-zA-Z]{1,40}$")
+_VALID_CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
+_VALID_LANGUAGE_RE = re.compile(r"^[0-9]{1,5}$")
+
+
+def check_pac_installed():
+    """Verify PAC CLI is on PATH. Exit 1 with install instructions if not."""
+    if shutil.which("pac") is None:
+        print(
+            "ERROR: pac CLI not found on PATH.\n"
+            "Install with: dotnet tool install --global Microsoft.PowerApps.CLI.Tool\n"
+            "If dotnet is also missing, install the .NET SDK first: https://dotnet.microsoft.com/download",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def check_auth_for_cloud(cloud):
+    """Confirm an active pac auth profile exists for the target cloud. Exit 1 if not."""
+    rc, out, _ = _run(["pac", "auth", "list"])
+    if rc != 0:
+        # First run with no profiles - pac sometimes returns non-zero
+        out = ""
+
+    # pac auth list output marks the active profile with '*'. The cloud
+    # column is one of {Public, Preprod, ...}. We accept any profile that
+    # mentions the target cloud, active or not.
+    if cloud.lower() not in out.lower():
+        print(
+            f"ERROR: no pac auth profile for cloud '{cloud}'.\n\n"
+            f"Run this command yourself (so you can see the device code):\n\n"
+            f"    pac auth create --cloud {cloud} --deviceCode\n\n"
+            "Open https://microsoft.com/devicelogin and enter the code shown.\n"
+            f"Sign in with your {cloud} tenant account, then re-run /provision.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def select_auth_profile(cloud):
+    """Switch the active pac auth profile to one matching the target cloud."""
+    rc, out, _ = _run(["pac", "auth", "list"])
+    if rc != 0:
+        return  # Will surface as failure on next pac call
+
+    # Each profile line: [1]  *  USER  user@tenant.com  Universal  Preprod
+    for line in out.splitlines():
+        m = re.match(r"\s*\[(\d+)\]", line)
+        if m and cloud.lower() in line.lower():
+            idx = m.group(1)
+            _run(["pac", "auth", "select", "--index", idx])
+            return
+
+
+# Per-tenant env type limits. Developer is per-user (3) but pac admin list
+# shows all tenant envs, so we warn but can't block precisely.
+_ENV_TYPE_LIMITS = {
+    "Trial": 1,
+}
+_DEVELOPER_PER_USER_LIMIT = 3
+
+
+def check_env_capacity(env_type):
+    """Count existing envs of the requested type and block/warn if at limit."""
+    limit = _ENV_TYPE_LIMITS.get(env_type)
+    if limit is None and env_type != "Developer":
+        return  # No fixed limit to check
+
+    rc, out, _ = _run(["pac", "admin", "list"])
+    if rc != 0:
+        # Can't list envs — skip the check, let pac admin create surface
+        # the real error.
+        return
+
+    # Count envs by type. The type column appears in pac admin list output
+    # as a word like "Developer", "Trial", "Sandbox", "Production", etc.
+    type_counts = {}
+    type_re = re.compile(r"\b(Developer|Trial|Sandbox|Production|Default|Teams)\b", re.IGNORECASE)
+    for line in (out or "").splitlines():
+        m = type_re.search(line)
+        if m:
+            t = m.group(1).capitalize()
+            type_counts[t] = type_counts.get(t, 0) + 1
+
+    current = type_counts.get(env_type, 0)
+
+    # Print capacity summary
+    print(f"\nEnvironment capacity check:", file=sys.stderr)
+    if env_type == "Developer":
+        print(f"  {env_type} environments in tenant: {current} (limit: {_DEVELOPER_PER_USER_LIMIT} per user)", file=sys.stderr)
+    else:
+        print(f"  {env_type} environments: {current} / {limit}", file=sys.stderr)
+    for t, count in sorted(type_counts.items()):
+        if t != env_type:
+            t_limit = _ENV_TYPE_LIMITS.get(t)
+            t_limit_str = str(t_limit) if t_limit else "∞"
+            if t == "Developer":
+                t_limit_str = f"{_DEVELOPER_PER_USER_LIMIT}/user"
+            print(f"  {t} environments: {count} ({t_limit_str})", file=sys.stderr)
+
+    # For Trial: tenant-wide limit, can block precisely
+    if limit is not None and current >= limit:
+        alternatives = []
+        if env_type != "Developer":
+            dev_current = type_counts.get("Developer", 0)
+            alternatives.append(f"  --type Developer ({dev_current} in tenant, limit {_DEVELOPER_PER_USER_LIMIT}/user)")
+        if env_type not in ("Sandbox", "Production"):
+            alternatives.append("  --type Sandbox (requires tenant DB capacity)")
+
+        alt_text = "\n".join(alternatives) if alternatives else "  (none available)"
+        print(
+            f"\nERROR: {env_type} environment limit reached ({current}/{limit}).\n"
+            f"You must delete an existing {env_type} env or use a different type.\n\n"
+            f"Available alternatives:\n{alt_text}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # For Developer: warn but don't block (can't tell per-user count)
+    if env_type == "Developer" and current >= _DEVELOPER_PER_USER_LIMIT:
+        print(
+            f"  ⚠ Warning: {current} Developer envs in tenant (limit is {_DEVELOPER_PER_USER_LIMIT} per user).\n"
+            f"    If you already have {_DEVELOPER_PER_USER_LIMIT}, this will fail. "
+            f"Consider --type Trial or --type Sandbox instead.",
+            file=sys.stderr,
+        )
+    else:
+        remaining = (limit - current) if limit else "?"
+        print(f"  ✓ Capacity OK\n", file=sys.stderr)
+
+
+def create_env(name, env_type, region, currency, language):
+    """Run `pac admin create` and look up the result via `pac admin list`.
+
+    PAC's create stdout is unstable across versions; list is more reliable
+    for extracting URL + GUIDs. PAC sometimes returns rc=0 on failure,
+    so output text is checked for error patterns regardless of exit code.
+    """
+    cmd = [
+        "pac", "admin", "create",
+        "--name", name,
+        "--type", env_type,
+        "--region", region,
+        "--currency", currency,
+        "--language", language,
+    ]
+    rc, out, err = _run(cmd, capture=True)
+    combined = (out or "") + "\n" + (err or "")
+    lower = combined.lower()
+
+    # PAC rc=0 doesn't guarantee success — check output for error patterns.
+    if rc != 0 or "error" in lower:
+        if "capacity" in lower or "quota" in lower or "limit" in lower:
+            print(f"ERROR: tenant out of {env_type} capacity or env limit reached. {combined.strip()[:500]}", file=sys.stderr)
+            sys.exit(2)
+        if "already exists" in lower or "duplicate" in lower or "name is taken" in lower:
+            print(f"ERROR: env name '{name}' already in use. {combined.strip()[:500]}", file=sys.stderr)
+            sys.exit(2)
+        if "unauthorized" in lower or "forbidden" in lower or "401" in lower or "403" in lower:
+            print(f"ERROR: pac auth expired or insufficient permissions. {combined.strip()[:500]}", file=sys.stderr)
+            sys.exit(1)
+        if rc != 0:
+            print(f"ERROR: pac admin create failed (rc={rc}). {combined.strip()[:800]}", file=sys.stderr)
+            sys.exit(3)
+
+    # Look up via `pac admin list` — more reliable than parsing create stdout.
+    return _lookup_env_in_list(name)
+
+
+def _lookup_env_in_list(name):
+    """Find env by name in `pac admin list`, extract URL and GUIDs.
+
+    PAC wraps each env across multiple lines; we use a 5-line window
+    around the name match to extract URL + GUID pairs.
+    """
+    rc, out, err = _run(["pac", "admin", "list"])
+    if rc != 0:
+        print(f"ERROR: pac admin list failed after create. stderr: {(err or '').strip()[:500]}", file=sys.stderr)
+        sys.exit(3)
+
+    lines = (out or "").splitlines()
+    guid_re = re.compile(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", re.IGNORECASE)
+    url_re = re.compile(r"https?://[a-z0-9.-]+\.dynamics\.com/?", re.IGNORECASE)
+
+    for i, line in enumerate(lines):
+        # Match the env name as a whole word so "v2test" doesn't match
+        # "v2testing", and pac's leading whitespace is tolerated.
+        if re.search(rf"\b{re.escape(name)}\b", line):
+            chunk = " ".join(lines[i:i + 5])
+            url_m = url_re.search(chunk)
+            guids = guid_re.findall(chunk)
+            if url_m and guids:
+                # First GUID is env ID; second (if present) is organization ID.
+                env_id = guids[0] if guids else None
+                org_id = guids[1] if len(guids) >= 2 else None
+                return {
+                    "envUrl": url_m.group(0).rstrip("/"),
+                    "envId": env_id,
+                    "organizationId": org_id,
+                }
+
+    print(
+        f"ERROR: pac admin create succeeded but env '{name}' was not found in pac admin list.\n"
+        f"This usually means the active pac auth profile is for a different ring than the one that\n"
+        f"received the new env. Check 'pac auth list' and 'pac auth select --index <N>'.",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a new Power Platform environment via PAC CLI")
+    parser.add_argument("--ring", required=True, choices=list(CLOUD_FOR_RING.keys()))
+    parser.add_argument("--name", required=True, help="Environment display name (alphanumeric + dash/underscore, 1-64 chars)")
+    parser.add_argument("--type", default="Developer",
+                        choices=["Developer", "Sandbox", "Production", "Trial"],
+                        help="Environment type (default: Developer; no capacity required)")
+    parser.add_argument("--region", default="unitedstates")
+    parser.add_argument("--currency", default="USD")
+    parser.add_argument("--language", default="1033")
+    args = parser.parse_args()
+
+    # Validate args before passing through shell=True (injection defense).
+    if not _VALID_ENV_NAME_RE.match(args.name):
+        print(
+            f"ERROR: --name {args.name!r} is not valid. Must be 1-64 chars, "
+            "alphanumeric plus '-' and '_' only.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if not _VALID_REGION_RE.match(args.region):
+        print(f"ERROR: --region {args.region!r} is not valid. Must be alphabetic, 1-40 chars.", file=sys.stderr)
+        sys.exit(2)
+    if not _VALID_CURRENCY_RE.match(args.currency):
+        print(f"ERROR: --currency {args.currency!r} is not valid. Must be a 3-letter ISO code (e.g. USD).", file=sys.stderr)
+        sys.exit(2)
+    if not _VALID_LANGUAGE_RE.match(args.language):
+        print(f"ERROR: --language {args.language!r} is not valid. Must be a numeric LCID (e.g. 1033).", file=sys.stderr)
+        sys.exit(2)
+
+    check_pac_installed()
+
+    cloud = CLOUD_FOR_RING[args.ring]
+    check_auth_for_cloud(cloud)
+    select_auth_profile(cloud)
+
+    # Pre-flight: check if we have capacity for the requested env type
+    # before wasting time on a doomed pac admin create.
+    check_env_capacity(args.type)
+
+    print(f"Creating env '{args.name}' (type={args.type}, ring={args.ring})...", file=sys.stderr)
+
+    result = create_env(args.name, args.type, args.region, args.currency, args.language)
+    result["envName"] = args.name
+    result["ring"] = args.ring
+
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -99,7 +99,15 @@ def run_environment_checks(runner) -> list[CheckResult]:
     # ---- ENV-008: DLP policies ----
     try:
         policies = pp.get_dlp_policies_for_env(env_id)
-        if policies:
+        if isinstance(policies, dict) and "_error" in policies:
+            results.append(CheckResult(
+                checkpoint_id="ENV-008", category="Environment",
+                priority=Priority.HIGH.value, status=Status.WARNING.value,
+                description="DLP policies",
+                result=f"Unable to list DLP policies: {policies['_error']}",
+                remediation="Requires Power Platform Admin role.",
+            ))
+        elif policies:
             results.append(CheckResult(
                 checkpoint_id="ENV-008", category="Environment",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/external_systems.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/external_systems.py
@@ -12,19 +12,30 @@ from ..runner import CheckResult, Status, Priority
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 
-# Flow name patterns per integration
-WORKDAY_PATTERNS = ("Workday",)
+# Flow name patterns per integration.
+# Workday uses exact ESS flow name prefixes to avoid matching unrelated
+# Workday flows that may exist in the environment.
+WORKDAY_PATTERNS = ("ESS HR Workday", "ESS IT Workday", "WorkdayRESTExecution")
 SERVICENOW_PATTERNS = ("ServiceNow",)
 SAP_PATTERNS = ("SAP", "SuccessFactors")
 
 
-def _match_flows(flows: list, patterns: tuple) -> list:
-    """Return flows whose display name contains any of the patterns."""
+def _match_flows(flows: list, patterns: tuple, prefix: bool = False) -> list:
+    """Return flows whose display name matches the patterns.
+
+    When prefix=True, matches if the display name starts with a pattern
+    (used for tighter ESS flow matching). When False, matches if the
+    pattern appears anywhere in the display name (legacy broad matching).
+    """
     matched = []
     for f in flows:
         name = f.get("properties", {}).get("displayName", f.get("displayName", ""))
-        if any(p.lower() in name.lower() for p in patterns):
-            matched.append(f)
+        if prefix:
+            if any(name.startswith(p) for p in patterns):
+                matched.append(f)
+        else:
+            if any(p.lower() in name.lower() for p in patterns):
+                matched.append(f)
     return matched
 
 
@@ -76,7 +87,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
     runner._all_flows = all_flows
 
     # ---- WD-001: Workday solution ----
-    wd_flows = _match_flows(all_flows, WORKDAY_PATTERNS)
+    wd_flows = _match_flows(all_flows, WORKDAY_PATTERNS, prefix=True)
     runner._workday_flows = wd_flows
     if wd_flows:
         results.append(CheckResult(
@@ -118,9 +129,13 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             doc_link=f"{DOC_BASE}/servicenow",
         ))
     else:
+        # In provision scope, non-target ISVs are not required — mark as
+        # SKIPPED so they don't trigger the provision-scope NOT_READY verdict.
+        absent_status = (Status.SKIPPED.value if runner.scope == "provision"
+                         else Status.NOT_CONFIGURED.value)
         results.append(CheckResult(
             checkpoint_id="SN-001", category="External Systems",
-            priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
+            priority=Priority.HIGH.value, status=absent_status,
             description="ServiceNow solution installed",
             result="No ServiceNow flows found in environment",
             remediation="Install the ServiceNow extension pack if you plan to integrate.",
@@ -139,9 +154,11 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             doc_link=f"{DOC_BASE}/sap-successfactors",
         ))
     else:
+        absent_status = (Status.SKIPPED.value if runner.scope == "provision"
+                         else Status.NOT_CONFIGURED.value)
         results.append(CheckResult(
             checkpoint_id="SAP-001", category="External Systems",
-            priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
+            priority=Priority.HIGH.value, status=absent_status,
             description="SAP SuccessFactors solution installed",
             result="No SAP SuccessFactors flows found",
             remediation="Install the SAP extension pack if you plan to integrate.",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -163,18 +163,44 @@ def run_workday_checks(runner) -> list[CheckResult]:
     # --- Connection References ---
     results.extend(_check_connections(runner))
 
+    # --- Connection Ref Bindings (provision scope only) ---
+    # Verify that ESS/Workday connection references are actually bound
+    # to a connection (not left unbound after install). Also checks that
+    # a Dataverse connection exists alongside Workday.
+    if runner.scope == "provision":
+        results.extend(_check_provision_bindings(runner))
+
     # --- Flow Status ---
     results.extend(_check_flow_status(runner, wd_flows))
 
     # --- SOAP Workflow Tests (only if Workday MCP creds available) ---
-    results.extend(_check_workflows(runner))
+    # Skip in provision scope — SOAP workflow tests require ISU credentials
+    # and env vars that the simplified /provision path defers to /connect workday.
+    if runner.scope != "provision":
+        results.extend(_check_workflows(runner))
 
     return results
 
 
 def _check_env_vars(runner) -> list[CheckResult]:
-    """Validate Workday environment variables in Dataverse."""
+    """Validate Workday environment variables in Dataverse.
+
+    In provision scope, these ISU/RaaS env vars are not yet configured
+    (the simplified OAuth path defers them to /connect workday), so we
+    skip rather than fail.
+    """
     results = []
+
+    if runner.scope == "provision":
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-001", category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description="Workday environment variables",
+            result="Skipped — provision uses simplified OAuth path; "
+                   "run /connect workday to configure ISU/RaaS env vars",
+        ))
+        return results
+
     env_url = runner.env_url
     dv_token = runner.dv_token
 
@@ -343,11 +369,18 @@ def _check_connections(runner) -> list[CheckResult]:
 
 
 def _get_conn_status(conn: dict) -> str:
-    """Extract connection status from the BAP API response."""
+    """Extract connection status from the BAP API response.
+
+    Prefers the token-target status (most reliable for OAuth connections).
+    Falls back to the first status entry if no token target exists.
+    """
     statuses = conn.get("properties", {}).get("statuses", [])
-    if isinstance(statuses, list) and statuses:
-        return statuses[0].get("status", "Unknown")
-    return "Unknown"
+    if not isinstance(statuses, list) or not statuses:
+        return "Unknown"
+    for s in statuses:
+        if s.get("target") == "token":
+            return s.get("status", "Unknown")
+    return statuses[0].get("status", "Unknown")
 
 
 def _check_flow_status(runner, wd_flows: list) -> list[CheckResult]:
@@ -376,6 +409,121 @@ def _check_flow_status(runner, wd_flows: list) -> list[CheckResult]:
             result=f"State: {'Enabled' if is_on else 'Disabled'}",
             remediation=f"Enable '{name}' in Power Automate." if not is_on else "",
             doc_link=f"{DOC_BASE}/workday#topics",
+        ))
+
+    return results
+
+
+def _check_provision_bindings(runner) -> list[CheckResult]:
+    """Verify connection ref bindings and Dataverse connection (provision scope).
+
+    Queries Dataverse connectionreferences for ESS/Workday refs and checks
+    that they have a non-empty connectionid (i.e., they are actually bound
+    to a connection). Also checks for at least one Dataverse connection in
+    the Power Platform connections list.
+    """
+    results = []
+    env_url = runner.env_url
+    dv_token = runner.dv_token
+
+    if not env_url or not dv_token:
+        results.append(CheckResult(
+            checkpoint_id="WD-BIND-001", category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description="Connection ref bindings",
+            result="Dataverse token not available — skipping binding check",
+        ))
+        return results
+
+    try:
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+        from auth import query_all
+
+        ess_filter = (
+            "startswith(connectionreferencelogicalname,'msdyn_ess') "
+            "or startswith(connectionreferencelogicalname,'msdyn_copilotforemployeeselfservice') "
+            "or startswith(connectionreferencelogicalname,'new_sharedworkdaysoap') "
+            "or startswith(connectionreferencelogicalname,'msviess_shared')"
+        )
+        refs = query_all(
+            env_url, dv_token,
+            "connectionreferences",
+            "connectionreferenceid,connectionreferencelogicalname,connectorid,connectionid",
+            ess_filter,
+        )
+
+        if not refs:
+            results.append(CheckResult(
+                checkpoint_id="WD-BIND-001", category="Workday",
+                priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
+                description="Connection ref bindings",
+                result="No ESS/Workday connection references found",
+                remediation="Ensure the Workday ISV solution is installed.",
+            ))
+            return results
+
+        bound = [r for r in refs if r.get("connectionid")]
+        unbound = [r for r in refs if not r.get("connectionid")]
+
+        if unbound:
+            unbound_names = [r.get("connectionreferencelogicalname", "?") for r in unbound]
+            results.append(CheckResult(
+                checkpoint_id="WD-BIND-001", category="Workday",
+                priority=Priority.CRITICAL.value, status=Status.FAILED.value,
+                description="Connection ref bindings",
+                result=f"{len(unbound)} of {len(refs)} refs unbound: {', '.join(unbound_names[:5])}",
+                remediation="Run bind_connection_refs.py or /provision to bind refs.",
+            ))
+        else:
+            results.append(CheckResult(
+                checkpoint_id="WD-BIND-001", category="Workday",
+                priority=Priority.HIGH.value, status=Status.PASSED.value,
+                description="Connection ref bindings",
+                result=f"All {len(bound)} ESS/Workday refs are bound",
+            ))
+
+        # Check for Dataverse connection presence
+        pp = runner.pp_admin
+        env_id = runner.env_id
+        if pp and env_id:
+            all_conns = pp.get_connections(env_id)
+            if isinstance(all_conns, list):
+                dv_conns = [
+                    c for c in all_conns
+                    if "commondataservice" in (
+                        c.get("properties", {}).get("apiId", "")
+                    ).lower()
+                ]
+                connected_dv = [c for c in dv_conns if _get_conn_status(c) == "Connected"]
+                if connected_dv:
+                    results.append(CheckResult(
+                        checkpoint_id="WD-BIND-002", category="Workday",
+                        priority=Priority.HIGH.value, status=Status.PASSED.value,
+                        description="Dataverse connection",
+                        result=f"{len(connected_dv)} Dataverse connection(s) Connected",
+                    ))
+                elif dv_conns:
+                    results.append(CheckResult(
+                        checkpoint_id="WD-BIND-002", category="Workday",
+                        priority=Priority.HIGH.value, status=Status.FAILED.value,
+                        description="Dataverse connection",
+                        result=f"{len(dv_conns)} Dataverse connection(s) found but none Connected",
+                        remediation="Authenticate the Dataverse connection in the maker portal.",
+                    ))
+                else:
+                    results.append(CheckResult(
+                        checkpoint_id="WD-BIND-002", category="Workday",
+                        priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
+                        description="Dataverse connection",
+                        result="No Dataverse connections found",
+                        remediation="Create a Dataverse connection via /provision or the maker portal.",
+                    ))
+    except Exception as e:
+        results.append(CheckResult(
+            checkpoint_id="WD-BIND-001", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="Connection ref bindings",
+            result=f"Unable to check: {e}",
         ))
 
     return results

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -18,12 +18,23 @@ Scopes:
     workday         — Workday deep validation
     local           — Local agent file validation
     publishing      — Publishing/QA checklist
+    provision       — Smoke test for /provision skill (env + external + workday)
 """
 
 import argparse
 import json
 import os
 import sys
+
+# Force UTF-8 on stdout/stderr so the summary's emoji (checkmarks, warnings,
+# em dashes) render on Windows consoles too. cp1252 is the default on
+# Windows and chokes on these glyphs. Available on Python 3.7+.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
 
 # Ensure scripts/ is on the path so we can import auth
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -54,6 +65,11 @@ SCOPE_MAP = {
     ],
     "local": [("Local Files", run_local_file_checks)],
     "publishing": [("Publishing", run_publishing_checks)],
+    "provision": [
+        ("Environment", run_environment_checks),
+        ("External Systems", run_external_systems_checks),
+        ("Workday", run_workday_checks),
+    ],
 }
 
 FULL_SCOPE = [
@@ -78,12 +94,18 @@ def main():
         "--output", default="workspace/flightcheck",
         help="Output directory (default: workspace/flightcheck)",
     )
+    parser.add_argument(
+        "--config",
+        help="Path to config JSON file (default: .local/config.json). "
+             "Allows callers like /provision to pass a custom config "
+             "without overwriting .local/config.json.",
+    )
     args = parser.parse_args()
 
     # Load config
-    config_path = os.path.join(".local", "config.json")
+    config_path = args.config or os.path.join(".local", "config.json")
     if not os.path.exists(config_path):
-        print("ERROR: .local/config.json not found. Run /setup first.")
+        print(f"ERROR: {config_path} not found. Run /setup first (or pass --config).")
         sys.exit(1)
 
     with open(config_path, "r", encoding="utf-8") as f:
@@ -91,7 +113,7 @@ def main():
 
     env_url = config.get("dataverseEndpoint", "")
     if not env_url:
-        print("ERROR: No dataverseEndpoint in .local/config.json.")
+        print(f"ERROR: No dataverseEndpoint in {config_path}.")
         sys.exit(1)
 
     # --- Banner ---
@@ -128,26 +150,49 @@ def main():
     tenant_id = discover_tenant(env_url)
     print(f"Tenant: {tenant_id}")
 
-    # Derive PP environment ID
-    print("Deriving Power Platform environment ID...")
-    env_id = derive_environment_id(env_url, dv_token)
+    # Derive PP environment ID — prefer config value (provision writes it),
+    # fall back to Dataverse organizations query.  The `environmentid` column
+    # does not exist on all Dataverse builds (missing in some preprod rings),
+    # so the config override is the reliable path for /provision callers.
+    env_id = config.get("envId") or config.get("environmentId")
     if env_id:
-        print(f"Environment ID: {env_id}")
+        env_id = env_id.lower().strip("{}")
+        print(f"Environment ID (from config): {env_id}")
     else:
-        print("WARNING: Could not derive environment ID. Some checks may be limited.")
+        print("Deriving Power Platform environment ID...")
+        env_id = derive_environment_id(env_url, dv_token)
+        if env_id:
+            print(f"Environment ID: {env_id}")
+        else:
+            print("WARNING: Could not derive environment ID. Some checks may be limited.")
 
-    # Initialize clients
-    print("Authenticating to Microsoft Graph...")
-    graph = GraphClient(tenant_id)
-    try:
-        graph.authenticate()
-        print("  Graph: OK")
-    except Exception as e:
-        print(f"  Graph: WARNING — {e}")
-        print("  (Some checks will be skipped)")
+    # Gate Microsoft Graph auth on scope. Graph is needed for license,
+    # role, and Entra checks (prerequisites / authentication / environment / full).
+    # Narrow scopes like `provision`, `workday`, `local`, `external` only
+    # run Dataverse + Workday checks and do not need Graph. Skipping Graph
+    # for these scopes avoids an interactive browser sign-in that would
+    # hang the /provision flow for users without a cached Graph token.
+    # (See test-run4-details.md trace for the original failure mode.)
+    graph = None
+    if args.scope in ("full", "prerequisites", "authentication", "environment"):
+        print("Authenticating to Microsoft Graph...")
+        graph = GraphClient(tenant_id)
+        try:
+            graph.authenticate()
+            print("  Graph: OK")
+        except Exception as e:
+            print(f"  Graph: WARNING — {e}")
+            print("  (Some checks will be skipped)")
+            graph = None
+    else:
+        print("Skipping Microsoft Graph auth (not required for this scope).")
+
+    # Read ring from config (provision writes it; default to prod for
+    # existing /setup configs that don't have it).
+    ring = config.get("ring", "prod")
 
     print("Authenticating to Power Platform Admin API...")
-    pp_admin = PPAdminClient(tenant_id)
+    pp_admin = PPAdminClient(tenant_id, ring=ring)
     try:
         pp_admin.authenticate()
         print("  Power Platform: OK")
@@ -222,12 +267,16 @@ def main():
 
     print("=" * 64)
 
-    # Print failures
-    failures = [r for r in result.results if r.status == Status.FAILED.value]
-    if failures:
-        print(f"\n  FAILED CHECKS ({len(failures)}):\n")
-        for r in failures:
-            print(f"    ❌ {r.checkpoint_id}: {r.result}")
+    # Print blocking checks (failures + provision-scope blockers)
+    blocking_statuses = {Status.FAILED.value}
+    if args.scope == "provision":
+        blocking_statuses |= {Status.ERROR.value, Status.NOT_CONFIGURED.value}
+    blockers = [r for r in result.results if r.status in blocking_statuses]
+    if blockers:
+        print(f"\n  BLOCKING CHECKS ({len(blockers)}):\n")
+        for r in blockers:
+            icon = "❌" if r.status == Status.FAILED.value else "🚫"
+            print(f"    {icon} {r.checkpoint_id} [{r.status}]: {r.result}")
             if r.remediation:
                 print(f"       → {r.remediation}")
         print()
@@ -235,8 +284,8 @@ def main():
     # Save results
     save_results(result, args.output)
 
-    # Exit code
-    sys.exit(1 if result.failed > 0 else 0)
+    # Exit code: non-zero when overall verdict is NOT_READY
+    sys.exit(1 if result.overall == "NOT_READY" else 0)
 
 
 if __name__ == "__main__":

--- a/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
@@ -16,20 +16,20 @@ import sys
 try:
     import msal
 except ImportError:
-    print("ERROR: 'msal' package not found. Run: pip install msal")
+    print("ERROR: 'msal' package not found. Run: pip install msal", file=sys.stderr)
     sys.exit(1)
 
 try:
     import requests
 except ImportError:
-    print("ERROR: 'requests' package not found. Run: pip install requests")
+    print("ERROR: 'requests' package not found. Run: pip install requests", file=sys.stderr)
     sys.exit(1)
 
 try:
     from urllib3.util.retry import Retry
     from requests.adapters import HTTPAdapter
 except ImportError:
-    print("ERROR: 'urllib3' / 'requests' not found. Run: pip install requests")
+    print("ERROR: 'urllib3' / 'requests' not found. Run: pip install requests", file=sys.stderr)
     sys.exit(1)
 
 
@@ -38,8 +38,22 @@ CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"
 BAP_BASE = "https://api.bap.microsoft.com"
 POWERAPPS_BASE = "https://api.powerapps.com"
 
+# Preprod ring uses different API hosts.
+BAP_BASE_BY_RING = {
+    "preprod": "https://api.preprod.bap.microsoft.com",
+    "prod": BAP_BASE,
+}
+POWERAPPS_BASE_BY_RING = {
+    "preprod": "https://api.preprod.powerapps.com",
+    "prod": POWERAPPS_BASE,
+}
+
 # The BAP / PowerApps APIs use this resource scope.
 PP_SCOPE = "https://service.powerapps.com//.default"
+PP_SCOPE_BY_RING = {
+    "preprod": "https://api.preprod.powerplatform.com/.default",
+    "prod": PP_SCOPE,
+}
 
 # Module-level requests Session with bounded retry-with-backoff for 429/5xx.
 # Mirrors the auth.py pattern - BAP and PowerApps APIs throttle aggressively
@@ -60,8 +74,12 @@ _SESSION.mount("https://", HTTPAdapter(max_retries=_RETRY))
 class PPAdminClient:
     """Power Platform Admin API client for environment and flow queries."""
 
-    def __init__(self, tenant_id: str):
+    def __init__(self, tenant_id: str, ring: str = "prod"):
         self.tenant_id = tenant_id
+        self.ring = ring
+        self.bap_base = BAP_BASE_BY_RING.get(ring, BAP_BASE)
+        self.powerapps_base = POWERAPPS_BASE_BY_RING.get(ring, POWERAPPS_BASE)
+        self._scope = PP_SCOPE_BY_RING.get(ring, PP_SCOPE)
         self._token: str | None = None
 
     def authenticate(self) -> str:
@@ -81,12 +99,12 @@ class PPAdminClient:
         accounts = app.get_accounts()
         result = None
         if accounts:
-            result = app.acquire_token_silent([PP_SCOPE], account=accounts[0])
+            result = app.acquire_token_silent([self._scope], account=accounts[0])
 
         if not result or "access_token" not in result:
             print("Opening browser for Power Platform sign-in...")
             result = app.acquire_token_interactive(
-                [PP_SCOPE], prompt="select_account"
+                [self._scope], prompt="select_account"
             )
 
         if "access_token" not in result:
@@ -128,14 +146,19 @@ class PPAdminClient:
         resp.raise_for_status()
         return resp.json()
 
-    def _get_all(self, base: str, path: str, params: dict | None = None) -> list:
-        """Paginate through results."""
+    def _get_all(self, base: str, path: str, params: dict | None = None) -> list | dict:
+        """Paginate through results.
+
+        Returns a list of items on success, or a dict with `_error` key
+        on 401/403 (matching `_get()` behavior) so callers can distinguish
+        "empty results" from "insufficient permissions".
+        """
         items: list = []
         url = f"{base}{path}"
         while url:
             resp = _SESSION.get(url, headers=self.headers, params=params, timeout=60)
             if resp.status_code in (401, 403):
-                return items
+                return {"_error": "insufficient_permissions", "_status": resp.status_code}
             resp.raise_for_status()
             data = resp.json()
             items.extend(data.get("value", []))
@@ -148,7 +171,7 @@ class PPAdminClient:
     def get_environment(self, env_id: str) -> dict:
         """Get a specific Power Platform environment."""
         return self._get(
-            BAP_BASE,
+            self.bap_base,
             f"/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/{env_id}",
             params={"api-version": "2021-04-01"},
         )
@@ -156,7 +179,7 @@ class PPAdminClient:
     def get_environments(self) -> list:
         """List all environments the user has admin access to."""
         return self._get_all(
-            BAP_BASE,
+            self.bap_base,
             "/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments",
             params={"api-version": "2021-04-01"},
         )
@@ -166,7 +189,7 @@ class PPAdminClient:
     def get_flows(self, env_id: str) -> list:
         """List all flows in an environment (admin scope)."""
         return self._get_all(
-            POWERAPPS_BASE,
+            self.powerapps_base,
             f"/providers/Microsoft.ProcessSimple/scopes/admin/environments/{env_id}/v2/flows",
             params={"api-version": "2016-11-01"},
         )
@@ -174,7 +197,7 @@ class PPAdminClient:
     def get_flow(self, env_id: str, flow_id: str) -> dict:
         """Get a specific flow."""
         return self._get(
-            POWERAPPS_BASE,
+            self.powerapps_base,
             f"/providers/Microsoft.ProcessSimple/scopes/admin/environments/{env_id}/flows/{flow_id}",
             params={"api-version": "2016-11-01"},
         )
@@ -184,7 +207,7 @@ class PPAdminClient:
     def get_connections(self, env_id: str) -> list:
         """List all connections in an environment (admin scope)."""
         return self._get_all(
-            POWERAPPS_BASE,
+            self.powerapps_base,
             f"/providers/Microsoft.PowerApps/scopes/admin/environments/{env_id}/connections",
             params={"api-version": "2016-11-01"},
         )
@@ -194,14 +217,16 @@ class PPAdminClient:
     def get_dlp_policies(self) -> list:
         """List all DLP policies."""
         return self._get_all(
-            BAP_BASE,
+            self.bap_base,
             "/providers/Microsoft.BusinessAppPlatform/scopes/admin/apiPolicies",
             params={"api-version": "2021-04-01"},
         )
 
-    def get_dlp_policies_for_env(self, env_id: str) -> list:
+    def get_dlp_policies_for_env(self, env_id: str) -> list | dict:
         """List DLP policies applied to a specific environment."""
         all_policies = self.get_dlp_policies()
+        if isinstance(all_policies, dict) and "_error" in all_policies:
+            return all_policies
         # Filter to policies that include this environment
         relevant = []
         for p in all_policies:
@@ -220,13 +245,11 @@ class PPAdminClient:
 def derive_environment_id(env_url: str, dataverse_token: str) -> str | None:
     """Derive the Power Platform Environment ID from a Dataverse URL.
 
-    Calls the Dataverse WhoAmI endpoint, then uses the OrganizationId
-    to query the BAP API for the matching environment.
+    Queries the Dataverse `organizations` table for the `environmentid`
+    column, which is the BAP environment GUID. This is more reliable than
+    using WhoAmI().OrganizationId, which is the Dataverse org ID and may
+    differ from the BAP environment ID in some tenants/rings.
     """
-    # HARD GATE: refuse to attach the Dataverse bearer to a non-HTTPS URL.
-    # env_url is config-supplied so a misconfigured or hostile value could
-    # otherwise exfiltrate the token over cleartext. Mirrors the
-    # _validate_https_url gate in auth.py.
     if not env_url.lower().startswith("https://"):
         raise ValueError(
             f"env_url must use https:// (got: {env_url!r}). Refusing to send "
@@ -237,16 +260,17 @@ def derive_environment_id(env_url: str, dataverse_token: str) -> str | None:
         "Accept": "application/json",
     }
     resp = _SESSION.get(
-        f"{env_url}/api/data/v9.2/WhoAmI()",
+        f"{env_url}/api/data/v9.2/organizations?$select=environmentid",
         headers=headers,
         timeout=15,
     )
     if resp.status_code != 200:
         return None
-    org_id = resp.json().get("OrganizationId")
-    if not org_id:
+    rows = resp.json().get("value", [])
+    if not rows:
+        return None
+    env_id = rows[0].get("environmentid")
+    if not env_id:
         return None
 
-    # The environment ID in BAP is the same as the OrganizationId
-    # (lowercase GUID without braces)
-    return org_id.lower().strip("{}")
+    return env_id.lower().strip("{}")

--- a/solutions/ess-maker-skills/scripts/flightcheck/runner.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/runner.py
@@ -130,10 +130,20 @@ class FlightCheckRunner:
         total_failed = sum(c.failed for c in cat_map.values())
         total_warnings = sum(c.warnings for c in cat_map.values())
         total_passed = sum(c.passed for c in cat_map.values())
+        total_errors = sum(c.errors for c in cat_map.values())
+        total_not_configured = sum(c.not_configured for c in cat_map.values())
 
-        if total_failed == 0 and total_warnings == 0:
+        # For the provision scope, ERROR and NOT_CONFIGURED statuses are
+        # blocking — they indicate that a required check could not run or
+        # the feature is absent, which means the env is not actually ready.
+        # For other scopes, only FAILED is blocking (existing behavior).
+        blocking = total_failed
+        if self.scope == "provision":
+            blocking += total_errors + total_not_configured
+
+        if blocking == 0 and total_warnings == 0:
             overall = "READY"
-        elif total_failed == 0:
+        elif blocking == 0:
             overall = "READY_WITH_WARNINGS"
         else:
             overall = "NOT_READY"
@@ -148,7 +158,7 @@ class FlightCheckRunner:
             passed=total_passed,
             failed=total_failed,
             warnings=total_warnings,
-            not_configured=sum(c.not_configured for c in cat_map.values()),
+            not_configured=total_not_configured,
             overall=overall,
         )
 

--- a/solutions/ess-maker-skills/scripts/pp_helpers.py
+++ b/solutions/ess-maker-skills/scripts/pp_helpers.py
@@ -1,0 +1,286 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Shared Power Platform Helpers
+
+Common utilities for /provision scripts: .env loading with alias resolution,
+MSAL token acquisition (device-code + browser), per-env host construction,
+persona/connector mappings.
+"""
+
+import os
+import sys
+
+try:
+    import msal
+except ImportError:
+    print("ERROR: 'msal' package not found. Run: pip install -r scripts/requirements.txt", file=sys.stderr)
+    sys.exit(3)
+
+
+SCOPES_BY_RING = {
+    "preprod": "https://api.preprod.powerplatform.com/.default",
+    "prod": "https://api.powerplatform.com/.default",
+}
+
+HOST_SUFFIX_BY_RING = {
+    "preprod": "environment.api.preprod.powerplatform.com",
+    "prod": "environment.api.powerplatform.com",
+}
+
+MAKER_HOST_BY_RING = {
+    "preprod": "make.preprod.powerapps.com",
+    "prod": "make.powerapps.com",
+}
+
+
+# .env key alias table — mirrors SKILL.md Step 0.
+ENV_ALIASES = {
+    "ESS_DEVKIT_EMPHUB_CLIENT_ID": [
+        "ESS_DEVKIT_EMPHUB_CLIENT_ID",
+        "ESS_PROVISION_CLIENT_ID",
+        "provision_client_id",
+        "ess_devkit_client_id",
+    ],
+    "WORKDAY_BASE_URL": [
+        "WORKDAY_BASE_URL",
+        "soap_url",
+        "wd_soap_url",
+        "wd_base_url",
+        "workday_soap_url",
+        "workday_base_url",
+    ],
+    "WORKDAY_TENANT": [
+        "WORKDAY_TENANT",
+        "tenant",
+        "wd_tenant",
+        "workday_tenant",
+        "workday_tenant_name",
+    ],
+    "WORKDAY_OAUTH_TOKEN_URL": [
+        "WORKDAY_OAUTH_TOKEN_URL",
+        "oauth_token_url",
+        "wd_oauth_token_url",
+        "workday_oauth_token_url",
+    ],
+    "WORKDAY_OAUTH_CLIENT_ID": [
+        "WORKDAY_OAUTH_CLIENT_ID",
+        "oauth_client_id",
+        "wd_oauth_client_id",
+        "workday_client_id",
+        "workday_oauth_client_id",
+    ],
+    "WORKDAY_ENTRA_APP_ID_URI": [
+        "WORKDAY_ENTRA_APP_ID_URI",
+        "microsoft_entra_resource_url",
+        "entra_resource_url",
+        "wd_entra_app_id_uri",
+        "workday_entra_app_id_uri",
+    ],
+    "WORKDAY_REST_URL": [
+        "WORKDAY_REST_URL",
+        "workday_rest_correct_endpoint",
+        "rest_base_url",
+        "workday_rest_url",
+    ],
+}
+
+
+# Allowlist — also used for OData filter injection defense.
+VALID_PERSONAS = {"hr", "it"}
+
+
+_CONNECTOR_SHORT_NAMES = {
+    "shared_workdaysoap": "workday",
+    "shared_commondataserviceforapps": "dataverse",
+    "shared_servicenow": "servicenow",
+    "shared_servicenowhrservicedelivery": "servicenowhr",
+    "shared_sapsuccessfactors": "successfactors",
+}
+
+
+def load_env_file(env_path):
+    """Load a .env file into a dict with normalized keys.
+
+    Keys are lowercased with spaces→underscores so `Workday REST correct Endpoint`
+    matches alias `workday_rest_correct_endpoint`. Handles UTF-8 BOM and
+    surrounding quotes. Returns {} if file doesn't exist.
+    """
+    if not os.path.exists(env_path):
+        return {}
+    env = {}
+    with open(env_path, "r", encoding="utf-8-sig") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            normalized_key = key.strip().lower().replace(" ", "_")
+            env[normalized_key] = value.strip().strip('"').strip("'")
+    return env
+
+
+def lookup_env(env_map, canonical_key):
+    """Resolve a canonical setting by trying its aliases in order.
+
+    The lookup is case-insensitive. Returns None if no alias matches.
+    """
+    for alias in ENV_ALIASES.get(canonical_key, [canonical_key]):
+        v = env_map.get(alias.lower())
+        if v:
+            return v
+    return None
+
+
+def per_env_host(env_id, ring):
+    """Build the per-environment API host.
+
+    Format: `{first 31 chars of dashless GUID}.{remaining}.{ring-suffix}`.
+    The 31+1 split is empirically required — MS Learn documents 30+2 but
+    Preprod DNS doesn't resolve that form.
+    """
+    if ring not in HOST_SUFFIX_BY_RING:
+        raise ValueError(f"Unknown ring {ring!r}. Use one of: {sorted(HOST_SUFFIX_BY_RING)}")
+    no_dashes = env_id.replace("-", "")
+    return f"{no_dashes[:31]}.{no_dashes[31:]}.{HOST_SUFFIX_BY_RING[ring]}"
+
+
+def short_connector_name(connector):
+    """Friendly short name for a connector unique name (e.g. shared_workdaysoap -> workday)."""
+    if connector in _CONNECTOR_SHORT_NAMES:
+        return _CONNECTOR_SHORT_NAMES[connector]
+    return connector.replace("shared_", "", 1)
+
+
+def bot_schema_name_for_persona(persona):
+    """Return the canonical ESS bot schema name for the given persona.
+
+    Raises ValueError if `persona` is not in VALID_PERSONAS.
+    """
+    p = persona.lower()
+    if p not in VALID_PERSONAS:
+        raise ValueError(f"persona must be one of {sorted(VALID_PERSONAS)}, got {persona!r}")
+    return f"msdyn_copilotforemployeeselfservice{p}"
+
+
+def acquire_device_code_token(client_id, tenant, scope, cache_prefix=None):
+    """Acquire an MSAL token via device-code flow with on-disk cache.
+
+    Cache at `.local/.token_cache_{prefix}.bin`, written atomically.
+    Tries silent first; falls back to device-code. Exits 1 on failure.
+    """
+    cache_dir = ".local"
+    prefix = cache_prefix or client_id[:8]
+    cache_path = os.path.join(cache_dir, f".token_cache_{prefix}.bin")
+
+    cache = msal.SerializableTokenCache()
+    if os.path.exists(cache_path):
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                cache.deserialize(f.read())
+        except Exception as e:
+            print(f"WARN: failed to load token cache (will re-prompt): {e}", file=sys.stderr)
+
+    authority = f"https://login.microsoftonline.com/{tenant}"
+    app = msal.PublicClientApplication(client_id, authority=authority, token_cache=cache)
+
+    # Silent first (uses cached refresh token if available).
+    accounts = app.get_accounts()
+    result = None
+    if accounts:
+        result = app.acquire_token_silent([scope], account=accounts[0])
+
+    if not result or "access_token" not in result:
+        print("Device-code sign-in required...", file=sys.stderr)
+        flow = app.initiate_device_flow(scopes=[scope])
+        if "user_code" not in flow:
+            err = flow.get("error", "unknown")
+            desc = flow.get("error_description", "")
+            print(f"ERROR: device-flow init failed: {err}: {desc}", file=sys.stderr)
+            sys.exit(1)
+        print(flow["message"], file=sys.stderr)
+        result = app.acquire_token_by_device_flow(flow)
+
+    if "access_token" not in result:
+        err = result.get("error", "unknown")
+        desc = result.get("error_description", "")
+        print(f"ERROR: token acquisition failed: {err}: {desc}", file=sys.stderr)
+        sys.exit(1)
+
+    if cache.has_state_changed:
+        _atomic_write_cache(cache_dir, cache_path, cache.serialize())
+
+    return result["access_token"]
+
+
+def acquire_browser_token(client_id, tenant, scope, cache_prefix=None):
+    """Acquire an MSAL token via interactive browser flow with on-disk cache.
+
+    Shares cache with acquire_device_code_token. Preferred for UX — one
+    click instead of copy-paste-code. Exits 1 on failure.
+    """
+    cache_dir = ".local"
+    prefix = cache_prefix or client_id[:8]
+    cache_path = os.path.join(cache_dir, f".token_cache_{prefix}.bin")
+
+    cache = msal.SerializableTokenCache()
+    if os.path.exists(cache_path):
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                cache.deserialize(f.read())
+        except Exception as e:
+            print(f"WARN: failed to load token cache (will re-prompt): {e}", file=sys.stderr)
+
+    authority = f"https://login.microsoftonline.com/{tenant}"
+    app = msal.PublicClientApplication(client_id, authority=authority, token_cache=cache)
+
+    # Silent first (uses cached refresh token if available).
+    accounts = app.get_accounts()
+    result = None
+    if accounts:
+        result = app.acquire_token_silent([scope], account=accounts[0])
+
+    if not result or "access_token" not in result:
+        print("Opening browser for Power Platform sign-in...", file=sys.stderr)
+        result = app.acquire_token_interactive(
+            [scope], prompt="select_account"
+        )
+
+    if "access_token" not in result:
+        err = result.get("error", "unknown")
+        # Don't echo error_description — may contain tenant IDs (CWE-209).
+        print(f"ERROR: browser auth failed: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    if cache.has_state_changed:
+        _atomic_write_cache(cache_dir, cache_path, cache.serialize())
+
+    return result["access_token"]
+
+
+def _atomic_write_cache(cache_dir, cache_path, payload):
+    """Atomic file write: tempfile + os.replace. Best-effort 0o600 perms."""
+    os.makedirs(cache_dir, exist_ok=True)
+    try:
+        os.chmod(cache_dir, 0o700)
+    except OSError:
+        pass
+    tmp_path = cache_path + ".tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(tmp_path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        os.replace(tmp_path, cache_path)
+        try:
+            os.chmod(cache_path, 0o600)
+        except OSError:
+            pass
+    except Exception:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        raise

--- a/solutions/ess-maker-skills/scripts/update_user_context_topic.py
+++ b/solutions/ess-maker-skills/scripts/update_user_context_topic.py
@@ -1,0 +1,228 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Update User Context Setup Topic
+
+PATCHes the `[Admin] - User Context - Setup` topic to redirect to
+`WorkdaySystemGetUserContextV2`, enabling worker-ID resolution at runtime.
+
+Usage:
+    python scripts/update_user_context_topic.py \\
+        --env-url https://orgxyz.crm.dynamics.com --persona hr
+
+Exit codes: 0 success, 1 auth, 2 patch/discovery, 3 unexpected.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: requests required. Run: pip install -r scripts/requirements.txt", file=sys.stderr)
+    sys.exit(3)
+
+from auth import authenticate, query_all
+from pp_helpers import VALID_PERSONAS
+
+
+def topic_yaml_for_persona(persona):
+    """Build the redirect YAML body for the given persona."""
+    return (
+        "kind: AdaptiveDialog\n"
+        "beginDialog:\n"
+        "  kind: OnRedirect\n"
+        "  id: main\n"
+        "  priority: 0\n"
+        "  actions:\n"
+        "    - kind: BeginDialog\n"
+        "      id: QVk2yi\n"
+        f"      dialog: msdyn_copilotforemployeeselfservice{persona}.topic.WorkdaySystemGetUserContextV2\n"
+    )
+
+
+def find_user_context_topic(env_url, token, persona):
+    """Find the [Admin] - User Context - Setup topic for the persona's bot.
+
+    Persona is validated against VALID_PERSONAS before OData interpolation.
+    """
+    if persona.lower() not in VALID_PERSONAS:
+        raise ValueError(f"persona must be one of {sorted(VALID_PERSONAS)}, got {persona!r}")
+    persona_prefix = f"msdyn_copilotforemployeeselfservice{persona.lower()}"
+
+    # Topic body lives in `data`, NOT `content`. CPS reads `data`; `content`
+    # is a metadata-only column. See push.py ~line 391 for precedent.
+    rows = query_all(
+        env_url,
+        token,
+        "botcomponents",
+        "botcomponentid,name,schemaname,data,componenttype",
+        f"startswith(schemaname,'{persona_prefix}') and componenttype eq 9",
+    )
+
+    # Match by name first, then schema name as fallback.
+    name_signals = ["user context", "usercontext"]
+    candidates = []
+    for row in rows:
+        name = (row.get("name") or "").lower()
+        schemaname = (row.get("schemaname") or "").lower()
+        if "setup" in name and any(sig in name for sig in name_signals):
+            candidates.append(row)
+        elif "setup" in schemaname and any(sig in schemaname for sig in name_signals):
+            candidates.append(row)
+
+    return candidates
+
+
+def patch_topic_content(env_url, token, botcomponentid, new_content):
+    """PATCH the topic's `data` field with new YAML.
+
+    Uses `data` (not `content`) — CPS reads topic body from `data`.
+    """
+    url = f"{env_url.rstrip('/')}/api/data/v9.2/botcomponents({botcomponentid})"
+    body = {"data": new_content}
+    resp = requests.patch(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "If-Match": "*",
+            "OData-MaxVersion": "4.0",
+            "OData-Version": "4.0",
+        },
+        json=body,
+        timeout=30,
+    )
+    return resp
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update the User Context Setup topic with the WorkdaySystemGetUserContextV2 redirect")
+    parser.add_argument("--env-url", required=True, help="Dataverse env URL")
+    parser.add_argument("--persona", required=True, choices=["hr", "it"], help="ESS persona (hr or it)")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be patched without actually patching")
+    parser.add_argument("--force", action="store_true", help="Overwrite even if the topic has non-empty custom content")
+    args = parser.parse_args()
+
+    new_yaml = topic_yaml_for_persona(args.persona)
+
+    # Auth via Dataverse Web API
+    token = authenticate(args.env_url)
+
+    # Discover the User Context Setup topic.
+    candidates = find_user_context_topic(args.env_url, token, args.persona)
+
+    if not candidates:
+        print(
+            f"ERROR: could not find a User Context Setup topic in the persona namespace "
+            f"'msdyn_copilotforemployeeselfservice{args.persona}'. Verify the Workday ISV "
+            f"is installed and the agent's bot components are visible.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if len(candidates) > 1:
+        # Show all candidates and pick the one that looks most like the User Context Setup topic.
+        print(f"Found {len(candidates)} candidate topics; picking the first. Candidates:", file=sys.stderr)
+        for c in candidates:
+            print(f"  - name='{c.get('name')}' schemaname='{c.get('schemaname')}'", file=sys.stderr)
+
+    topic = candidates[0]
+    botcomponentid = topic.get("botcomponentid")
+    topic_name = topic.get("name")
+    topic_schema = topic.get("schemaname")
+
+    # Safety: refuse to overwrite non-trivial custom content without --force.
+    existing_data = (topic.get("data") or "").strip()
+    is_empty = not existing_data
+    is_bare_scaffold = (
+        existing_data
+        and "OnRedirect" in existing_data
+        and "BeginDialog" not in existing_data
+        and ("actions" not in existing_data
+             or "actions: []" in existing_data
+             or "actions:\n" in existing_data)
+    )
+    is_already_correct = (
+        existing_data
+        and "WorkdaySystemGetUserContextV2" in existing_data
+    )
+
+    if not is_empty and not is_bare_scaffold and not is_already_correct:
+        if not args.force:
+            print(
+                f"ERROR: topic '{topic_name}' already has custom content that does not "
+                f"match the expected empty/scaffold state. Refusing to overwrite.\n"
+                f"Current content (first 300 chars): {existing_data[:300]}\n\n"
+                f"Use --force to overwrite, or --dry-run to inspect.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        print(
+            f"WARNING: topic has custom content but --force was specified. Overwriting.",
+            file=sys.stderr,
+        )
+
+    if is_already_correct and not args.force:
+        out = {
+            "action": "already-correct",
+            "topic": {
+                "botcomponentid": botcomponentid,
+                "name": topic_name,
+                "schemaname": topic_schema,
+            },
+        }
+        print(json.dumps(out, indent=2))
+        sys.exit(0)
+
+    if args.dry_run:
+        out = {
+            "action": "dry-run",
+            "topic": {
+                "botcomponentid": botcomponentid,
+                "name": topic_name,
+                "schemaname": topic_schema,
+                "currentContent": (topic.get("data") or "")[:500],
+            },
+            "newContent": new_yaml,
+        }
+        print(json.dumps(out, indent=2))
+        sys.exit(0)
+
+    print(f"Patching topic '{topic_name}' (botcomponentid={botcomponentid})...", file=sys.stderr)
+
+    resp = patch_topic_content(args.env_url, token, botcomponentid, new_yaml)
+
+    if resp.status_code in (200, 204):
+        out = {
+            "action": "patched",
+            "topic": {
+                "botcomponentid": botcomponentid,
+                "name": topic_name,
+                "schemaname": topic_schema,
+                "previousContent": existing_data[:500] if existing_data else None,
+            },
+            "newContent": new_yaml,
+            "httpStatus": resp.status_code,
+        }
+        print(json.dumps(out, indent=2))
+        sys.exit(0)
+    elif resp.status_code == 401:
+        print(f"ERROR: 401 auth rejected. Body: {resp.text[:300]}", file=sys.stderr)
+        sys.exit(1)
+    elif 400 <= resp.status_code < 500:
+        print(f"ERROR: PATCH {resp.status_code}: {resp.text[:600]}", file=sys.stderr)
+        sys.exit(2)
+    else:
+        print(f"ERROR: PATCH {resp.status_code}: {resp.text[:600]}", file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/whoami.py
+++ b/solutions/ess-maker-skills/scripts/whoami.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Environment Probe (WhoAmI)
+
+Authenticates via MSAL and calls WhoAmI to verify Dataverse access.
+
+Usage:  python scripts/whoami.py --env-url https://orgxyz.crm.dynamics.com
+Exit codes: 0 ok, 1 auth/permissions, 2 network/DNS, 3 unexpected.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' package not found. Run: pip install requests", file=sys.stderr)
+    sys.exit(3)
+
+from auth import authenticate
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Probe a Power Platform env via WhoAmI")
+    parser.add_argument("--env-url", required=True, help="Dataverse env URL")
+    args = parser.parse_args()
+
+    env_url = args.env_url.rstrip("/")
+
+    # JSON on stdout; all errors to stderr.
+    try:
+        token = authenticate(env_url)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except Exception as e:
+        print(f"ERROR: auth failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        resp = requests.get(
+            f"{env_url}/api/data/v9.2/WhoAmI()",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            },
+            timeout=10,
+        )
+    except requests.exceptions.Timeout as e:
+        print(f"ERROR: timeout reaching {env_url}: {e}", file=sys.stderr)
+        sys.exit(2)
+    except requests.exceptions.SSLError as e:
+        print(f"ERROR: TLS failure on {env_url}: {e}", file=sys.stderr)
+        sys.exit(2)
+    except requests.exceptions.ConnectionError as e:
+        print(f"ERROR: cannot reach {env_url}: {e}", file=sys.stderr)
+        sys.exit(2)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except Exception as e:
+        print(f"ERROR: unexpected: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    if resp.status_code == 200:
+        try:
+            data = resp.json()
+        except Exception as e:
+            print(f"ERROR: WhoAmI 200 but body was not JSON: {e}", file=sys.stderr)
+            sys.exit(3)
+        out = {
+            "status": "ok",
+            "userId": data.get("UserId"),
+            "organizationId": data.get("OrganizationId"),
+            "businessUnitId": data.get("BusinessUnitId"),
+        }
+        print(json.dumps(out))
+        sys.exit(0)
+    elif resp.status_code in (401, 403):
+        print(f"ERROR: access denied ({resp.status_code}). User lacks Dataverse permission on this env.", file=sys.stderr)
+        sys.exit(1)
+    elif resp.status_code == 404:
+        print(f"ERROR: env not found ({resp.status_code}). Verify the URL.", file=sys.stderr)
+        sys.exit(2)
+    else:
+        print(f"ERROR: unexpected status {resp.status_code}: {resp.text[:300]}", file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/wire_flow_bindings.py
+++ b/solutions/ess-maker-skills/scripts/wire_flow_bindings.py
@@ -1,0 +1,142 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Wire Flow Runtime Bindings
+
+Enables Workday flows post-ISV-install and prints manual CPS wiring
+instructions (the user-connections API requires legacy PVA permissions
+not grantable to custom Entra apps — see step3.md §3.9).
+
+Usage:
+    python scripts/wire_flow_bindings.py \\
+        --env-url https://orgxyz.crm.dynamics.com \\
+        --persona hr --workday-connection-name MyWorkdayConn
+
+Exit codes: 0 success, 1 auth, 2 flow discovery/enable, 3 unexpected.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' required. Run: pip install -r scripts/requirements.txt", file=sys.stderr)
+    sys.exit(3)
+
+from auth import authenticate, query_all, update_record
+from pp_helpers import VALID_PERSONAS
+
+
+def discover_workday_flows(env_url, dataverse_token, persona):
+    """Query workflows table for Workday-related flows.
+
+    Persona is validated against VALID_PERSONAS before OData interpolation
+    (defense in depth against injection if argparse is bypassed).
+    """
+    if persona.lower() not in VALID_PERSONAS:
+        raise ValueError(f"persona must be one of {sorted(VALID_PERSONAS)}, got {persona!r}")
+    persona_specific = f"ESS {persona.upper()} Workday"
+    name_filter = (
+        f"(name eq '{persona_specific}' or name eq 'WorkdayRESTExecution')"
+    )
+    rows = query_all(
+        env_url,
+        dataverse_token,
+        "workflows",
+        "workflowid,name,statecode,statuscode",
+        name_filter,
+    )
+    return rows
+
+
+def enable_workflow_if_disabled(env_url, dataverse_token, workflow):
+    """Set statecode=1, statuscode=2 (Activated) on a workflow if not already."""
+    wf_id = workflow.get("workflowid")
+    current_state = workflow.get("statecode")
+    if current_state == 1:
+        return {"workflowId": wf_id, "name": workflow.get("name"), "action": "already-enabled"}
+
+    try:
+        update_record(env_url, dataverse_token, "workflows", wf_id, {"statecode": 1, "statuscode": 2})
+        return {"workflowId": wf_id, "name": workflow.get("name"), "action": "enabled"}
+    except Exception as e:
+        return {"workflowId": wf_id, "name": workflow.get("name"), "action": "enable-failed", "error": str(e)[:200]}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Enable Workday flows and print manual wiring instructions")
+    parser.add_argument("--env-url", required=True, help="Dataverse env URL")
+    parser.add_argument("--persona", required=True, choices=["hr", "it"], help="ESS persona (hr or it)")
+    parser.add_argument("--workday-connection-name", default="", help="Workday connection display name (for instructions)")
+    args = parser.parse_args()
+
+    # 1) Dataverse auth.
+    dataverse_token = authenticate(args.env_url)
+
+    # 2) Discover the Workday flows in this env.
+    flows = discover_workday_flows(args.env_url, dataverse_token, args.persona)
+    if not flows:
+        print(
+            "ERROR: no Workday flows found in env. Workday ISV install may not have completed, "
+            "or the flow names do not match expected patterns.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Verify both expected flows are present.
+    persona_specific = f"ESS {args.persona.upper()} Workday"
+    expected_names = {persona_specific, "WorkdayRESTExecution"}
+    found_names = {f.get("name") for f in flows}
+    missing = expected_names - found_names
+    if missing:
+        print(
+            f"ERROR: missing expected Workday flow(s): {missing}. "
+            f"Found: {found_names}. Workday ISV install may be incomplete.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    print(f"Found {len(flows)} Workday flow(s):", file=sys.stderr)
+    for f in flows:
+        print(f"  - {f.get('name')} (statecode={f.get('statecode')})", file=sys.stderr)
+
+    # 3) Enable any disabled flows.
+    enable_results = []
+    for f in flows:
+        result = enable_workflow_if_disabled(args.env_url, dataverse_token, f)
+        enable_results.append(result)
+        print(f"  enable: {result.get('name')}: {result.get('action')}", file=sys.stderr)
+
+    # 4) Output results + manual wiring instructions.
+    conn_name = args.workday_connection_name or "(your Workday connection)"
+    flow_names = sorted(found_names)
+
+    output = {
+        "flowEnables": enable_results,
+        "manualWiringRequired": True,
+        "instructions": {
+            "summary": "Flow runtime bindings must be wired manually in Copilot Studio.",
+            "reason": "The user-connections API requires legacy PowerVirtualAgents.* permissions not available in the current API catalog.",
+            "steps": [
+                "Open Copilot Studio (copilotstudio.microsoft.com or copilotstudio.preview.microsoft.com for preprod)",
+                "Switch to the target environment",
+                f"Open the Employee Self-Service {args.persona.upper()} agent -> Actions",
+                *[f"Select '{fn}' -> Connect -> choose '{conn_name}'" for fn in flow_names],
+                "For EACH flow: click 'See details' under Manage -> Connection parameters tab -> toggle 'Allow permission to share parameters' ON -> Save",
+            ],
+        },
+    }
+    print(json.dumps(output, indent=2))
+
+    enable_failures = [r for r in enable_results if r.get("action") == "enable-failed"]
+    sys.exit(0 if not enable_failures else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/src/skills/provision/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/provision/SKILL.md
@@ -1,0 +1,408 @@
+# Provision Skill
+
+Provision a Power Platform environment with ESS base + ISV extension, end to end, in a single command.
+
+Every **Message** block is the exact text to show the user. Copy it verbatim.
+Do not rephrase, add commentary, or tell the user what tools you are calling
+or what files you are reading.
+
+**Do NOT show internal variable names or assignments to the user.** Never
+display text like `ENV_URL = ...` or `RUN_KEY = ...` in chat.
+
+**CRITICAL RULES:**
+- **Execute all scripts and tool calls immediately.** Do not ask the user
+  for permission to run commands. The /provision flow is designed to be
+  fully automated — prompts like "Shall I run this?" or "Allow?" break the
+  UX. The only time to pause and ask is when the step doc explicitly says
+  to show a Message block and wait for user input.
+- Composition over construction. This skill is mostly orchestration. It calls
+  existing scripts (`scripts/auth.py`, `scripts/flightcheck/cli.py`) and
+  delegates to other skill step files. Do NOT reimplement what `/setup`,
+  `/connect`, or `/flightcheck` already do.
+- ESS base AND the Workday ISV are both installed via `pac application install`,
+  which pulls from AppSource. This is what enables the Copilot Studio
+  **Settings → Customize** tab and avoids unverified direct REST endpoints.
+- All provision run state lives under `my/provision/{ENV_NAME}/` — `tasks.md`
+  (checklist) and `config.json` (gathered values). This is separate from the
+  shared auth/config cache in `.local/` used by core scripts (`auth.py`,
+  `/setup`, `/flightcheck`). Re-running the skill picks up the existing run
+  rather than restarting from zero.
+- "Ready" is strict: ESS installed, ISV imported, 2 connections active,
+  all tasks.md items checked, config.json status is `ready`. Loose
+  definitions of "ready" let bugs ship.
+
+### ISV extensibility
+
+This PR implements Workday end-to-end. The design is intentionally
+ISV-aware so future PRs can add ServiceNow, SuccessFactors, etc. by:
+
+1. **Step 2** — ISV picker already lists all ISVs; just remove the
+   "not yet implemented" guard.
+2. **step3.md** — ISV-specific sections are marked with `<!-- ISV: workday -->`.
+   Add a parallel `step3-servicenow.md` (or conditional blocks) for the new
+   ISV's connector IDs, connection ref prefixes, and flow names.
+3. **scripts/** — `create_connection.py` accepts `--connector` (generic).
+   `bind_connection_refs.py` uses `CONNECTOR_UNIQUE_NAMES` dict — add the
+   new ISV's connector names there. `wire_flow_bindings.py` filters flows
+   by persona prefix — extend the prefix list.
+4. **.env** — Workday keys (`WORKDAY_*`) are ISV-specific. Add a parallel
+   set for the new ISV (e.g., `SERVICENOW_INSTANCE_URL`).
+
+---
+
+## Start
+
+If the user invoked this skill with arguments like `/provision ess with workday`,
+parse the ISV from the phrase ("workday", "servicenow hr", "servicenow it",
+"successfactors"). Save as PRE_SELECTED_ISV. If the invocation had no ISV,
+leave PRE_SELECTED_ISV unset — Step 2 will ask.
+
+Do not ask any question here. The first question to the user is Step 1
+(persona pick). The ISV question, if needed, comes after persona in Step 2.
+
+---
+
+## Step 0: Load defaults from .env (optional)
+
+Check if `.local/.env` exists (relative to the kit folder
+`solutions/ess-maker-skills/`). If yes, read it and parse each line as
+`KEY=VALUE`. Ignore blank lines and lines starting with `#`. Trim
+whitespace and surrounding quotes from each value. If the file doesn't
+exist, ENV is empty and every prompt below runs interactively.
+
+**Matching is case-insensitive and supports aliases.** Different teams
+write .env keys in different conventions (UPPER_SNAKE, lower_snake,
+short prefixed, vendor-specific naming). For each logical setting,
+accept any of the listed key names. Save the resolved value into ENV
+using the **canonical key** (left column). Downstream steps reference
+ENV with canonical names only.
+
+| Logical setting | Canonical key (used downstream) | Accepted aliases (case-insensitive) |
+|-----------------|---------------------------------|-------------------------------------|
+| Persona | `PERSONA` | `persona`, `ess_persona` |
+| Target env URL | `ENV_URL` | `env_url`, `dataverse_url`, `dataverse_endpoint` |
+| Env short name | `ENV_NAME` | `env_name`, `environment_name` |
+| Workday SOAP base URL | `WORKDAY_BASE_URL` | `soap_url`, `wd_soap_url`, `wd_base_url`, `workday_soap_url`, `workday_base_url` |
+| Workday tenant name | `WORKDAY_TENANT` | `tenant`, `wd_tenant`, `workday_tenant`, `workday_tenant_name` |
+| Workday OAuth token URL | `WORKDAY_OAUTH_TOKEN_URL` | `oauth_token_url`, `wd_oauth_token_url`, `workday_oauth_token_url` |
+| Workday OAuth client ID | `WORKDAY_OAUTH_CLIENT_ID` | `oauth_client_id`, `wd_oauth_client_id`, `workday_client_id`, `workday_oauth_client_id` |
+| Workday Entra app ID URI | `WORKDAY_ENTRA_APP_ID_URI` | `microsoft_entra_resource_url`, `entra_resource_url`, `wd_entra_app_id_uri`, `workday_entra_app_id_uri` |
+| ESS Dev Kit custom Entra app client ID | `ESS_DEVKIT_EMPHUB_CLIENT_ID` | `ESS_PROVISION_CLIENT_ID`, `provision_client_id`, `ess_devkit_client_id` |
+| Power Platform ring | `RING` | `ring`, `pp_ring`, `power_platform_ring` |
+
+**Lookup procedure for each logical setting:**
+
+1. Pick the canonical key.
+2. Try the canonical key first (case-insensitive).
+3. If not found, try each alias in order (case-insensitive).
+4. First match wins. Store under the canonical key.
+
+Keys not in this table are ignored. Never echo any value from ENV to
+chat — these may be sensitive in some setups even though `.local/` is
+gitignored.
+
+### Pre-flight checklist
+
+After loading .env, validate that all prerequisites are in place before
+starting the interactive flow. Check each item and build a status table:
+
+| Item | How to check | Required? |
+|------|-------------|-----------|
+| `.local/.env` exists | File exists check | Yes |
+| `ESS_DEVKIT_EMPHUB_CLIENT_ID` set | Present in ENV after alias resolution | Yes |
+| Workday config keys set | `WORKDAY_BASE_URL`, `WORKDAY_TENANT`, `WORKDAY_OAUTH_TOKEN_URL`, `WORKDAY_OAUTH_CLIENT_ID`, `WORKDAY_ENTRA_APP_ID_URI` all present in ENV | Yes (when ISV = workday) |
+| PAC CLI installed | `pac --version` exits 0 | Yes |
+| PAC auth profile active | `pac auth list` shows at least one profile | Yes |
+
+**If any required item is missing**, show:
+
+**Message:**
+
+Before I can provision, a few things need to be set up:
+
+| Prerequisite | Status |
+|-------------|--------|
+| .local/.env file | {OK or MISSING} |
+| ESS Dev Kit app client ID | {OK or MISSING — add ESS_DEVKIT_EMPHUB_CLIENT_ID to .local/.env} |
+| Workday connection config | {OK or MISSING — add WORKDAY_BASE_URL, WORKDAY_TENANT, etc.} |
+| PAC CLI | {OK or MISSING — run: dotnet tool install --global Microsoft.PowerApps.CLI.Tool} |
+| PAC auth profile | {OK or MISSING — run: pac auth create --cloud Preprod --deviceCode} |
+
+See the [README](../../README.md) for setup instructions including
+Entra app registration and API permissions.
+
+**End message.**
+
+Stop here until the user fixes the missing items and re-runs `/provision`.
+
+**If all required items are present**, continue silently to Step 1.
+
+---
+
+## Step 1: Pick HR or IT persona
+
+ESS ships in two persona bundles. The persona drives which AppSource
+package and which ISV extension variant get installed downstream.
+
+**If ENV.PERSONA is set to `hr` or `it`:** save it as PERSONA and skip the
+question entirely. Do not show any chat message about it. Continue to
+Step 2.
+
+**Otherwise:** ask the user which one to provision:
+
+```json
+[
+  {
+    "header": "Persona",
+    "question": "Which ESS persona should this environment use?",
+    "options": [
+      { "label": "ESS HR", "description": "Employee-facing HR assistant (recommended)", "recommended": true },
+      { "label": "ESS IT", "description": "Employee-facing IT assistant" }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+Save as PERSONA (`hr` or `it`).
+
+---
+
+## Step 2: Pick the ISV
+
+If PRE_SELECTED_ISV (from intent parsing in Start) is set to `workday`,
+save it as ISV and skip this question.
+
+If PRE_SELECTED_ISV is set to any other value (servicenow hr,
+servicenow it, successfactors), show:
+
+**Message:**
+
+That ISV is not implemented yet in `/provision`. Workday is the only
+supported ISV right now. Re-run with `/provision ess with workday`
+or pick Workday from the menu.
+
+**End message.**
+
+Stop here.
+
+**If PRE_SELECTED_ISV is not set,** ask:
+
+```json
+[
+  {
+    "header": "ISV",
+    "question": "Which integration should be added on top of ESS {PERSONA}?",
+    "options": [
+      { "label": "Workday HCM", "description": "Workday HCM extension pack (only Workday is implemented today)" },
+      { "label": "ServiceNow HR", "description": "Not yet implemented in /provision" },
+      { "label": "ServiceNow IT", "description": "Not yet implemented in /provision" },
+      { "label": "SuccessFactors", "description": "Not yet implemented in /provision" }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+Save as ISV. If the user picks anything other than Workday HCM, show the
+"not implemented" message above and stop.
+
+---
+
+## Step 3: Pick or create the target environment
+
+The skill supports two modes for the target Power Platform environment:
+
+- **Bind**: an env already exists. The skill takes the URL and uses it.
+- **Create**: no existing env. The skill creates one via PAC CLI
+  (`pac admin create`) in the ring the user selects (preprod or prod).
+
+Decide the mode in this order:
+
+1. **If ENV.ENV_URL is set** (from `.local/.env`): save it as ENV_URL and
+   set MODE = `bind`. Skip to Step 3a-ring (ring question below), then
+   to Step 3b (env name).
+2. **Otherwise**, ask the user to choose:
+
+```json
+[
+  {
+    "header": "Env source",
+    "question": "I don't have an env URL in .env. Do you want me to create a new env, or use an existing one?",
+    "options": [
+      { "label": "Create a new env", "description": "Create via PP Admin API in the ring you pick (recommended for fresh setup)", "recommended": true },
+      { "label": "Use an existing env", "description": "Paste a Dataverse URL of an env you already created" }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+### 3a — If MODE = `bind` (existing env, user prompted)
+
+Ask for the URL:
+
+```json
+[
+  {
+    "header": "Env URL",
+    "question": "Paste the Dataverse URL of the target environment (e.g. https://yourorg.crm.dynamics.com)"
+  }
+]
+```
+
+Save as ENV_URL. Then continue to **3a-ring** below.
+
+### 3a-ring — Resolve ring (both modes, including .env)
+
+Downstream scripts (`create_connection.py`) need the ring to construct
+the correct per-env API host. The ring cannot be reliably derived from
+the URL alone.
+
+**If ENV.RING is set** (from `.local/.env`) to `preprod` or `prod`: save
+it as RING and skip the question.
+
+**Otherwise**, ask:
+
+```json
+[
+  {
+    "header": "Ring",
+    "question": "Which ring is this environment in?",
+    "options": [
+      { "label": "Preprod (PPE)", "description": "Environment is in the Preprod ring (aka.ms/ppacppe)", "recommended": true },
+      { "label": "Prod", "description": "Environment is in the Prod ring (aka.ms/ppac)" }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+Save as RING (`preprod` or `prod`).
+
+**If MODE = `bind`:** continue to Step 3b.
+**If MODE = `create`:** continue below (3a-create).
+
+### 3a-create — If MODE = `create` (new env)
+
+The ring was already resolved in 3a-ring above.
+
+ENV_URL is not known yet. It will be assigned by step1.md after the env
+is created via the PP Admin API.
+
+### 3b — Env name (both modes)
+
+**If MODE = `bind`:** derive ENV_NAME from the URL host (e.g. `yourorg`
+from `https://yourorg.crm.dynamics.com`). If derivation fails, prompt.
+
+**If MODE = `create`:**
+
+If ENV.ENV_NAME is set (from `.local/.env`), save it as ENV_NAME and skip
+the prompt below.
+
+Otherwise ask the user. Be explicit so they know free-text input is
+expected — the askQuestions tool with no options renders as a plain text
+field and users sometimes submit empty:
+
+```json
+[
+  {
+    "header": "Env name",
+    "question": "Type a short name for the new environment and press Enter. Example: essdev-gouthams-wd-20260511 (lowercase, no spaces, will be the env's display name)"
+  }
+]
+```
+
+If the user submits an empty value, do NOT re-prompt. Generate a default
+of `essdev-{current-user-alias}-{isv}-{yyyymmdd}` using the current OS
+username (e.g. `$env:USERNAME` on Windows or `$USER` on Unix) and proceed.
+The user can always rename or delete the env later.
+
+Save as ENV_NAME.
+
+---
+
+## Step 4: Initialize run state
+
+Create the directory `my/provision/{ENV_NAME}/` if it does not exist.
+
+Write `my/provision/{ENV_NAME}/config.json`. The `envUrl` is empty for
+create mode (filled in by step1.md after the create call succeeds):
+
+```json
+{
+  "envName": "{ENV_NAME}",
+  "envUrl": "{ENV_URL or empty string if MODE = create}",
+  "mode": "{bind or create}",
+  "ring": "{RING}",
+  "persona": "{PERSONA}",
+  "isv": "workday",
+  "status": "in-progress",
+  "createdAt": "{current ISO datetime}"
+}
+```
+
+Copy `src/skills/provision/tasks.md` to `my/provision/{ENV_NAME}/tasks.md`
+if it doesn't already exist (preserves prior progress on re-runs).
+
+---
+
+## Step 5: Run each provisioning step
+
+Read each step file in order and follow it. The step file is responsible
+for updating its own checkbox in `my/provision/{ENV_NAME}/tasks.md`.
+
+If a step file detects its work is already complete (from a previous run),
+it should skip and continue.
+
+1. Read `src/skills/provision/step1.md` and follow it.
+   (Env binding for existing envs, or env creation via PAC CLI for the
+   create mode. Verifies the env is reachable in both cases.)
+
+2. Read `src/skills/provision/step2.md` and follow it.
+   (Install the ESS base persona pack via `pac application install`.)
+
+3. Read `src/skills/provision/step3.md` and follow it.
+   (Install the Workday ISV via `pac application install`; wire connections.)
+
+4. Read `src/skills/provision/step4.md` and follow it.
+   (Verify all provision tasks completed; mark readiness.)
+
+---
+
+## Step 6: Mark complete
+
+When all four step files report success, update
+`my/provision/{ENV_NAME}/config.json`:
+
+```json
+{
+  "status": "ready",
+  "completedAt": "{current ISO datetime}"
+}
+```
+
+**Message:**
+
+Provisioning complete.
+
+| Item | Status |
+|------|--------|
+| Environment | {ENV_NAME} |
+| ESS base | ESS {PERSONA} installed |
+| ISV | Workday ({hr or it} extension imported) |
+| Connections | Workday OAuthUser + Dataverse OAuth (signed-in user) |
+| Flow wiring | Manual in Copilot Studio portal (user confirmed done) |
+| Health check | All provision tasks verified via checklist |
+
+Next steps:
+
+| Command | What it does |
+|---------|--------------|
+| `/setup` | Extract the freshly provisioned agent into your local workspace for editing |
+| `/flightcheck` | Run the full 41-check readiness validation |
+| `/connect` | Add another ISV (ServiceNow, SuccessFactors) to this env |
+
+**End message.**
+
+Stop here. Do not continue.

--- a/solutions/ess-maker-skills/src/skills/provision/step1.md
+++ b/solutions/ess-maker-skills/src/skills/provision/step1.md
@@ -1,0 +1,274 @@
+# Provision Step 1: Environment Binding
+
+Every **Message** block is the exact text to show the user. Copy it verbatim.
+Do not rephrase, add commentary, or tell the user what tools you are calling.
+
+This step ensures the provisioning run has a target environment that is
+reachable. It handles two modes:
+
+- **`bind`**: ENV_URL is already known from `.local/.env` or interactive
+  prompt. Just verify it's reachable.
+- **`create`**: ENV_URL is empty. Call the PP Admin API to create a new
+  env in the selected RING, poll until Dataverse is provisioned, capture
+  the new URL, then verify it's reachable.
+
+Read `my/provision/{ENV_NAME}/config.json` for ENV_URL, ENV_NAME, MODE,
+and RING.
+
+---
+
+## 1.1 — Skip if already complete
+
+Read `my/provision/{ENV_NAME}/tasks.md`. If "Environment bound" is `- [x]`,
+skip to 1.6.
+
+---
+
+## 1.2 — Create the env (only if MODE = create)
+
+**If MODE = `bind`:** skip this section, go to 1.3.
+
+**If MODE = `create`:** call the create-env helper to provision a new
+Power Platform environment in the selected ring.
+
+```
+python scripts/create_env.py --ring {RING} --name {ENV_NAME}
+```
+
+The helper is a thin wrapper around PAC CLI's `pac admin create`. It:
+1. Checks that `pac` is on PATH. If not, prints install instructions
+   and exits 1.
+2. Checks for an active `pac auth` profile matching the requested cloud
+   (`Preprod` for PPE, `Public` for prod). If none, prints the
+   device-code command for the user to run themselves, then exits 1.
+3. Runs `pac admin create --type Developer --region unitedstates
+   --currency USD --language 1033 --name <ENV_NAME>`. Developer type
+   is the default because it requires no capacity.
+4. Parses pac's stdout for the env URL, env ID, and organization ID.
+5. Returns JSON on stdout.
+
+While the helper runs, pac shows its own progress (it polls internally).
+Surface its output to the user as-is.
+
+**If exit code is 0:** parse the JSON stdout. Save these fields into
+`my/provision/{ENV_NAME}/config.json`:
+
+- `envUrl` from the JSON → save as `envUrl` (also referenced as ENV_URL downstream)
+- `envId` from the JSON → save as `envId` (also referenced as ENV_ID downstream). **Required by step3.md.** Without it, downstream `--env-id` arguments expand to empty and helpers fail.
+- `organizationId` from the JSON → save as `organizationId` (DATAVERSE_ORG_ID)
+
+Proceed to 1.3.
+
+**If exit code is 1:** show the stderr and stop. Common reasons:
+
+- `pac` CLI not installed. The error message includes the install command.
+  After the user installs it, type **retry**.
+- No auth profile for the selected cloud. The error message tells the
+  user exactly which `pac auth create --cloud X --deviceCode` to run.
+  They run it in their terminal, complete sign-in, then type **retry**.
+- pac auth expired during the operation. Same fix: re-run the
+  device-code command.
+
+**If exit code is 2:** the env could not be created. Parse the stderr to
+determine the reason and offer recovery options:
+
+**If the error mentions "limit" or "capacity"** (Developer env limit
+reached):
+
+Ask the user what to do:
+
+```json
+[
+  {
+    "header": "Env limit recovery",
+    "question": "You've hit the Developer environment limit (3 per user). How would you like to proceed?",
+    "options": [
+      { "label": "Retry as Sandbox", "description": "Create a Sandbox env instead (uses tenant capacity — check with your admin)", "recommended": true },
+      { "label": "Retry as Trial", "description": "Create a Trial env instead (free, but expires after 30 days)" },
+      { "label": "Delete an existing env and retry", "description": "Go delete one of your Developer envs, then come back and type retry" },
+      { "label": "Use an existing env", "description": "Bind to an env you already have instead of creating a new one" },
+      { "label": "Cancel", "description": "Stop provisioning" }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+Handle the user's choice:
+- **Retry as Sandbox**: re-run `create_env.py` with `--type Sandbox` instead
+  of `--type Developer`. Proceed normally on success.
+- **Retry as Trial**: re-run `create_env.py` with `--type Trial` instead
+  of `--type Developer`. Warn that Trial envs expire after 30 days.
+  Proceed normally on success.
+- **Delete an existing env and retry**: wait for the user to type **retry**,
+  then re-run the original Developer command.
+- **Use an existing env**: switch MODE to `bind` and ask for a Dataverse URL
+  (same as the bind path in SKILL.md Step 3a). Update config.json with the
+  new mode and URL.
+- **Cancel**: stop the skill.
+
+**If the error mentions "already exists" or "name is taken":**
+
+Ask the user for a different name and retry with the new name. Update
+ENV_NAME and config.json accordingly.
+
+**For any other exit code 2 reason:** show the stderr and stop.
+
+**If exit code is 3:** the pac command returned an error we did not
+recognize. Show the full stderr to the user and stop the skill.
+
+---
+
+## 1.3 — Authenticate and verify env is reachable
+
+This skill talks to Power Platform Admin, Dataverse, and the Marketplace
+install API on the user's behalf. Authentication is via MSAL interactive
+browser flow with on-disk token caching (`auth.py`). On first run, a
+browser tab opens for sign-in; subsequent calls reuse the cached token
+silently.
+
+The `scripts/whoami.py` helper does both auth (opens a browser tab on
+first run if needed) and a WhoAmI probe in one shot. Run it silently:
+
+```
+python scripts/whoami.py --env-url {ENV_URL}
+```
+
+Capture stdout and the exit code.
+
+**If exit code is 0:** parse the JSON stdout. Save `organizationId` as
+DATAVERSE_ORG_ID in `my/provision/{ENV_NAME}/config.json`. Proceed to 1.4.
+
+**If exit code is 1 (auth failed or access denied):**
+
+**Message:**
+
+I couldn't authenticate to the environment. Two things to check:
+
+- **Did you sign in with the right Microsoft account?** Use the account
+  that has access to the target Power Platform environment.
+- **Does your account have permission on the target env?** You need at
+  least the System Customizer role on the Dataverse environment.
+
+Type **retry** when ready, or **cancel** to stop.
+
+**End message.**
+
+Wait for the user. On retry, re-run the script.
+
+**If exit code is 2 (network or DNS failure):**
+
+**Message:**
+
+The environment URL doesn't resolve. You gave me `{ENV_URL}` — check
+that it's a Power Platform environment URL (typically ending in
+`.crm.dynamics.com`).
+
+Type **back** to enter a different URL.
+
+**End message.**
+
+On `back`, return to SKILL.md Step 3 to re-collect ENV_URL.
+
+**If exit code is 3 (unexpected error):** show the stderr text from the
+script directly to the user and stop the skill. This is an
+unrecoverable condition that needs investigation.
+
+---
+
+## 1.3b — Warm up Power Platform Connectivity token
+
+The connection-creation step (step3, §3.4) needs a Power Platform
+Connectivity API token. Acquire it now so the user does all browser
+sign-ins upfront instead of being interrupted mid-flow.
+
+Read `ESS_DEVKIT_EMPHUB_CLIENT_ID` from ENV (loaded in Step 0).
+
+```
+python scripts/create_connection.py --env-id {ENV_ID} --env-url {ENV_URL} --ring {RING} --connector _warmup --client-id {ESS_DEVKIT_EMPHUB_CLIENT_ID}
+```
+
+The `_warmup` connector acquires and caches the token without creating
+anything, then exits 0.
+
+If a browser sign-in opens, tell the user:
+
+**Message:**
+
+Please sign in to the Power Platform API in the browser window that
+just opened. This is the last sign-in — all subsequent steps will
+reuse this token.
+
+**End message.**
+
+On success, the token is cached in `.local/` for step3 to reuse silently.
+
+---
+
+## 1.4 — Derive env ID for bind mode (only if MODE = bind)
+
+In `create` mode, `create_env.py` already emits `envId` and §1.2 saved it.
+Skip this section.
+
+In `bind` mode, the user pasted a Dataverse URL but the Power Platform env
+GUID (`envId`) is not in the URL. Now that auth is established (§1.3),
+derive it via:
+
+```
+GET {ENV_URL}/api/data/v9.2/organizations?$select=environmentid
+```
+
+Use the bearer token cached by §1.3's `whoami.py` run (auth.py persists
+the token cache so subsequent Dataverse calls reuse it silently).
+
+Take the first row's `environmentid` value and save as `envId` in
+`my/provision/{ENV_NAME}/config.json`. Downstream helpers require it.
+
+---
+
+## 1.5 — Detect existing state
+
+Silently check whether ESS or any ISV solution is already installed in
+this env. This affects whether step2 and step3 skip or run.
+
+Use the Dataverse Web API (the bearer token is the one cached by step 1.3):
+
+```
+GET {ENV_URL}/api/data/v9.2/solutions?$select=uniquename,version,ismanaged&$filter=startswith(uniquename,'msdyn_copilotforemployeeselfservice') or startswith(uniquename,'msdyn_essh') or startswith(uniquename,'msdyn_essit')
+```
+
+Parse the response. For each found solution, save to config.json:
+
+```json
+{
+  "preExistingSolutions": [
+    { "uniqueName": "...", "version": "...", "isManaged": true }
+  ]
+}
+```
+
+This is informational only — step2 and step3 will use this to decide whether
+to skip work.
+
+---
+
+## 1.6 — Mark complete
+
+Update `my/provision/{ENV_NAME}/tasks.md` — change "Environment bound" to `- [x]`.
+
+**Message:**
+
+Bound to environment **{ENV_NAME}**.
+
+| Check | Status |
+|-------|--------|
+| Dataverse auth | OK |
+| Power Platform API auth | OK |
+| Pre-existing ESS solutions | {count from preExistingSolutions} |
+
+**End message.**
+
+Continue to step2.md.
+
+---
+

--- a/solutions/ess-maker-skills/src/skills/provision/step2.md
+++ b/solutions/ess-maker-skills/src/skills/provision/step2.md
@@ -1,0 +1,161 @@
+# Provision Step 2: Install ESS Base via PAC Application Install
+
+Every **Message** block is the exact text to show the user. Copy it verbatim.
+Do not rephrase, add commentary, or tell the user what tools you are calling.
+
+This step installs the ESS HR or ESS IT base persona pack using PAC CLI's
+`pac application install` command. PAC handles the AppSource lookup, install
+polling, and dependency resolution internally. This replaces an earlier
+BAP REST API approach that turned out to be unreliable (wrong API path
+and version).
+
+Read `my/provision/{ENV_NAME}/config.json` for ENV_URL, ENV_NAME, PERSONA.
+
+---
+
+## 2.1 — Skip if already complete
+
+Read `my/provision/{ENV_NAME}/tasks.md`. If "ESS base installed" is `- [x]`,
+skip to 2.5.
+
+Check `preExistingSolutions` in config.json (populated by step1.md §1.5).
+If a solution starting with `msdyn_copilotforemployeeselfservice{persona}`
+is already present, mark the task complete and skip to 2.5.
+
+---
+
+## 2.2 — Resolve application name from persona
+
+Map PERSONA to the AppSource application name:
+
+- PERSONA `hr` → `msdyn_CopilotForEmployeeSelfServiceHR`
+- PERSONA `it` → `msdyn_CopilotForEmployeeSelfServiceIT`
+
+Save as APP_NAME.
+
+---
+
+## 2.3 — Ensure PAC is authenticated for the correct ring
+
+In create mode, `create_env.py` already validated and selected the PAC auth
+profile. In bind mode, no such check has run yet.
+
+Read RING from `my/provision/{ENV_NAME}/config.json`. Map to PAC cloud:
+- RING `preprod` → cloud `Preprod`
+- RING `prod` → cloud `Public`
+
+Run silently:
+
+```
+pac auth list
+```
+
+Check the output for a profile matching the target cloud. If none exists,
+show the user:
+
+**Message:**
+
+PAC CLI is not authenticated for the {cloud} cloud. Run:
+
+```
+pac auth create --cloud {cloud} --deviceCode
+```
+
+Then type **done** to continue.
+
+**End message.**
+
+If a profile exists but is not the active one, run:
+
+```
+pac auth select --index {N}
+```
+
+where N is the index of the matching profile.
+
+---
+
+## 2.4 — Install via `pac application install`
+
+**Message:**
+
+Installing ESS {persona} base. This typically takes 1-3 minutes.
+
+**End message.**
+
+Run in the terminal:
+
+```
+pac application install --environment {ENV_URL} --application-name {APP_NAME}
+```
+
+PAC polls AppSource internally and surfaces its own progress output. Let
+the user see PAC's output as-is. Do not pre-poll or post-poll yourself.
+
+**If pac returns exit code 0:**
+
+Verify the install landed by querying Dataverse. Use `startswith` because
+the AppSource application name (e.g. `msdyn_CopilotForEmployeeSelfServiceHR`)
+may differ in casing or suffix from the Dataverse solution unique name:
+
+```
+GET {ENV_URL}/api/data/v9.2/solutions?$select=uniquename,version,ismanaged&$filter=startswith(uniquename,'msdyn_copilotforemployeeselfservice{persona}')
+```
+
+Expect at least one row with `ismanaged: true`. If no matching row is found,
+treat the install as failed and stop the skill with a clear message asking
+the user to check PAC's output.
+
+Save to config.json:
+
+```json
+{
+  "essBase": {
+    "uniqueName": "{APP_NAME}",
+    "version": "{version from query}",
+    "installedAt": "{current ISO datetime}"
+  }
+}
+```
+
+Proceed to 2.5.
+
+**If pac returns non-zero:**
+
+**Message:**
+
+The ESS {persona} install failed.
+
+The most likely causes:
+
+- **PAC auth profile expired or missing.** Re-run
+  `pac auth create --cloud Preprod --deviceCode` (or `--cloud Public`
+  for prod ring), sign in, then type **retry**.
+- **AppSource package not available in your tenant region.** Some preview
+  packages are gated. Check that the package shows "Get it now" in the
+  marketplace listing for your region.
+- **Insufficient permissions on the target env.** You need at least
+  System Administrator on the Dataverse environment.
+
+PAC's full output is above. Fix the issue and type **retry**, or
+**cancel** to stop.
+
+**End message.**
+
+On retry, re-run `pac application install`. On cancel, stop the skill.
+
+---
+
+## 2.5 — Mark complete
+
+Update `my/provision/{ENV_NAME}/tasks.md` — change "ESS base installed" to `- [x]`.
+
+**Message:**
+
+ESS {persona} base installed (v{version}). The Copilot Studio
+**Settings → Customize** tab is now available, which is what the
+next step needs to load the Workday extension.
+
+**End message.**
+
+Continue to step3.md.

--- a/solutions/ess-maker-skills/src/skills/provision/step3.md
+++ b/solutions/ess-maker-skills/src/skills/provision/step3.md
@@ -1,0 +1,524 @@
+# Provision Step 3 (New): Workday ISV Install + Parallel Connection Setup
+
+Every **Message** block is the exact text to show the user. Copy it verbatim.
+Do not rephrase, add commentary, or tell the user what tools you are calling.
+
+**This is the simplified post-auth-simplification path.** It assumes the
+Workday extension uses delegated OAuth (signed-in user's identity flows
+to Workday at runtime). The legacy ISU + SAML path is still required for
+existing customer environments and lives separately under
+`src/skills/connect/workday/step3.md`. Do not conflate the two.
+
+This step parallelizes Workday ISV install with the OAuth handshake for the
+two connections. The connections are created up-front (instantly), then
+the install runs while the user signs in to both connections in the maker
+portal. By the time the install finishes, both connections are typically
+Connected and we auto-bind them to the connection references the install
+just registered.
+
+Read `my/provision/{ENV_NAME}/config.json` for ENV_URL, ENV_NAME, PERSONA,
+and ENV_ID.
+
+## Auth-mode decision (open, defer to revisit)
+
+The Workday SOAP connector supports four auth modes (`basic`, `oauth`,
+`oauthapim`, `oauth2generic`). The current default is `oauth` (Microsoft
+Entra ID Integrated) to match the production auth-simplification model
+where every runtime call flows under the signed-in user's identity. The
+trade-off is that `oauth` requires a one-time browser sign-in to complete
+the SAML+OAuth handshake for the connection, which is why this step
+parallelizes that sign-in with the ISV install.
+
+If you ever switch to `oauth2generic` (Workday OAuth client credentials)
+the sign-in step goes away entirely — connections become Connected
+immediately. The trade-off is service-identity runtime auth (one Workday
+identity used for every call, regardless of who signed in). See the project
+memory note `project_pp_connectivity_api.md` for the full discussion.
+
+---
+
+## 3.1 — Skip if already complete
+
+Read `my/provision/{ENV_NAME}/tasks.md`. Only skip this step if ALL five
+Step 3 task items are `- [x]`:
+
+- ISV imported
+- Connections active
+- Connection refs bound
+- Flow runtime connections wired
+- User Context Setup topic configured
+
+If all five are checked, skip to 3.11 (Persist final state).
+
+If only some are checked, resume from the first incomplete subsection:
+
+- ISV imported unchecked → start at 3.2 (PAC auth check, then 3.3)
+- ISV imported checked but Connections active unchecked → if `connections.workday.connectionId` AND `connections.dataverse.connectionId` already exist in config.json, skip to 3.7 (verify status); otherwise start at 3.4
+- Both checked but Connection refs bound unchecked → start at 3.8
+- Connection refs bound checked but Flow runtime unchecked → start at 3.9
+- Flow runtime checked but User Context unchecked → start at 3.10
+
+---
+
+## 3.2 — Ensure PAC is authenticated for the correct ring
+
+Step 2 runs this check, but if Step 2 was skipped (ESS base already present),
+the PAC auth profile may not be set to the correct ring for this provision.
+
+Read RING from config.json. Map to PAC cloud:
+- RING `preprod` → cloud `Preprod`
+- RING `prod` → cloud `Public`
+
+Run `pac auth list`. If no profile exists for the target cloud, ask the user
+to create one (`pac auth create --cloud {cloud} --deviceCode`). If a profile
+exists but is not active, run `pac auth select --index {N}`.
+
+---
+
+## 3.3 — Resolve ISV application name from persona
+
+Map PERSONA to the AppSource application name:
+
+- PERSONA `hr` → `msdyn_EssHRWorkday`
+- PERSONA `it` → `msdyn_EssITWorkday`
+
+Save as ISV_APP_NAME.
+
+---
+
+## 3.4 — Pre-create the Workday and Dataverse connections
+
+The `/provision` path uses a simplified two-connection model: one Workday
+SOAP (OAuthUser) and one Dataverse connection. All Workday connection refs
+in the ISV solution are bound to the single Workday connection. For
+advanced multi-identity setups (ISU_WQL, ISU_Generic), use `/connect workday`
+after provisioning.
+
+Both connections can be created **before** the Workday ISV installs — the
+underlying connectors (`shared_workdaysoap`, `shared_commondataserviceforapps`)
+are platform-level and exist in every env. We create them now so the user
+can complete OAuth in parallel with the install.
+
+Run silently:
+
+```
+python scripts/create_connection.py --env-id {ENV_ID} --env-url {ENV_URL} --ring {RING} --connector shared_workdaysoap
+```
+
+Capture the `connectionId` and `displayName` from the JSON stdout. Save as
+WORKDAY_CONNECTION_ID and WORKDAY_CONNECTION_DISPLAY_NAME.
+
+Then:
+
+```
+python scripts/create_connection.py --env-id {ENV_ID} --env-url {ENV_URL} --ring {RING} --connector shared_commondataserviceforapps
+```
+
+Capture the `connectionId` and `displayName` from the JSON stdout. Save as
+DATAVERSE_CONNECTION_ID and DATAVERSE_CONNECTION_DISPLAY_NAME.
+
+Both connections come back in `status: Error, target: token` ("Unauthenticated").
+This is expected — the OAuth handshake has not happened yet.
+
+Write the IDs and display names to `my/provision/{ENV_NAME}/config.json`:
+
+```json
+{
+  "connections": {
+    "workday": {"connectionId": "{WORKDAY_CONNECTION_ID}", "displayName": "{WORKDAY_CONNECTION_DISPLAY_NAME}", "status": "Unauthenticated"},
+    "dataverse": {"connectionId": "{DATAVERSE_CONNECTION_ID}", "displayName": "{DATAVERSE_CONNECTION_DISPLAY_NAME}", "status": "Unauthenticated"}
+  }
+}
+```
+
+If either script exits non-zero, show the stderr to the user and stop the
+skill. Common causes: PAC token cache expired (re-run `pac auth create`),
+the browser sign-in was cancelled, or the custom Entra app's permissions
+on the Preprod resource are missing.
+
+---
+
+## 3.5 — Ask the user to sign in to both connections (parallel with install)
+
+Build MAKER_HOST from RING:
+- RING `preprod` → MAKER_HOST = `make.preprod.powerapps.com`
+- RING `prod` → MAKER_HOST = `make.powerapps.com`
+
+**Message:**
+
+I've created the two connections this env needs. While I install the Workday
+extension (takes 2-3 minutes), please sign in to both connections so they
+are ready when the install finishes.
+
+Open this page in your browser:
+
+https://{MAKER_HOST}/environments/{ENV_ID}/connections
+
+Then:
+
+1. Find the connection named **{WORKDAY_CONNECTION_DISPLAY_NAME}** in the list.
+   Click it → click **Connect** or **Sign in** → complete the Microsoft
+   sign-in flow. Status should flip to **Connected**.
+2. Find the connection named **{DATAVERSE_CONNECTION_DISPLAY_NAME}** in the same
+   list. Click it → **Connect** → sign in. Status should flip to
+   **Connected**.
+
+Type **done** when both connections show **Connected** in the maker portal,
+or **skip** if you want to keep going and come back to this later (the
+final validation step will fail until both are Connected).
+
+**End message.**
+
+Immediately after showing the message above, proceed to 3.6 to start the
+ISV install. **Do NOT wait** for the user's `done` response — the install
+runs in the terminal while the user signs in via their browser. Show both
+the informational message and the install command output in the same turn.
+The user's `done` response will be collected after the install finishes
+in §3.7.
+
+---
+
+## 3.6 — Install Workday ISV via `pac application install`
+
+**Message:**
+
+Installing Workday {persona} extension now. This typically takes 2-3 minutes.
+The PAC CLI will poll until the install completes — you'll see its progress
+below. Keep signing in to the connections in the other tab while this runs.
+
+**End message.**
+
+Run in the terminal:
+
+```
+pac application install --environment {ENV_URL} --application-name {ISV_APP_NAME}
+```
+
+PAC polls AppSource internally. Let the user see PAC's output as-is.
+
+**If pac returns exit code 0:**
+
+Verify via Dataverse. Use `startswith` because the AppSource application
+name may differ from the Dataverse solution unique name:
+
+```
+GET {ENV_URL}/api/data/v9.2/solutions?$select=uniquename,version,ismanaged&$filter=startswith(uniquename,'msdyn_ess{persona}')
+```
+
+Expect at least one row with `ismanaged: true`. Save to config.json:
+
+```json
+{
+  "isvSolution": {
+    "uniqueName": "{ISV_APP_NAME}",
+    "version": "{version}",
+    "installedAt": "{current ISO datetime}"
+  }
+}
+```
+
+Update `my/provision/{ENV_NAME}/tasks.md` — change "ISV imported" to `- [x]`.
+
+**If pac returns non-zero:** show stderr and stop. Same recovery as step2 §2.3.
+
+---
+
+## 3.7 — Verify both connections are active
+
+If the user already typed **done** while the install was running, skip to
+the verification below.
+
+If not, prompt now:
+
+**Message:**
+
+Workday {persona} extension installed.
+
+Last thing: please confirm both connections show **Connected** in the maker
+portal at https://{MAKER_HOST}/environments/{ENV_ID}/connections.
+
+Type **done** when both show Connected. Type **skip** to leave them in
+unauthenticated state (validation will fail).
+
+**End message.**
+
+Wait for the user. **Cap the wait at 30 minutes** (max 60 polls at 30s
+intervals). After 30 minutes without `done` from the user, stop the skill
+with a message that says "OAuth not completed within 30 min — re-run
+`/provision` later to resume."
+
+Once the user types **done**, verify both connections are actually Connected
+by querying the Power Platform Connectivity API.
+
+**Auth for the Connectivity API:** Use the same MSAL token flow as
+`create_connection.py` — acquire a token with the ring-appropriate scope
+from `pp_helpers.SCOPES_BY_RING[RING]` (preprod:
+`https://api.preprod.powerplatform.com/.default`, prod:
+`https://api.powerplatform.com/.default`). The token cache from Step 1's
+`whoami.py` / `auth.py` is separate (Dataverse scope); the Connectivity
+API needs the Power Platform scope. Use the cached MSAL token if available,
+otherwise `acquire_token_silent` will handle it.
+
+Build the per-env host from ENV_ID and RING using the same format as
+`pp_helpers.per_env_host()`:
+
+```
+{first 31 chars of ENV_ID without dashes}.{remaining chars}.{ring-suffix}
+```
+
+Where ring-suffix is `environment.api.preprod.powerplatform.com` for preprod
+or `environment.api.powerplatform.com` for prod.
+
+Check each connection:
+
+```
+GET https://{PER_ENV_HOST}/connectivity/connectors/shared_workdaysoap/connections/{WORKDAY_CONNECTION_ID}?api-version=1
+```
+
+```
+GET https://{PER_ENV_HOST}/connectivity/connectors/shared_commondataserviceforapps/connections/{DATAVERSE_CONNECTION_ID}?api-version=1
+```
+
+Look at `properties.statuses` for each. Prefer the entry where
+`target == "token"` (most reliable for OAuth connections). If no token
+target exists, fall back to `statuses[0]`. If the status is `Connected`,
+the connection is ready. If both are `Connected`, proceed.
+
+If either is still `Error` or not Connected:
+
+**Message:**
+
+Connection **{name}** is not yet Connected (status: {actual_status}).
+Please complete the OAuth sign-in in the maker portal and type **done**
+again.
+
+**End message.**
+
+Return to waiting. After 3 failed verifications, stop the skill with a
+message directing the user to check the connections manually.
+
+Once both connections are Connected, update `my/provision/{ENV_NAME}/tasks.md`
+— change "Connections active" to `- [x]`.
+
+---
+
+## 3.8 — Auto-bind connection references to the connections
+
+Now that the Workday ISV is installed, the connection references it registers
+exist in the env. Bind each to the matching connection we created in 3.3.
+
+Run:
+
+```
+python scripts/bind_connection_refs.py \
+    --env-id {ENV_ID} \
+    --env-url {ENV_URL} \
+    --workday-connection {WORKDAY_CONNECTION_ID} \
+    --dataverse-connection {DATAVERSE_CONNECTION_ID}
+```
+
+The script:
+1. Queries all connection refs in the env
+2. Classifies each by connector type (workday / dataverse / etc.)
+3. PATCHes each ref's `connectionid` to the matching connection we created
+
+**If exit code is 0:** all bindings succeeded. Parse the JSON stdout for the
+`bindings` array and add to config.json:
+
+```json
+{
+  "connectionBindings": [
+    {"refLogicalName": "new_sharedworkdaysoap_ff0df", "connectionId": "{WORKDAY_CONNECTION_ID}", "status": "bound"},
+    ...
+  ]
+}
+```
+
+Update `my/provision/{ENV_NAME}/tasks.md` — change "Connection refs bound" to `- [x]`.
+
+**If exit code is 2 (one or more PATCH failures):** show the failures from
+the JSON output. The helper uses the simple lookup-field PATCH form
+(`{"connectionid": "<guid>"}`), which is confirmed working against
+Dataverse Web API v9.2 for the `connectionreferences` table. If a future
+Dataverse version rejects this form, the navigation-property form
+(`{"connection@odata.bind": "/connections(<guid>)"}`) is the documented
+alternative — surface the exact response so the helper can be updated.
+
+---
+
+## 3.9 — Wire flow runtime connections (semi-automated)
+
+After the Workday ISV install, two flows in the agent need their runtime
+connections explicitly wired in Copilot Studio. The solution-level
+connection references bound in 3.8 are not enough — Copilot Studio's
+flow runtime needs a separate per-flow binding through its own API.
+
+Additionally: because connections were unauthenticated at install time,
+the install logic leaves the flows in `Draft` / off state. They must be
+enabled before the binding can succeed.
+
+First, run the helper to discover and enable the flows:
+
+```
+python scripts/wire_flow_bindings.py \
+    --env-url {ENV_URL} \
+    --persona {hr or it} \
+    --workday-connection-name {WORKDAY_CONNECTION_DISPLAY_NAME}
+```
+
+The helper:
+1. Queries the `workflows` table for `ESS {persona} Workday` and
+   `WorkdayRESTExecution` flows.
+2. PATCHes any disabled flow to `statecode=1, statuscode=2` (Activated).
+3. Outputs manual wiring instructions (see Steps A and B below).
+
+**If exit code is 0:** flows are enabled. Proceed to Step A.
+
+**If exit code is non-zero:** show stderr and stop. Common causes:
+- Workday ISV install may be incomplete (missing flows).
+- Dataverse auth failed.
+
+> **Why are Steps A and B manual?** The user-connections API requires
+> legacy `PowerVirtualAgents.Tokens.Read` and `All.All.ReadWrite`
+> permissions that no longer exist in the Power Platform API permission
+> catalog. Custom Entra apps cannot acquire them, and the CPS first-party
+> app (`a522f059-...`) blocks both device-code (AADSTS7000218) and
+> localhost redirect (AADSTS50011) flows from CLI. Only the CPS portal's
+> own browser session can call this endpoint.
+
+**Message:**
+
+I've enabled both Workday flows. The remaining wiring needs to be done
+in the Copilot Studio portal:
+
+### Step A — Wire flows to connection
+
+1. Open **{CPS_URL}** (use `copilotstudio.preview.microsoft.com` for
+   preprod, `copilotstudio.microsoft.com` for prod)
+2. Switch to the **{ENV_NAME}** environment
+3. Open **Employee Self-Service {PERSONA}** agent → **Actions**
+4. For each flow (`ESS {PERSONA} Workday` and `WorkdayRESTExecution`):
+   - Click the flow → **Connect** → select **{WORKDAY_CONNECTION_NAME}**
+
+### Step B — Share connection parameters
+
+For each flow you just connected:
+
+1. Click **See details** (under the **Manage** section)
+2. Go to the **Connection parameters** tab
+3. Toggle **"Allow permission to share parameters"** to ON
+   _(Allowing the end-user to use this authentication will provide
+   improved responses)_
+4. Click **Save**
+
+Repeat for both `ESS {PERSONA} Workday` and `WorkdayRESTExecution`.
+
+Type **done** when both flows are connected and parameter sharing is enabled.
+
+**End message.**
+
+When the user types **done**, update `my/provision/{ENV_NAME}/tasks.md`
+— change "Flow runtime connections wired" to `- [x]`.
+
+---
+
+## 3.10 — Update the User Context Setup topic (automated)
+
+The agent's `[Admin] - User Context - Setup` topic must redirect to
+`WorkdaySystemGetUserContextV2` so every Workday topic can resolve the
+signed-in user's worker ID at runtime. After a fresh install, this topic
+is empty. The `update_user_context_topic.py` helper finds the topic by
+querying the `botcomponents` table and PATCHes the `data` field with the
+correct redirect YAML for the persona.
+
+**Important:** Copilot Studio reads the `data` field, **not** `content`,
+for topic body. PATCHing `content` succeeds (HTTP 204) but is invisible
+to CPS. This distinction is enforced in the helper.
+
+Run silently:
+
+```
+python scripts/update_user_context_topic.py \
+    --env-url {ENV_URL} \
+    --persona {hr or it}
+```
+
+The helper:
+1. Authenticates to Dataverse via auth.py (PAC CLI app).
+2. Queries `botcomponents` for components in the
+   `msdyn_copilotforemployeeselfservice{hr|it}` namespace.
+3. Filters client-side for the User Context Setup topic by name/schema.
+4. PATCHes the topic's `data` field with the persona-correct YAML (CPS reads `data`, not `content`):
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnRedirect
+  id: main
+  priority: 0
+  actions:
+    - kind: BeginDialog
+      id: QVk2yi
+      dialog: msdyn_copilotforemployeeselfservice{hr|it}.topic.WorkdaySystemGetUserContextV2
+```
+
+**If exit code is 0:** parse stdout for the patched topic info. Update
+config.json:
+
+```json
+{
+  "userContextTopicPatched": {
+    "botcomponentid": "...",
+    "name": "[Admin] - User Context - Setup",
+    "schemaname": "...",
+    "patchedAt": "{current ISO datetime}"
+  }
+}
+```
+
+Update `my/provision/{ENV_NAME}/tasks.md` — change "User Context Setup topic configured" to `- [x]`.
+
+**If exit code is 2 (topic not found or PATCH rejected):**
+- Topic not found usually means the Workday ISV install did not complete
+  cleanly. Re-run the helper after verifying the ISV solution exists.
+- PATCH rejected may indicate the topic is part of a managed solution
+  that does not allow direct content modification. Fall back to the
+  manual maker-portal edit. The helper has a `--dry-run` flag that
+  prints the current and proposed content for inspection.
+- Topic has custom content (safety check blocked overwrite). Use
+  `--force` if the overwrite is intended.
+
+Do NOT mark the checkbox on failure. Type **retry** or **cancel**.
+
+---
+
+## 3.11 — Persist final state and proceed
+
+Save to config.json:
+
+```json
+{
+  "connectionsCompletedAt": "{current ISO datetime}",
+  "manualConfigCompletedAt": "{current ISO datetime}"
+}
+```
+
+**Message:**
+
+Workday {persona} extension installed and fully wired.
+
+| Item | Status |
+|------|--------|
+| Solution imported | {ISV_APP_NAME} |
+| Workday connection | Connected |
+| Dataverse connection | Connected |
+| Connection refs bound | {N of N} |
+| ESS HR Workday flow connected | yes |
+| WorkdayRESTExecution flow connected | yes |
+| User Context Setup topic configured | yes |
+
+The env is now ready for end-to-end Workday queries from the agent.
+
+**End message.**
+
+Continue to step4.md.

--- a/solutions/ess-maker-skills/src/skills/provision/step4.md
+++ b/solutions/ess-maker-skills/src/skills/provision/step4.md
@@ -1,0 +1,66 @@
+# Provision Step 4: Validate Readiness
+
+Every **Message** block is the exact text to show the user. Copy it verbatim.
+Do not rephrase, add commentary, or tell the user what tools you are calling.
+
+This step reviews the provision tasks.md checklist to confirm all prior
+steps completed successfully. Each step already validates its own work
+(solutions installed, connections active, refs bound, topic patched),
+so a separate FlightCheck run is not needed here — FlightCheck's
+BAP/PowerApps Admin APIs are unreachable from external networks in preprod
+and would produce only false warnings.
+
+> **Future:** A Dataverse-only provision health check (solutions, workflows,
+> connectionreferences queried directly) can be added in a follow-up PR
+> to provide automated post-provision validation without the BAP dependency.
+
+Read `my/provision/{ENV_NAME}/config.json` for ENV_URL, ENV_NAME, PERSONA.
+
+---
+
+## 4.1 — Skip if already complete
+
+Read `my/provision/{ENV_NAME}/tasks.md`. If "Health check passed" is `- [x]`,
+this step is already done from a previous run. Continue back to SKILL.md
+**Step 6** (summary + mark complete) without doing anything else.
+
+---
+
+## 4.2 — Review checklist
+
+Read `my/provision/{ENV_NAME}/tasks.md`. Every line should be `- [x]`
+except "Health check passed" (which this step will mark).
+
+If any earlier task is still `- [ ]`:
+
+**Message:**
+
+The following provision tasks are not yet complete:
+
+{list unchecked items}
+
+These must be resolved before the environment can be marked ready.
+Would you like to go back and complete them, or mark this provision
+as incomplete and stop here?
+
+**End message.**
+
+If the user wants to go back, return to the appropriate step.
+If the user wants to stop, leave tasks.md as-is and stop.
+
+---
+
+## 4.3 — Mark complete
+
+If all tasks (except "Health check passed") are checked:
+
+Update `my/provision/{ENV_NAME}/tasks.md` — change "Health check passed"
+to `- [x]`.
+
+**Message:**
+
+All provision tasks verified. The environment is ready.
+
+**End message.**
+
+Continue back to SKILL.md Step 6 (summary + mark complete).

--- a/solutions/ess-maker-skills/src/skills/provision/tasks.md
+++ b/solutions/ess-maker-skills/src/skills/provision/tasks.md
@@ -1,0 +1,10 @@
+# Provision Checklist
+
+- [ ] **Environment bound** — Target env URL captured and reachable
+- [ ] **ESS base installed** — ESS HR or ESS IT persona pack installed via `pac application install`
+- [ ] **ISV imported** — Workday extension solution installed via `pac application install`
+- [ ] **Connections active** — Workday OAuthUser + Dataverse OAuth (signed-in user) both connected
+- [ ] **Connection refs bound** — Solution connection references PATCHed to point at the new connections
+- [ ] **Flow runtime connections wired** — ESS HR Workday + WorkdayRESTExecution flows connected via Copilot Studio
+- [ ] **User Context Setup topic configured** — Redirect to WorkdaySystemGetUserContextV2 added
+- [ ] **Health check passed** — All provision tasks verified


### PR DESCRIPTION
 Adds the `/provision` command that automates end-to-end Power Platform
 environment provisioning with ESS base + Workday ISV extension.

 ## What it does
 - Creates or binds a PP environment (PAC CLI with capacity pre-checks)
 - Installs ESS base + Workday ISV via `pac application install`
 - Creates Workday SOAP + Dataverse connections (Connectivity API)
 - Binds connection references to connections (Dataverse PATCH)
 - Enables flows and outputs manual CPS wiring instructions
 - Configures User Context Setup topic redirect
 - Validates readiness via FlightCheck

## Description
Introduces 7 new Python scripts and 6 skill docs that together automate provisioning a Power Platform environment with the ESS agent + Workday ISV. The skill follows the same AI-as-orchestrator pattern used by  `/connect` and `/onboarding` , markdown step files guide the agent, Python scripts handle the API calls. Flow runtime binding requires a manual Copilot Studio step (PVA API needs legacy permissions not available to custom Entra apps). 
**Design is ISV-extensible for ServiceNow/SAP in future PRs.**

## Related issue
Refs #

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing 
functionality to not work as expected)
 - [x] Documentation update
 - [ ] Refactor / cleanup
 
 ## Testing
End-to-end tested against Preprod ring. 
Final run verified:
env creation, ESS + Workday ISV install, connection creation (Workday SOAP + Dataverse), connection ref binding, flow enablement, topic redirect patch and FlightCheck validation, all passing. Manual CPS wiring confirmed functional post-script.
 
 ## Checklist
 - [x] My code follows the existing style
 - [ ] I have added/updated tests where applicable
 - [x] I have updated documentation as needed