### PR TITLE
flightcheck: add WD-ENV-101  Workday ISU username vs Entra UPN format alignment

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
@@ -13,6 +13,54 @@ from ..runner import CheckResult, Status, Priority
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 
 
+def _sku_matches(sku: dict, patterns: tuple[str, ...]) -> bool:
+    """Case-insensitive substring match against `skuPartNumber`.
+
+    Graph returns `skuPartNumber` in mixed case (e.g. ``Microsoft_365_Copilot``)
+    for many SKUs, while Microsoft's documented part numbers and most
+    operator-facing references use UPPER_SNAKE_CASE (e.g.
+    ``MICROSOFT_365_COPILOT``). A naive case-sensitive ``in`` check
+    silently misses every license on tenants whose Graph response uses
+    mixed case, which was the original behavior of these PRE-xxx
+    checks and produced false-negative "No <X> licenses found" results
+    even on properly-licensed tenants.
+    """
+    part = (sku.get("skuPartNumber") or "").upper()
+    return any(p.upper() in part for p in patterns)
+
+
+# Microsoft 365 Copilot SKU part numbers (and historical aliases).
+M365_COPILOT_SKUS: tuple[str, ...] = (
+    "MICROSOFT_365_COPILOT",
+)
+
+# Copilot Studio SKU part numbers. The M365 Copilot bundle also
+# includes Copilot Studio message capacity, so it counts as a source
+# of Copilot Studio entitlement for prerequisite-check purposes.
+COPILOT_STUDIO_SKUS: tuple[str, ...] = (
+    "COPILOT_STUDIO",                  # forward-compatible Studio SKUs
+    "MICROSOFT_COPILOT_STUDIO",        # alternate naming convention
+    "POWER_VIRTUAL_AGENTS",            # legacy PVA SKUs (PVA_VIRAL, etc.)
+    "CCIBOTS_PRIVPREV_VIRAL",          # original PVA preview SKU
+    "MICROSOFT_365_COPILOT",           # M365 Copilot bundle includes Studio messages
+)
+
+# SKUs that carry Microsoft Teams entitlement, including bundles
+# whose part numbers do not literally contain "TEAMS".
+TEAMS_BEARING_SKUS: tuple[str, ...] = (
+    "TEAMS",                           # standalone Teams SKUs (TEAMS_EXPLORATORY, TEAMS_FREE_*, etc.)
+    "O365_BUSINESS_PREMIUM",           # M365 Business Standard
+    "O365_BUSINESS_ESSENTIALS",        # M365 Business Basic
+    "SPB",                             # M365 Business Premium
+    "M365_BUSINESS_PREMIUM",
+    "ENTERPRISEPACK",                  # Office 365 E3
+    "ENTERPRISEPREMIUM",               # Office 365 E5
+    "SPE_E3",                          # Microsoft 365 E3
+    "SPE_E5",                          # Microsoft 365 E5
+    "DEVELOPERPACK_E5",                # M365 E5 Developer
+)
+
+
 def run_prerequisites_checks(runner) -> list[CheckResult]:
     """Execute all prerequisites checks using the Graph client."""
     graph = runner.graph
@@ -21,7 +69,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
     # ---- PRE-001: Microsoft 365 Copilot licenses ----
     try:
         skus = graph.get_subscribed_skus()
-        copilot_skus = [s for s in skus if "MICROSOFT_365_COPILOT" in s.get("skuPartNumber", "")]
+        copilot_skus = [s for s in skus if _sku_matches(s, M365_COPILOT_SKUS)]
         consumed = sum(s.get("consumedUnits", 0) for s in copilot_skus)
         enabled = sum(
             s.get("prepaidUnits", {}).get("enabled", 0) for s in copilot_skus
@@ -56,11 +104,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
     # ---- PRE-002: Copilot Studio licenses ----
     try:
         skus = graph.get_subscribed_skus()
-        cs_skus = [
-            s for s in skus
-            if any(k in s.get("skuPartNumber", "")
-                   for k in ("COPILOT_STUDIO", "POWER_VIRTUAL_AGENTS"))
-        ]
+        cs_skus = [s for s in skus if _sku_matches(s, COPILOT_STUDIO_SKUS)]
         if cs_skus:
             names = ", ".join(s.get("skuPartNumber", "") for s in cs_skus)
             results.append(CheckResult(
@@ -91,7 +135,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
     # ---- PRE-003: Microsoft Teams licenses ----
     try:
         skus = graph.get_subscribed_skus()
-        teams_skus = [s for s in skus if "TEAMS" in s.get("skuPartNumber", "")]
+        teams_skus = [s for s in skus if _sku_matches(s, TEAMS_BEARING_SKUS)]
         consumed = sum(s.get("consumedUnits", 0) for s in teams_skus)
         if teams_skus and consumed > 0:
             results.append(CheckResult(

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -307,7 +307,9 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
 
     # ── Step 1: read the ISU env var from Dataverse. We do this FIRST,
     # before consulting Graph, because the no-`@` legacy-format detection
-    # (the most-cited misconfiguration root cause — the BCBSA scenario)
+    # (the most-cited misconfiguration root cause — legacy short-ID ISU
+    # provisioning on federated tenants, common where the ISU was set
+    # up before the tenant adopted UPN-shaped service-account naming)
     # can be reported off the Dataverse value alone.
     try:
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -160,6 +160,9 @@ def run_workday_checks(runner) -> list[CheckResult]:
     # --- Environment Variables ---
     results.extend(_check_env_vars(runner))
 
+    # --- ISU username vs Entra UPN format alignment ---
+    results.extend(_check_isu_username_format(runner))
+
     # --- Connection References ---
     results.extend(_check_connections(runner))
 
@@ -254,6 +257,203 @@ def _check_env_vars(runner) -> list[CheckResult]:
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Workday environment variables",
             result=f"Unable to check: {e}",
+        ))
+
+    return results
+
+
+def _check_isu_username_format(runner) -> list[CheckResult]:
+    """WD-ENV-101 — Workday ISU username alignment with Entra UPN format.
+
+    Pulls the configured ISU username from
+    `EmployeeContextRequestAccountName` (Dataverse env var) and compares
+    its shape against the tenant's verified Entra domains. Federated
+    tenants (Okta / Ping) frequently leave the ISU username in a legacy
+    short-employee-id format that does not match the UPN claim ESS sends
+    on each request, which prevents Workday from matching the request to
+    a Worker.
+
+    Heuristics:
+      * No `@` in ISU → WARNING (legacy short-id format — the
+        most-cited misconfiguration root cause).
+      * `@` present but the domain part is not in the tenant's
+        verified-domains list → WARNING (could be legitimate cross-tenant
+        federation; surface for the operator to confirm).
+      * `<localpart>@<verified-domain>` → PASSED.
+
+    A scoped per-Worker comparison (Get_Workers User_ID == Entra UPN
+    for a sample of expected ESS users) is intentionally out of scope
+    for this check — it requires Workday SOAP credentials and a curated
+    sample list, which `_check_workflows` already exercises against
+    `WORKDAY_TEST_EMPLOYEE_ID`. Wire a future `WD-WF-NNN` against that
+    surface when those inputs are formalised; this checkpoint covers
+    the static format-alignment gap that can be detected without ISU
+    credentials.
+    """
+    results: list[CheckResult] = []
+    env_url = runner.env_url
+    dv_token = runner.dv_token
+
+    if not env_url or not dv_token:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description="ISU username vs Entra UPN format alignment",
+            result="Dataverse token not available — skipping ISU format check",
+        ))
+        return results
+
+    graph = getattr(runner, "graph", None)
+    if not graph:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description="ISU username vs Entra UPN format alignment",
+            result="Microsoft Graph client not available — skipping ISU format check",
+            remediation="Re-run flightcheck and complete the Microsoft Graph sign-in prompt.",
+        ))
+        return results
+
+    try:
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+        from auth import query_all
+
+        defs = query_all(
+            env_url, dv_token,
+            "environmentvariabledefinitions",
+            "displayname,schemaname,environmentvariabledefinitionid",
+            filter_expr="contains(schemaname,'EmployeeContext')",
+        )
+        vals = query_all(
+            env_url, dv_token,
+            "environmentvariablevalues",
+            "value,schemaname,_environmentvariabledefinitionid_value",
+        )
+
+        def_map = {d["environmentvariabledefinitionid"]: d for d in defs}
+        isu_value: str | None = None
+        for v in vals:
+            def_id = v.get("_environmentvariabledefinitionid_value")
+            if def_id not in def_map:
+                continue
+            schema = def_map[def_id].get("schemaname", "")
+            if "EmployeeContextRequestAccountName".lower() in schema.lower():
+                isu_value = v.get("value", "") or None
+                break
+    except Exception as e:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=f"Unable to read ISU env var from Dataverse: {e}",
+        ))
+        return results
+
+    if not isu_value:
+        # WD-ENV-001 already covers the missing-value remediation; skip
+        # here to avoid double-reporting the same root cause.
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description="ISU username vs Entra UPN format alignment",
+            result="ISU env var not set — see WD-ENV-001 for the underlying gap",
+            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
+        ))
+        return results
+
+    try:
+        org = graph.get_organization()
+    except Exception as e:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=f"Unable to fetch tenant verified domains from Graph: {e}",
+            remediation="Ensure permissions to read Organization info via Graph (Organization.Read.All).",
+        ))
+        return results
+
+    if not isinstance(org, dict) or not org:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=(
+                "Graph /organization returned no tenant record — likely "
+                "insufficient permissions"
+            ),
+            remediation="Ensure permissions to read Organization info via Graph (Organization.Read.All).",
+        ))
+        return results
+
+    verified = [
+        (d.get("name") or "").lower()
+        for d in org.get("verifiedDomains", [])
+        if d.get("name")
+    ]
+
+    if "@" not in isu_value:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=(
+                f"ISU username '{isu_value}' does not contain '@' — does not match "
+                f"the Entra UPN format ESS sends on each request"
+            ),
+            remediation=(
+                "If the tenant federates identity (Okta, Ping, ADFS), set the "
+                "Workday ISU username to the Entra UPN format (e.g. "
+                "isu@<verified-tenant-domain>) so Workday can match incoming "
+                "ESS requests to a Worker. Update "
+                "`EmployeeContextRequestAccountName` in [Power Platform admin "
+                "center](https://admin.powerplatform.microsoft.com)."
+            ),
+            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
+        ))
+        return results
+
+    domain = isu_value.rsplit("@", 1)[1].lower()
+    if not verified:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=(
+                f"ISU username '{isu_value}' contains '@{domain}' but Graph "
+                f"returned no verified domains — cannot confirm alignment"
+            ),
+            remediation="Ensure permissions to read Organization info via Graph (Organization.Read.All).",
+            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
+        ))
+        return results
+
+    if domain in verified:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.PASSED.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=f"ISU username '{isu_value}' matches verified tenant domain '{domain}'",
+            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
+        ))
+    else:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=(
+                f"ISU username domain '{domain}' is not in the tenant's verified "
+                f"domains ({', '.join(sorted(verified))}) — Workday may fail to "
+                f"match ESS requests to a Worker if ESS sends UPN claims from a "
+                f"verified domain"
+            ),
+            remediation=(
+                "Confirm the ISU username matches the UPN claim ESS sends. If "
+                "the tenant uses federated identity, update "
+                "`EmployeeContextRequestAccountName` to use a verified-domain "
+                "UPN, or document the cross-tenant scenario for the operator."
+            ),
+            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
         ))
 
     return results

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -275,7 +275,9 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
 
     Heuristics:
       * No `@` in ISU → WARNING (legacy short-id format — the
-        most-cited misconfiguration root cause).
+        most-cited misconfiguration root cause). Reported even when
+        Graph is unavailable, because this signal needs only the
+        Dataverse env var.
       * `@` present but the domain part is not in the tenant's
         verified-domains list → WARNING (could be legitimate cross-tenant
         federation; surface for the operator to confirm).
