### PR TITLE
flightcheck: AGENTS.md guidance updates from PR #87 post-mortem

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
+++ b/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
@@ -47,6 +47,44 @@ existing patterns.
 
 ---
 
+## Power Platform identity gotchas
+
+These bit us in PR #87's post-mortem. Read before adding any check
+that handles Power Platform identifiers, hosts, or audience tokens.
+
+**Dataverse Organization ID ≠ BAP environment ID.** Most tenants
+have different GUIDs for the two. Never derive the BAP env id from
+Dataverse `WhoAmI()` / `OrganizationId`. Always list BAP environments
+and match on `linkedEnvironmentMetadata.instanceUrl` against the
+Dataverse env URL. See `pva_client._discover_gateway()` and
+`pp_admin_client.find_environment_id_by_dataverse_url()` for the
+pattern. `runner.env_id` is **always** the BAP id and never the
+Dataverse OrgId — do not pass it where a Dataverse identifier is
+expected, and do not derive one from the other.
+
+**BAP returns 404 (not 403) when handed an unknown env id.** If a
+BAP admin call returns 404 for an env you know exists, your env id
+is wrong, not the env. Permission failures surface as 401/403.
+
+**Host ↔ audience pairing for Power Platform APIs.** Each host
+requires its own audience token; mixing produces 401 even when the
+account has the right roles.
+
+| Host | Audience scope | Used for |
+|---|---|---|
+| `api.bap.microsoft.com` | `service.powerapps.com//.default` | BAP environments, DLP, capacity |
+| `api.powerapps.com` | `service.powerapps.com//.default` | PowerApps Admin (connections, etc.) |
+| `api.flow.microsoft.com` | `service.flow.microsoft.com//.default` | Power Automate Admin (flow listing) — **separate audience** |
+| `graph.microsoft.com` | `graph.microsoft.com/.default` | Microsoft Graph |
+| `<dataverse-url>` (`https://orgX.crm.dynamics.com`) | `{env_url}/user_impersonation` | Dataverse Web API |
+| `<island-gateway-url>` (region-specific) | `96ff4394-9197-43aa-b393-6a41652e21f8/.default` | Copilot Studio runtime |
+
+A 401 against `api.flow.microsoft.com` with a `service.powerapps.com`
+token is the classic symptom. When adding a client, document the
+host+audience+example-endpoint triple in `tests/fixtures/cassettes/INDEX.md`.
+
+---
+
 ## The cardinal rule
 
 > **Every FlightCheck check that calls an external API must verify the
@@ -112,6 +150,39 @@ If you're not sure whether a query param changes the shape, capture it.
 The cost of an unnecessary cassette is a few KB; the cost of a check
 built against a guessed shape is a false-confidence FlightCheck pass.
 
+### Sanity-checking a capture before pinning it
+
+The cassette infrastructure trusts what the recorder captures. If the
+captured response itself is wrong (wrong URL, wrong audience, wrong
+auth context), pinning it as `validated` ground truth codifies the
+bug with full ceremony. PR #87's post-mortem found exactly this: a
+404 from the wrong host (`api.powerapps.com` instead of
+`api.flow.microsoft.com`) had been pinned as "expected behavior for
+Dataverse-only environments" — a plausible-sounding rationale for an
+incorrect capture.
+
+Before adding a cassette row, especially for an unexpected status
+(4xx/5xx) or an unexpectedly empty body:
+
+1. **Cite the vendor doc URL** that documents the operation. The
+   status you captured must match a status the doc page describes —
+   or your explanation in `INDEX.md` must reference the specific text
+   that justifies the discrepancy. "Plausible-sounding folklore" is
+   not justification.
+2. **Re-capture against a second tenant** known to have the resource.
+   If both tenants produce the same anomalous status, your explanation
+   is more likely correct. If they diverge, your capture is
+   environmental and the cassette is not ground truth.
+3. **A 4xx from a happy-path call is a red flag, not a feature.**
+   Pinning a 4xx as "expected for this configuration" requires citing
+   both (a) the vendor doc for that status and (b) at least two
+   tenant captures.
+4. **A regression test that pins a 404 needs justification.** Do not
+   write a test whose only job is to assert that the production code
+   crashes on an empty/error response, unless you have first verified
+   you are calling the right endpoint with the right auth. If the
+   endpoint is wrong, fix the endpoint; don't pin the wrong-URL 404.
+
 ---
 
 ## Workflow when adding a new check that calls an external API
