### PR TITLE
flightcheck: add WD-CONN-101  Workday connection token / grant health (deep)

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -607,7 +607,17 @@ TOKEN_HEALTH_ERROR_CODES = {
     "AADSTS50076": "MFA challenge required. Have the connection owner re-authenticate and complete MFA.",
     "Unauthorized": "Power Platform marked the credential unauthorized. Re-authenticate the connection.",
     "Unauthenticated": "Connection is not authenticated. Have the connection owner sign in to Power Platform.",
+    "ConfigurationNeeded": "Connection was created but never fully configured (required parameter missing). Either finish setup in Power Platform or delete the unbound connection.",
 }
+
+# Error-code values from TOKEN_HEALTH_ERROR_CODES that indicate the
+# connection was created but never configured (vs. lapsed auth on a
+# previously-working connection). Used by _classify_token_health_error
+# to set the severity/remediation class.
+_CONFIG_ERROR_CODES = frozenset({"ConfigurationNeeded"})
+# Error-code values that indicate a previously-working auth that has
+# lapsed and needs the owner to re-authenticate.
+_AUTH_ERROR_CODES = frozenset({"Unauthorized", "Unauthenticated"})
 
 # Matches Entra error-code identifiers like "AADSTS50173" or "AADSTS700082"
 # anywhere in a string. Anchored to a 5-7 digit AADSTS prefix to avoid
@@ -617,10 +627,12 @@ TOKEN_HEALTH_ERROR_CODES = {
 _AADSTS_CODE_RE = re.compile(r"\b(AADSTS\d{5,7})\b")
 
 
-def _classify_token_health_error(conn: dict) -> tuple[str | None, str | None, str]:
+def _classify_token_health_error(
+    conn: dict,
+) -> tuple[str | None, str | None, str, str]:
     """Inspect ``statuses[0].error`` on a connection record and return
-    ``(reported_code, reported_message, hint)`` for token-health
-    classification.
+    ``(reported_code, reported_message, hint, severity_class)`` for
+    token-health classification.
 
     The PowerApps connections API includes a structured ``error`` block
     on non-Connected statuses (target, code, message). The actual
@@ -639,19 +651,35 @@ def _classify_token_health_error(conn: dict) -> tuple[str | None, str | None, st
          code/message the API returned so the operator can search
          for it in MS Learn.
 
-    Returns ``(None, None, no-status-hint)`` only when the entire
-    ``statuses`` array is missing or empty.
+    ``severity_class`` is one of:
+      - ``"config"`` — connection was never fully configured (e.g.
+        ``ConfigurationNeeded`` with ``Parameter value missing``).
+        Different remediation path: finish setup OR delete the
+        orphan; "re-authenticate" doesn't apply to something that
+        was never authenticated.
+      - ``"auth"`` — auth grant on a previously-working connection
+        has lapsed (any AADSTS code, ``Unauthorized``,
+        ``Unauthenticated``). Owner must re-authenticate.
+      - ``"unknown"`` — error block present but neither config nor
+        auth shape recognized. Treated as auth-style in remediation
+        but flagged as needing investigation.
+
+    Returns ``(None, None, no-status-hint, "unknown")`` only when the
+    entire ``statuses`` array is missing or empty.
 
     Cited consumer: ``_check_connection_token_health`` (this file).
     Source (validated): ``tests/fixtures/cassettes/flightcheck_pp_admin.yaml``
     lines 2661-2680 capture the live AADSTS50173-in-message shape;
     lines 2682-2700+ capture the ``Unauthenticated`` ("never signed in")
     shape; the production fields used (``status`` / ``target`` / ``code``
-    / ``message``) all appear in the cassette.
+    / ``message``) all appear in the cassette. The ``ConfigurationNeeded``
+    shape was observed live on 2026-05-21 in env
+    ``PROD - ESS + WD + SNow`` on 3-of-7 Workday SOAP connections that
+    were created but never had their ``sku`` parameter populated.
     """
     statuses = conn.get("properties", {}).get("statuses", [])
     if not isinstance(statuses, list) or not statuses:
-        return None, None, "No status information returned by Power Platform."
+        return None, None, "No status information returned by Power Platform.", "unknown"
     err = statuses[0].get("error") or {}
     raw_code = err.get("code")
     raw_message = err.get("message") or ""
@@ -664,7 +692,7 @@ def _classify_token_health_error(conn: dict) -> tuple[str | None, str | None, st
             aadsts_code,
             "Unrecognized AADSTS error. Re-authenticate the connection in Power Platform.",
         )
-        return aadsts_code, raw_message, hint
+        return aadsts_code, raw_message, hint, "auth"
 
     # Tier 2: fall back to the coarser error.code value.
     if raw_code:
@@ -672,13 +700,19 @@ def _classify_token_health_error(conn: dict) -> tuple[str | None, str | None, st
             raw_code,
             "Unrecognized token-health error. Re-authenticate the connection in Power Platform.",
         )
-        return raw_code, raw_message or None, hint
+        if raw_code in _CONFIG_ERROR_CODES:
+            severity = "config"
+        elif raw_code in _AUTH_ERROR_CODES:
+            severity = "auth"
+        else:
+            severity = "unknown"
+        return raw_code, raw_message or None, hint, severity
 
     # Tier 3: error block present but neither an AADSTS code nor a code field.
     return None, raw_message or None, (
         "Connection reported an error but Power Platform did not include a "
         "structured error code. Re-authenticate the connection."
-    )
+    ), "unknown"
 
 
 def _check_connection_token_health(runner) -> list[CheckResult]:
@@ -688,22 +722,43 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
     ``Connected`` state. WD-CONN-101 goes one level deeper: for any
     Workday connection NOT in ``Connected`` state, it parses the
     structured ``statuses[0].error.{code,message}`` block the
-    PowerApps connections API returns and surfaces a remediation
-    pinned to the specific Entra error code (e.g. AADSTS50173 grant
-    expired vs AADSTS70008 refresh-token-expired-due-to-inactivity vs
-    AADSTS50076 MFA challenge required). The customer-facing failure
-    mode this catches: a Workday SOAP connection that worked yesterday
-    silently flips to 401/403 at runtime because the connection
-    creator's Entra grant lapsed — WD-CONN-001 says ``Error`` and
-    points at "re-authenticate", WD-CONN-101 names the user, the
-    grant code, and what specifically expired.
+    PowerApps connections API returns, classifies the failure into
+    config-needed vs lapsed-auth vs unknown, cross-references each
+    unhealthy connection against the env's flow connection-references
+    to determine in-use vs orphan, and emits up to two CheckResults:
+
+      - FAILED — connections that are unhealthy AND referenced by an
+        active flow (these will break flow execution at runtime).
+      - WARNING — connections that are unhealthy but not referenced by
+        any flow (cleanup task: orphan leftovers from solution
+        imports, abandoned manual creation attempts, etc.).
+
+    Each entry in the results carries enough operator-actionable
+    detail to fix the issue without leaving the FlightCheck output:
+
+      - Connection display name + short id suffix (so operators can
+        disambiguate between 7 connections all named "Workday").
+      - Owner — falls back to ``createdBy.userPrincipalName`` /
+        ``createdBy.displayName`` when ``accountName`` is null
+        (frequently the case for admin-scope listings of connections
+        owned by other users).
+      - Creation date — helps the operator spot stale records.
+      - Deep link to the maker portal connections page.
+      - For config-needed orphans: the exact
+        ``Remove-AdminPowerAppConnection`` PowerShell command,
+        pre-filled with env id, connection name, and connector name.
+      - For lapsed-auth connections: the maker URL the owner needs
+        to visit to re-authenticate, plus the per-AADSTS-code hint
+        from TOKEN_HEALTH_ERROR_CODES.
 
     Mock tier (validated): backed by ``tests/mocks/pp_admin.py``
     (MOCK_STATUS = "validated", cassette
     ``tests/fixtures/cassettes/flightcheck_pp_admin.yaml``). Same
     endpoint as WD-CONN-001 — ``GET /providers/Microsoft.PowerApps/
     scopes/admin/environments/{env_id}/connections`` — so no new
-    cassette is required.
+    cassette is required. The flow-listing step uses
+    ``pp.get_flows(env_id)`` against the validated Flow admin
+    endpoint (also in the cassette).
 
     Scope notes (intentionally narrower than the issue suggested):
       * The runtime ESS Workday integration uses WS-Security
@@ -773,12 +828,18 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
         ))
         return results
 
-    unhealthy: list[tuple[dict, str | None, str | None, str]] = []
+    unhealthy: list[dict] = []
     for c in wd_conns:
         if _get_conn_status(c) == "Connected":
             continue
-        code, message, hint = _classify_token_health_error(c)
-        unhealthy.append((c, code, message, hint))
+        code, message, hint, severity = _classify_token_health_error(c)
+        unhealthy.append({
+            "conn": c,
+            "code": code,
+            "message": message,
+            "hint": hint,
+            "severity": severity,
+        })
 
     if not unhealthy:
         results.append(CheckResult(
@@ -790,31 +851,284 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
         ))
         return results
 
-    detail_lines: list[str] = []
-    remediation_lines: list[str] = []
-    for c, code, message, hint in unhealthy:
-        props = c.get("properties", {})
-        name = props.get("displayName", "(unnamed)")
-        owner = props.get("accountName", "(unknown owner)")
-        code_str = code or "no-error-code"
-        msg_excerpt = (message or "").split("\n", 1)[0][:140]
-        detail_lines.append(
-            f"'{name}' (owner={owner}): {code_str} — {msg_excerpt}".rstrip(" —")
-        )
-        remediation_lines.append(f"'{name}' (owner={owner}): {hint}")
+    # In-use cross-reference. None ⇒ couldn't determine (treat all as
+    # in-use for safety; better to over-report FAILED than to silently
+    # demote a real flow-breaker to WARNING).
+    in_use_names = _get_in_use_workday_connection_names(runner)
 