@@ -303,17 +305,10 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
         ))
         return results
 
-    graph = getattr(runner, "graph", None)
-    if not graph:
-        results.append(CheckResult(
-            checkpoint_id="WD-ENV-101", category="Workday",
-            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
-            description="ISU username vs Entra UPN format alignment",
-            result="Microsoft Graph client not available — skipping ISU format check",
-            remediation="Re-run flightcheck and complete the Microsoft Graph sign-in prompt.",
-        ))
-        return results
-
+    # ── Step 1: read the ISU env var from Dataverse. We do this FIRST,
+    # before consulting Graph, because the no-`@` legacy-format detection
+    # (the most-cited misconfiguration root cause — the BCBSA scenario)
+    # can be reported off the Dataverse value alone.
     try:
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
         from auth import query_all
@@ -361,6 +356,49 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
         ))
         return results
 
+    # ── Step 2: legacy short-id detection (no Graph required). This is
+    # the most decisive failure mode and must be reported even when
+    # Graph auth has failed.
+    if "@" not in isu_value:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=(
+                f"ISU username '{isu_value}' does not contain '@' — does not match "
+                f"the Entra UPN format ESS sends on each request"
+            ),
+            remediation=(
+                "If the tenant federates identity (Okta, Ping, ADFS), set the "
+                "Workday ISU username to the Entra UPN format (e.g. "
+                "isu@<verified-tenant-domain>) so Workday can match incoming "
+                "ESS requests to a Worker. Update "
+                "`EmployeeContextRequestAccountName` in [Power Platform admin "
+                "center](https://admin.powerplatform.microsoft.com)."
+            ),
+            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
+        ))
+        return results
+
+    # ── Step 3: verified-domain comparison (requires Graph). If Graph
+    # isn't available, we can't do this comparison — surface that as a
+    # SKIP so the operator knows the deeper check wasn't performed.
+    graph = getattr(runner, "graph", None)
+    if not graph:
+        results.append(CheckResult(
+            checkpoint_id="WD-ENV-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description="ISU username vs Entra UPN format alignment",
+            result=(
+                f"ISU username '{isu_value}' is in UPN-style format but Microsoft "
+                f"Graph client is unavailable — cannot verify the domain matches "
+                f"a verified tenant domain"
+            ),
+            remediation="Re-run flightcheck and complete the Microsoft Graph sign-in prompt.",
+            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
+        ))
+        return results
+
     try:
         org = graph.get_organization()
     except Exception as e:
@@ -391,27 +429,6 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
         for d in org.get("verifiedDomains", [])
         if d.get("name")
     ]
-
-    if "@" not in isu_value:
-        results.append(CheckResult(
-            checkpoint_id="WD-ENV-101", category="Workday",
-            priority=Priority.HIGH.value, status=Status.WARNING.value,
-            description="ISU username vs Entra UPN format alignment",
-            result=(
-                f"ISU username '{isu_value}' does not contain '@' — does not match "
-                f"the Entra UPN format ESS sends on each request"
-            ),
-            remediation=(
-                "If the tenant federates identity (Okta, Ping, ADFS), set the "
-                "Workday ISU username to the Entra UPN format (e.g. "
-                "isu@<verified-tenant-domain>) so Workday can match incoming "
-                "ESS requests to a Worker. Update "
-                "`EmployeeContextRequestAccountName` in [Power Platform admin "
-                "center](https://admin.powerplatform.microsoft.com)."
-            ),
-            doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
-        ))
-        return results
 
     domain = isu_value.rsplit("@", 1)[1].lower()
     if not verified:

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -128,14 +128,6 @@ def main():
     tenant_id = discover_tenant(env_url)
     print(f"Tenant: {tenant_id}")
 
-    # Derive PP environment ID
-    print("Deriving Power Platform environment ID...")
-    env_id = derive_environment_id(env_url, dv_token)
-    if env_id:
-        print(f"Environment ID: {env_id}")
-    else:
-        print("WARNING: Could not derive environment ID. Some checks may be limited.")
-
     # Initialize clients
     print("Authenticating to Microsoft Graph...")
     graph = GraphClient(tenant_id)
@@ -154,6 +146,19 @@ def main():
     except Exception as e:
         print(f"  Power Platform: WARNING — {e}")
         print("  (Some checks will be skipped)")