@@ -169,6 +240,33 @@ mock builder docstring. The author's schema walk-through IS the
 validation — you're attesting that the contract you coded against
 came from the schema, not memory or guesswork. Proceed to step 3.
 
+**`validatable` validates shape, not values.** The CSDL tells you
+the field type, not the value vocabulary. For any field whose
+meaningful values come from a documented enum, a vendor-published
+list, or a runtime convention (e.g., licence SKU part numbers, role
+template IDs, principal-type strings), you must additionally:
+
+1. Cite the **vendor-published reference list** for the values. For
+   licence SKUs:
+   `https://learn.microsoft.com/entra/identity/users/licensing-service-plan-reference`
+   (table of `String ID` ↔ `GUID` ↔ included service plans).
+2. Match values **case-insensitively unless the reference explicitly
+   says case is significant.** Graph regularly returns the same SKU
+   in different casings across tenants (`Microsoft_365_Copilot` vs
+   `MICROSOFT_365_COPILOT`).
+3. For SKUs and other bundles: list the bundles that *include* the
+   service you care about, not just the singleton SKU. The
+   licensing-service-plan-reference table tells you which service-plan
+   GUIDs are contained in each SKU. PRE-003 (Teams entitlement)
+   previously only matched `"TEAMS"` substrings and missed Teams
+   delivered via O365_BUSINESS_PREMIUM, ENTERPRISEPACK, SPE_E3, etc.
+4. Add a unit test that loads the published reference table (or a
+   representative subset captured into the test) and asserts the
+   check matches every SKU that contains the target service plan.
+
+This rule applies whenever the check's pass/fail branches on a
+specific string value, not just on whether a field exists.
+
 **If the tier is `documented`:** fetch the MS Learn (or vendor) doc
 page for the operation. Locate the "Response" section; copy the
 example JSON verbatim into the mock builder docstring. Cite the doc
@@ -194,7 +292,7 @@ Runner attributes available to checks (set up by `cli.py`):
 |-----------|------|-------------|
 | `runner.env_url` | `str` | Dataverse environment URL |
 | `runner.dv_token` | `str` | Dataverse bearer token |
-| `runner.env_id` | `str` | Power Platform (BAP) environment ID |
+| `runner.env_id` | `str` | Power Platform (BAP) environment ID. **NOT** the Dataverse OrgId — these are different GUIDs on most tenants. Derived via `pp_admin_client.find_environment_id_by_dataverse_url()` (instance-URL match against the BAP env list). See "Power Platform identity gotchas." |
 | `runner.graph` | `GraphClient \| None` | Microsoft Graph client |
 | `runner.pp_admin` | `PowerPlatformAdminClient \| None` | BAP admin client |
 | `runner.pva` | `PVAClient \| None` | Island Gateway client |
@@ -250,6 +348,28 @@ and do the per-tier verification.
    Available scopes: `full`, `prerequisites`, `environment`,
    `authentication`, `external`, `workday`, `local`, `publishing`.
 3. Verify the check produces useful output in both pass AND fail states.
+
+### 5a. End-to-end smoke against a real tenant — required for new endpoints
+
+Mocks validate logic; live runs validate that the endpoint exists,
+the host+audience pair is right, and the gate chain that feeds your
+check actually populates. Unit tests passing while the production
+endpoint returns 404 is exactly how PR #87's three latent bugs
+survived. **If your PR adds a check that calls an API host or
+audience not already covered by an existing `runner.<client>`
+method, the PR description must include:**
+
+* The exact `python scripts/flightcheck/cli.py --scope <scope>`
+  command you ran.
+* The output line showing the new checkpoint ID firing with a
+  terminal status (PASSED, WARNING, FAILED, or NOT_CONFIGURED) —
+  NOT SKIPPED. A SKIPPED result means the check did not actually
+  execute and the live run did not exercise the new endpoint.
+* A note confirming the run was against a real tenant, not a mock.
+
+If your check is gated by an upstream check (e.g. a Workday check
+that only runs when `_workday_flows` is non-empty), use a tenant
+where the upstream gate opens. Otherwise the smoke proves nothing.
 
 ---
 