-    results.append(CheckResult(
-        checkpoint_id="WD-CONN-101", category="Workday",
-        priority=Priority.HIGH.value, status=Status.FAILED.value,
-        description="Workday connection token health",
-        result=(
-            f"{len(unhealthy)} of {len(wd_conns)} Workday connection(s) have "
-            f"unhealthy auth state: " + "; ".join(detail_lines)
-        ),
-        remediation=" | ".join(remediation_lines),
-        doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
-    ))
+    failed_entries: list[dict] = []
+    warning_entries: list[dict] = []
+    for entry in unhealthy:
+        conn_name = entry["conn"].get("name", "")
+        if in_use_names is None:
+            is_in_use = True
+        else:
+            is_in_use = conn_name in in_use_names
+        entry["in_use"] = is_in_use
+        entry["in_use_determined"] = in_use_names is not None
+        if is_in_use:
+            failed_entries.append(entry)
+        else:
+            warning_entries.append(entry)
+
+    if failed_entries:
+        details = [_format_unhealthy_detail(e) for e in failed_entries]
+        remediations = [_format_unhealthy_remediation(e, env_id) for e in failed_entries]
+        results.append(CheckResult(
+            checkpoint_id="WD-CONN-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.FAILED.value,
+            description="Workday connection token health",
+            result=(
+                f"{len(failed_entries)} of {len(wd_conns)} Workday connection(s) "
+                f"have unhealthy auth state and are referenced by a flow: "
+                + "; ".join(details)
+            ),
+            remediation=" | ".join(remediations),
+            doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
+        ))
+
+    if warning_entries:
+        details = [_format_unhealthy_detail(e) for e in warning_entries]
+        remediations = [_format_unhealthy_remediation(e, env_id) for e in warning_entries]
+        results.append(CheckResult(
+            checkpoint_id="WD-CONN-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="Workday connection token health",
+            result=(
+                f"{len(warning_entries)} orphan Workday connection(s) "
+                f"(unhealthy but not referenced by any flow — cleanup task): "
+                + "; ".join(details)
+            ),
+            remediation=" | ".join(remediations),
+            doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
+        ))
+
     return results
+
+
+# ── Operator-actionable formatting helpers for WD-CONN-101 ────────────
+#
+# Each unhealthy connection emits two strings into the CheckResult:
+#
+#   1. detail   — short identifier line that goes into the ``result``
+#                 (the "what's broken") field.
+#   2. remediation — actionable hint that goes into the ``remediation``
+#                    field (the "what to do about it") field, including
+#                    deep links and pre-filled PowerShell commands.
+#
+# The split exists because in the FlightCheck report, ``result`` shows
+# in the summary table and ``remediation`` shows in the expandable
+# detail — operators scan the summary first to triage, then read the
+# remediation when they're ready to act.
+
+
+def _extract_conn_id_suffix(name: str) -> str:
+    """Return a short stable identifier from a connection's full name.
+
+    PowerApps connection names follow the shape
+    ``shared-<connector>-<guid>``, e.g.
+    ``shared-workdaysoap-ac42a2e7-2ebf-4217-a7d7-0488d0fd48da``. We
+    return the first 8-hex-digit segment from the GUID (e.g.
+    ``ac42a2e7``) so operators can disambiguate between connections
+    that all share the display name "Workday".
+    """
+    match = re.search(r"\b([0-9a-f]{8})\b", name.lower())
+    if match:
+        return match.group(1)
+    # Fallback: last 8 chars of whatever we got.
+    return name[-8:] if len(name) >= 8 else name or "(no-id)"
+
+
+def _resolve_owner(props: dict) -> str:
+    """Return the most useful owner identity available on a connection.
+
+    Admin-scope connection listings (the endpoint WD-CONN-101 uses)
+    frequently return ``accountName: null`` even when the connection
+    has a clear creator — observed live on 2026-05-21 across 7 Workday
+    connections owned by ``lmoulet@EmployeeHub.onmicrosoft.com`` where
+    ``accountName`` was null but ``createdBy.userPrincipalName`` was
+    populated.
+
+    Falls back through ``accountName`` → ``createdBy.userPrincipalName``
+    → ``createdBy.displayName`` → ``"(unknown owner)"`` so the
+    operator gets the most actionable identity available.
+    """
+    account = props.get("accountName")
+    if account:
+        return account
+    created_by = props.get("createdBy") or {}
+    upn = created_by.get("userPrincipalName")
+    if upn:
+        return upn
+    display = created_by.get("displayName")
+    if display:
+        return display
+    return "(unknown owner)"
+
+
+def _format_created_date(props: dict) -> str:
+    """Return the YYYY-MM-DD portion of ``createdTime`` for compact display."""
+    ts = props.get("createdTime") or ""
+    if len(ts) >= 10 and ts[4] == "-" and ts[7] == "-":
+        return ts[:10]
+    return "(unknown date)"
+
+
+def _extract_connector_name(conn: dict) -> str:
+    """Extract the connector type name (e.g. ``shared_workdaysoap``)
+    from the connection's ``apiId`` path. Used to build the
+    ``-ConnectorName`` argument of the PowerShell delete command."""
+    api_id = conn.get("properties", {}).get("apiId", "")
+    match = re.search(r"/apis/([^/]+)/?$", api_id)
+    return match.group(1) if match else "shared_workdaysoap"
+
+
+def _maker_connections_url(env_id: str) -> str:
+    """Direct link to the Power Automate maker connections page.
+
+    We use make.powerautomate.com over make.powerapps.com because the
+    PowerAutomate experience renders the env-scoped connections list
+    more reliably across the multiple PPAC IA churns observed in
+    2024-2026.
+    """
+    return f"https://make.powerautomate.com/environments/{env_id}/connections"
+
+
+def _format_unhealthy_detail(entry: dict) -> str:
+    """Single-connection detail line for the ``result`` field.
+
+    Shape: ``'<display>' (id=<suffix>, owner=<owner>, created=<date>):
+    <code> — <message>``
+    """
+    c = entry["conn"]
+    props = c.get("properties", {})
+    name = props.get("displayName", "(unnamed)")
+    suffix = _extract_conn_id_suffix(c.get("name", ""))
+    owner = _resolve_owner(props)
+    date = _format_created_date(props)
+    code = entry["code"] or "no-error-code"
+    msg_excerpt = (entry["message"] or "").split("\n", 1)[0][:140]
+    return (
+        f"'{name}' (id={suffix}, owner={owner}, created={date}): "
+        f"{code} — {msg_excerpt}"
+    ).rstrip(" —")
+
+
+def _format_unhealthy_remediation(entry: dict, env_id: str) -> str:
+    """Single-connection remediation hint for the ``remediation`` field.
+
+    Template varies by severity_class × in_use:
+      - config + in-use:    owner must finish setup (flow depends on this)
+      - config + orphan:    PowerShell delete command (never used, safe to remove)
+      - auth + in-use:      owner must re-authenticate (admins can't re-auth others)
+      - auth + orphan:      owner re-auth OR PowerShell delete
+      - unknown + in-use:   owner investigates (we don't know what's wrong)
+      - unknown + orphan:   owner investigates OR PowerShell delete
+    """
+    c = entry["conn"]
+    props = c.get("properties", {})
+    name = props.get("displayName", "(unnamed)")
+    suffix = _extract_conn_id_suffix(c.get("name", ""))
+    owner = _resolve_owner(props)
+    severity = entry["severity"]
+    hint = entry["hint"]
+    in_use = entry["in_use"]
+    conn_name = c.get("name", "")
+    connector = _extract_connector_name(c)
+    maker_url = _maker_connections_url(env_id)
+    delete_cmd = (
+        f"Remove-AdminPowerAppConnection -EnvironmentName {env_id} "
+        f"-ConnectionName {conn_name} -ConnectorName {connector}"
+    )
+    prefix = f"'{name}' (id={suffix}, owner={owner}):"
+
+    if severity == "config":
+        if in_use:
+            return (
+                f"{prefix} {hint} Connection is referenced by an active flow — "
+                f"owner ({owner}) must finish setup at {maker_url}; admins "
+                f"cannot configure on owner's behalf."
+            )
+        return (
+            f"{prefix} {hint} Connection is not referenced by any flow "
+            f"(likely solution-import leftover). Delete as Power Platform "
+            f"Admin: `{delete_cmd}`"
+        )
+
+    if severity == "auth":
+        if in_use:
+            return (
+                f"{prefix} {hint} Connection is referenced by an active flow — "
+                f"owner ({owner}) must re-authenticate at {maker_url}; admins "
+                f"cannot re-auth on owner's behalf (would change the identity "
+                f"the flow runs under)."
+            )
+        return (
+            f"{prefix} {hint} Connection is not referenced by any flow. "
+            f"Either owner re-authenticates at {maker_url} or delete as "
+            f"orphan: `{delete_cmd}`"
+        )
+
+    # unknown
+    if in_use:
+        return (
+            f"{prefix} {hint} Connection is referenced by an active flow — "
+            f"owner ({owner}) should investigate at {maker_url}."
+        )
+    return (
+        f"{prefix} {hint} Connection is not referenced by any flow. Either "
+        f"owner investigates at {maker_url} or delete as orphan: `{delete_cmd}`"
+    )
+
+
+def _get_in_use_workday_connection_names(runner) -> set[str] | None:
+    """Return the set of Workday connection names referenced by any
+    flow in the environment, or ``None`` if we couldn't determine it.
+
+    Each flow's ``properties.connectionReferences.{ref_key}`` carries
+    the apiId of the connector and the bound connection's name. We
+    collect every connection name where the apiId contains 'workday'.
+
+    ``None`` ⇒ couldn't enumerate flows (flow API failed, returned
+    insufficient_permissions, raised). The caller treats this as
+    "unknown ⇒ assume in-use" so we don't silently demote real
+    flow-breakers to WARNING.
+    """
+    pp = getattr(runner, "pp_admin", None)
+    env_id = getattr(runner, "env_id", None)
+    if not pp or not env_id:
+        return None
+    try:
+        flows = pp.get_flows(env_id)
+    except Exception:
+        return None
+    if isinstance(flows, dict) and "_error" in flows:
+        return None
+    if not isinstance(flows, list):
+        return None
+    in_use: set[str] = set()
+    for f in flows:
+        refs = (f.get("properties") or {}).get("connectionReferences") or {}
+        if not isinstance(refs, dict):
+            continue
+        for _ref_key, ref in refs.items():
+            if not isinstance(ref, dict):
+                continue
+            api_id = (
+                ref.get("apiId")
+                or (ref.get("api") or {}).get("name", "")
+                or ""
+            )
+            if "workday" not in api_id.lower():
+                continue
+            conn_name = (
+                ref.get("connectionName")
+                or (ref.get("connection") or {}).get("name", "")
+                or ""
+            )
+            if conn_name:
+                in_use.add(conn_name)
+    return in_use
 
 
 def _check_flow_status(runner, wd_flows: list) -> list[CheckResult]:

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -14,6 +14,7 @@ or, when running standalone, build SOAP envelopes directly with httpx.
 import getpass
 import json
 import os