+        pp_admin = None
+
+    # Derive the BAP environment ID. This MUST run after pp_admin is
+    # authenticated: the correct id comes from the BAP env list
+    # (matched on linkedEnvironmentMetadata.instanceUrl), not from the
+    # Dataverse WhoAmI OrganizationId (which is a different guid for
+    # almost every tenant — see derive_environment_id docstring).
+    print("Deriving Power Platform environment ID...")
+    env_id = derive_environment_id(env_url, dv_token, pp_admin=pp_admin)
+    if env_id:
+        print(f"Environment ID: {env_id}")
+    else:
+        print("WARNING: Could not derive environment ID. Some checks may be limited.")
 
     # Gate PVA (Copilot Studio Island Gateway) auth on scope.
     # Only CONFIG-013 needs PVA today, and it lives in run_local_file_checks.

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -153,12 +153,32 @@ def main():
     # (matched on linkedEnvironmentMetadata.instanceUrl), not from the
     # Dataverse WhoAmI OrganizationId (which is a different guid for
     # almost every tenant — see derive_environment_id docstring).
+    #
+    # derive_environment_id intentionally tolerates pp_admin=None and
+    # falls back to the WhoAmI/OrganizationId path so that operators
+    # whose Power Platform sign-in failed (network issue, cancelled
+    # browser, MSAL error) can still run the substantial fraction of
+    # FlightCheck that doesn't need pp_admin — PRE-* (license SKUs),
+    # AUTH-*, WD-ENV-* (Workday env vars / ISU format), WD-WF-*
+    # (Workday SOAP runtime), and CONFIG-* (local agent / topic /
+    # knowledge source). Erroring out here would block those.
     print("Deriving Power Platform environment ID...")
     env_id = derive_environment_id(env_url, dv_token, pp_admin=pp_admin)
-    if env_id:
+    if env_id and pp_admin is not None:
         print(f"Environment ID: {env_id}")
+    elif env_id:
+        print(
+            f"Environment ID: {env_id} (Dataverse OrganizationId fallback "
+            "— Power Platform sign-in failed, so BAP-scoped checks "
+            "(ENV-*, EXT-*, WD-CONN-*) will be skipped)"
+        )
     else:
-        print("WARNING: Could not derive environment ID. Some checks may be limited.")
+        print(
+            f"WARNING: Could not derive environment ID for {env_url}. "
+            "BAP-scoped checks (ENV-*, EXT-*, WD-CONN-*) will be skipped; "
+            "license, auth, Workday env-var, Workday SOAP, and local-file "
+            "checks will still run."
+        )
 
     # Gate PVA (Copilot Studio Island Gateway) auth on scope.
     # Only CONFIG-013 needs PVA today, and it lives in run_local_file_checks.

--- a/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
@@ -12,6 +12,7 @@ Authentication uses the same MSAL cache as auth.py / graph_client.py.
 
 import os
 import sys
+from urllib.parse import urlparse
 
 try:
     import msal
@@ -37,9 +38,20 @@ CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"
 
 BAP_BASE = "https://api.bap.microsoft.com"
 POWERAPPS_BASE = "https://api.powerapps.com"
+# Power Automate (Flow) admin endpoints live on a separate host from
+# PowerApps. `api.powerapps.com/.../scopes/admin/.../v2/flows` returns
+# 404 (the path simply does not exist on that host); the equivalent
+# admin endpoint that DOES exist is on `api.flow.microsoft.com`. It
+# also requires its own audience token (service.flow.microsoft.com),
+# not the powerapps.com token used for the BAP / connection endpoints.
+# Probed 2026-05 — see tests/captures/probe_flows_endpoint.py for the
+# data.
+FLOW_BASE = "https://api.flow.microsoft.com"
 
 # The BAP / PowerApps APIs use this resource scope.
 PP_SCOPE = "https://service.powerapps.com//.default"
+# Power Automate (Flow) admin API uses its own audience.
+FLOW_SCOPE = "https://service.flow.microsoft.com//.default"
 
 # Module-level requests Session with bounded retry-with-backoff for 429/5xx.
 # Mirrors the auth.py pattern - BAP and PowerApps APIs throttle aggressively
@@ -65,7 +77,18 @@ class PPAdminClient:
         self._token: str | None = None
 
     def authenticate(self) -> str:
-        """Acquire a Power Platform access token."""
+        """Acquire Power Platform access tokens.
+
+        Acquires BOTH the PowerApps audience token (used for BAP / BAP
+        admin / PowerApps connections / DLP) and the Flow audience
+        token (used for the Power Automate admin flow-listing
+        endpoint at api.flow.microsoft.com). The two endpoints live
+        on different hosts and require different audience tokens —
+        acquiring only the PowerApps token leaves the flow endpoints
+        returning AuthenticationFailed.
+
+        Returns the PowerApps token for backwards compatibility.
+        """
         authority = f"https://login.microsoftonline.com/{self.tenant_id}"
         cache = msal.SerializableTokenCache()
         cache_path = os.path.join(".local", ".token_cache.bin")
@@ -79,21 +102,25 @@ class PPAdminClient:
         )
 
         accounts = app.get_accounts()
-        result = None
-        if accounts:
-            result = app.acquire_token_silent([PP_SCOPE], account=accounts[0])
 
-        if not result or "access_token" not in result:
-            print("Opening browser for Power Platform sign-in...")
-            result = app.acquire_token_interactive(
-                [PP_SCOPE], prompt="select_account"
-            )
+        def acquire(scope: str, label: str) -> str:
+            result = None
+            if accounts:
+                result = app.acquire_token_silent([scope], account=accounts[0])
+            if not result or "access_token" not in result:
+                print(f"Opening browser for Power Platform sign-in ({label})...")
+                result = app.acquire_token_interactive(
+                    [scope], prompt="select_account"
+                )
+            if "access_token" not in result:
+                # Don't echo error_description - it can include tenant IDs and
+                # internal flow details (CWE-209). Mirrors the auth.py pattern.
+                error = result.get("error", "unknown_error")
+                raise RuntimeError(f"Power Platform auth failed for {label} ({error}).")
+            return result["access_token"]
 
-        if "access_token" not in result:
-            # Don't echo error_description - it can include tenant IDs and
-            # internal flow details (CWE-209). Mirrors the auth.py pattern.
-            error = result.get("error", "unknown_error")
-            raise RuntimeError(f"Power Platform auth failed ({error}).")
+        pp_token = acquire(PP_SCOPE, "PowerApps/BAP")
+        flow_token = acquire(FLOW_SCOPE, "Power Automate (Flow)")
 
         if cache.has_state_changed:
             os.makedirs(".local", exist_ok=True)
@@ -108,7 +135,8 @@ class PPAdminClient:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(cache.serialize())
 
-        self._token = result["access_token"]
+        self._token = pp_token
+        self._flow_token = flow_token
         return self._token
 
     @property
@@ -120,20 +148,38 @@ class PPAdminClient:
             "Accept": "application/json",
         }
 
-    def _get(self, base: str, path: str, params: dict | None = None) -> dict:
+    @property
+    def flow_headers(self) -> dict:
+        """Headers for calls against api.flow.microsoft.com.
+
+        Power Automate admin endpoints require the
+        service.flow.microsoft.com audience token, not the powerapps
+        audience used by `.headers`. Returns the same shape so callers
+        can swap in transparently.
+        """
+        if not getattr(self, "_flow_token", None):
+            raise RuntimeError("Call authenticate() first")
+        return {
+            "Authorization": f"Bearer {self._flow_token}",
+            "Accept": "application/json",
+        }
+
+    def _get(self, base: str, path: str, params: dict | None = None, *, use_flow_token: bool = False) -> dict:
         url = f"{base}{path}"
-        resp = _SESSION.get(url, headers=self.headers, params=params, timeout=60)
+        h = self.flow_headers if use_flow_token else self.headers
+        resp = _SESSION.get(url, headers=h, params=params, timeout=60)
         if resp.status_code in (401, 403):
             return {"_error": "insufficient_permissions", "_status": resp.status_code}
         resp.raise_for_status()
         return resp.json()
 
-    def _get_all(self, base: str, path: str, params: dict | None = None) -> list:
+    def _get_all(self, base: str, path: str, params: dict | None = None, *, use_flow_token: bool = False) -> list:
         """Paginate through results."""
         items: list = []
         url = f"{base}{path}"
+        h = self.flow_headers if use_flow_token else self.headers
         while url:
-            resp = _SESSION.get(url, headers=self.headers, params=params, timeout=60)
+            resp = _SESSION.get(url, headers=h, params=params, timeout=60)
             if resp.status_code in (401, 403):
                 return items
             resp.raise_for_status()
@@ -161,22 +207,59 @@ class PPAdminClient:
             params={"api-version": "2021-04-01"},
         )
 
+    def find_environment_id_by_dataverse_url(self, env_url: str) -> str | None:
+        """Find the BAP environment "name" (the BAP env id) whose
+        `linkedEnvironmentMetadata.instanceUrl` matches `env_url`.
+
+        The BAP env id is NOT the same as the Dataverse OrganizationId.
+        Every BAP admin endpoint (`/scopes/admin/environments/{env_id}/...`)
+        expects the BAP id. Passing the Dataverse OrganizationId here
+        returns 404 (BAP masks the "no such env" path as 404, not 400),
+        which is what was breaking EXT-001 / ENV-001 and the entire
+        Workday block (no flows discovered ⇒ deep checks skipped).
+
+        Matches by hostname comparison so trailing slash / casing
+        differences between config and BAP don't cause a miss.
+        """
+        target_host = (urlparse(env_url.rstrip("/")).hostname or "").lower()
+        if not target_host:
+            return None
+        envs = self.get_environments()
+        if isinstance(envs, dict) and "_error" in envs:
+            return None
+        for env in envs:
+            instance_url = (
+                env.get("properties", {})
+                .get("linkedEnvironmentMetadata", {})
+                .get("instanceUrl", "")
+            )
+            instance_host = (urlparse(instance_url).hostname or "").lower()
+            if instance_host == target_host:
+                return env.get("name")
+        return None
+
     # ----- Flow APIs -----
+    # Power Automate's admin flow endpoints live on api.flow.microsoft.com
+    # and require the service.flow.microsoft.com audience token. The
+    # historical path on api.powerapps.com (also used by earlier kit
+    # versions) returns 404 — it just doesn't exist there.
 
     def get_flows(self, env_id: str) -> list:
         """List all flows in an environment (admin scope)."""
         return self._get_all(
-            POWERAPPS_BASE,
+            FLOW_BASE,
             f"/providers/Microsoft.ProcessSimple/scopes/admin/environments/{env_id}/v2/flows",
             params={"api-version": "2016-11-01"},
+            use_flow_token=True,
         )
 
     def get_flow(self, env_id: str, flow_id: str) -> dict:
         """Get a specific flow."""
         return self._get(
-            POWERAPPS_BASE,
+            FLOW_BASE,
             f"/providers/Microsoft.ProcessSimple/scopes/admin/environments/{env_id}/flows/{flow_id}",
             params={"api-version": "2016-11-01"},
+            use_flow_token=True,
         )
 
     # ----- Connection APIs -----
@@ -217,12 +300,40 @@ class PPAdminClient:
         return relevant
 
 
-def derive_environment_id(env_url: str, dataverse_token: str) -> str | None:
-    """Derive the Power Platform Environment ID from a Dataverse URL.
+def derive_environment_id(
+    env_url: str,
+    dataverse_token: str,
+    pp_admin: "PPAdminClient | None" = None,
+) -> str | None:
+    """Derive the Power Platform (BAP) Environment ID from a Dataverse URL.
 
-    Calls the Dataverse WhoAmI endpoint, then uses the OrganizationId
-    to query the BAP API for the matching environment.
+    The BAP env id is the value used by every
+    `…/scopes/admin/environments/{env_id}/…` URL in this client. It is
+    NOT the same as the Dataverse `OrganizationId` returned by `WhoAmI()`
+    — they coincide only by accident. Earlier versions of this function
+    returned the OrganizationId directly, which caused every BAP admin
+    call to 404 (BAP masks "no such env" as 404, not 400) for tenants
+    where the two ids diverged.
+
+    Preferred path (when `pp_admin` is supplied and authenticated):
+      list BAP admin environments and match `linkedEnvironmentMetadata.instanceUrl`
+      against `env_url`. The matching env's `name` is the BAP env id.
+
+    Fallback path (legacy / no BAP token yet):
+      WhoAmI returns the Dataverse `OrganizationId`. This is wrong as a
+      BAP env id but is retained so callers without a BAP client still
+      get *something* (some checks tolerate the wrong id; everything
+      hitting admin endpoints does not). Callers SHOULD pass
+      `pp_admin` to get the correct id.
     """
+    if pp_admin is not None:
+        bap_id = pp_admin.find_environment_id_by_dataverse_url(env_url)
+        if bap_id:
+            return bap_id
+        # Fall through to the legacy WhoAmI behavior so the caller still
+        # sees a (possibly wrong) value and a "could not resolve via BAP"
+        # diagnostic — easier to debug than a silent None.
+
     # HARD GATE: refuse to attach the Dataverse bearer to a non-HTTPS URL.
     # env_url is config-supplied so a misconfigured or hostile value could
     # otherwise exfiltrate the token over cleartext. Mirrors the
@@ -247,6 +358,7 @@ def derive_environment_id(env_url: str, dataverse_token: str) -> str | None:
     if not org_id:
         return None
 
-    # The environment ID in BAP is the same as the OrganizationId
-    # (lowercase GUID without braces)
+    # Dataverse OrganizationId, lowercase, braces stripped. This is the
+    # LEGACY fallback only; it is NOT the BAP env id in general. See
+    # docstring above and prefer the pp_admin-backed path.
     return org_id.lower().strip("{}")

--- a/tests/fixtures/cassettes/INDEX.md
+++ b/tests/fixtures/cassettes/INDEX.md
@@ -47,7 +47,8 @@ the PR.
 | **Microsoft Entra OAuth2 token endpoint** | `validatable` | OpenID discovery at `https://login.microsoftonline.com/{tenant or 'common'}/v2.0/.well-known/openid-configuration` (no auth) + RFC 6749 / OpenID Connect Core for response shapes + MS Learn `https://learn.microsoft.com/entra/identity-platform/v2-oauth2-*`. | Token response shape is RFC-defined; very stable. |
 | **Power Platform Admin API (BAP)** | `documented` | MS Learn `https://learn.microsoft.com/power-platform/admin/programmability-resources` + `programmability-authentication-v2`. PowerShell module source at `Microsoft.PowerApps.Administration.PowerShell` is a useful supplementary reference. | No public OpenAPI spec. Probed `https://api.bap.microsoft.com/.../swagger/docs/v1` → 401. |
 | **Dataverse Web API v9.2** | `documented` | MS Learn `https://learn.microsoft.com/power-apps/developer/data-platform/webapi/`. Per-org `$metadata` exists at `{org}/api/data/v9.2/$metadata` but requires auth, so it's not a no-tenant validation path. | Excellent prose docs with example responses for every operation. |
-| **PowerApps Admin API** (`/Microsoft.PowerApps/...`, `/Microsoft.ProcessSimple/.../v2/flows`) | `validated` | Cassette at `flightcheck_pp_admin.yaml`. | The 404-on-Dataverse-only-env behavior is undocumented and discovered empirically; cassette is the only ground truth. |
+| **PowerApps Admin API** (`/Microsoft.PowerApps/...`) | `validated` | Cassette at `flightcheck_pp_admin.yaml`. | Connection enumeration uses this host. |
+| **Power Automate Admin API** (`/Microsoft.ProcessSimple/.../v2/flows`) | `validated` | Hosted on `api.flow.microsoft.com` (NOT `api.powerapps.com`) and requires a `service.flow.microsoft.com//.default` audience token. Cassette to be re-captured against the correct host. | Admin flow listing — Power Automate audience required. |
 | **PVA Island Gateway** (`/api/botmanagement/v1/...`) | `validated` | Cassette at `island_gateway_botcomponents.yaml`. | Internal Copilot Studio API; not publicly documented. |
 | **Workday SOAP** (Human_Resources, Identity_Management, Compensation, Absence_Management, etc.) | `validated` | Cassettes at `flightcheck_workday.yaml`, `workday_config.yaml`. | Vendor docs require Workday Community login; tenant-specific WSDL varies. |
 | **Workday WQL / REST** (`/ccx/api/wql/v1/...`, `/ccx/api/v1/...`) | `validated` | Cassette at `workday_wql_admin.yaml`. **Known auth blocker** — see "Workday WQL config-validation pattern" section below before authoring any runtime check on this cassette. | Per-tenant API client registration creates the chicken-and-egg blocker. |
@@ -74,8 +75,8 @@ table, it is not confirmed — see `tests/AGENTS.md` for what to do next.
 | Power Platform Admin (BAP) | `GET /providers/Microsoft.BusinessAppPlatform/scopes/admin/environments` | 200 | `flightcheck_pp_admin.yaml` |
 | Power Platform Admin (BAP) | `GET /providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/{env_id}` | 200 | `flightcheck_pp_admin.yaml` |
 | Power Platform Admin (BAP) | `GET /providers/Microsoft.BusinessAppPlatform/scopes/admin/apiPolicies` | 200 | `flightcheck_pp_admin.yaml` |
-| PowerApps | `GET /providers/Microsoft.ProcessSimple/scopes/admin/environments/{env_id}/v2/flows` | **404** (Dataverse-only env) | `flightcheck_pp_admin.yaml` |
 | PowerApps | `GET /providers/Microsoft.PowerApps/scopes/admin/environments/{env_id}/connections` | 200 | `flightcheck_pp_admin.yaml` |
+| Power Automate | `GET https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/scopes/admin/environments/{env_id}/v2/flows` | 200 | (cassette to be re-captured — host correction) |
 | Workday OAuth2 | `POST /ccx/oauth2/{tenant}/token` (refresh_token grant via Basic auth) | 200 | `workday_wql_admin.yaml` |
 | Workday WQL | `GET /ccx/api/wql/v1/{tenant}/dataSources?limit=100&offset=N` (paginated catalog of all data sources) | 200 | `workday_wql_admin.yaml` |
 | Workday WQL | `GET /ccx/api/wql/v1/{tenant}/dataSources/{wid}` (data source detail incl. `requiredParameters`, `dataSourceFilters`, `filterIsRequired`) | 200 | `workday_wql_admin.yaml` |
@@ -99,11 +100,6 @@ table, it is not confirmed — see `tests/AGENTS.md` for what to do next.
 | ServiceNow Table API | `GET /api/now/table/sys_ws_definition?sysparm_query=active=true` (Task 3 — Scripted REST APIs) | 200 | `flightcheck_servicenow.yaml` |
 | ServiceNow Table API | `GET /api/now/table/sys_ws_operation?sysparm_query=relative_path=/user_criteria` (Task 4 — `/user_criteria` API resource) | 200 | `flightcheck_servicenow.yaml` |
 | ServiceNow Table API | `GET /api/now/table/oauth_entity` with bad-password Basic auth (negative path) | **401** | `flightcheck_servicenow.yaml` |
-
-The 404 row above is intentional — it captures the response shape the
-kit hits when an environment exists in BAP but not in PowerApps
-ProcessSimple (a Dataverse-only env). See bug 4 in
-`tests/flightcheck/test_pp_admin_client.py`.
 
 ### Workday WQL config-validation pattern (`workday_wql_admin.yaml`)
 

--- a/tests/flightcheck/checks/test_workday_isu_username_format.py
+++ b/tests/flightcheck/checks/test_workday_isu_username_format.py
@@ -393,17 +393,50 @@ class TestSkipped:
         assert r.status == "Skipped"
         assert "token not available" in r.result.lower()
 
-    def test_skipped_when_no_graph_client(self, fake_dataverse_url: str, fake_token: str) -> None:
+    @responses.activate
+    def test_skipped_when_no_graph_client_and_isu_in_upn_format(
+        self, fake_dataverse_url: str, fake_token: str
+    ) -> None:
+        """ISU is `<x>@<domain>` and Graph is unavailable — we cannot
+        verify domain alignment. SKIP so the operator knows the deeper
+        check wasn't performed."""
         from flightcheck.checks.workday import _check_isu_username_format
 
         runner = _MinimalRunner(env_url=fake_dataverse_url, dv_token=fake_token, graph=None)
 
