### PR TITLE
fix(eval): resolve parent-child linking when multiple eval sets share…

### DIFF
--- a/solutions/ess-maker-skills/scripts/push.py
+++ b/solutions/ess-maker-skills/scripts/push.py
@@ -715,13 +715,15 @@ def main():
                 if len(_folder_matches) == 1:
                     parent_id = _folder_matches[0][1]
                 elif len(_folder_matches) > 1:
-                    # Multiple parents in same folder — match by prefix.
+                    # Multiple parents in same folder — match by longest prefix.
+                    _best = (None, -1)  # (p_id, stem_length)
                     for p_path, p_id in _folder_matches:
                         p_stem = p_path.replace("\\", "/").split("/")[-1] \
                             .replace(".mcs.yml", "")
-                        if child_fname.startswith(p_stem + "-"):
-                            parent_id = p_id
-                            break
+                        if child_fname.startswith(p_stem + "-") and len(p_stem) > _best[1]:
+                            _best = (p_id, len(p_stem))
+                    if _best[0] is not None:
+                        parent_id = _best[0]
                     if parent_id is None:
                         # No prefix match; fall back to first.
                         parent_id = _folder_matches[0][1]
@@ -746,12 +748,14 @@ def main():
                     parent_id = _cm_matches[0][1]
                 elif len(_cm_matches) > 1:
                     child_fname = filepath.replace("\\", "/").split("/")[-1]
+                    _best = (None, -1)  # (p_id, stem_length)
                     for p_path, p_id in _cm_matches:
                         p_stem = p_path.replace("\\", "/").split("/")[-1] \
                             .replace(".mcs.yml", "")
-                        if child_fname.startswith(p_stem + "-"):
-                            parent_id = p_id
-                            break
+                        if child_fname.startswith(p_stem + "-") and len(p_stem) > _best[1]:
+                            _best = (p_id, len(p_stem))
+                    if _best[0] is not None:
+                        parent_id = _best[0]
                     if parent_id is None:
                         parent_id = _cm_matches[0][1]
 

--- a/solutions/ess-maker-skills/scripts/push.py
+++ b/solutions/ess-maker-skills/scripts/push.py
@@ -718,8 +718,10 @@ def main():
                     # Multiple parents in same folder — match by longest prefix.
                     _best = (None, -1)  # (p_id, stem_length)
                     for p_path, p_id in _folder_matches:
-                        p_stem = p_path.replace("\\", "/").split("/")[-1] \
+                        p_stem = (
+                            p_path.replace("\\", "/").split("/")[-1]
                             .replace(".mcs.yml", "")
+                        )
                         if child_fname.startswith(p_stem + "-") and len(p_stem) > _best[1]:
                             _best = (p_id, len(p_stem))
                     if _best[0] is not None:

--- a/solutions/ess-maker-skills/scripts/push.py
+++ b/solutions/ess-maker-skills/scripts/push.py
@@ -699,19 +699,38 @@ def main():
                 parent_id = entry["parentbotcomponentid"]
 
             # 2. Parent created in THIS push, same folder.
+            #    When multiple parents share a folder, prefer the one
+            #    whose filename stem is a prefix of the child filename
+            #    (e.g. parent "topic-triggering.mcs.yml" matches child
+            #    "topic-triggering-base-compensation.mcs.yml").
             if parent_id is None:
+                child_fname = filepath.replace("\\", "/").split("/")[-1]
+                _folder_matches = []
                 for p_path, p_id in eval_parent_ids.items():
                     p_folder = "/".join(
                         p_path.replace("\\", "/").split("/")[:-1]
                     )
                     if p_folder == child_folder:
-                        parent_id = p_id
-                        break
+                        _folder_matches.append((p_path, p_id))
+                if len(_folder_matches) == 1:
+                    parent_id = _folder_matches[0][1]
+                elif len(_folder_matches) > 1:
+                    # Multiple parents in same folder — match by prefix.
+                    for p_path, p_id in _folder_matches:
+                        p_stem = p_path.replace("\\", "/").split("/")[-1] \
+                            .replace(".mcs.yml", "")
+                        if child_fname.startswith(p_stem + "-"):
+                            parent_id = p_id
+                            break
+                    if parent_id is None:
+                        # No prefix match; fall back to first.
+                        parent_id = _folder_matches[0][1]
 
             # 3. Existing parent already in component_map, same folder.
             #    This is the common case: customer adds a new test case
             #    under an evaluation set that was extracted by /setup.
             if parent_id is None:
+                _cm_matches = []
                 for p_path, p_entry in component_map.items():
                     if p_entry.get("componenttype") != 19:
                         continue
@@ -721,8 +740,20 @@ def main():
                         p_path.replace("\\", "/").split("/")[:-1]
                     )
                     if p_folder == child_folder:
