### PR TITLE
Eval: add guardrails, browse tables, and review-before-push

### DIFF
--- a/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
@@ -499,11 +499,17 @@ graders:
 >
 > | # | Conversation chain | Turns |
 > |---|-------------------|-------|
-> | 1 | Get Salary → Get Service Anniversary | 2 |
-> | 2 | Create Ticket → List Tickets → Update Ticket | 3 |
+> | 1 | Create Ticket → Get User Tickets → Get Ticket Details | 3 |
+> | 2 | Get Job Info → Update Job Title (manager) | 2 |
+> | 3 | Get Employee ID → Get Cost Center → Get Company Code | 3 |
 > | ... | ... | ... |
 >
 > Want to **adjust these pairs**, **add your own**, or **proceed**?
+
+Each chain should represent a **natural user journey** — the second turn should
+logically follow from the first (e.g., creating a ticket then checking its
+status, or reviewing a direct report's info before updating it). Avoid pairing
+unrelated lookups that a user wouldn't chain in the same session.
 
 4. Create 3-5 positive conversation scenarios based on confirmed pairs,
    each with 2-4 turns.
@@ -516,17 +522,17 @@ graders:
 **Additionally, include 1-2 boundary and 1-2 negative multi-turn scenarios:**
 
 - **Boundary**: A conversation where the user uses typos or casual abbreviations
-  mid-conversation (e.g., turn 1: "Show my PTO balance" → turn 2: "whats my
-  compeny code"). The agent should still handle each turn correctly.
+  mid-conversation (e.g., turn 1: "Create a ticket for my laptop" → turn 2:
+  "show me my tkts"). The agent should still handle each turn correctly.
 - **Negative**: A conversation where the user pivots to an out-of-scope or
   cross-domain request mid-conversation (e.g., turn 1: "Show my open tickets" →
   turn 2: "Now book me a flight to New York"). The agent should handle the
   valid turn and gracefully decline the invalid one.
 
 **Example positive scenarios:**
-- Employee profile lookup chain: "What is my employee ID?" → "What about my cost center?" → "Show me my company code"
-- Ticket lifecycle: "Create a ticket for my laptop issue" → "Show me my open tickets" → "Add a comment to ticket INC001"
-- Manager review: "Show me the job titles of my direct reports" → "What are their cost centers?" → "Update John's job title to Senior Engineer"
+- Ticket lifecycle: "Create a ticket for my laptop issue" → "Show me my open tickets" → "What's the latest update on ticket INC001?"
+- Employee profile chain: "What is my employee ID?" → "What about my cost center?" → "Show me my company code"
+- Manager review then update: "Show me the job titles of my direct reports" → "Update John's job title to Senior Engineer"
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
@@ -71,8 +71,11 @@ AND contains at least one `.mcs.yml` file. Mark it as **existing** or **missing*
 
 **If ALL categories are missing** (fresh agent, no eval sets yet):
 
-> I found **{N}** user-facing topics in your agent. I can generate evaluation
-> test sets in these categories:
+> I found **{N}** user-facing topics in your agent. With positive, boundary,
+> and negative cases per topic, this will generate roughly **{N×3} to {N×5}**
+> test cases for TopicTriggering alone (plus other categories).
+>
+> Want to generate for **all topics**, or pick a **subset** to start with?
 >
 > | Category | Description | Tests based on |
 > |----------|-------------|---------------|
@@ -490,12 +493,25 @@ graders:
 1. Identify topic pairs that users commonly chain together (e.g., check
    compensation → check service anniversary, list tickets → update a ticket).
 2. Read the topic files for each topic in the chain to understand the flow.
-3. Create 3-5 positive conversation scenarios, each with 2-4 turns.
-4. Each turn should be a natural follow-up that a real user would ask in the
+3. **Show the proposed topic pairs to the user before generating:**
+
+> I identified these topic pairs for multi-turn conversations:
+>
+> | # | Conversation chain | Turns |
+> |---|-------------------|-------|
+> | 1 | Get Salary → Get Service Anniversary | 2 |
+> | 2 | Create Ticket → List Tickets → Update Ticket | 3 |
+> | ... | ... | ... |
+>
+> Want to **adjust these pairs**, **add your own**, or **proceed**?
+
+4. Create 3-5 positive conversation scenarios based on confirmed pairs,
+   each with 2-4 turns.
+5. Each turn should be a natural follow-up that a real user would ask in the
    same session.
-5. The agent `text` for each turn should describe what the agent does at
+6. The agent `text` for each turn should describe what the agent does at
    that step — these are used by `GeneralQualityGrader` to assess quality.
-6. Always alternate user → agent → user → agent. Start with user, end with agent.
+7. Always alternate user → agent → user → agent. Start with user, end with agent.
 
 **Additionally, include 1-2 boundary and 1-2 negative multi-turn scenarios:**
 
@@ -525,20 +541,56 @@ Run `python scripts/checkpoint.py "before evaluation test set creation"` to save
 Create the `evaluations/` folder inside the agent folder if it doesn't exist.
 Write each EvaluationSet and EvaluationData file as described above.
 
-### 4.3 — Dry run
+### 4.3 — Review before push
+
+Show the user a summary of what was generated and ask for confirmation:
+
+> Here's what I generated:
+>
+> | Category | Positive | Boundary | Negative | Total |
+> |----------|----------|----------|----------|-------|
+> | Topic Triggering | {n} | {n} | {n} | {n} |
+> | Integration Data | {n} | {n} | {n} | {n} |
+> | ... | ... | ... | ... | ... |
+>
+> Want to **review specific test cases** before pushing, or **push now**?
+
+**If IntegrationData tests were generated**, add a placeholder reminder:
+
+> ⚠️ **Note:** Integration Data test cases contain `<placeholder>` values
+> (e.g., `<ticket-number>`, `<employee-name>`). You'll need to replace these
+> with real values from your system before running evals, or those tests will fail.
+>
+> Files with placeholders:
+> - `integration-data-get-salary.mcs.yml` — `<salary-amount>`
+> - `integration-data-get-ticket.mcs.yml` — `<ticket-number>`
+> - ...
+>
+> Want to **fill them in now** or **after pushing**?
+
+- **If user says now**: Walk through each placeholder and ask the user for
+  the real value. Update the files before pushing.
+- **If user says after pushing**: Proceed, but remind them again in the
+  final summary (Step 4.6).
+
+- **If user says review**: Show the test cases they want to inspect, let them
+  request edits, then re-confirm push.
+- **If user says push**: Proceed to dry run.
+
+### 4.4 — Dry run
 
 Run `python scripts/push.py --dry-run` to preview what will be pushed. Confirm the
 evaluation files are detected as new botcomponent records.
 
 Show the user the dry run output and ask for confirmation.
 
-### 4.4 — Push
+### 4.5 — Push
 
-Run `python scripts/push.py --yes` to push the evaluation test sets to Copilot Studio.
+Run `python scripts/push.py` to push the evaluation test sets to Copilot Studio.
 The push script handles two-pass ordering automatically: parent EvaluationSet records
 are created first, then child EvaluationData records are linked via `parentbotcomponentid`.
 
-### 4.5 — Show summary
+### 4.6 — Show summary
 
 Print a summary table:
 

--- a/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
@@ -39,6 +39,19 @@ Determine whether the user wants to:
 - **Delete an entire test set** — remove the EvaluationSet file AND all its
   child EvaluationData files
 
+If the user wants to delete a single test case but hasn't specified which one,
+show a table of all test cases in the relevant category:
+
+> Here are the test cases in **{Category Name}** ({N} total):
+>
+> | # | Input | Expected Output | File |
+> |---|-------|----------------|------|
+> | 1 | "What is my employee ID?" | "The agent should display..." | `topic-triggering-employee-id.mcs.yml` |
+> | 2 | "empolyee ID" | "The agent should display..." | `topic-triggering-employee-id-boundary.mcs.yml` |
+> | ... | ... | ... | ... |
+>
+> Which test case do you want to delete? (enter a number or describe what you're looking for)
+
 ## Step 2: Confirm Deletion
 
 Show the user what will be deleted:
@@ -67,19 +80,35 @@ For an entire test set: delete the parent EvaluationSet file AND all child
 EvaluationData files that reference it (check `parentbotcomponentid` in the
 component map).
 
-## Step 5: Dry Run
+## Step 5: Review before push
+
+Show the user a summary of what will be deleted and ask for final confirmation:
+
+> Here's what will be removed:
+>
+> | # | File | Input |
+> |---|------|-------|
+> | 1 | `topic-triggering-salary.mcs.yml` | "Show my salary" |
+> | ... | ... | ... |
+>
+> This will delete **{N}** file(s) from Copilot Studio. Proceed?
+
+- **If user confirms**: Proceed to dry run.
+- **If user cancels**: Revert local deletions via `python scripts/checkpoint.py --revert`.
+
+## Step 6: Dry Run
 
 Run `python scripts/push.py --dry-run`. Confirm the expected files show as
 deleted.
 
-## Step 6: Push
+## Step 7: Push
 
-Run `python scripts/push.py --yes`. The push script automatically orders
+Run `python scripts/push.py`. The push script automatically orders
 evaluation deletions — children are deleted before parents.
 
 **If the push fails:** show the error and offer retry or revert.
 
-## Step 7: Verify
+## Step 8: Verify
 
 > ✅ Evaluation test {case/set} deleted from Copilot Studio.
 >

--- a/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
@@ -41,6 +41,19 @@ modifications:
 | "Remove a test case" | Delete the EvaluationData file (use delete skill) |
 | "Replace placeholder values" | Update `<placeholder>` tokens in `expectedOutput` |
 
+Once the user picks a category (or if they're not sure which test case), show
+a table of all test cases in that category so they can identify the one to update:
+
+> Here are the test cases in **{Category Name}** ({N} total):
+>
+> | # | Type | Input | Expected Output | File |
+> |---|------|-------|----------------|------|
+> | 1 | Positive | "What is my employee ID?" | "The agent should display..." | `topic-triggering-employee-id.mcs.yml` |
+> | 2 | Boundary | "empolyee ID" | "The agent should display..." | `topic-triggering-employee-id-boundary.mcs.yml` |
+> | ... | ... | ... | ... | ... |
+>
+> Which test case do you want to update? (enter a number or describe what you're looking for)
+
 ## Step 2: Checkpoint
 
 Run in the terminal:
@@ -67,14 +80,30 @@ extensionData:
 For new test cases, create new `.mcs.yml` files following the naming convention:
 `{set-name}-{short-slug}.mcs.yml`.
 
-## Step 4: Dry Run
+## Step 4: Review before push
+
+Show the user a summary of what changed and ask for confirmation:
+
+> Here's what I changed:
+>
+> | # | File | Field | Before | After |
+> |---|------|-------|--------|-------|
+> | 1 | `topic-triggering-salary.mcs.yml` | input | "Show my salary" | "What is my base salary?" |
+> | ... | ... | ... | ... | ... |
+>
+> Want to **review the full file** before pushing, or **push now**?
+
+- **If user says review**: Show the full YAML of the changed file(s).
+- **If user says push**: Proceed to dry run.
+
+## Step 5: Dry Run
 
 Run `python scripts/push.py --dry-run` to preview changes. Show the user the
 output confirming modified/new/deleted evaluation files.
 
-## Step 5: Push
+## Step 6: Push
 
-Run `python scripts/push.py --yes` to push changes to Copilot Studio.
+Run `python scripts/push.py` to push changes to Copilot Studio.
 
 **If the push fails:** show the error and offer retry or revert
 (`python scripts/checkpoint.py --revert`).

--- a/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
@@ -108,7 +108,7 @@ Run `python scripts/push.py` to push changes to Copilot Studio.
 **If the push fails:** show the error and offer retry or revert
 (`python scripts/checkpoint.py --revert`).
 
-## Step 6: Verify
+## Step 7: Verify
 
 > ✅ Evaluation test cases updated in Copilot Studio.
 >


### PR DESCRIPTION
Add guardrails, browse tables, and review-before-push to eval skills

**Problem:**
The eval skills would generate or delete test cases and push them without giving the user a chance to review what's happening. For large agents with many topics, this meant dozens of test cases pushed without the user knowing what was created. For deletes, there was no confirmation of what's being removed.

**What this PR adds:**

- Volume preview (create) — Shows estimated test count before generating so users can choose all topics or a subset
- Multi-turn topic pair confirmation (create) — Shows proposed topic pairs before generating multi-turn tests so users can adjust
- Review before push (create + delete) — Summary table of what was generated/will be deleted, with a chance to review or cancel before pushing
- Browse test cases table (update + delete) — Numbered table of existing test cases so users can pick the right one to edit or delete
- Placeholder reminder (create) — Warns about <placeholder> values in IntegrationData tests that need real values before running evals
- Removed --yes from push commands (all 3 skills) — Push is interactive and should let users confirm

https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7426471

<img width="1022" height="692" alt="image" src="https://github.com/user-attachments/assets/32e33d12-df67-4231-8c0c-aacae1e82a4c" />

<img width="856" height="632" alt="image" src="https://github.com/user-attachments/assets/2644d03f-f8b0-4d02-ae0d-2a4f637268e9" />

<img width="747" height="692" alt="image" src="https://github.com/user-attachments/assets/9c3f005f-913f-4bf1-b07a-52c363c38aaa" />

<img width="732" height="172" alt="image" src="https://github.com/user-attachments/assets/dd5de2b6-c05a-4259-8043-d04e58cf71df" />

<img width="778" height="687" alt="image" src="https://github.com/user-attachments/assets/590523b5-18eb-48ed-be48-908e1c5f02f1" />

<img width="788" height="698" alt="image" src="https://github.com/user-attachments/assets/cd0b90d0-7304-45ba-9292-e64ff7ad1185" />

<img width="760" height="682" alt="image" src="https://github.com/user-attachments/assets/4ca8b6ae-2bce-431a-98da-e6cfc4bb877c" />

<img width="1051" height="573" alt="image" src="https://github.com/user-attachments/assets/06838cf7-df9f-4270-baa9-3b67cb24be6a" />
<img width="1045" height="416" alt="image" src="https://github.com/user-attachments/assets/ac5d7d6d-05ec-4879-9a32-b6633ae44fdf" />
<img width="1050" height="542" alt="image" src="https://github.com/user-attachments/assets/e3c319ac-3e6f-4a69-83d3-a8c49699446f" />
<img width="1037" height="306" alt="image" src="https://github.com/user-attachments/assets/66d6d7d0-e6ed-4aba-ba43-d4a8fe4fedfc" />

<img width="1067" height="198" alt="image" src="https://github.com/user-attachments/assets/cb852fff-3355-4295-88d2-a4f231ee6cc8" />

<img width="887" height="752" alt="image" src="https://github.com/user-attachments/assets/61857fae-9fa3-4465-9799-0b8583973d94" />