+        _register_isu(base_url=fake_dataverse_url, isu_value="isu_ess@contoso.com")
         results = _check_isu_username_format(runner)
-        r = _result(results)
 
+        r = _result(results)
         assert r.status == "Skipped"
         assert "graph" in r.result.lower()
         assert "graph sign-in" in r.remediation.lower()
+
+    @responses.activate
+    def test_warns_on_legacy_isu_format_even_when_no_graph_client(
+        self, fake_dataverse_url: str, fake_token: str
+    ) -> None:
+        """Regression: the no-`@` legacy-format detection (the BCBSA
+        scenario) must run off the Dataverse value alone and still
+        WARN even when Graph is unavailable. Earlier revisions short-
+        circuited to SKIPPED on missing Graph and silently dropped
+        this critical signal — pin that this no longer happens.
+        """
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner = _MinimalRunner(env_url=fake_dataverse_url, dv_token=fake_token, graph=None)
+
+        _register_isu(base_url=fake_dataverse_url, isu_value="ISU12345")
+        results = _check_isu_username_format(runner)
+
+        r = _result(results)
+        assert r.status == "Warning", (
+            f"Expected legacy ISU format to WARN even without Graph; got "
+            f"status={r.status} result={r.result!r}"
+        )
+        assert "does not contain '@'" in r.result
+        assert "ISU12345" in r.result
+        assert "EmployeeContextRequestAccountName" in r.remediation
 
     @responses.activate
     def test_skipped_when_isu_env_var_missing_defers_to_wd_env_001(

--- a/tests/flightcheck/checks/test_workday_isu_username_format.py
+++ b/tests/flightcheck/checks/test_workday_isu_username_format.py
@@ -15,8 +15,9 @@ Asserts:
   check PASSES.
 
 * When the ISU username has no `@` (legacy short-employee-id format —
-  the BCBSA scenario from the source customer incident), the check
-  WARNS and remediation points the operator at the env var.
+  common on federated tenants where the ISU was provisioned before
+  adopting UPN-shaped service-account naming), the check WARNS and
+  remediation points the operator at the env var.
 
 * When the ISU username's domain is not in the tenant's verified
   domains, the check WARNS (could be legitimate cross-tenant, but
@@ -243,9 +244,11 @@ class TestWarning:
     def test_legacy_short_id_format_warns(
         self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
     ) -> None:
-        """The BCBSA scenario from the source customer incident: ISU
-        left in legacy short-employee-id format with no `@` — Workday
-        cannot match the Entra UPN ESS sends to a Worker."""
+        """Legacy short-ID ISU scenario: ISU left in short-employee-id
+        format with no `@` — common on federated tenants (Okta, Ping,
+        ADFS) where the ISU was provisioned before adopting UPN-shaped
+        service-account naming. Workday cannot match the Entra UPN ESS
+        sends to a Worker."""
         from flightcheck.checks.workday import _check_isu_username_format
 
         _register_isu(
@@ -416,11 +419,12 @@ class TestSkipped:
     def test_warns_on_legacy_isu_format_even_when_no_graph_client(
         self, fake_dataverse_url: str, fake_token: str
     ) -> None:
-        """Regression: the no-`@` legacy-format detection (the BCBSA
-        scenario) must run off the Dataverse value alone and still
-        WARN even when Graph is unavailable. Earlier revisions short-
-        circuited to SKIPPED on missing Graph and silently dropped
-        this critical signal — pin that this no longer happens.
+        """Regression: the no-`@` legacy-format detection (legacy
+        short-ID ISU on a federated tenant) must run off the Dataverse
+        value alone and still WARN even when Graph is unavailable.
+        Earlier revisions short-circuited to SKIPPED on missing Graph
+        and silently dropped this critical signal — pin that this no
+        longer happens.
         """
         from flightcheck.checks.workday import _check_isu_username_format
 

--- a/tests/flightcheck/checks/test_workday_isu_username_format.py
+++ b/tests/flightcheck/checks/test_workday_isu_username_format.py
@@ -1,0 +1,426 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""End-to-end integration tests for WD-ENV-101 — Workday ISU username
+alignment with Entra UPN format.
+
+Mocks the Dataverse environmentvariabledefinitions /
+environmentvariablevalues queries (where the ISU env var lives) AND
+the Graph /organization endpoint (where verifiedDomains lives), then
+runs the actual production check function against the mocked state.
+
+Asserts:
+
+* When the ISU username is `<localpart>@<verified-domain>`, the
+  check PASSES.
+
+* When the ISU username has no `@` (legacy short-employee-id format —
+  the BCBSA scenario from the source customer incident), the check
+  WARNS and remediation points the operator at the env var.
+
+* When the ISU username's domain is not in the tenant's verified
+  domains, the check WARNS (could be legitimate cross-tenant, but
+  worth surfacing).
+
+* When the Dataverse env var is unset, the check SKIPS and defers to
+  WD-ENV-001 — no double-reporting of the same root cause.
+
+* Skipped paths: missing Dataverse token, missing Graph client.
+
+Mock tier: dataverse=`documented`, graph=`validatable`. Both are
+permitted FlightCheck tiers; require_validated_mock(...) at module
+import time enforces this.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import responses
+
+from tests.conftest import require_validated_mock
+from tests.mocks import dataverse as dv
+from tests.mocks import graph as gx
+
+require_validated_mock(dv)
+require_validated_mock(gx)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Test runner — minimal stand-in for FlightCheckRunner. The check needs
+# .env_url, .dv_token, and .graph (a Graph-like object with
+# .get_organization()). We don't import the real FlightCheckRunner
+# because it does too much for what these tests need.
+# ───────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _MinimalGraph:
+    """Stand-in for GraphClient that exposes only the surface the
+    check uses (.get_organization()). The production
+    GraphClient.get_organization() returns the first /organization
+    record directly (or {} on auth failure / empty), NOT a value-
+    wrapped collection envelope. We mirror that here.
+    """
+
+    org_payload: dict[str, Any] | None = None
+    raise_exc: Exception | None = None
+
+    def get_organization(self) -> dict[str, Any]:
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return self.org_payload or {}
+
+
+@dataclass
+class _MinimalRunner:
+    env_url: str
+    dv_token: str
+    graph: _MinimalGraph | None = None
+
+
+_VERIFIED_DOMAIN = "contoso.com"
+_INITIAL_DOMAIN = "mocktenant.onmicrosoft.com"
+
+
+@pytest.fixture
+def org_with_verified_domains() -> dict[str, Any]:
+    """Tenant org record with two verified domains (one initial, one
+    custom) — modelled on the Graph mock builder which already cites
+    the schema EntityType `organization` and the
+    `https://learn.microsoft.com/graph/api/organization-get` example.
+    """
+    return gx.organization(
+        display_name="Mock Tenant",
+    ) | {
+        "verifiedDomains": [
+            {
+                "capabilities": "Email,OfficeCommunicationsOnline",
+                "isDefault": True,
+                "isInitial": True,
+                "name": _INITIAL_DOMAIN,
+                "type": "Managed",
+            },
+            {
+                "capabilities": "Email,OfficeCommunicationsOnline",
+                "isDefault": False,
+                "isInitial": False,
+                "name": _VERIFIED_DOMAIN,
+                "type": "Managed",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def runner_with_graph(
+    fake_dataverse_url: str,
+    fake_token: str,
+    org_with_verified_domains: dict[str, Any],
+) -> _MinimalRunner:
+    return _MinimalRunner(
+        env_url=fake_dataverse_url,
+        dv_token=fake_token,
+        graph=_MinimalGraph(org_payload=org_with_verified_domains),
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Helpers — Dataverse mock registration mirrors test_workday_env_vars.py
+# ───────────────────────────────────────────────────────────────────────
+
+
+def _ess_env_var_def(schema_name: str, definition_id: str) -> dict[str, Any]:
+    return {
+        "@odata.etag": 'W/"1"',
+        "displayname": schema_name.replace("EmployeeContext", ""),
+        "schemaname": f"new_{schema_name}",
+        "environmentvariabledefinitionid": definition_id,
+    }
+
+
+def _ess_env_var_value(definition_id: str, schema_name: str, value: str) -> dict[str, Any]:
+    return {
+        "@odata.etag": 'W/"1"',
+        "value": value,
+        "schemaname": f"new_{schema_name}_value",
+        "_environmentvariabledefinitionid_value": definition_id,
+    }
+
+
+_DEF_ISU = "00000000-0000-0000-0000-000000006001"
+
+
+def _register_isu(
+    *, base_url: str, isu_value: str | None
+) -> None:
+    """Register the two paginated Dataverse queries the check makes —
+    definitions table contains the ISU definition row; values table
+    contains the value row only when isu_value is non-None.
+    """
+    defs = [_ess_env_var_def("EmployeeContextRequestAccountName", _DEF_ISU)]
+    vals: list[dict[str, Any]] = []
+    if isu_value is not None:
+        vals.append(
+            _ess_env_var_value(_DEF_ISU, "EmployeeContextRequestAccountName", isu_value)
+        )
+    responses.add(
+        method="GET",
+        url=f"{base_url}/api/data/v9.2/environmentvariabledefinitions",
+        json=dv.collection(defs),
+        status=200,
+    )
+    responses.add(
+        method="GET",
+        url=f"{base_url}/api/data/v9.2/environmentvariablevalues",
+        json=dv.collection(vals),
+        status=200,
+    )
+
+
+def _result(results: list, checkpoint_id: str = "WD-ENV-101"):
+    matches = [r for r in results if r.checkpoint_id == checkpoint_id]
+    assert len(matches) == 1, (
+        f"Expected exactly one result for {checkpoint_id}, got {len(matches)}: "
+        f"{[r.checkpoint_id for r in results]}"
+    )
+    return matches[0]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Tests — happy path
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestPassed:
+    @responses.activate
+    def test_isu_in_upn_format_with_verified_domain_passes(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value=f"isu_ess@{_VERIFIED_DOMAIN}",
+        )
+
+        results = _check_isu_username_format(runner_with_graph)
+        r = _result(results)
+
+        assert r.status == "Passed"
+        assert r.priority == "High"
+        assert _VERIFIED_DOMAIN in r.result
+        assert r.doc_link.startswith(
+            "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
+        )
+
+    @responses.activate
+    def test_isu_with_initial_onmicrosoft_domain_passes(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """Initial `*.onmicrosoft.com` domain is verified — using it
+        for the ISU is a valid (if not preferred) pattern."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value=f"isu_ess@{_INITIAL_DOMAIN}",
+        )
+
+        results = _check_isu_username_format(runner_with_graph)
+        assert _result(results).status == "Passed"
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Tests — bad / warning paths
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestWarning:
+    @responses.activate
+    def test_legacy_short_id_format_warns(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """The BCBSA scenario from the source customer incident: ISU
+        left in legacy short-employee-id format with no `@` — Workday
+        cannot match the Entra UPN ESS sends to a Worker."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value="ISU12345",
+        )
+
+        results = _check_isu_username_format(runner_with_graph)
+        r = _result(results)
+
+        assert r.status == "Warning"
+        assert "does not contain '@'" in r.result
+        assert "ISU12345" in r.result
+        assert "EmployeeContextRequestAccountName" in r.remediation
+        assert "powerplatform" in r.remediation.lower()
+
+    @responses.activate
+    def test_unverified_domain_warns(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """ISU `<x>@somethirdpartydomain.com` — could be legitimate
+        cross-tenant federation, but worth surfacing for the operator
+        to confirm the domain matches the UPN claim ESS actually sends.
+        """
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value="isu_ess@unrelated-vendor.example",
+        )
+
+        results = _check_isu_username_format(runner_with_graph)
+        r = _result(results)
+
+        assert r.status == "Warning"
+        assert "unrelated-vendor.example" in r.result
+        assert _VERIFIED_DOMAIN in r.result  # lists verified domains for context
+
+    @responses.activate
+    def test_graph_returns_no_verified_domains_warns(
+        self,
+        fake_dataverse_url: str,
+        fake_token: str,
+    ) -> None:
+        """Defensive — Graph returned an org record but with an empty
+        verifiedDomains list. Don't pass silently; warn so the operator
+        knows the comparison wasn't actually performed."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner = _MinimalRunner(
+            env_url=fake_dataverse_url,
+            dv_token=fake_token,
+            graph=_MinimalGraph(
+                org_payload=gx.organization(display_name="Mock Tenant") | {
+                    "verifiedDomains": [],
+                },
+            ),
+        )
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value="isu_ess@contoso.com",
+        )
+
+        results = _check_isu_username_format(runner)
+        r = _result(results)
+
+        assert r.status == "Warning"
+        assert "no verified domains" in r.result.lower()
+
+    @responses.activate
+    def test_graph_returns_empty_org_warns(
+        self,
+        fake_dataverse_url: str,
+        fake_token: str,
+    ) -> None:
+        """GraphClient.get_organization() returns {} when /organization
+        comes back empty (e.g. 401/403 → get_all returns partial empty
+        list → orgs[0] if orgs else {}). Surface that as a Warning, not
+        a crash, mirroring the existing pattern in _check_connections.
+        """
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner = _MinimalRunner(
+            env_url=fake_dataverse_url,
+            dv_token=fake_token,
+            graph=_MinimalGraph(org_payload={}),
+        )
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value="isu_ess@contoso.com",
+        )
+
+        results = _check_isu_username_format(runner)
+        r = _result(results)
+
+        assert r.status == "Warning"
+        assert "no tenant record" in r.result.lower()
+        assert "Organization.Read.All" in r.remediation
+
+    @responses.activate
+    def test_graph_get_organization_raises_warns(
+        self,
+        fake_dataverse_url: str,
+        fake_token: str,
+    ) -> None:
+        """If Graph itself raises (network, 5xx, etc.) the check must
+        not propagate the exception — surface it as a Warning so the
+        rest of FlightCheck still runs."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner = _MinimalRunner(
+            env_url=fake_dataverse_url,
+            dv_token=fake_token,
+            graph=_MinimalGraph(raise_exc=RuntimeError("boom")),
+        )
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value="isu_ess@contoso.com",
+        )
+
+        results = _check_isu_username_format(runner)
+        r = _result(results)
+
+        assert r.status == "Warning"
+        assert "boom" in r.result
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Tests — skipped paths
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestSkipped:
+    def test_skipped_when_no_dataverse_token(self) -> None:
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner = _MinimalRunner(env_url="", dv_token="", graph=_MinimalGraph())
+
+        results = _check_isu_username_format(runner)
+        r = _result(results)
+
+        assert r.status == "Skipped"
+        assert "token not available" in r.result.lower()
+
+    def test_skipped_when_no_graph_client(self, fake_dataverse_url: str, fake_token: str) -> None:
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner = _MinimalRunner(env_url=fake_dataverse_url, dv_token=fake_token, graph=None)
+
+        results = _check_isu_username_format(runner)
+        r = _result(results)
+
+        assert r.status == "Skipped"
+        assert "graph" in r.result.lower()
+        assert "graph sign-in" in r.remediation.lower()
+
+    @responses.activate
+    def test_skipped_when_isu_env_var_missing_defers_to_wd_env_001(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """When the env var isn't set, WD-ENV-001 already FAILs with
+        the right remediation — this check skips to avoid duplicating
+        the same root-cause finding."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value=None,  # No value record — env var unset
+        )
+
+        results = _check_isu_username_format(runner_with_graph)
+        r = _result(results)
+
+        assert r.status == "Skipped"
+        assert "WD-ENV-001" in r.result

