### PR TITLE
Add root-level copilot-instructions.md to redirect maker skill users

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# Repository Root — Copilot Instructions
+
+## Important: You are at the repository root
+
+The ESS Maker Kit skills and customization tools live in `solutions/ess-maker-skills/`.
+If the user is trying to run maker commands (`/setup`, `/create`, `/update`, `/delete`,
+`/scan`, `/push`, `/flightcheck`, `/evaluate`, or any ESS agent customization task),
+they need to open that folder as their workspace.
+
+**When a user asks to run any maker skill from this root folder, respond with:**
+
+> It looks like you're working from the repository root. The ESS Maker Kit runs
+> from the `solutions/ess-maker-skills` folder. Please open that folder in VS Code
+> (File → Open Folder → select `solutions/ess-maker-skills`) and try again.
+
+Do NOT attempt to run skills, read `.local/config.json`, or perform any maker
+operations from the root folder — the paths won't resolve correctly.
+
+## What this repo contains
+
+This is the Employee Self-Service Agent Developer Kit monorepo. It contains:
+
+- `solutions/ess-maker-skills/` — The maker kit (Copilot-assisted ESS agent customization)
+- `samples/` — Sample topics and configurations
+- `tests/` — Test suite for kit scripts and tooling
+- `.github/agents/` — GitHub Copilot coding agent skills for repo maintenance
+
+For repo-level tasks (CI, contributing, issues, PRs), you can help normally.
+For ESS agent customization, direct users to open `solutions/ess-maker-skills/`.


### PR DESCRIPTION
When users open the repo root in VS Code and try to run maker skills (/setup, /create, /update, etc.), Copilot will now inform them to open the solutions/ess-maker-skills folder instead of silently failing due to unresolved relative paths.

## Description
<!-- What does this PR do? Why is it needed? -->

## Related issue
<!-- Use one of: `Fixes #123`, `Closes #123`, or `Refs #123` so the issue closes on merge. -->
Fixes #

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / cleanup

## Testing
<!-- How was this change tested? -->

## Checklist
- [ ] My code follows the existing style
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation as needed

<!-- The Microsoft CLA bot will comment automatically if a CLA signature is required. No checkbox needed. -->