### PR TITLE
refactor(flightcheck): extract shared connection-status utility

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/connections.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/connections.py
@@ -1,0 +1,172 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Shared connection-status utilities for FlightCheck checks.
+
+Provides common helpers for inspecting Power Platform connection records
+returned by the BAP Admin API (``GET /providers/Microsoft.PowerApps/scopes/
+admin/environments/{env_id}/connections``). Used by workday.py, servicenow.py,
+environment.py, and any future connector-specific check modules.
+"""
+
+from __future__ import annotations
+
+from ..runner import CheckResult, Priority, Status
+
+
+def get_connection_status(conn: dict) -> str:
+    """Extract connection status from the BAP API response.
+
+    The PowerApps Admin API returns a ``statuses`` array on each connection
+    record under ``properties.statuses``. The first entry's ``status`` field
+    holds the overall connection state (e.g. "Connected", "Error").
+
+    Args:
+        conn: A single connection record dict from ``pp_admin.get_connections()``.
+
+    Returns:
+        The status string (e.g. "Connected", "Error"), or "Unknown" if the
+        statuses array is missing or empty.
+    """
+    statuses = conn.get("properties", {}).get("statuses", [])
+    if isinstance(statuses, list) and statuses:
+        return statuses[0].get("status", "Unknown")
+    return "Unknown"
+
+
+def filter_connections_by_connector(
+    all_conns: list[dict],
+    connector_keyword: str,
+) -> list[dict]:
+    """Filter connections by connector keyword in apiId or displayName.
+
+    Args:
+        all_conns: Full list of connection records from the BAP API.
+        connector_keyword: Case-insensitive substring to match against the
+            connection's ``properties.apiId`` and ``properties.displayName``
+            (e.g. "workday", "service-now").
+
+    Returns:
+        List of connections whose apiId or displayName contains the keyword.
+    """
+    keyword_lower = connector_keyword.lower()
+    return [
+        c for c in all_conns
+        if keyword_lower in (
+            c.get("properties", {}).get("apiId", "")
+            + c.get("properties", {}).get("displayName", "")
+        ).lower()
+    ]
+
+
+def check_connector_connections(
+    runner,
+    *,
+    connector_keyword: str,
+    checkpoint_prefix: str,
+    category: str,
+    not_found_remediation: str,
+    doc_link: str = "",
+) -> list[CheckResult]:
+    """Generic connection check for any Power Platform connector.
+
+    Discovers connections matching ``connector_keyword``, reports summary
+    and per-connection status. Produces checkpoint IDs like
+    ``{checkpoint_prefix}-001`` (summary) and ``{checkpoint_prefix}-002+``
+    (per-connection detail).
+
+    Args:
+        runner: FlightCheck runner with ``pp_admin`` and ``env_id``.
+        connector_keyword: Substring to match in apiId/displayName
+            (e.g. "workday", "service-now").
+        checkpoint_prefix: Prefix for checkpoint IDs (e.g. "WD-CONN", "SN-CONN").
+        category: Check category (e.g. "Workday", "ServiceNow").
+        not_found_remediation: Remediation text when no connections are found.
+        doc_link: Optional documentation link for the check results.
+
+    Returns:
+        List of CheckResult entries.
+    """
+    results: list[CheckResult] = []
+    pp = runner.pp_admin
+    env_id = runner.env_id
+
+    if not env_id or pp is None:
+        results.append(CheckResult(
+            checkpoint_id=f"{checkpoint_prefix}-001",
+            category=category,
+            priority=Priority.HIGH.value,
+            status=Status.SKIPPED.value,
+            description=f"{category} connections",
+            result="Power Platform Admin API not available — skipping connection checks",
+        ))
+        return results
+
+    try:
+        all_conns = pp.get_connections(env_id)
+        if isinstance(all_conns, dict) and "_error" in all_conns:
+            results.append(CheckResult(
+                checkpoint_id=f"{checkpoint_prefix}-001",
+                category=category,
+                priority=Priority.HIGH.value,
+                status=Status.WARNING.value,
+                description=f"{category} connections",
+                result=f"Unable to list connections: {all_conns['_error']}",
+                remediation="Requires Power Platform Admin role.",
+            ))
+            return results
+
+        conns = filter_connections_by_connector(all_conns, connector_keyword)
+
+        if conns:
+            connected = [c for c in conns if get_connection_status(c) == "Connected"]
+            errored = [c for c in conns if get_connection_status(c) != "Connected"]
+
+            results.append(CheckResult(
+                checkpoint_id=f"{checkpoint_prefix}-001",
+                category=category,
+                priority=Priority.HIGH.value,
+                status=Status.PASSED.value if connected else Status.FAILED.value,
+                description=f"{category} connections",
+                result=f"{len(conns)} total — {len(connected)} connected, {len(errored)} errored",
+                remediation="Re-authenticate errored connections in Power Platform." if errored else "",
+                doc_link=doc_link,
+            ))
+
+            for i, c in enumerate(conns):
+                props = c.get("properties", {})
+                name = props.get("displayName", f"Connection {i + 1}")
+                status = get_connection_status(c)
+                cid = f"{checkpoint_prefix}-{i + 2:03d}"
+                results.append(CheckResult(
+                    checkpoint_id=cid,
+                    category=category,
+                    priority=Priority.HIGH.value,
+                    status=Status.PASSED.value if status == "Connected" else Status.FAILED.value,
+                    description=f"Connection: {name}",
+                    result=f"Status: {status}",
+                    remediation=f"Re-authenticate '{name}' in Power Platform." if status != "Connected" else "",
+                ))
+        else:
+            results.append(CheckResult(
+                checkpoint_id=f"{checkpoint_prefix}-001",
+                category=category,
+                priority=Priority.HIGH.value,
+                status=Status.NOT_CONFIGURED.value,
+                description=f"{category} connections",
+                result=f"No {category} connections found",
+                remediation=not_found_remediation,
+                doc_link=doc_link,
+            ))
+    except Exception as e:
+        results.append(CheckResult(
+            checkpoint_id=f"{checkpoint_prefix}-001",
+            category=category,
+            priority=Priority.HIGH.value,
+            status=Status.WARNING.value,
+            description=f"{category} connections",
+            result=f"Unable to check: {e}",
+        ))
+
+    return results

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -31,6 +31,7 @@ from defusedxml import ElementTree as ET
 from defusedxml.common import DefusedXmlException
 
 from ..runner import CheckResult, Status, Priority
+from .connections import check_connector_connections, filter_connections_by_connector, get_connection_status
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 
@@ -482,93 +483,17 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
 
 def _check_connections(runner) -> list[CheckResult]:
     """Validate Workday connection references in Power Platform."""
-    results = []
-    pp = runner.pp_admin
-    env_id = runner.env_id
-
-    if not env_id:
-        return results
-
-    try:
-        all_conns = pp.get_connections(env_id)
-        if isinstance(all_conns, dict) and "_error" in all_conns:
-            results.append(CheckResult(
-                checkpoint_id="WD-CONN-001", category="Workday",
-                priority=Priority.HIGH.value, status=Status.WARNING.value,
-                description="Workday connections",
-                result=f"Unable to list connections: {all_conns['_error']}",
-                remediation="Requires Power Platform Admin role.",
-            ))
-            return results
-
-        wd_conns = [
-            c for c in all_conns
-            if "workday" in (
-                c.get("properties", {}).get("apiId", "") +
-                c.get("properties", {}).get("displayName", "")
-            ).lower()
-        ]
-
-        if wd_conns:
-            connected = [
-                c for c in wd_conns
-                if _get_conn_status(c) == "Connected"
-            ]
-            errored = [
-                c for c in wd_conns
-                if _get_conn_status(c) != "Connected"
-            ]
-
-            results.append(CheckResult(
-                checkpoint_id="WD-CONN-001", category="Workday",
-                priority=Priority.HIGH.value,
-                status=Status.PASSED.value if connected else Status.FAILED.value,
-                description="Workday connections",
-                result=f"{len(wd_conns)} total — {len(connected)} connected, {len(errored)} errored",
-                remediation="Re-authenticate errored connections in Power Platform." if errored else "",
-                doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
-            ))
-
-            # Detail each connection
-            for i, c in enumerate(wd_conns):
-                props = c.get("properties", {})
-                name = props.get("displayName", f"Connection {i+1}")
-                status = _get_conn_status(c)
-                cid = f"WD-CONN-{i+2:03d}"
-                results.append(CheckResult(
-                    checkpoint_id=cid, category="Workday",
-                    priority=Priority.HIGH.value,
-                    status=Status.PASSED.value if status == "Connected" else Status.FAILED.value,
-                    description=f"Connection: {name}",
-                    result=f"Status: {status}",
-                    remediation=f"Re-authenticate '{name}' in Power Platform." if status != "Connected" else "",
-                ))
-        else:
-            results.append(CheckResult(
-                checkpoint_id="WD-CONN-001", category="Workday",
-                priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
-                description="Workday connections",
-                result="No Workday connections found",
-                remediation="Configure Workday SOAP connections in the environment.",
-                doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
-            ))
-    except Exception as e:
-        results.append(CheckResult(
-            checkpoint_id="WD-CONN-001", category="Workday",
-            priority=Priority.HIGH.value, status=Status.WARNING.value,
-            description="Workday connections",
-            result=f"Unable to check: {e}",
-        ))
-
-    return results
-
-
-def _get_conn_status(conn: dict) -> str:
-    """Extract connection status from the BAP API response."""
-    statuses = conn.get("properties", {}).get("statuses", [])
-    if isinstance(statuses, list) and statuses:
-        return statuses[0].get("status", "Unknown")
-    return "Unknown"
+    # Legacy behavior: silently skip when env_id is unavailable
+    if not runner.env_id:
+        return []
+    return check_connector_connections(
+        runner,
+        connector_keyword="workday",
+        checkpoint_prefix="WD-CONN",
+        category="Workday",
+        not_found_remediation="Configure Workday SOAP connections in the environment.",
+        doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
+    )
 
 
 # OAuth grant-expiry / token-health error codes the Power Platform
@@ -809,13 +734,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
         ))
         return results
 
-    wd_conns = [
-        c for c in all_conns
-        if "workday" in (
-            c.get("properties", {}).get("apiId", "")
-            + c.get("properties", {}).get("displayName", "")
-        ).lower()
-    ]
+    wd_conns = filter_connections_by_connector(all_conns, "workday")
 
     if not wd_conns:
         results.append(CheckResult(
@@ -830,7 +749,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
 
     unhealthy: list[dict] = []
     for c in wd_conns:
-        if _get_conn_status(c) == "Connected":
+        if get_connection_status(c) == "Connected":
             continue
         code, message, hint, severity = _classify_token_health_error(c)
         unhealthy.append({


### PR DESCRIPTION
Extract _get_conn_status and connection-checking logic from workday.py into a new checks/connections.py module with generic helpers:

- get_connection_status(): extract status from BAP API response
- filter_connections_by_connector(): filter by connector keyword
- check_connector_connections(): full connection validation for any connector (summary + per-connection detail)

Update workday.py to use the shared module. The token-health check (WD-CONN-101) now uses get_connection_status and
filter_connections_by_connector from the shared module.

This enables PR #96 (ServiceNow) and PR #101 (ENV-004) to reuse the same utilities instead of duplicating the logic.

## Description
<!-- What does this PR do? Why is it needed? -->

## Related issue
<!-- Use one of: `Fixes #123`, `Closes #123`, or `Refs #123` so the issue closes on merge. -->
Fixes #

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / cleanup

## Testing
<!-- How was this change tested? -->

## Checklist
- [ ] My code follows the existing style
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation as needed

<!-- The Microsoft CLA bot will comment automatically if a CLA signature is required. No checkbox needed. -->