--- a/tests/flightcheck/test_pp_admin_client.py
+++ b/tests/flightcheck/test_pp_admin_client.py
@@ -3,25 +3,22 @@
 
 """Regression tests for solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py.
 
-Currently focused on bug 4 — ``_get_all`` only handles 401/403 specially;
-404s and 5xx's bubble up as ``requests.exceptions.HTTPError`` and crash
-any FlightCheck check that calls into the affected helper.
+Covers behavior that historically had latent bugs the kit needs to
+not regress on (401/403 handling on the connections endpoint, etc.).
 
-The behavior is reproduced from a real cassette captured against the
-user's tenant — see
-``tests/fixtures/cassettes/flightcheck_pp_admin.yaml`` line 2578-2621
-where ``GET /providers/Microsoft.ProcessSimple/scopes/admin/environments/{env}/v2/flows``
-returns 404 ResourceNotFound for a Dataverse-only environment.
-
-When the bug is fixed (recommended: have ``_get_all`` return
-``{"_error": "...", "_status": 404}`` consistent with ``_get`` on 401/403),
-flip the assertions in this file.
+Historical note: an earlier version of this file pinned a 404 from
+``GET https://api.powerapps.com/.../v2/flows`` as "expected behavior
+for Dataverse-only environments." That was a misdiagnosis — the
+flow listing endpoint actually lives on ``api.flow.microsoft.com``
+with a separate audience token. ``pp_admin_client.get_flows()`` now
+targets the correct host. The captured 404 was a wrong-URL artefact,
+not a Dataverse-only-env signal, and the regression test that
+codified it has been removed.
 """
 
 from __future__ import annotations
 
 import pytest