+import re
 import sys
 from xml.sax.saxutils import escape as xml_escape
 
@@ -352,10 +353,31 @@ def _get_conn_status(conn: dict) -> str:
 
 
 # OAuth grant-expiry / token-health error codes the Power Platform
-# connection layer surfaces in statuses[0].error.code when the connection
-# creator's Entra OAuth grant has lapsed. Mapping each code to a one-line
-# remediation hint lets WD-CONN-101 tell the operator *what* expired and
-# *what to do*, instead of just "Error". Codes sourced from MS Learn:
+# connection layer surfaces when the connection creator's Entra OAuth
+# grant has lapsed. There are two places to find them:
+#
+#   1. ``statuses[0].error.message`` — contains the actual Entra
+#      ``AADSTSnnnnn`` token-failure code embedded in a longer prose
+#      message, e.g. "Failed to refresh access token... AADSTS50173:
+#      The provided grant has expired due to it being revoked..."
+#      This is where the actionable code actually lives in production
+#      (verified against ``tests/fixtures/cassettes/flightcheck_pp_admin.yaml``
+#      lines 2661-2680).
+#   2. ``statuses[0].error.code`` — a coarser Power-Platform-side
+#      classification: typically ``Unauthorized`` (for token-refresh
+#      failures including AADSTSnnnnn) or ``Unauthenticated`` (for a
+#      connection that was never authenticated). These show up
+#      regardless of whether an AADSTS code is present.
+#
+# WD-CONN-101 inspects (1) first via a regex on the message text, and
+# falls back to (2) only if the message has no recognizable AADSTS
+# code. That order matters: the message-level AADSTS code tells the
+# operator *which* Entra failure mode they hit (grant expired vs MFA
+# required vs refresh-token-too-old) and therefore *what specific
+# action* to take; the code-level "Unauthorized" only tells them
+# something is wrong with the token, generically.
+#
+# Codes sourced from MS Learn:
 # https://learn.microsoft.com/entra/identity-platform/reference-error-codes
 TOKEN_HEALTH_ERROR_CODES = {
     "AADSTS50173": "Auth grant expired (token revoked or password changed). Re-authenticate the connection in Power Platform.",
@@ -365,37 +387,79 @@ TOKEN_HEALTH_ERROR_CODES = {
     "AADSTS700084": "Refresh token used after revocation. Re-authenticate the connection.",
     "AADSTS50076": "MFA challenge required. Have the connection owner re-authenticate and complete MFA.",
     "Unauthorized": "Power Platform marked the credential unauthorized. Re-authenticate the connection.",
+    "Unauthenticated": "Connection is not authenticated. Have the connection owner sign in to Power Platform.",
 }
+
+# Matches Entra error-code identifiers like "AADSTS50173" or "AADSTS700082"
+# anywhere in a string. Anchored to a 5-7 digit AADSTS prefix to avoid
+# matching unrelated digit sequences. Used by _classify_token_health_error
+# to extract the specific failure code from the (often long, prose-y)
+# ``statuses[0].error.message`` field.
+_AADSTS_CODE_RE = re.compile(r"\b(AADSTS\d{5,7})\b")
 
 
 def _classify_token_health_error(conn: dict) -> tuple[str | None, str | None, str]:
     """Inspect ``statuses[0].error`` on a connection record and return
-    ``(error_code, error_message, hint)`` for token-health classification.
+    ``(reported_code, reported_message, hint)`` for token-health
+    classification.
 
     The PowerApps connections API includes a structured ``error`` block
-    on non-Connected statuses (target, code, message). We surface the
-    code and message verbatim so the operator can search/grep for them,
-    and add a one-line hint pulled from TOKEN_HEALTH_ERROR_CODES when we
-    recognize the AADSTS code. Returns (None, None, generic-hint) when
-    the error block is missing or unrecognized.
+    on non-Connected statuses (target, code, message). The actual
+    actionable Entra failure code (e.g. ``AADSTS50173``) is embedded
+    in ``error.message`` rather than ``error.code`` (which is the
+    coarser Power-Platform-side classification — typically
+    ``Unauthorized`` or ``Unauthenticated``). We:
 
-    Cited consumer: this function only.
-    Source (validated): tests/fixtures/cassettes/flightcheck_pp_admin.yaml
-    captures the statuses[0].error shape the live BAP API returns on a
-    Workday SOAP connection whose Entra grant has expired with
-    AADSTS50173.
+      1. First try to extract an ``AADSTSnnnnn`` code from
+         ``error.message``. If found, that becomes the reported code
+         and we look its hint up in TOKEN_HEALTH_ERROR_CODES.
+      2. Otherwise we report the ``error.code`` field verbatim and
+         look that up.
+      3. If neither resolves to a known entry, we fall back to a
+         generic re-authenticate hint and still surface whatever
+         code/message the API returned so the operator can search
+         for it in MS Learn.
+
+    Returns ``(None, None, no-status-hint)`` only when the entire
+    ``statuses`` array is missing or empty.
+
+    Cited consumer: ``_check_connection_token_health`` (this file).
+    Source (validated): ``tests/fixtures/cassettes/flightcheck_pp_admin.yaml``
+    lines 2661-2680 capture the live AADSTS50173-in-message shape;
+    lines 2682-2700+ capture the ``Unauthenticated`` ("never signed in")
+    shape; the production fields used (``status`` / ``target`` / ``code``
+    / ``message``) all appear in the cassette.
     """
     statuses = conn.get("properties", {}).get("statuses", [])
     if not isinstance(statuses, list) or not statuses:
         return None, None, "No status information returned by Power Platform."
     err = statuses[0].get("error") or {}
-    code = err.get("code")
-    message = err.get("message")
-    hint = TOKEN_HEALTH_ERROR_CODES.get(
-        code or "",
-        "Unrecognized token-health error. Re-authenticate the connection in Power Platform.",
+    raw_code = err.get("code")
+    raw_message = err.get("message") or ""
+
+    # Tier 1: extract AADSTS code from message (production shape).
+    aadsts_match = _AADSTS_CODE_RE.search(raw_message)
+    if aadsts_match:
+        aadsts_code = aadsts_match.group(1)
+        hint = TOKEN_HEALTH_ERROR_CODES.get(
+            aadsts_code,
+            "Unrecognized AADSTS error. Re-authenticate the connection in Power Platform.",
+        )
+        return aadsts_code, raw_message, hint
+
+    # Tier 2: fall back to the coarser error.code value.
+    if raw_code:
+        hint = TOKEN_HEALTH_ERROR_CODES.get(
+            raw_code,
+            "Unrecognized token-health error. Re-authenticate the connection in Power Platform.",
+        )
+        return raw_code, raw_message or None, hint
+
+    # Tier 3: error block present but neither an AADSTS code nor a code field.
+    return None, raw_message or None, (
+        "Connection reported an error but Power Platform did not include a "
+        "structured error code. Re-authenticate the connection."
     )
-    return code, message, hint
 
 
 def _check_connection_token_health(runner) -> list[CheckResult]:

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -162,6 +162,7 @@ def run_workday_checks(runner) -> list[CheckResult]:
 
     # --- Connection References ---
     results.extend(_check_connections(runner))
+    results.extend(_check_connection_token_health(runner))
 
     # --- Flow Status ---
     results.extend(_check_flow_status(runner, wd_flows))
@@ -348,6 +349,189 @@ def _get_conn_status(conn: dict) -> str:
     if isinstance(statuses, list) and statuses:
         return statuses[0].get("status", "Unknown")
     return "Unknown"
+
+
+# OAuth grant-expiry / token-health error codes the Power Platform
+# connection layer surfaces in statuses[0].error.code when the connection
+# creator's Entra OAuth grant has lapsed. Mapping each code to a one-line
+# remediation hint lets WD-CONN-101 tell the operator *what* expired and
+# *what to do*, instead of just "Error". Codes sourced from MS Learn:
+# https://learn.microsoft.com/entra/identity-platform/reference-error-codes
+TOKEN_HEALTH_ERROR_CODES = {
+    "AADSTS50173": "Auth grant expired (token revoked or password changed). Re-authenticate the connection in Power Platform.",
+    "AADSTS70008": "Refresh token expired due to inactivity. Re-authenticate the connection in Power Platform.",
+    "AADSTS50058": "Silent sign-in failed (no active Entra session). Have the connection owner re-authenticate.",
+    "AADSTS700082": "Refresh token has expired due to inactivity. Re-authenticate the connection.",
+    "AADSTS700084": "Refresh token used after revocation. Re-authenticate the connection.",
+    "AADSTS50076": "MFA challenge required. Have the connection owner re-authenticate and complete MFA.",
+    "Unauthorized": "Power Platform marked the credential unauthorized. Re-authenticate the connection.",
+}
+
+
+def _classify_token_health_error(conn: dict) -> tuple[str | None, str | None, str]:
+    """Inspect ``statuses[0].error`` on a connection record and return
+    ``(error_code, error_message, hint)`` for token-health classification.
+
+    The PowerApps connections API includes a structured ``error`` block
+    on non-Connected statuses (target, code, message). We surface the
+    code and message verbatim so the operator can search/grep for them,
+    and add a one-line hint pulled from TOKEN_HEALTH_ERROR_CODES when we
+    recognize the AADSTS code. Returns (None, None, generic-hint) when
+    the error block is missing or unrecognized.
+
+    Cited consumer: this function only.
+    Source (validated): tests/fixtures/cassettes/flightcheck_pp_admin.yaml
+    captures the statuses[0].error shape the live BAP API returns on a
+    Workday SOAP connection whose Entra grant has expired with
+    AADSTS50173.
+    """
+    statuses = conn.get("properties", {}).get("statuses", [])
+    if not isinstance(statuses, list) or not statuses:
+        return None, None, "No status information returned by Power Platform."
+    err = statuses[0].get("error") or {}
+    code = err.get("code")
+    message = err.get("message")
+    hint = TOKEN_HEALTH_ERROR_CODES.get(
+        code or "",
+        "Unrecognized token-health error. Re-authenticate the connection in Power Platform.",
+    )
+    return code, message, hint
+
+
+def _check_connection_token_health(runner) -> list[CheckResult]:
+    """WD-CONN-101 — Workday connection token / grant health (deep).
+
+    WD-CONN-001 reports whether each Workday connection is in
+    ``Connected`` state. WD-CONN-101 goes one level deeper: for any
+    Workday connection NOT in ``Connected`` state, it parses the
+    structured ``statuses[0].error.{code,message}`` block the
+    PowerApps connections API returns and surfaces a remediation
+    pinned to the specific Entra error code (e.g. AADSTS50173 grant
+    expired vs AADSTS70008 refresh-token-expired-due-to-inactivity vs
+    AADSTS50076 MFA challenge required). The customer-facing failure
+    mode this catches: a Workday SOAP connection that worked yesterday
+    silently flips to 401/403 at runtime because the connection
+    creator's Entra grant lapsed — WD-CONN-001 says ``Error`` and
+    points at "re-authenticate", WD-CONN-101 names the user, the
+    grant code, and what specifically expired.
+
+    Mock tier (validated): backed by ``tests/mocks/pp_admin.py``
+    (MOCK_STATUS = "validated", cassette
+    ``tests/fixtures/cassettes/flightcheck_pp_admin.yaml``). Same
+    endpoint as WD-CONN-001 — ``GET /providers/Microsoft.PowerApps/
+    scopes/admin/environments/{env_id}/connections`` — so no new
+    cassette is required.
+
+    Scope notes (intentionally narrower than the issue suggested):
+      * The runtime ESS Workday integration uses WS-Security
+        UsernameToken (Basic auth via ISU username + password), so
+        there is no Workday-side OAuth/refresh token to inspect. The
+        OAuth surface that DOES exist is the Power Platform
+        connection's wrapper grant — the Entra token from the user
+        who created the connection ref. That is what WD-CONN-101
+        inspects.
+      * The issue also suggested an active SOAP probe
+        (Get_Server_Timestamp / Get_Workers count=1). That ground is
+        already covered by the existing WD-WF-* checks, which call
+        17 real ESS workflows against the live Workday tenant when
+        ISU credentials are supplied. WD-CONN-101 deliberately stays
+        offline-only against the BAP cassette to avoid duplicating
+        WD-WF-001 and to keep the check fast in CI.
+      * The PowerApps connections API does NOT expose a
+        ``lastRefreshedTimestamp`` field on connection records (not
+        present in the validated cassette), so the issue's
+        "warn-if-token-older-than-IdP-lifetime" branch is not
+        implementable from this surface. Documented as a follow-up.
+    """
+    results: list[CheckResult] = []
+    pp = runner.pp_admin
+    env_id = runner.env_id
+
+    if not env_id or pp is None:
+        return results
+
+    try:
+        all_conns = pp.get_connections(env_id)
+    except Exception as e:
+        results.append(CheckResult(
+            checkpoint_id="WD-CONN-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="Workday connection token health",
+            result=f"Unable to check: {e}",
+        ))
+        return results
+
+    if isinstance(all_conns, dict) and "_error" in all_conns:
+        results.append(CheckResult(
+            checkpoint_id="WD-CONN-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description="Workday connection token health",
+            result=f"Unable to list connections: {all_conns['_error']}",
+            remediation="Requires Power Platform Administrator role.",
+        ))
+        return results
+
+    wd_conns = [
+        c for c in all_conns
+        if "workday" in (
+            c.get("properties", {}).get("apiId", "")
+            + c.get("properties", {}).get("displayName", "")
+        ).lower()
+    ]
+
+    if not wd_conns:
+        results.append(CheckResult(
+            checkpoint_id="WD-CONN-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
+            description="Workday connection token health",
+            result="No Workday connections found",
+            remediation="Configure Workday SOAP connections in the environment.",
+            doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
+        ))
+        return results
+
+    unhealthy: list[tuple[dict, str | None, str | None, str]] = []
+    for c in wd_conns:
+        if _get_conn_status(c) == "Connected":
+            continue
+        code, message, hint = _classify_token_health_error(c)
+        unhealthy.append((c, code, message, hint))
+
+    if not unhealthy:
+        results.append(CheckResult(
+            checkpoint_id="WD-CONN-101", category="Workday",
+            priority=Priority.HIGH.value, status=Status.PASSED.value,
+            description="Workday connection token health",
+            result=f"All {len(wd_conns)} Workday connection(s) report healthy auth state",
+            doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
+        ))
+        return results
+
+    detail_lines: list[str] = []
+    remediation_lines: list[str] = []
+    for c, code, message, hint in unhealthy:
+        props = c.get("properties", {})
+        name = props.get("displayName", "(unnamed)")
+        owner = props.get("accountName", "(unknown owner)")
+        code_str = code or "no-error-code"
+        msg_excerpt = (message or "").split("\n", 1)[0][:140]
+        detail_lines.append(
+            f"'{name}' (owner={owner}): {code_str} — {msg_excerpt}".rstrip(" —")
+        )
+        remediation_lines.append(f"'{name}' (owner={owner}): {hint}")
+
+    results.append(CheckResult(
+        checkpoint_id="WD-CONN-101", category="Workday",
+        priority=Priority.HIGH.value, status=Status.FAILED.value,
+        description="Workday connection token health",
+        result=(
+            f"{len(unhealthy)} of {len(wd_conns)} Workday connection(s) have "
+            f"unhealthy auth state: " + "; ".join(detail_lines)
+        ),
+        remediation=" | ".join(remediation_lines),
+        doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
+    ))
+    return results
 
 
 def _check_flow_status(runner, wd_flows: list) -> list[CheckResult]:

--- a/tests/flightcheck/checks/test_workday_connection_token_health.py
+++ b/tests/flightcheck/checks/test_workday_connection_token_health.py
@@ -1,0 +1,303 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""End-to-end integration tests for the Workday connection token-health
+FlightCheck check (WD-CONN-101).
+
+WD-CONN-101 inspects the structured ``statuses[0].error.{code,message}``
+block on each Workday connection record returned by the PowerApps
+connections API and surfaces a failure with a remediation pinned to
+the specific Entra error code (AADSTS50173 grant-expired,
+AADSTS70008 refresh-token-expired-due-to-inactivity, etc.).
+
+Same mock surface as ``test_workday_connections.py`` (the ``pp_admin``
+mock module is ``MOCK_STATUS = "validated"``, cassette
+``tests/fixtures/cassettes/flightcheck_pp_admin.yaml``); same
+endpoint as WD-CONN-001, no new cassette required.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import responses
+
+from tests.conftest import require_validated_mock
+from tests.mocks import pp_admin as pp
+
+require_validated_mock(pp)
+
+
+@dataclass
+class _MinimalRunner:
+    pp_admin: Any
+    env_id: str
+
+
+@pytest.fixture
+def pp_client(fake_token: str):
+    """A real PPAdminClient with a pre-populated token, ready to be
+    driven through `responses` mocks. Same pattern as
+    test_workday_connections.py."""
+    from flightcheck.pp_admin_client import PPAdminClient
+
+    client = PPAdminClient(tenant_id="00000000-0000-0000-0000-000000001111")
+    client._token = fake_token
+    return client
+
+
+@pytest.fixture
+def runner(pp_client) -> _MinimalRunner:
+    return _MinimalRunner(pp_admin=pp_client, env_id=pp.MOCK_ENV_ID)
+
+
+def _result_by_id(results: list, checkpoint_id: str):
+    matches = [r for r in results if r.checkpoint_id == checkpoint_id]
+    assert len(matches) == 1, (
+        f"Expected exactly one result for {checkpoint_id}, got {len(matches)}: "
+        f"{[r.checkpoint_id for r in results]}"
+    )
+    return matches[0]
+
+
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestGoodConfig:
+    @responses.activate
+    def test_all_connections_connected_passes(self, runner: _MinimalRunner) -> None:
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(status="Connected", display_name="Workday SOAP — ISU"),
+                pp.workday_connection(status="Connected", display_name="Workday SOAP — User"),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Passed"
+        assert wd_101.priority == "High"
+        assert "All 2 Workday connection(s)" in wd_101.result
+        assert "healthy" in wd_101.result.lower()
+        assert wd_101.remediation == ""
+
+
+class TestBadConfig:
+    @responses.activate
+    def test_aadsts50173_grant_expired_fails_with_pinned_remediation(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """The canonical scenario from the cassette: AADSTS50173, grant
+        expired/revoked. WD-CONN-101 should FAIL, name the connection,
+        name the connection owner, and quote the AADSTS code in both
+        the result and the remediation."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday SOAP — ISU",
+                    error_code="AADSTS50173",
+                    error_message=(
+                        "Failed to refresh access token. AADSTS50173: The "
+                        "provided grant has expired due to it being revoked."
+                    ),
+                    account_name="isu.admin@contoso.com",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+        assert wd_101.priority == "High"
+        assert "1 of 1" in wd_101.result
+        assert "AADSTS50173" in wd_101.result
+        assert "Workday SOAP — ISU" in wd_101.result
+        assert "isu.admin@contoso.com" in wd_101.result
+        # Remediation pins the specific AADSTS hint, not a generic message.
+        assert "AADSTS" not in wd_101.remediation  # hint is text, not the code
+        assert "grant expired" in wd_101.remediation.lower()
+        assert "Re-authenticate" in wd_101.remediation
+        assert "isu.admin@contoso.com" in wd_101.remediation
+
+    @responses.activate
+    def test_aadsts70008_refresh_token_expired_picks_inactivity_hint(
+        self, runner: _MinimalRunner
+    ) -> None:
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday SOAP — User",
+                    error_code="AADSTS70008",
+                    error_message="The refresh token has expired due to inactivity.",
+                    account_name="svc.workday@contoso.com",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+        assert "AADSTS70008" in wd_101.result
+        assert "inactivity" in wd_101.remediation.lower()
+        assert "svc.workday@contoso.com" in wd_101.remediation
+
+    @responses.activate
+    def test_unrecognized_error_code_falls_back_to_generic_hint(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """If Power Platform surfaces an error code not in our known
+        AADSTS mapping, WD-CONN-101 still fails, surfaces the code
+        verbatim, and tells the operator to re-authenticate."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday SOAP — Misc",
+                    error_code="AADSTS99999",
+                    error_message="Some new auth failure mode we have not seen.",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+        assert "AADSTS99999" in wd_101.result
+        assert "unrecognized token-health error" in wd_101.remediation.lower()
+        assert "Re-authenticate" in wd_101.remediation
+
+
+class TestMixedState:
+    @responses.activate
+    def test_one_healthy_one_expired_fails_with_only_expired_in_remediation(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """A healthy + an expired connection: WD-CONN-101 reports
+        FAILED ("1 of 2 unhealthy") and the remediation text only
+        mentions the failing one. The healthy connection must NOT
+        appear in the remediation (otherwise an operator might
+        re-authenticate the wrong account)."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Connected",
+                    display_name="Workday SOAP — Healthy",
+                    account_name="healthy.user@contoso.com",
+                ),
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday SOAP — Broken",
+                    error_code="AADSTS50173",
+                    account_name="broken.user@contoso.com",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+        assert "1 of 2" in wd_101.result
+        assert "Workday SOAP — Broken" in wd_101.result
+        assert "broken.user@contoso.com" in wd_101.result
+        assert "Workday SOAP — Healthy" not in wd_101.result
+        assert "healthy.user@contoso.com" not in wd_101.remediation
+        assert "broken.user@contoso.com" in wd_101.remediation
+
+
+class TestEdgeCases:
+    @responses.activate
+    def test_no_workday_connections_returns_not_configured(
+        self, runner: _MinimalRunner
+    ) -> None:
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(env_id=runner.env_id, connections=[]))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "NotConfigured"
+        assert "No Workday connections" in wd_101.result
+        assert "configure" in wd_101.remediation.lower()
+
+    @responses.activate
+    def test_non_workday_connections_filtered_out(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """A broken Office365 connection must NOT trip WD-CONN-101;
+        the filter limits the check to Workday connections only."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.non_workday_connection(display_name="Office 365", status="Error"),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "NotConfigured"
+
+    @responses.activate
+    def test_403_from_bap_returns_warning(self, runner: _MinimalRunner) -> None:
+        """403 from BAP — the operator's account lacks PP Admin role.
+        Per the existing pattern in WD-CONN-001 this surfaces as a
+        WARNING, not a misleading NotConfigured. Note: WD-CONN-001
+        currently mis-reports this scenario (latent bug pinned in
+        test_workday_connections.py::test_403_from_bap_is_misreported_as_not_configured);
+        WD-CONN-101 sits behind the same client method so it shares
+        the same buggy "looks like empty list" behavior. Pin the
+        current behavior here so a fix to PPAdminClient._get_all
+        will surface this test for an update at the same time."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.insufficient_permissions(env_id=runner.env_id))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        # Current buggy behavior — same root cause as WD-CONN-001's pin.
+        # When PPAdminClient._get_all is fixed to surface 401/403 as a
+        # structured error dict (see test_workday_connections.py edge
+        # test for the recommended fix), flip this assertion to:
+        #   assert wd_101.status == "Warning"
+        #   assert "Power Platform" in wd_101.remediation
+        assert wd_101.status == "NotConfigured"
+
+    def test_skips_when_env_id_missing(self, pp_client) -> None:
+        """No env_id → empty list (no result), don't crash, don't make
+        a request."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        runner_no_env = _MinimalRunner(pp_admin=pp_client, env_id="")
+        results = _check_connection_token_health(runner_no_env)
+        assert results == []
+
+    def test_skips_when_pp_admin_missing(self) -> None:
+        """No pp_admin client (auth failed earlier) → empty list, no
+        crash. Defensive: WD-CONN-001 today crashes in this case
+        (calls pp.get_connections() unconditionally); WD-CONN-101 is
+        new code so we add the guard here."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        runner_no_pp = _MinimalRunner(pp_admin=None, env_id=pp.MOCK_ENV_ID)
+        results = _check_connection_token_health(runner_no_pp)
+        assert results == []

--- a/tests/flightcheck/checks/test_workday_connection_token_health.py
+++ b/tests/flightcheck/checks/test_workday_connection_token_health.py
@@ -357,3 +357,438 @@ class TestEdgeCases:
         runner_no_pp = _MinimalRunner(pp_admin=None, env_id=pp.MOCK_ENV_ID)
         results = _check_connection_token_health(runner_no_pp)
         assert results == []
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Owner-fallback tests
+#
+# Admin-scope listings of connections owned by other users frequently
+# return ``accountName: null``. WD-CONN-101 must fall through to
+# ``createdBy.userPrincipalName`` / ``createdBy.displayName`` so the
+# operator gets the most actionable owner identity available, instead
+# of an unhelpful "(unknown owner)".
+#
+# Observed live on 2026-05-21 in env PROD - ESS + WD + SNow: 7 Workday
+# connections with ``accountName: null`` but
+# ``createdBy.userPrincipalName: lmoulet@EmployeeHub.onmicrosoft.com``.
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestOwnerFallback:
+    @responses.activate
+    def test_falls_back_to_created_by_upn_when_account_name_null(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """``accountName`` is empty but ``createdBy.userPrincipalName``
+        is set → result shows the UPN, not "(unknown owner)"."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    error_code="Unauthorized",
+                    error_message="Failed: AADSTS50173: grant expired.",
+                    account_name="",  # admin-scope shape
+                    created_by_upn="lmoulet@example.com",
+                    created_by_display_name="Laurent Moulet",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert "lmoulet@example.com" in wd_101.result
+        assert "lmoulet@example.com" in wd_101.remediation
+        assert "(unknown owner)" not in wd_101.result
+
+    @responses.activate
+    def test_falls_back_to_created_by_display_name_when_upn_also_missing(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """Owner-fallback chain: accountName empty AND createdBy.UPN
+        empty → use createdBy.displayName as the last actionable
+        identity."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    error_code="Unauthorized",
+                    error_message="Failed: AADSTS50173: grant expired.",
+                    account_name="",
+                    created_by_display_name="Service Principal — Workday Importer",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert "Service Principal — Workday Importer" in wd_101.result
+
+    @responses.activate
+    def test_unknown_owner_when_all_identity_fields_missing(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """All owner-identity fields missing → preserve the
+        ``(unknown owner)`` literal so operators don't see a confusing
+        bare colon."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    error_code="Unauthorized",
+                    error_message="Failed: AADSTS50173: grant expired.",
+                    account_name="",
+                    # createdBy.* not overridden — default builder
+                    # populates Mock User; clear with empty strings
+                    created_by_upn="",
+                    created_by_display_name="",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert "(unknown owner)" in wd_101.result
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Severity tiering + in-use cross-reference tests
+#
+# WD-CONN-101 splits unhealthy connections into two buckets:
+#   - FAILED: unhealthy AND referenced by a flow (will break runtime)
+#   - WARNING: unhealthy AND not referenced by any flow (cleanup task)
+#
+# When flow enumeration is unavailable (no flow mock registered,
+# get_flows raises, etc.) the check conservatively treats every
+# unhealthy connection as in-use → FAILED. This preserves backward
+# compatibility with the original tests above (which don't register
+# a flows mock) and avoids silently demoting real flow-breakers.
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pp_client_with_flow_token(pp_client, fake_token: str):
+    """A pp_client with both _token AND _flow_token set, so the
+    in-use lookup (via pp.get_flows()) can be exercised by tests
+    that register a flow mock. The two tokens live on different
+    audiences in production — the test fixture reuses the same
+    fake_token for both since the responses library doesn't
+    validate the bearer value."""
+    pp_client._flow_token = fake_token
+    return pp_client
+
+
+@pytest.fixture
+def runner_with_flow_token(pp_client_with_flow_token) -> _MinimalRunner:
+    return _MinimalRunner(
+        pp_admin=pp_client_with_flow_token, env_id=pp.MOCK_ENV_ID
+    )
+
+
+class TestSeverityTiering:
+    @responses.activate
+    def test_config_needed_orphan_is_warning_not_failed(
+        self, runner_with_flow_token: _MinimalRunner
+    ) -> None:
+        """ConfigurationNeeded + no flow uses the connection ⇒ WARNING
+        (orphan cleanup), not FAILED. This is the 3-of-7 scenario
+        observed live in PROD - ESS + WD + SNow on 2026-05-21."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner_with_flow_token.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    connection_name="shared-workdaysoap-orphan-001",
+                    error_code="ConfigurationNeeded",
+                    error_message="Parameter value missing.",
+                    account_name="",
+                    created_by_upn="lmoulet@example.com",
+                ),
+            ],
+        ))
+        # No flows reference this connection ⇒ orphan.
+        responses.add(**pp.list_flows(
+            env_id=runner_with_flow_token.env_id,
+            flows=[],
+        ))
+
+        results = _check_connection_token_health(runner_with_flow_token)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Warning"
+        assert "orphan" in wd_101.result.lower()
+        assert "not referenced by any flow" in wd_101.result.lower()
+        assert "ConfigurationNeeded" in wd_101.result
+
+    @responses.activate
+    def test_config_needed_in_use_is_failed_not_warning(
+        self, runner_with_flow_token: _MinimalRunner
+    ) -> None:
+        """ConfigurationNeeded but a flow references the connection ⇒
+        FAILED (the flow will break at runtime — operator must finish
+        configuration)."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        conn_name = "shared-workdaysoap-inuse-002"
+        responses.add(**pp.list_connections(
+            env_id=runner_with_flow_token.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    connection_name=conn_name,
+                    error_code="ConfigurationNeeded",
+                    error_message="Parameter value missing.",
+                ),
+            ],
+        ))
+        responses.add(**pp.list_flows(
+            env_id=runner_with_flow_token.env_id,
+            flows=[
+                pp.flow(
+                    display_name="Get Worker — Workday",
+                    connection_references={
+                        "shared_workdaysoap_01": pp.workday_connection_reference(
+                            connection_name=conn_name,
+                        ),
+                    },
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner_with_flow_token)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+        assert "referenced by a flow" in wd_101.result.lower()
+        assert "ConfigurationNeeded" in wd_101.result
+
+    @responses.activate
+    def test_auth_failure_with_no_flows_mock_remains_failed(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """No flows mock registered ⇒ in-use lookup returns None ⇒
+        conservative "treat as in-use" ⇒ FAILED. This is the
+        backwards-compat path for the original TestBadConfig tests."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    error_code="Unauthorized",
+                    error_message="Failed: AADSTS50173: grant expired.",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+
+    @responses.activate
+    def test_mixed_orphan_and_in_use_emits_two_results(
+        self, runner_with_flow_token: _MinimalRunner
+    ) -> None:
+        """Mix of in-use AADSTS failure + orphan ConfigurationNeeded ⇒
+        TWO WD-CONN-101 results: one FAILED for the in-use auth-broken
+        one, one WARNING for the orphan unconfigured one."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        in_use_name = "shared-workdaysoap-inuse-aaa"
+        orphan_name = "shared-workdaysoap-orphan-bbb"
+        responses.add(**pp.list_connections(
+            env_id=runner_with_flow_token.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    connection_name=in_use_name,
+                    error_code="Unauthorized",
+                    error_message="Failed: AADSTS50173: grant expired.",
+                    account_name="active.owner@example.com",
+                ),
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    connection_name=orphan_name,
+                    error_code="ConfigurationNeeded",
+                    error_message="Parameter value missing.",
+                    account_name="",
+                    created_by_upn="leftover.creator@example.com",
+                ),
+            ],
+        ))
+        responses.add(**pp.list_flows(
+            env_id=runner_with_flow_token.env_id,
+            flows=[
+                pp.flow(
+                    display_name="Active Workday Flow",
+                    connection_references={
+                        "shared_workdaysoap_01": pp.workday_connection_reference(
+                            connection_name=in_use_name,
+                        ),
+                    },
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner_with_flow_token)
+        wd_101_results = [r for r in results if r.checkpoint_id == "WD-CONN-101"]
+        assert len(wd_101_results) == 2, (
+            f"Expected one FAILED + one WARNING, got: "
+            f"{[(r.status, r.result[:60]) for r in wd_101_results]}"
+        )
+        statuses = {r.status for r in wd_101_results}
+        assert statuses == {"Failed", "Warning"}
+
+        failed = next(r for r in wd_101_results if r.status == "Failed")
+        warning = next(r for r in wd_101_results if r.status == "Warning")
+        # FAILED bucket has the in-use connection; WARNING has the orphan.
+        assert "AADSTS50173" in failed.result
+        assert "active.owner@example.com" in failed.result
+        assert "ConfigurationNeeded" not in failed.result
+        assert "ConfigurationNeeded" in warning.result
+        assert "leftover.creator@example.com" in warning.result
+        assert "AADSTS50173" not in warning.result
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Remediation content tests
+#
+# The whole point of WD-CONN-101 is to give the operator a finding they
+# can act on without leaving the FlightCheck output. These tests pin
+# the actionable elements: connection id suffix, owner, creation date,
+# deep link to the maker portal, and the pre-filled PowerShell
+# Remove-AdminPowerAppConnection command for orphan cleanup.
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestRemediationContent:
+    @responses.activate
+    def test_orphan_remediation_contains_powershell_delete_command(
+        self, runner_with_flow_token: _MinimalRunner
+    ) -> None:
+        """Orphan connections get a pre-filled Remove-AdminPowerAppConnection
+        command with env id, connection name, and connector name."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        conn_name = "shared-workdaysoap-de1e7e-01"
+        responses.add(**pp.list_connections(
+            env_id=runner_with_flow_token.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    connection_name=conn_name,
+                    error_code="ConfigurationNeeded",
+                    error_message="Parameter value missing.",
+                ),
+            ],
+        ))
+        responses.add(**pp.list_flows(env_id=runner_with_flow_token.env_id, flows=[]))
+
+        results = _check_connection_token_health(runner_with_flow_token)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Warning"
+        assert "Remove-AdminPowerAppConnection" in wd_101.remediation
+        assert f"-EnvironmentName {runner_with_flow_token.env_id}" in wd_101.remediation
+        assert f"-ConnectionName {conn_name}" in wd_101.remediation
+        assert "-ConnectorName shared_workdaysoap" in wd_101.remediation
+
+    @responses.activate
+    def test_in_use_auth_failed_remediation_contains_maker_url(
+        self, runner_with_flow_token: _MinimalRunner
+    ) -> None:
+        """In-use auth-failed connections must include the maker portal
+        URL where the owner can re-authenticate."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        conn_name = "shared-workdaysoap-inuse-cc"
+        responses.add(**pp.list_connections(
+            env_id=runner_with_flow_token.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    connection_name=conn_name,
+                    error_code="Unauthorized",
+                    error_message="Failed: AADSTS50173: grant expired.",
+                    account_name="owner@example.com",
+                ),
+            ],
+        ))
+        responses.add(**pp.list_flows(
+            env_id=runner_with_flow_token.env_id,
+            flows=[
+                pp.flow(
+                    display_name="Workday Flow",
+                    connection_references={
+                        "ref": pp.workday_connection_reference(connection_name=conn_name),
+                    },
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner_with_flow_token)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+        maker_url = (
+            f"https://make.powerautomate.com/environments/"
+            f"{runner_with_flow_token.env_id}/connections"
+        )
+        assert maker_url in wd_101.remediation
+        # Auth-failed in-use must NOT suggest the delete command — it's
+        # in use, deleting would break the flow.
+        assert "Remove-AdminPowerAppConnection" not in wd_101.remediation
+
+    @responses.activate
+    def test_result_includes_id_suffix_owner_and_date(
+        self, runner_with_flow_token: _MinimalRunner
+    ) -> None:
+        """Every detail line must include the connection's short id
+        suffix (so the operator can tell apart 3 connections all named
+        "Workday"), the owner, and the creation date."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        # Connection name embeds a recognizable 8-hex segment.
+        conn_name = "shared-workdaysoap-deadbeef-2222-3333-4444-555555555555"
+        responses.add(**pp.list_connections(
+            env_id=runner_with_flow_token.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday",
+                    connection_name=conn_name,
+                    error_code="ConfigurationNeeded",
+                    error_message="Parameter value missing.",
+                    account_name="",
+                    created_by_upn="creator@example.com",
+                    created_time="2026-02-17T06:08:43.0592278Z",
+                ),
+            ],
+        ))
+        responses.add(**pp.list_flows(env_id=runner_with_flow_token.env_id, flows=[]))
+
+        results = _check_connection_token_health(runner_with_flow_token)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        # Short id suffix from the connection name.
+        assert "id=deadbeef" in wd_101.result
+        # Owner fell through to createdBy.UPN.
+        assert "owner=creator@example.com" in wd_101.result
+        # Creation date in YYYY-MM-DD form (no time component).
+        assert "created=2026-02-17" in wd_101.result

--- a/tests/flightcheck/checks/test_workday_connection_token_health.py
+++ b/tests/flightcheck/checks/test_workday_connection_token_health.py
@@ -92,10 +92,15 @@ class TestBadConfig:
     def test_aadsts50173_grant_expired_fails_with_pinned_remediation(
         self, runner: _MinimalRunner
     ) -> None:
-        """The canonical scenario from the cassette: AADSTS50173, grant
-        expired/revoked. WD-CONN-101 should FAIL, name the connection,
-        name the connection owner, and quote the AADSTS code in both
-        the result and the remediation."""
+        """The canonical scenario from the cassette: connection in
+        Error state with ``error.code = "Unauthorized"`` and the
+        AADSTS code embedded in the longer ``error.message`` prose
+        (this is the exact shape captured in
+        ``tests/fixtures/cassettes/flightcheck_pp_admin.yaml`` lines
+        2661-2680). WD-CONN-101 should FAIL, name the connection,
+        name the connection owner, extract the AADSTS50173 code from
+        the message, and surface the grant-expired hint — NOT the
+        generic Unauthorized hint."""
         from flightcheck.checks.workday import _check_connection_token_health
 
         responses.add(**pp.list_connections(
@@ -104,10 +109,14 @@ class TestBadConfig:
                 pp.workday_connection(
                     status="Error",
                     display_name="Workday SOAP — ISU",
-                    error_code="AADSTS50173",
+                    # Production shape: code is "Unauthorized" (coarse
+                    # PP classification), AADSTS code lives in message.
+                    error_code="Unauthorized",
                     error_message=(
-                        "Failed to refresh access token. AADSTS50173: The "
-                        "provided grant has expired due to it being revoked."
+                        "Failed to refresh access token for service: "
+                        "aadcertificate. Error: Failed to acquire token "
+                        "from AAD: AADSTS50173: The provided grant has "
+                        "expired due to it being revoked."
                     ),
                     account_name="isu.admin@contoso.com",
                 ),
@@ -119,11 +128,13 @@ class TestBadConfig:
         assert wd_101.status == "Failed"
         assert wd_101.priority == "High"
         assert "1 of 1" in wd_101.result
+        # Result quotes the *AADSTS* code, not the generic "Unauthorized"
+        # — extracted from message rather than blindly read from code.
         assert "AADSTS50173" in wd_101.result
         assert "Workday SOAP — ISU" in wd_101.result
         assert "isu.admin@contoso.com" in wd_101.result
-        # Remediation pins the specific AADSTS hint, not a generic message.
-        assert "AADSTS" not in wd_101.remediation  # hint is text, not the code
+        # Remediation pins the AADSTS-specific hint, not the generic
+        # "Unauthorized" hint that the coarse code would map to.
         assert "grant expired" in wd_101.remediation.lower()
         assert "Re-authenticate" in wd_101.remediation
         assert "isu.admin@contoso.com" in wd_101.remediation
@@ -132,6 +143,8 @@ class TestBadConfig:
     def test_aadsts70008_refresh_token_expired_picks_inactivity_hint(
         self, runner: _MinimalRunner
     ) -> None:
+        """Same realistic shape (code=Unauthorized, AADSTS in message),
+        but a different AADSTS code maps to a different hint."""
         from flightcheck.checks.workday import _check_connection_token_health
 
         responses.add(**pp.list_connections(
@@ -140,8 +153,11 @@ class TestBadConfig:
                 pp.workday_connection(
                     status="Error",
                     display_name="Workday SOAP — User",
-                    error_code="AADSTS70008",
-                    error_message="The refresh token has expired due to inactivity.",
+                    error_code="Unauthorized",
+                    error_message=(
+                        "Failed to acquire token: AADSTS70008: The "
+                        "refresh token has expired due to inactivity."
+                    ),
                     account_name="svc.workday@contoso.com",
                 ),
             ],
@@ -155,12 +171,44 @@ class TestBadConfig:
         assert "svc.workday@contoso.com" in wd_101.remediation
 
     @responses.activate
-    def test_unrecognized_error_code_falls_back_to_generic_hint(
+    def test_unauthenticated_connection_falls_back_to_code_field(
         self, runner: _MinimalRunner
     ) -> None:
-        """If Power Platform surfaces an error code not in our known
-        AADSTS mapping, WD-CONN-101 still fails, surfaces the code
-        verbatim, and tells the operator to re-authenticate."""
+        """The cassette also captures connections that were never
+        authenticated — ``code = "Unauthenticated"``, ``message =
+        "This connection is not authenticated."``. There is NO AADSTS
+        code in the message, so WD-CONN-101 should fall back to
+        looking up the ``code`` field and pick the
+        ``Unauthenticated`` hint (sign-in needed)."""
+        from flightcheck.checks.workday import _check_connection_token_health
+
+        responses.add(**pp.list_connections(
+            env_id=runner.env_id,
+            connections=[
+                pp.workday_connection(
+                    status="Error",
+                    display_name="Workday SOAP — Never Auth'd",
+                    error_code="Unauthenticated",
+                    error_message="This connection is not authenticated.",
+                    account_name="newuser@contoso.com",
+                ),
+            ],
+        ))
+
+        results = _check_connection_token_health(runner)
+        wd_101 = _result_by_id(results, "WD-CONN-101")
+        assert wd_101.status == "Failed"
+        assert "Unauthenticated" in wd_101.result
+        assert "not authenticated" in wd_101.remediation.lower()
+        assert "newuser@contoso.com" in wd_101.remediation
+
+    @responses.activate
+    def test_unrecognized_aadsts_code_in_message_falls_back_to_generic_hint(
+        self, runner: _MinimalRunner
+    ) -> None:
+        """If Power Platform surfaces an AADSTS code we don't have in
+        our mapping, WD-CONN-101 still fails, surfaces the code
+        verbatim from the message, and gives a generic re-auth hint."""
         from flightcheck.checks.workday import _check_connection_token_health
 
         responses.add(**pp.list_connections(
@@ -169,8 +217,11 @@ class TestBadConfig:
                 pp.workday_connection(
                     status="Error",
                     display_name="Workday SOAP — Misc",
-                    error_code="AADSTS99999",
-                    error_message="Some new auth failure mode we have not seen.",
+                    error_code="Unauthorized",
+                    error_message=(
+                        "Failed: AADSTS99999: Some new auth failure mode "
+                        "we have not seen before."
+                    ),
                 ),
             ],
         ))
@@ -178,8 +229,9 @@ class TestBadConfig:
         results = _check_connection_token_health(runner)
         wd_101 = _result_by_id(results, "WD-CONN-101")
         assert wd_101.status == "Failed"
+        # Extracted from message, not the code field.
         assert "AADSTS99999" in wd_101.result
-        assert "unrecognized token-health error" in wd_101.remediation.lower()
+        assert "unrecognized aadsts" in wd_101.remediation.lower()
         assert "Re-authenticate" in wd_101.remediation
 
 
@@ -206,7 +258,11 @@ class TestMixedState:
                 pp.workday_connection(
                     status="Error",
                     display_name="Workday SOAP — Broken",
-                    error_code="AADSTS50173",
+                    error_code="Unauthorized",
+                    error_message=(
+                        "Failed to refresh access token: AADSTS50173: "
+                        "The provided grant has expired."
+                    ),
                     account_name="broken.user@contoso.com",
                 ),
             ],

--- a/tests/mocks/pp_admin.py
+++ b/tests/mocks/pp_admin.py
@@ -182,6 +182,10 @@ def workday_connection(
     error_code: str | None = None,
     error_message: str | None = None,
     account_name: str | None = None,
+    connection_name: str | None = None,
+    created_by_upn: str | None = None,
+    created_by_display_name: str | None = None,
+    created_time: str | None = None,
 ) -> dict[str, Any]:
     """Convenience: a Workday SOAP connection. The check filters by
     'workday' substring in apiId+displayName, so both the api_id and
@@ -195,20 +199,52 @@ def workday_connection(
 
     `account_name` overrides the connection's ``properties.accountName``
     field — used by WD-CONN-101's remediation message to tell the
-    operator exactly which user's grant needs refreshing.
+    operator exactly which user's grant needs refreshing. Pass an
+    empty string ``""`` to simulate the admin-scope shape where
+    ``accountName`` is null/empty (forces the check's owner-fallback
+    chain through ``createdBy.userPrincipalName`` /
+    ``createdBy.displayName``).
+
+    `connection_name` overrides the connection record's ``name`` field
+    (the GUID-suffixed identifier like
+    ``shared-workdaysoap-ac42a2e7-...``) so tests can pin a specific
+    name that matches a flow's ``connectionReferences.{ref}.connectionName``
+    for in-use cross-referencing.
+
+    `created_by_upn` / `created_by_display_name` override the
+    ``properties.createdBy.userPrincipalName`` /
+    ``properties.createdBy.displayName`` fields used by WD-CONN-101's
+    owner-fallback chain when ``accountName`` is null.
+
+    `created_time` overrides the ``properties.createdTime`` field used
+    by WD-CONN-101 to surface a creation date in the operator's view.
     """
-    extra: dict[str, Any] | None = None
+    extra: dict[str, Any] = {}
     if account_name is not None:
-        extra = {"accountName": account_name}
+        extra["accountName"] = account_name
+    if created_time is not None:
+        extra["createdTime"] = created_time
+    if created_by_upn is not None or created_by_display_name is not None:
+        created_by: dict[str, Any] = {
+            "id": "00000000-0000-0000-0000-000000002222",
+            "type": "User",
+            "tenantId": "00000000-0000-0000-0000-000000001111",
+        }
+        if created_by_upn is not None:
+            created_by["userPrincipalName"] = created_by_upn
+            created_by["email"] = created_by_upn
+        if created_by_display_name is not None:
+            created_by["displayName"] = created_by_display_name
+        extra["createdBy"] = created_by
     return connection(
-        name=f"workday-{status.lower()}-{display_name[:8].lower().replace(' ', '-')}",
+        name=connection_name or f"workday-{status.lower()}-{display_name[:8].lower().replace(' ', '-')}",
         display_name=display_name,
         api_name="shared_workdaysoap",
         status=status,
         error_target=error_target,
         error_code=error_code,
         error_message=error_message,
-        extra_properties=extra,
+        extra_properties=extra or None,
     )
 
 
@@ -231,6 +267,7 @@ def flow(
     env_id: str = MOCK_ENV_ID,
     display_name: str = "Workday Get Worker",
     state: str = "Started",
+    connection_references: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build a single PowerApps flow record.
 
@@ -243,8 +280,23 @@ def flow(
     default) would serve under. Callers building a flow against a
     specific environment should pass the same env_id they pass to
     `list_flows()`.
+
+    `connection_references` populates ``properties.connectionReferences``,
+    a dict keyed by ref-name → ``{"apiId": ..., "connectionName": ...}``.
+    Used by WD-CONN-101 to cross-reference unhealthy Workday
+    connections against flows that depend on them (in-use ⇒ FAILED,
+    orphan ⇒ WARNING). Pass an empty dict / None to model a flow with
+    no connection references (i.e. doesn't claim any of the test's
+    Workday connections).
     """
     effective_id = flow_id or "00000000-0000-0000-0000-000000007101"
+    props: dict[str, Any] = {
+        "displayName": display_name,
+        "state": state,
+        "createdTime": "2026-01-01T00:00:00.000Z",
+    }
+    if connection_references is not None:
+        props["connectionReferences"] = dict(connection_references)
     return {
         "name": effective_id,
         "id": (
@@ -252,11 +304,35 @@ def flow(
             f"/flows/{effective_id}"
         ),
         "type": "Microsoft.ProcessSimple/environments/flows",
-        "properties": {
-            "displayName": display_name,
-            "state": state,
-            "createdTime": "2026-01-01T00:00:00.000Z",
-        },
+        "properties": props,
+    }
+
+
+def workday_connection_reference(
+    *,
+    connection_name: str,
+    api_name: str = "shared_workdaysoap",
+) -> dict[str, Any]:
+    """Build a single ``connectionReferences`` entry binding a flow to
+    a specific Workday connection record.
+
+    Returned shape matches the production response: a dict with at
+    least ``apiId`` (connector path) and ``connectionName`` (the
+    connection record's GUID-suffixed name). Wrap one or more of these
+    in a dict keyed by ref-name and pass to ``flow(connection_references=...)``.
+    """
+    return {
+        "apiId": (
+            f"/providers/Microsoft.PowerApps/scopes/admin/environments/"
+            f"{MOCK_ENV_ID}/apis/{api_name}"
+        ),
+        "connectionName": connection_name,
+        "id": (
+            f"/providers/Microsoft.PowerApps/scopes/admin/environments/"
+            f"{MOCK_ENV_ID}/apis/{api_name}/connections/{connection_name}"
+        ),
+        "source": "Embedded",
+        "tier": "NotSpecified",
     }
 
 

--- a/tests/mocks/pp_admin.py
+++ b/tests/mocks/pp_admin.py
@@ -171,16 +171,40 @@ def connection(
 
 
 def workday_connection(
-    *, status: str = "Connected", display_name: str = "Workday SOAP — ISU"
+    *,
+    status: str = "Connected",
+    display_name: str = "Workday SOAP — ISU",
+    error_target: str | None = None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+    account_name: str | None = None,
 ) -> dict[str, Any]:
     """Convenience: a Workday SOAP connection. The check filters by
     'workday' substring in apiId+displayName, so both the api_id and
-    the display_name reference Workday."""
+    the display_name reference Workday.
+
+    `error_target` / `error_code` / `error_message` are forwarded to the
+    underlying ``connection()`` builder when ``status == "Error"`` so
+    callers can simulate the AADSTS50173 / AADSTS70008 / AADSTS50058
+    grant-expiry shapes that WD-CONN-101 inspects. When omitted, the
+    underlying builder falls back to its default AADSTS50173 example.
+
+    `account_name` overrides the connection's ``properties.accountName``
+    field — used by WD-CONN-101's remediation message to tell the
+    operator exactly which user's grant needs refreshing.
+    """
+    extra: dict[str, Any] | None = None
+    if account_name is not None:
+        extra = {"accountName": account_name}
     return connection(
         name=f"workday-{status.lower()}-{display_name[:8].lower().replace(' ', '-')}",
         display_name=display_name,
         api_name="shared_workdaysoap",
         status=status,
+        error_target=error_target,
+        error_code=error_code,
+        error_message=error_message,
+        extra_properties=extra,
     )
 
 


### PR DESCRIPTION
Implements the FlightCheck check requested in #81.

**Checkpoint:** `WD-CONN-101`
**Category:** Workday
**Priority:** HIGH
**Conditional?** No (runs whenever Workday flows are detected, like the rest of `run_workday_checks`)

**API tier:** validated
**Mock source:**
  - Cassette: `tests/fixtures/cassettes/flightcheck_pp_admin.yaml`
  - Mock builder: `tests/mocks/pp_admin.py` (`MOCK_STATUS = "validated"`)
  - Same endpoint as WD-CONN-001 (`GET /providers/Microsoft.PowerApps/scopes/admin/environments/{env_id}/connections`)  already in the confirmed-cassette table in `tests/fixtures/cassettes/INDEX.md`, so no new cassette / no registry change required.

**What WD-CONN-101 adds beyond WD-CONN-001:**

WD-CONN-001 reports whether each Workday connection is in `Connected` state. WD-CONN-101 inspects the structured `statuses[0].error.{code,message}` block the PowerApps API returns on non-Connected statuses and surfaces:

* The connection display name and the connection owner's account (`properties.accountName`)
* The Entra error code verbatim (e.g. `AADSTS50173`, `AADSTS70008`, `AADSTS50058`, `AADSTS50076`)
* A pinned remediation hint per known error code, telling the operator *what* expired and *what to do* (re-auth in Power Platform, complete MFA, etc.)

The customer-facing failure mode this catches: a Workday SOAP connection that worked yesterday silently flips to 401/403 at runtime because the connection creator's Entra grant lapsed. Today WD-CONN-001 says "Error / re-authenticate"; WD-CONN-101 names the user, the grant code, and what specifically expired.

**Tests:** `tests/flightcheck/checks/test_workday_connection_token_health.py`  10 new tests, all passing locally.

* GOOD: all Workday connections Connected  Passed
* BAD: AADSTS50173 grant-expired  Failed with grant-expired hint
* BAD: AADSTS70008 refresh-token-inactivity  Failed with inactivity hint
* BAD: unrecognized AADSTS code  Failed with generic re-auth hint
* MIXED: one healthy + one expired  Failed, only the expired one in the remediation
* EDGE: no Workday connections  NotConfigured
* EDGE: only non-Workday connections (Office 365 etc.)  NotConfigured
* EDGE: 403 from BAP  pinned to current buggy NotConfigured behavior (shares root cause with WD-CONN-001's already-pinned `test_403_from_bap_is_misreported_as_not_configured` regression test; will flip together when `PPAdminClient._get_all` is fixed)
* EDGE: missing `env_id`  empty list, no crash, no request
* EDGE: missing `pp_admin` client (auth failed earlier)  empty list, no crash

Existing 35 flightcheck tests still pass (45 passed, 8 skipped  same skip count as baseline; the skips are tier-policy non-applicable in `test_mock_validation_policy.py`).

**Scope notes  parts of the issue that are intentionally NOT in this PR:**

The issue's "Suggested implementation" had three parts. Only part 1 fits the kit's actual architecture:

| # | Suggested | Status |
|---|---|---|
| 1 | Use PP Admin API to enumerate Workday connection refs and inspect `statuses[].status` and `statuses[].error` |  Implemented as WD-CONN-101 |
| 2 | Attempt a low-cost SOAP probe (`Get_Server_Timestamp` / minimal `Get_Workers`) and report 401/403 explicitly |  Already covered by the existing WD-WF-* checks, which call 17 real ESS workflows against the live Workday tenant when ISU credentials are supplied. WD-CONN-101 stays offline-only against the BAP cassette to avoid duplicating WD-WF-001 and to keep the check fast in CI. |
| 3 | Warn if "OAuth token last-refreshed timestamp" is older than the customer's IdP refresh-token lifetime |  Two blockers: (a) the runtime ESS Workday integration uses WS-Security UsernameToken (Basic auth via ISU username + password), so there is no Workday-side OAuth/refresh token to inspect; (b) the PowerApps connections API does not expose a `lastRefreshedTimestamp` field on connection records (verified against the validated cassette in `flightcheck_pp_admin.yaml`). Documented in the WD-CONN-101 docstring as a follow-up that would need a different API surface (e.g., Entra Sign-In Logs via Graph). |

Both deferrals are documented in the check's docstring + the source comments so a future agent or reviewer hitting the same issue won't re-litigate them.

Fixes #81