@@ -373,9 +493,9 @@ x-cci-cdsbotid: {bot_id}            (optional, for bot-scoped requests)
 ```
 
 **Key gotcha:** The BAP environment ID is NOT the same as the Dataverse
-environment ID. The BAP env ID is discovered by listing environments from the
-BAP API and matching on the Dataverse instance URL. See `pva_client.py`
-`_discover_gateway()` for the implementation pattern.
+environment ID. See "Power Platform identity gotchas" near the top of
+this file for the cross-cutting rule that applies to every client that
+needs a BAP env id, including the implementation pattern.
 
 **Read all bot components:**
 ```


### PR DESCRIPTION
## Summary

Process update prompted by the post-mortem of PR #87 (WD-ENV-101 Workday ISU username vs Entra UPN format alignment). While validating that PR end-to-end against a real tenant, three latent bugs surfaced — all from the original May 7 Python scripts commit, all with passing unit tests:

| Bug | Symptom | Root cause |
|---|---|---|
| BAP env id derivation | Every BAP-scoped check 404'd on most tenants | `derive_environment_id()` returned the Dataverse OrgId, not the BAP env id (different GUIDs on most tenants) |
| Flow listing endpoint | EXT-001 + Workday block silently gated out | `get_flows()` hit `api.powerapps.com` when the admin flow API lives on `api.flow.microsoft.com` with a separate audience token |
| License SKU matching | PRE-001/002/003 FAILED on tenants with valid licenses | Case-sensitive `in` checks against UPPER_CASE patterns; Graph returns mixed case |

The bugs themselves are fixed in **PR #87**. This PR is the corresponding **guidance update** so future agents don't reintroduce the same classes of mistake.

## What this PR changes

Five additions to `solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md`:

1. **New top-level section "Power Platform identity gotchas"** — promotes the BAP-id-vs-Dataverse-OrgId gotcha from the buried PVA subsection to a cross-cutting rule. Adds the host↔audience pairing table for all six API surfaces the kit uses (including the `api.flow.microsoft.com` + `service.flow.microsoft.com//.default` pair that bug 2 missed). Also adds "BAP returns 404 (not 403) when handed an unknown env id" to prevent misdiagnosing wrong-id as permission failure.

2. **New subsection "Sanity-checking a capture before pinning it"** (under "What counts as the same endpoint") — documents the failure mode that produced bug 2. The cardinal rule was supposed to prevent guessing, but a misdiagnosed *capture* locks in the wrong contract with full ceremony. Adds four sanity rules: cite vendor docs; re-capture against a second tenant; treat 4xx-on-happy-path as a red flag; don't pin a 404 regression test before verifying the endpoint is correct.

3. **New paragraph "`validatable` validates shape, not values"** (under "If the tier is `validatable`") — documents the failure mode that produced bug 3. CSDL guarantees field shape, not value vocabulary. Requires vendor-published reference list citation, case-insensitive matching by default, bundle-expansion awareness, and a unit test that loads the reference table.

4. **Annotated `runner.env_id` table row** — was "Power Platform (BAP) environment ID" (true but easy to read past). Now explicitly says NOT the Dataverse OrgId, names the derivation pattern, and cross-references the new identity-gotchas section.

5. **New "step 5a. End-to-end smoke against a real tenant"** — required PR-description content for any new check that calls a host/audience pair not covered by an existing `runner.<client>` method: the exact CLI command, the output line showing the new checkpoint firing with a *terminal* status (NOT SKIPPED), and confirmation the run was against a real tenant. Mocks validate logic; live runs validate that the endpoint exists. PR #87's three bugs all had passing unit tests precisely because the mocks themselves were wrong.

## Why this is its own PR

Separation of concerns: PR #87 contains the code fixes plus the test infrastructure that aligns with them (including INDEX.md row corrections — those are tightly coupled to the code change). This PR contains the *aspirational rules* for future work — distinct review concern, distinct audience (process-minded reviewers vs. code-minded reviewers).

## Out of scope

- Re-capturing `flightcheck_pp_admin.yaml` against the correct `api.flow.microsoft.com` host (noted as a TODO in INDEX.md by PR #87).
- Promoting these rules into `tests/AGENTS.md` (the companion test-authoring file) — cross-references in flightcheck/AGENTS.md make the new rules discoverable from there, but a dedicated mirror could come in a follow-up if reviewers prefer.

Related: #87