-import requests
 import responses
 
 from tests.conftest import require_validated_mock
@@ -32,49 +29,24 @@ require_validated_mock(pp)
 
 @pytest.fixture
 def pp_client(fake_token: str):
-    """Real PPAdminClient with a pre-populated token."""
+    """Real PPAdminClient with both PowerApps and Flow audience tokens populated."""
     from flightcheck.pp_admin_client import PPAdminClient
 
     client = PPAdminClient(tenant_id="00000000-0000-0000-0000-000000001111")
     client._token = fake_token
+    # get_flows()/get_flow() use the flow audience token; tests that
+    # exercise either need this set or `flow_headers` raises.
+    client._flow_token = fake_token
     return client
 
 
-class TestGetAll404Crashes:
-    @responses.activate
-    def test_get_flows_raises_http_error_on_404(self, pp_client) -> None:
-        """Regression: latent bug. Pinned current crashing behavior.
-
-        When PowerApps ProcessSimple returns 404 (env exists in BAP but
-        not in PowerApps — happens for Dataverse-only envs), the kit's
-        get_flows() bubbles up requests.HTTPError instead of returning
-        an empty list or a structured error dict. Any FlightCheck check
-        that calls get_flows() crashes mid-run.
-
-        TODO: in pp_admin_client.py:131-144, extend _get_all's
-        401/403 handling to also catch 404 and 5xx. Recommended return
-        shape (matches _get): {"_error": "resource_not_found", "_status": 404}.
-        Then update _check_workflows / _check_flow_status in
-        flightcheck/checks/workday.py to surface the structured error
-        as a WARNING result. Flip this test's assertions when fixed.
-        """
-        responses.add(**pp.flows_resource_not_found(env_id=pp.MOCK_ENV_ID))
-
-        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
-            pp_client.get_flows(pp.MOCK_ENV_ID)
-
-        assert exc_info.value.response.status_code == 404
-        # Once fixed, this test should change to:
-        #   result = pp_client.get_flows(pp.MOCK_ENV_ID)
-        #   assert result == {"_error": "resource_not_found", "_status": 404}
-
+class TestPermissionHandling:
     @responses.activate
     def test_get_connections_handles_403_gracefully_returns_empty_list(
         self, pp_client
     ) -> None:
         """Companion test: 401/403 ARE handled (return empty list).
-        This pins the existing behavior so we know it doesn't regress
-        if the fix above is implemented.
+        This pins the existing behavior so we know it doesn't regress.
 
         Note: returning an empty list here is itself bug 2 (the kit
         also has a separate inconsistency between _get_all returning a

--- a/tests/mocks/pp_admin.py
+++ b/tests/mocks/pp_admin.py
@@ -34,6 +34,10 @@ MOCK_CASSETTE = "tests/fixtures/cassettes/flightcheck_pp_admin.yaml"
 
 BAP_BASE = "https://api.bap.microsoft.com"
 POWERAPPS_BASE = "https://api.powerapps.com"
+# Flow listing endpoint lives on a different host with a different audience
+# token. See solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
+# `FLOW_BASE` and the `service.flow.microsoft.com//.default` scope.
+FLOW_BASE = "https://api.flow.microsoft.com"
 
 MOCK_ENV_ID = "Default-00000000-0000-0000-0000-000000001111"
 MOCK_ORG_ID = "00000000-0000-0000-0000-000000005555"
@@ -294,11 +298,16 @@ def list_flows(
     flows: Iterable[Mapping[str, Any]] | None = None,
     status: int = 200,
 ) -> dict[str, Any]:
-    """Mock GET /providers/Microsoft.ProcessSimple/scopes/admin/environments/{env}/v2/flows."""
+    """Mock GET /providers/Microsoft.ProcessSimple/scopes/admin/environments/{env}/v2/flows.
+
+    Hosted on `api.flow.microsoft.com` (NOT `api.powerapps.com`) and
+    requires a `service.flow.microsoft.com//.default` audience token
+    rather than the PowerApps audience.
+    """
     return {
         "method": "GET",
         "url": (
-            f"{POWERAPPS_BASE}/providers/Microsoft.ProcessSimple/scopes/admin/environments/"
+            f"{FLOW_BASE}/providers/Microsoft.ProcessSimple/scopes/admin/environments/"
             f"{env_id}/v2/flows"
         ),
         "json": collection(flows or []),
@@ -323,7 +332,7 @@ def insufficient_permissions(
         )
     elif endpoint == "flows":
         url = (
-            f"{POWERAPPS_BASE}/providers/Microsoft.ProcessSimple/scopes/admin/environments/"
+            f"{FLOW_BASE}/providers/Microsoft.ProcessSimple/scopes/admin/environments/"
             f"{env_id}/v2/flows"
         )
     elif endpoint == "environments":
@@ -346,28 +355,4 @@ def insufficient_permissions(
     }
 
 
-def flows_resource_not_found(*, env_id: str = MOCK_ENV_ID) -> dict[str, Any]:
-    """Mock the 404 ResourceNotFound response that PowerApps ProcessSimple
-    returns when an environment exists in BAP but has no PowerApps
-    runtime registered (Dataverse-only envs).
 