-                        parent_id = p_entry.get("botcomponentid")
-                        break
+                        _cm_matches.append(
+                            (p_path, p_entry.get("botcomponentid")))
+                if len(_cm_matches) == 1:
+                    parent_id = _cm_matches[0][1]
+                elif len(_cm_matches) > 1:
+                    child_fname = filepath.replace("\\", "/").split("/")[-1]
+                    for p_path, p_id in _cm_matches:
+                        p_stem = p_path.replace("\\", "/").split("/")[-1] \
+                            .replace(".mcs.yml", "")
+                        if child_fname.startswith(p_stem + "-"):
+                            parent_id = p_id
+                            break
+                    if parent_id is None:
+                        parent_id = _cm_matches[0][1]
 
             if parent_id is None:
                 # Fail closed: don't create an orphan eval case in

--- a/solutions/ess-maker-skills/scripts/push.py
+++ b/solutions/ess-maker-skills/scripts/push.py
@@ -698,13 +698,30 @@ def main():
             if entry and entry.get("parentbotcomponentid"):
                 parent_id = entry["parentbotcomponentid"]
 
+            child_fname = filepath.replace("\\", "/").split("/")[-1]
+
+            def _match_parent_by_prefix(candidates):
+                """Pick the candidate whose filename stem is the longest
+                prefix of *child_fname*.  Returns the matched parent ID
+                or None."""
+                best_id = None
+                best_stem_len = -1
+                for p_path, p_id in candidates:
+                    p_stem = (
+                        p_path.replace("\\", "/").split("/")[-1]
+                        .replace(".mcs.yml", "")
+                    )
+                    if child_fname.startswith(p_stem + "-") and len(p_stem) > best_stem_len:
+                        best_id = p_id
+                        best_stem_len = len(p_stem)
+                return best_id
+
             # 2. Parent created in THIS push, same folder.
             #    When multiple parents share a folder, prefer the one
             #    whose filename stem is a prefix of the child filename
             #    (e.g. parent "topic-triggering.mcs.yml" matches child
             #    "topic-triggering-base-compensation.mcs.yml").
             if parent_id is None:
-                child_fname = filepath.replace("\\", "/").split("/")[-1]
                 _folder_matches = []
                 for p_path, p_id in eval_parent_ids.items():
                     p_folder = "/".join(
@@ -715,17 +732,7 @@ def main():
                 if len(_folder_matches) == 1:
                     parent_id = _folder_matches[0][1]
                 elif len(_folder_matches) > 1:
-                    # Multiple parents in same folder — match by longest prefix.
-                    _best = (None, -1)  # (p_id, stem_length)
-                    for p_path, p_id in _folder_matches:
-                        p_stem = (
-                            p_path.replace("\\", "/").split("/")[-1]
-                            .replace(".mcs.yml", "")
-                        )
-                        if child_fname.startswith(p_stem + "-") and len(p_stem) > _best[1]:
-                            _best = (p_id, len(p_stem))
-                    if _best[0] is not None:
-                        parent_id = _best[0]
+                    parent_id = _match_parent_by_prefix(_folder_matches)
                     if parent_id is None:
                         # No prefix match; fall back to first.
                         parent_id = _folder_matches[0][1]
@@ -749,17 +756,14 @@ def main():
                 if len(_cm_matches) == 1:
                     parent_id = _cm_matches[0][1]
                 elif len(_cm_matches) > 1:
-                    child_fname = filepath.replace("\\", "/").split("/")[-1]
-                    _best = (None, -1)  # (p_id, stem_length)
-                    for p_path, p_id in _cm_matches:
-                        p_stem = p_path.replace("\\", "/").split("/")[-1] \
-                            .replace(".mcs.yml", "")
-                        if child_fname.startswith(p_stem + "-") and len(p_stem) > _best[1]:
-                            _best = (p_id, len(p_stem))
-                    if _best[0] is not None:
-                        parent_id = _best[0]
+                    parent_id = _match_parent_by_prefix(_cm_matches)
                     if parent_id is None:
-                        parent_id = _cm_matches[0][1]
+                        print(
+                            f"  ❌ Failed: {filepath}: multiple eval parents found "
+                            f"in {child_folder}/ but none matches the filename "
+                            f"prefix deterministically. Rename the case to use a "
+                            f"parent prefix or remove the ambiguity."
+                        )
 
             if parent_id is None:
                 # Fail closed: don't create an orphan eval case in


### PR DESCRIPTION
**Description**
push.py matched EvaluationData children to their EvaluationSet parent by folder only. When multiple eval sets existed in the same folder, the first parent found got all children — regardless of which eval set they actually belonged to.

This fix adds prefix-based matching when multiple parents share a folder. For example, child topic-triggering-base-compensation matches parent topic-triggering (not ambiguous-prompts). Single-parent folders are unaffected.

**Type of change**

 Bug fix (non-breaking change which fixes an issue)

**Testing**
Created 6 eval sets with 105 test cases across shared subfolders
Pushed to Copilot Studio — all children linked to correct parents
Verified in Copilot Studio UI that each eval set shows only its own test cases
Single-parent folders still work as before