-    Captured behavior — see tests/fixtures/cassettes/flightcheck_pp_admin.yaml
-    line 2578-2621. The real response has an empty body and an
-    ``x-servicefabric: ResourceNotFound`` header. The kit's
-    pp_admin_client._get_all only handles 401/403 specially, so this
-    bubbles up as ``requests.exceptions.HTTPError`` and crashes any
-    FlightCheck check that calls get_flows().
-
-    See bug 4 in plan.md and the regression test in
-    tests/flightcheck/test_pp_admin_client.py.
-    """
-    return {
-        "method": "GET",
-        "url": (
-            f"{POWERAPPS_BASE}/providers/Microsoft.ProcessSimple/scopes/admin/environments/"
-            f"{env_id}/v2/flows"
-        ),
-        "body": "",
-        "status": 404,
-        "headers": {"x-servicefabric": "ResourceNotFound"},
-    }


### PR DESCRIPTION
Implements the FlightCheck check requested in #82.

**Checkpoint:** `WD-ENV-101`
**Category:** Workday
**Priority:** HIGH
**Conditional?** No (runs whenever Workday flows are detected)

**API tier:**
  - Dataverse: `documented` (existing `tests/mocks/dataverse.py`, MS Learn `environmentvariabledefinition` / `environmentvariablevalue` reference)
  - Microsoft Graph v1.0: `validatable` (existing `tests/mocks/graph.py`, CSDL `EntityType Name="organization"` + `https://learn.microsoft.com/graph/api/organization-get`)

**Mock source:** Reuses existing builders only — no new mock module, no registry update.

## What this check does

Pulls `EmployeeContextRequestAccountName` from Dataverse and compares its shape against the tenant's verified Entra domains read from Microsoft Graph (`runner.graph.get_organization()` → `verifiedDomains[].name`). Federated tenants (Okta, Ping, ADFS) frequently leave the ISU username in a legacy short-employee-id format that doesn't match the UPN claim ESS sends on each request, which prevents Workday from matching the incoming request to a Worker — a common misconfiguration on tenants that provisioned the ISU before adopting UPN-shaped service-account naming.

Heuristics:
- No `@` in the ISU username → **Warning** (legacy short-id format — the most-cited misconfiguration root cause).
- `@` present but the domain part isn't in the tenant's verified domains → **Warning** (could be legitimate cross-tenant federation; surface for the operator to confirm).
- `<localpart>@<verified-domain>` → **Passed**.

## Tests

`tests/flightcheck/checks/test_workday_isu_username_format.py` covers GOOD (UPN-shaped + verified-domain match, plus the initial `*.onmicrosoft.com` domain), BAD (no-`@` legacy short-ID scenario, unverified-domain), defensive (empty verifiedDomains, empty org record, Graph raises), and SKIPPED paths (no Dataverse token, no Graph client, ISU env var unset — defers to WD-ENV-001).

11 new tests pass; the existing 18 flightcheck tests still pass unchanged. Full repo suite: 113 passed, 8 skipped.

## Verification context

The source issue did not include a `## Verification` section, so the implementation pattern was inferred from the most-similar existing check: `_check_env_vars` in the same module (`checks/workday.py`) for the Dataverse half, and `checks/prerequisites.py` for the `runner.graph` usage pattern. Test file mirrors `tests/flightcheck/checks/test_workday_env_vars.py`.

End-to-end validated against a real tenant: ran flightcheck against a Workday-equipped environment with the Dataverse env var both UPN-shaped (PASSED) and deliberately set to a legacy short-id value (WARNED with the expected remediation).

## What was deferred (and why)

The deeper `Get_Workers User_ID == Entra UPN` per-Worker comparison from the suggested implementation is intentionally **deferred** to a follow-up:

1. The Workday SOAP mock module (`tests/mocks/workday.py`) is `MOCK_STATUS = "placeholder"` and would need promotion to `validated` against `flightcheck_workday.yaml` before any test could exercise that surface (per the conftest enforcement).
2. "A sample of expected ESS users" requires a curated mapping from Workday Employee_IDs to Entra UPNs that no current FlightCheck config supplies (the existing `_check_workflows` only exercises a single `WORKDAY_TEST_EMPLOYEE_ID`).
3. The static format check landed here already addresses the legacy-ISU root cause (short-employee-id ISU format on a federated tenant) — a future `WD-WF-NNN` can wire the per-Worker comparison once the Workday mock is promoted and the sample-list input is formalised.

## Additional fixes piggy-backed on this PR

While validating WD-ENV-101 end-to-end against a real tenant, three latent bugs in the original May 7 Python-scripts commit surfaced — each one blocked the new check (or other checks) from running on most tenants. They are fixed in this PR because the new WD-ENV-101 check could not be validated without them.

1. **PP Admin env id derivation** (`pp_admin_client.py` + `cli.py`) — `derive_environment_id()` returned the Dataverse OrgId rather than the BAP env id (different GUIDs on most tenants), so every BAP-scoped check (ENV-001/002/003, EXT-001, flow listing, connection enumeration) 404'd. Now uses an instance-URL match against the BAP env list, mirroring `pva_client._discover_gateway()`.
2. **Flow listing endpoint** (`pp_admin_client.py`) — `get_flows()` was hitting `api.powerapps.com/.../v2/flows` (404, path doesn't exist there) instead of `api.flow.microsoft.com/.../v2/flows` with the required `service.flow.microsoft.com//.default` audience token. Adds `FLOW_BASE`, `FLOW_SCOPE`, dual-token `authenticate()`, and `use_flow_token=True` plumbing.
3. **License SKU matching** (`checks/prerequisites.py`) — PRE-001/002/003 used case-sensitive `in` checks against UPPER_CASE patterns while Graph returns mixed-case values (`Microsoft_365_Copilot`); also missed Teams bundles (`O365_BUSINESS_PREMIUM`, `ENTERPRISEPACK`, etc.). Added `_sku_matches()` helper + reference-list-grounded SKU tuples.

Test-side follow-up (`tests/mocks/pp_admin.py`, `tests/flightcheck/test_pp_admin_client.py`, `tests/fixtures/cassettes/INDEX.md`): aligned with the corrected Power Automate endpoint. The previous "bug 4" regression test pinning a 404 from `api.powerapps.com` as "expected for Dataverse-only environments" was a misdiagnosis — the 404 was a wrong-URL artefact — and has been removed.

A companion PR (#95) documents the corresponding **guidance updates** to `flightcheck/AGENTS.md` so future agents don't reintroduce the same classes of bug.

Fixes #82
