### PR TITLE
feat(connect): support Workday simplified 2-connection install

### DIFF
--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -234,8 +234,8 @@ For detailed patterns, see `src/reference/ess-docs/customization/customize.md`.
 - New scenarios only need a **template config** in Dataverse (XML SOAP template) + a **topic** — do NOT create new flows
 - Topics call the shared system topic (`WorkdaySystemGetCommonExecution`) which routes through the shared flow
 - The shared flow reads the template config by `scenarioName` and executes the Workday SOAP API call
-- **Entra SSO is mandatory.** The OAuthUser connection (`ff0df`) uses `runtimeSource: invoker` — it authenticates to Workday AS the employee. The other two connections (`d6081`, `0786a`) use Basic auth with ISU service accounts.
-- **Three connections, three different auth types.** Never use the same auth type for all three. See the connect skill step3.md for the exact mapping.
+- **Entra SSO is mandatory.** The OAuthUser connection (`ff0df`) uses `runtimeSource: invoker` — it authenticates to Workday AS the employee. This applies to both install paths.
+- **Two install paths.** Microsoft ships a **simplified** install (OAuthUser `ff0df` + Dataverse only; no ISU accounts, security groups, or RaaS report — user context comes from the REST `/workers/me` endpoint) and a **legacy** install (the older 4-connection setup where `d6081` and `0786a` use Basic auth with ISU service accounts). Fresh installs default to simplified; existing legacy installs stay supported. See the connect skill step1.md/step3.md for detection and the exact connection mapping.
 - See `src/reference/ess-docs/integrations/workday.md` for connector setup
 - See `src/reference/ess-docs/integrations/workday-extensibility.md` for extensibility patterns
 

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -193,21 +193,28 @@ Connect your agent to ServiceNow for IT tickets, HR cases, and service catalog i
 
 Connect your agent to Workday for employee data, compensation, time off, and org lookups. Run `/connect workday` to start.
 
-**What the kit sets up:**
-- **SAML SSO via Entra ID** — verifies or creates the Entra enterprise app, configures SAML trust with Workday, and pre-authorizes the Power Platform connector
+**Two supported install paths** — the kit detects which one applies and routes automatically:
+
+- **Simplified** (Microsoft's default for new installs) — just one Workday connection (OAuthUser via Entra ID) plus Dataverse. No ISU service accounts, security groups, or custom reports. User context comes from the Workday REST `/workers/me` endpoint.
+- **Legacy** — the older setup with ISU accounts, security groups, domain permissions, and the `WD_User_Context` RaaS report. Still fully supported for existing installs.
+
+**What the kit sets up (simplified path):**
+- **SSO via Entra ID** — verifies or creates the Entra enterprise app, configures trust with Workday, and pre-authorizes the Power Platform connector
+- **Extension pack installation** — installs the Workday extension in Copilot Studio with the OAuthUser and Dataverse connection references configured (including the Workday REST base URL)
+
+**What the kit additionally sets up on the legacy path:**
 - **Integration System Users (ISUs)** — automatically creates `ISU_WQL_COPILOT` (for reports) and `ISU_GENERIC_COPILOT` (for API calls) via the Workday SOAP API
 - **Security groups and domain permissions** — guides you through creating `ISSG_WQL_COPILOT` and `ISSG_GENERIC_COPILOT` with the correct domain policies
-- **OAuth API client** — walks you through registering a SAML Bearer Grant client (for Entra SSO) or Authorization Code Grant client (for Basic auth)
+- **OAuth API client** — walks you through registering a SAML Bearer Grant client
 - **WD_User_Context RaaS report** — verifies or guides creation of the custom report that maps Workday usernames to employee context data
-- **Extension pack installation** — installs the Workday extension in Copilot Studio with all three SOAP connection references configured
 
 **Supported auth methods:**
 | Method | Use case |
 |--------|----------|
-| Microsoft Entra ID Integrated | Production — employees SSO through Microsoft, SAML token exchange with Workday |
-| Basic auth | Dev/test only — ISU username/password directly |
+| Microsoft Entra ID Integrated | Both paths — employees SSO through Microsoft, token exchange with Workday |
+| Basic auth | Legacy path's ISU connections (`d6081`, `0786a`) |
 
-**Verify-first approach:** The kit runs API checks against your Workday tenant before asking you to configure anything. If ISU accounts, auth policies, permissions, or the RaaS report are already set up (common on shared tenants), those tasks are automatically skipped.
+**Verify-first approach:** The kit runs API checks against your Workday tenant before asking you to configure anything. On the legacy path, if ISU accounts, auth policies, permissions, or the RaaS report are already set up (common on shared tenants), those tasks are automatically skipped.
 
 **What you can build after connecting:**
 - Look up employee information, compensation, service anniversary, cost center

--- a/solutions/ess-maker-skills/src/skills/connect/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/connect/SKILL.md
@@ -43,33 +43,50 @@ Each integration has its own folder with its own tasks.md and step files:
   - Tasks template: `src/skills/connect/workday/tasks.md`
   - State file: `.local/connect/workday/tasks.md`
   - Config file: `.local/connect/workday/config.json`
-  - Step 1: `step1.md` — gather info, MCP setup, connectivity check, detect existing state (Entra app, extension pack, RaaS report)
-  - Step 2: `step2.md` — Entra SSO setup (mandatory), ISU accounts, security groups, auth policies, API client, domain permissions, RaaS report
-  - Step 3: `step3.md` — extension pack install (or diagnose existing), connection setup (3 different auth types), post-install verification, topic redirect auto-push, end-to-end test
+  - Step 1: `step1.md` — gather info, MCP setup, connectivity check, detect existing state (Entra app, extension pack, RaaS report) and classify the install path (simplified vs legacy)
+  - Step 2: `step2.md` — admin setup. Simplified path = Entra SSO only. Legacy path = Entra SSO + ISU accounts, security groups, auth policies, API client, domain permissions, RaaS report
+  - Step 3: `step3.md` — extension pack install (or diagnose existing), connection setup (simplified: 2 connections; legacy: 4 connections / 3 auth types), post-install verification, topic redirect auto-push, end-to-end test
 
 **Workday key principles:**
-- **Entra SSO is MANDATORY.** The Workday extension pack's OAuthUser
-  connection (`ff0df`) uses `runtimeSource: invoker` — it authenticates
-  to Workday AS the employee via Entra SSO. Do NOT offer to skip SSO
-  setup. Do NOT use Basic auth for all 3 connections.
-- **Three connections, three configs.** The 3 Workday SOAP connections
-  need DIFFERENT auth types:
+- **Two supported install paths.** Detect which one applies in step 1
+  and branch:
+  - **Simplified** (Microsoft's current default for new installs) —
+    only the OAuthUser connection (`ff0df`) + Dataverse. No ISU service
+    accounts, no security groups, no RaaS report. User context comes
+    from the Workday REST `/workers/me` endpoint via the V2 user-context
+    topic. The OAuthUser connection requires a **Workday REST base URL**
+    field in addition to the SOAP base URL.
+  - **Legacy** — the older 4-connection install (`d6081`, `0786a`,
+    `ff0df`, Dataverse) with ISU accounts, security groups, and the
+    `WD_User_Context` RaaS report. Still fully supported; keep existing
+    installs on this path. Fresh installs DEFAULT to simplified.
+- **Entra SSO is MANDATORY on BOTH paths.** The Workday extension pack's
+  OAuthUser connection (`ff0df`) uses `runtimeSource: invoker` — it
+  authenticates to Workday AS the employee via Entra SSO. Do NOT offer
+  to skip SSO setup.
+- **Legacy path: three connections, three configs.** The 3 Workday SOAP
+  connections need DIFFERENT auth types:
   - `d6081` (Context Generic) = Basic auth with ISU_WQL credentials
   - `0786a` (Generic User) = Basic auth with ISU_GENERIC credentials
   - `ff0df` (OAuthUser) = Microsoft Entra ID Integrated (employee SSO)
 - **Never skip tasks based on MCP pre-flight.** The Workday MCP uses
   the user's admin credentials. The Power Platform flows use ISU
-  accounts. These have different permissions. A passing MCP check does
-  NOT mean ISU accounts work at runtime.
-- **Verify-then-create pattern.** Use idempotent creation (Add_Only=true,
-  catch "already exists") to detect existing ISU accounts and security
-  groups without asking the user to search the Workday UI.
+  accounts (legacy) or the employee's Entra identity (simplified).
+  These have different permissions. A passing MCP check does NOT
+  mean the runtime connections work.
+- **Verify-then-create pattern (legacy).** Use idempotent creation
+  (Add_Only=true, catch "already exists") to detect existing ISU
+  accounts and security groups without asking the user to search the
+  Workday UI.
 - **Auto-push the topic redirect.** The `[Admin] - User Context - Setup`
-  topic must redirect to `WorkdaySystemGetUserContext`. Push this via
-  push.py automatically — do NOT leave as a manual portal step.
+  topic must redirect to the Workday user-context system topic
+  (`WorkdaySystemGetUserContext` on legacy, the V2 REST topic on
+  simplified). Push this via push.py automatically — do NOT leave it as
+  a manual portal step.
 - **Post-install verification.** After extension pack install, verify
-  ALL 7 items programmatically: 3 connection refs, 2 flows, 1 env var,
-  1 topic redirect. Do NOT accept "done" without checking.
+  programmatically: connection refs (2 for simplified, 3 for legacy),
+  2 flows, the topic redirect, plus the env var on legacy. Do NOT
+  accept "done" without checking.
 
 Each integration's tasks.md and config.json persist after completion.
 Running `/connect` again lets the user add a different integration

--- a/solutions/ess-maker-skills/src/skills/connect/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/connect/SKILL.md
@@ -44,7 +44,7 @@ Each integration has its own folder with its own tasks.md and step files:
   - State file: `.local/connect/workday/tasks.md`
   - Config file: `.local/connect/workday/config.json`
   - Step 1: `step1.md` — gather info, MCP setup, connectivity check, detect existing state (Entra app, extension pack, RaaS report) and classify the install path (simplified vs legacy)
-  - Step 2: `step2.md` — admin setup. Simplified path = Entra SSO only. Legacy path = Entra SSO + ISU accounts, security groups, auth policies, API client, domain permissions, RaaS report
+  - Step 2: `step2.md` — admin setup. Simplified path = Entra SSO + register the Workday API client (the `ff0df` connection's `oauthClientId`). Legacy path = Entra SSO + ISU accounts, security groups, auth policies, API client, domain permissions, RaaS report
   - Step 3: `step3.md` — extension pack install (or diagnose existing), connection setup (simplified: 2 connections; legacy: 4 connections / 3 auth types), post-install verification, topic redirect auto-push, end-to-end test
 
 **Workday key principles:**
@@ -55,7 +55,9 @@ Each integration has its own folder with its own tasks.md and step files:
     accounts, no security groups, no RaaS report. User context comes
     from the Workday REST `/workers/me` endpoint via the V2 user-context
     topic. The OAuthUser connection requires a **Workday REST base URL**
-    field in addition to the SOAP base URL.
+    field in addition to the SOAP base URL, and signs in with a
+    customer-registered **Workday API client** whose Client ID
+    (`oauthClientId`) is captured during admin setup.
   - **Legacy** — the older 4-connection install (`d6081`, `0786a`,
     `ff0df`, Dataverse) with ISU accounts, security groups, and the
     `WD_User_Context` RaaS report. Still fully supported; keep existing

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
@@ -261,6 +261,12 @@ Save the results, then classify the install:
   `d6081`/`0786a` are absent → extension pack installed on the
   **simplified** path. Set EXTENSION_INSTALLED = true and
   INSTALL_PATH = `simplified`.
+- If **either `d6081` or `0786a` is present** (i.e. any legacy-only
+  connection ref exists, even partially) → treat as a partial/failed
+  **legacy** install. Set EXTENSION_INSTALLED = true and
+  INSTALL_PATH = `legacy`, and save PARTIAL_INSTALL = true so step3 can
+  warn the user and finish the missing connection(s) instead of starting
+  a fresh simplified install on top.
 - If **no** Workday connection references exist → fresh install. Set
   EXTENSION_INSTALLED = false and INSTALL_PATH = `simplified` (the
   default for new installs).
@@ -352,7 +358,8 @@ Update `.local/connect/workday/config.json` — merge all discovered values:
   "entraAppObjectId": "{WD_ENTRA_APP_OBJECT_ID or null}",
   "entraSSO": true/false,
   "reportOwner": "{REPORT_OWNER or null}",
-  "raasReportExists": true/false
+  "raasReportExists": true/false,
+  "partialInstall": true/false
 }
 ```
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
@@ -13,13 +13,15 @@ display text like "BASE_URL = ..." or "TENANT = ..." in chat.
     needs only the OAuthUser connection (`ff0df`) + Dataverse. No ISU
     service accounts, no security groups, no RaaS report. User context
     comes from the Workday REST `/workers/me` endpoint.
-  - **Legacy** — the older 3-connection install (`d6081`, `0786a`,
-    `ff0df`) with ISU accounts, security groups, and the
-    `WD_User_Context` RaaS report. Still fully supported; keep existing
-    installs on this path.
+  - **Legacy** — the older 4-connection install (the 3 Workday SOAP
+    refs `d6081`, `0786a`, `ff0df` plus Dataverse) with ISU accounts,
+    security groups, and the `WD_User_Context` RaaS report. Still fully
+    supported; keep existing installs on this path.
   For a FRESH install (no Workday extension pack detected yet), DEFAULT
-  to simplified. Only use legacy when the tenant already has a
-  3-connection install in place.
+  to simplified. Only use legacy when the tenant already has the 3
+  Workday SOAP connection refs (`d6081`, `0786a`, `ff0df`) in place
+  (Dataverse is common to both paths, so it is not part of the count
+  that drives detection).
 - Entra SSO is MANDATORY for BOTH paths. Do NOT offer to skip it. The
   OAuthUser connection (`ff0df`) uses `runtimeSource: invoker` which
   requires employee identity via Entra SSO regardless of install path.

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step1.md
@@ -7,9 +7,22 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 display text like "BASE_URL = ..." or "TENANT = ..." in chat.
 
 **CRITICAL RULES (from retro — read these before proceeding):**
-- Entra SSO is MANDATORY for the Workday extension pack. Do NOT offer
-  to skip it. The OAuthUser connection uses `runtimeSource: invoker`
-  which requires employee identity via Entra SSO.
+- There are TWO supported install paths. Detect which one applies
+  before doing any admin setup:
+  - **Simplified** (Microsoft's current default for new installs) —
+    needs only the OAuthUser connection (`ff0df`) + Dataverse. No ISU
+    service accounts, no security groups, no RaaS report. User context
+    comes from the Workday REST `/workers/me` endpoint.
+  - **Legacy** — the older 3-connection install (`d6081`, `0786a`,
+    `ff0df`) with ISU accounts, security groups, and the
+    `WD_User_Context` RaaS report. Still fully supported; keep existing
+    installs on this path.
+  For a FRESH install (no Workday extension pack detected yet), DEFAULT
+  to simplified. Only use legacy when the tenant already has a
+  3-connection install in place.
+- Entra SSO is MANDATORY for BOTH paths. Do NOT offer to skip it. The
+  OAuthUser connection (`ff0df`) uses `runtimeSource: invoker` which
+  requires employee identity via Entra SSO regardless of install path.
 - NEVER say "check with your teammates" or "ask your admin." Use Azure
   CLI, Workday MCP, and Dataverse MCP to discover state yourself.
 - NEVER accept "done" from the user without programmatic verification.
@@ -239,9 +252,18 @@ SELECT TOP 5 connectionreferencelogicalname, connectionreferencedisplayname,
   WHERE connectorid LIKE '%workday%'
 ```
 
-Save the results. If 3 Workday connection references exist (`d6081`,
-`0786a`, `ff0df`), the extension pack is already installed. Set
-EXTENSION_INSTALLED = true.
+Save the results, then classify the install:
+
+- If **3** Workday connection references exist (`d6081`, `0786a`,
+  `ff0df`) → extension pack installed on the **legacy** path. Set
+  EXTENSION_INSTALLED = true and INSTALL_PATH = `legacy`.
+- If only the OAuthUser reference (`ff0df`) exists (plus Dataverse) and
+  `d6081`/`0786a` are absent → extension pack installed on the
+  **simplified** path. Set EXTENSION_INSTALLED = true and
+  INSTALL_PATH = `simplified`.
+- If **no** Workday connection references exist → fresh install. Set
+  EXTENSION_INSTALLED = false and INSTALL_PATH = `simplified` (the
+  default for new installs).
 
 ### 1.7b — Check for existing Entra SSO app
 
@@ -279,10 +301,16 @@ Save as DOMAIN_NAME.
 **If no results found**: Set ENTRA_SSO_EXISTS = false. Still get
 DOMAIN_NAME and TENANT_ID.
 
-### 1.7c — Check for existing RaaS report owner
+### 1.7c — Check for existing RaaS report owner (legacy path only)
 
-Try known ISU account patterns for the WD_User_Context report. Run
-each silently via the Workday MCP `run_report` tool until one succeeds:
+**Skip this entire sub-step if INSTALL_PATH is `simplified`** — the
+simplified path uses the REST `/workers/me` endpoint for user context,
+not the `WD_User_Context` RaaS report. Set RAAS_REPORT_EXISTS = false
+and move on to 1.7d.
+
+For the **legacy** path, try known ISU account patterns for the
+WD_User_Context report. Run each silently via the Workday MCP
+`run_report` tool until one succeeds:
 
 1. `ISU_WQL_COPILOT@{DOMAIN_NAME}` / `WD_User_Context`
 2. `ISU_WQL_COPILOT@{WD_TENANT}` / `WD_User_Context`
@@ -293,10 +321,15 @@ Use a known test username like `lmcneil` in the params.
 If any succeeds, save the working report owner as REPORT_OWNER and
 set RAAS_REPORT_EXISTS = true.
 
-### 1.7d — Derive the OAuth token URL
+### 1.7d — Derive the OAuth token URL and REST base URL
 
-Build: `https://{WD_TOKEN_HOST}/ccx/oauth2/{WD_TENANT}/token`
+Build the OAuth token URL: `https://{WD_TOKEN_HOST}/ccx/oauth2/{WD_TENANT}/token`
 Save as WD_OAUTH_TOKEN_URL.
+
+Build the Workday REST base URL: `https://{WD_TOKEN_HOST}/ccx/api`
+Save as WD_REST_BASE_URL. The simplified-path OAuthUser connection
+requires this in addition to the SOAP base URL (it backs the
+`/workers/me` user-context lookup).
 
 ### 1.7e — Update config with discovered state
 
@@ -305,11 +338,13 @@ Update `.local/connect/workday/config.json` — merge all discovered values:
 ```json
 {
   "baseUrl": "{WD_BASE_URL}",
+  "restBaseUrl": "{WD_REST_BASE_URL}",
   "tenant": "{WD_TENANT}",
   "tokenHost": "{WD_TOKEN_HOST}",
   "oauthTokenUrl": "{WD_OAUTH_TOKEN_URL}",
   "domainName": "{DOMAIN_NAME}",
   "tenantId": "{TENANT_ID}",
+  "installPath": "simplified|legacy",
   "status": "in-progress",
   "extensionInstalled": true/false,
   "entraAppId": "{WD_ENTRA_APP_ID or null}",
@@ -329,6 +364,30 @@ Update `.local/connect/workday/tasks.md` — change step 1 from
 `- [ ]` to `- [x]`.
 
 Build a status summary from the detected state.
+
+**If INSTALL_PATH is `simplified`, show this table:**
+
+**Message:**
+
+✅ Connected to Workday tenant **{WD_TENANT}**.
+
+Here's what I found in your environment:
+
+| Check | Status |
+|-------|--------|
+| Workday connectivity | ✅ |
+| Entra SSO app | {✅ if ENTRA_SSO_EXISTS else "⬜ needs setup"} |
+| Extension pack installed | {✅ if EXTENSION_INSTALLED else "⬜ not yet"} |
+
+This tenant uses the streamlined Workday setup — just one Workday
+connection plus Dataverse. No service accounts or custom reports needed.
+
+{If ENTRA_SSO_EXISTS is false, add this line:}
+The Workday extension requires Entra SSO — I'll set that up in the next step.
+
+**End message.**
+
+**If INSTALL_PATH is `legacy`, show this table instead:**
 
 **Message:**
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
@@ -10,6 +10,7 @@ Read `.local/connect/workday/config.json` for ALL values — WD_BASE_URL (baseUr
 WD_TENANT (tenant), WD_TOKEN_HOST (tokenHost), DOMAIN_NAME (domainName),
 TENANT_ID (tenantId), WD_ENTRA_APP_ID (entraAppId),
 WD_ENTRA_APP_ID_URI (entraAppIdUri), WD_OAUTH_TOKEN_URL (oauthTokenUrl),
+WD_OAUTH_CLIENT_ID (oauthClientId),
 ENTRA_SSO_EXISTS (entraSSO), REPORT_OWNER (reportOwner),
 RAAS_REPORT_EXISTS (raasReportExists).
 
@@ -21,10 +22,13 @@ Do NOT ask the user about MCP internals — handle reconnection silently.
 
 **CRITICAL RULES (from retro):**
 - There are TWO install paths (set as `installPath` in config by step 1):
-  - **simplified** — only Task 1 (Entra SSO) applies. ISU accounts,
-    security groups, auth policies, API client, domain permissions, and
-    the RaaS report are NOT needed (the `ff0df` connection + REST
-    `/workers/me` replace them). After Task 1, skip straight to 2.7.
+  - **simplified** — Task 1 (Entra SSO) and Task 4 (Register API
+    Client) apply. ISU accounts, security groups, auth policies, domain
+    permissions, and the RaaS report are NOT needed (the `ff0df`
+    connection + REST `/workers/me` replace them). The `ff0df` OAuthUser
+    connection still signs in with a Workday API client whose Client ID
+    (`oauthClientId`) is entered at install time, so Task 4 is required.
+    After Task 1, do Task 4, then skip to 2.7.
   - **legacy** — all 6 tasks apply, as documented below.
   Read `installPath` from `my/connect/workday/config.json` and follow
   the matching path. When in doubt for a fresh install, the path is
@@ -57,15 +61,16 @@ Read `installPath` from `my/connect/workday/config.json`.
 
 **Message:**
 
-There's just one admin task for the streamlined Workday setup: enabling
-Microsoft Entra single sign-on so employees authenticate as themselves.
-I'll handle as much as possible automatically and verify it before
+There are two admin tasks for the streamlined Workday setup: enabling
+Microsoft Entra single sign-on so employees authenticate as themselves,
+and registering the Workday API client the connection signs in with.
+I'll handle as much as possible automatically and verify each before
 moving on.
 
 **End message.**
 
-Do Task 1 (Entra SSO Setup) below, then skip directly to section 2.7.
-Do NOT do Tasks 2–6.
+Do Task 1 (Entra SSO Setup) and Task 4 (Register API Client) below, then
+skip directly to section 2.7. Do NOT do Tasks 2, 3, 5, or 6.
 
 **If INSTALL_PATH is `legacy`:**
 
@@ -120,12 +125,14 @@ with Application ID URI `{WD_ENTRA_APP_ID_URI}`.
 
 **End message.**
 
-Skip to Task 2.
+If `installPath` is `simplified`, skip to Task 4. Otherwise continue to
+Task 2.
 
 **If the connector is NOT pre-authorized:** add it using `az rest`
 to PATCH `api.preAuthorizedApplications` (follow the pattern in
-`src/skills/connect/azure/app-registration.md` section B.5). Then
-skip to Task 2.
+`src/skills/connect/azure/app-registration.md` section B.5). Then, if
+`installPath` is `simplified`, skip to Task 4; otherwise continue to
+Task 2.
 
 **If ENTRA_SSO_EXISTS is false:** proceed to 2.1b.
 
@@ -307,14 +314,19 @@ Update `.local/connect/workday/config.json`:
 }
 ```
 
+**Task 1 done.** If `installPath` is `simplified`, skip Tasks 2 and 3 and
+go to **Task 4 (Register API Client)** now. If `legacy`, continue to
+Task 2.
+
 ---
 
 ## Task 2: ISU Accounts and Security Groups
 
-**LEGACY PATH ONLY.** If `installPath` is `simplified`, skip Tasks 2–6
-entirely and go to section 2.7 now — the simplified install needs no ISU
-accounts, security groups, auth policies, API client, domain
-permissions, or RaaS report.
+**LEGACY PATH ONLY.** If `installPath` is `simplified`, skip Tasks 2 and
+3 and go to **Task 4 (Register API Client)** now; after Task 4, skip
+Tasks 5 and 6 and go to section 2.7. The simplified install still needs
+the API client but no ISU accounts, security groups, auth policies,
+domain permissions, or RaaS report.
 
 **Do NOT skip this task based on pre-flight.** The pre-flight uses
 the MCP admin credentials, not ISU credentials. Always verify ISU
@@ -587,6 +599,9 @@ Update `.local/connect/workday/config.json`:
 ✅ API client registered.
 
 **End message.**
+
+**If `installPath` is `simplified`, admin setup is done - skip Tasks 5
+and 6 and go to section 2.7 now.** For legacy, continue to Task 5.
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
@@ -30,7 +30,7 @@ Do NOT ask the user about MCP internals — handle reconnection silently.
     (`oauthClientId`) is entered at install time, so Task 4 is required.
     After Task 1, do Task 4, then skip to 2.7.
   - **legacy** — all 6 tasks apply, as documented below.
-  Read `installPath` from `my/connect/workday/config.json` and follow
+  Read `installPath` from `.local/connect/workday/config.json` and follow
   the matching path. When in doubt for a fresh install, the path is
   `simplified`.
 - Entra SSO is MANDATORY on BOTH paths. Do not ask if the user wants it.
@@ -55,7 +55,7 @@ Do NOT ask the user about MCP internals — handle reconnection silently.
 
 ## 2.0 — Show task overview
 
-Read `installPath` from `my/connect/workday/config.json`.
+Read `installPath` from `.local/connect/workday/config.json`.
 
 **If INSTALL_PATH is `simplified`:**
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step2.md
@@ -20,9 +20,19 @@ step1.md (pip install + server start). Then retry the failed call.
 Do NOT ask the user about MCP internals — handle reconnection silently.
 
 **CRITICAL RULES (from retro):**
-- Entra SSO is MANDATORY. Do not ask if the user wants it. Do not skip
-  Task 1. The OAuthUser connection reference uses `runtimeSource: invoker`
-  which requires Entra SSO for employee-scoped API calls.
+- There are TWO install paths (set as `installPath` in config by step 1):
+  - **simplified** — only Task 1 (Entra SSO) applies. ISU accounts,
+    security groups, auth policies, API client, domain permissions, and
+    the RaaS report are NOT needed (the `ff0df` connection + REST
+    `/workers/me` replace them). After Task 1, skip straight to 2.7.
+  - **legacy** — all 6 tasks apply, as documented below.
+  Read `installPath` from `my/connect/workday/config.json` and follow
+  the matching path. When in doubt for a fresh install, the path is
+  `simplified`.
+- Entra SSO is MANDATORY on BOTH paths. Do not ask if the user wants it.
+  Do not skip Task 1. The OAuthUser connection reference uses
+  `runtimeSource: invoker` which requires Entra SSO for employee-scoped
+  API calls.
 - NEVER skip tasks based on pre-flight tests run with MCP admin credentials.
   The MCP uses the user's admin account. The Power Platform flows use ISU
   accounts. These have DIFFERENT permissions. A passing pre-flight does NOT
@@ -40,6 +50,24 @@ Do NOT ask the user about MCP internals — handle reconnection silently.
 ---
 
 ## 2.0 — Show task overview
+
+Read `installPath` from `my/connect/workday/config.json`.
+
+**If INSTALL_PATH is `simplified`:**
+
+**Message:**
+
+There's just one admin task for the streamlined Workday setup: enabling
+Microsoft Entra single sign-on so employees authenticate as themselves.
+I'll handle as much as possible automatically and verify it before
+moving on.
+
+**End message.**
+
+Do Task 1 (Entra SSO Setup) below, then skip directly to section 2.7.
+Do NOT do Tasks 2–6.
+
+**If INSTALL_PATH is `legacy`:**
 
 **Message:**
 
@@ -282,6 +310,11 @@ Update `.local/connect/workday/config.json`:
 ---
 
 ## Task 2: ISU Accounts and Security Groups
+
+**LEGACY PATH ONLY.** If `installPath` is `simplified`, skip Tasks 2–6
+entirely and go to section 2.7 now — the simplified install needs no ISU
+accounts, security groups, auth policies, API client, domain
+permissions, or RaaS report.
 
 **Do NOT skip this task based on pre-flight.** The pre-flight uses
 the MCP admin credentials, not ISU credentials. Always verify ISU
@@ -948,6 +981,25 @@ Wait for the user on retry. Re-run `get_user_context`.
 
 Update `.local/connect/workday/tasks.md` — change step 2 from
 `- [ ]` to `- [x]`.
+
+**If INSTALL_PATH is `simplified`:**
+
+**Message:**
+
+✅ Admin setup complete!
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Environment configured | ✅ |
+| 2 | Entra SSO enabled | ✅ |
+| 3 | Connection verified | ⬜ |
+
+One more step — let's install the Workday extension and run the final
+verification.
+
+**End message.**
+
+**If INSTALL_PATH is `legacy`:**
 
 **Message:**
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
@@ -118,7 +118,16 @@ Do this silently — do not tell the user about app role assignments.
 
 ## 3.4 — Guide extension pack installation
 
-Read `installPath` from `my/connect/workday/config.json`.
+Read `installPath` and `partialInstall` from `my/connect/workday/config.json`.
+
+**If `partialInstall` is `true`**, the tenant has 1 or 2 legacy Workday
+connection refs (`d6081` and/or `0786a`) but not the full 3 — likely a
+prior install that errored out. Do NOT start a fresh simplified install
+on top. Use the **Legacy path** section below, walk the user through
+creating the missing connection(s) only, and skip the connections that
+already show as configured in Power Platform. Surface a brief note to
+the user that you detected a partial legacy install and are completing
+it rather than switching paths.
 
 ### Simplified path (2 connections)
 
@@ -153,6 +162,11 @@ Name it: `Workday SOAP - OAuthUser SSO (ff0df)`
 
 → Sign in with your Microsoft account when prompted.
 
+> **If the OAuthUser connection screen does not show a "Workday REST
+> base URL" field**, you have an older Workday extension pack version
+> that only supports the 3-connection legacy install. Type **legacy**
+> and the skill will restart this step on the legacy path instead.
+
 ---
 
 **Connection 2 — Dataverse**
@@ -167,6 +181,12 @@ Type **done** when the installation finishes.
 **End message.**
 
 Wait for the user. Then go to section 3.5.
+
+**If the user types `legacy` instead of `done`** (older extension pack
+without the REST base URL field), set `installPath = legacy` in
+`my/connect/workday/config.json`, then go back to step2 task 2 to run
+the legacy ISU/security-group/RaaS admin setup before retrying 3.4 on
+the Legacy path.
 
 ### Legacy path (4 connections)
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
@@ -295,6 +295,13 @@ Check the connection references based on `installPath`:
 - **legacy** — expect all 3 Workday connection references
   (`d6081`, `0786a`, `ff0df`) to exist with `statuscode = 1`.
 
+The Dataverse connection uses the platform Dataverse connector, not a
+`%workday%` one, so it does NOT appear in the query above. Confirm it
+from the green check it showed during the extension install in 3.4; the
+completion summary's `Connection: Dataverse` row reflects that install
+result, not this query. Do not report a Dataverse status this query
+cannot actually see.
+
 If any expected reference shows `statuscode != 1`, note which ones are
 broken.
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
@@ -11,20 +11,33 @@ Read `.local/config.json` for agent details (dataverseEndpoint, agent.botId,
 agent.name, agent.schemaName, agent.isManaged).
 
 **CRITICAL RULES (from retro):**
-- The 3 Workday connections need DIFFERENT configurations:
+- This step branches on `installPath` from config:
+  - **simplified** — the extension install prompts for only **2**
+    connections: OAuthUser (`ff0df`, Microsoft Entra ID Integrated) and
+    Dataverse. There are no ISU/Basic connections, no
+    `EmployeeContextRequestAccountName` env var, and no RaaS report. The
+    OAuthUser connection additionally requires a **Workday REST base
+    URL** field. User context comes from the REST `/workers/me`
+    endpoint via the **User Context V2** topic.
+  - **legacy** — the extension install prompts for **4** connections
+    (`d6081`, `0786a`, `ff0df`, Dataverse) with the ISU env var and the
+    `WD_User_Context` RaaS report, as documented in the legacy sections.
+- For the **legacy** path, the 3 Workday connections need DIFFERENT
+  configurations:
   - `d6081` (Context Generic) = Basic auth with ISU_WQL
   - `0786a` (Generic User) = Basic auth with ISU_GENERIC
   - `ff0df` (OAuthUser) = **Microsoft Entra ID Integrated** (SSO)
   This is because `ff0df` uses `runtimeSource: invoker` in the flow —
   it authenticates AS the employee, not as a service account.
-- Power Platform AUTO-FILLS connections 2 and 3 when you create #1.
-  The user MUST create each connection separately. Warn explicitly.
+- Power Platform AUTO-FILLS the other connections when you create the
+  first. The user MUST create each connection separately. Warn explicitly.
 - Name each connection distinctively (append the reference ID suffix)
   so they're distinguishable in dropdowns.
 - The topic redirect MUST be pushed automatically via push.py — do NOT
   leave it as a manual portal step.
 - After install, verify EVERYTHING programmatically: connection refs,
-  flows, env vars, topic redirect. Do NOT accept "done" without checking.
+  flows, env vars (legacy only), topic redirect. Do NOT accept "done"
+  without checking.
 - Environment variables are in the Default Solution, NOT a "Workday" solution.
 
 ---
@@ -104,6 +117,60 @@ Do this silently — do not tell the user about app role assignments.
 ---
 
 ## 3.4 — Guide extension pack installation
+
+Read `installPath` from `my/connect/workday/config.json`.
+
+### Simplified path (2 connections)
+
+**Use this section when INSTALL_PATH is `simplified`.** Read
+`entraAppIdUri`, `oauthTokenUrl`, `oauthClientId`, `baseUrl`,
+`restBaseUrl`, and `tenant` from config.
+
+**Message:**
+
+Now let's install the Workday extension pack.
+
+1. Open your agent in [Copilot Studio](https://copilotstudio.microsoft.com/)
+2. Go to **Settings** → **Customize**
+3. Select **Workday** and choose **Install**
+
+You'll be asked to set up 2 connections.
+
+---
+
+**Connection 1 — OAuthUser SSO (`ff0df`)**
+Name it: `Workday SOAP - OAuthUser SSO (ff0df)`
+
+| Field | Value |
+|-------|-------|
+| **Authentication type** | **Microsoft Entra ID Integrated** |
+| **Microsoft Entra resource URL (Application ID URI)** | `{entraAppIdUri}` |
+| **Workday OAuth token URL** | `{oauthTokenUrl}` |
+| **Workday OAuth client ID** | `{oauthClientId}` |
+| **SOAP base URL** | `{baseUrl}` |
+| **Workday REST base URL** | `{restBaseUrl}` |
+| **Tenant name** | `{tenant}` |
+
+→ Sign in with your Microsoft account when prompted.
+
+---
+
+**Connection 2 — Dataverse**
+Should auto-connect with your account. Just click to confirm.
+
+---
+
+Once both show green checkmarks, click **Next** to complete the install.
+
+Type **done** when the installation finishes.
+
+**End message.**
+
+Wait for the user. Then go to section 3.5.
+
+### Legacy path (4 connections)
+
+**Use this section when INSTALL_PATH is `legacy`.**
 
 Read the ISU passwords from config (`isuWqlPassword`, `isuGenericPassword`).
 Read `entraAppIdUri`, `oauthTokenUrl`, `oauthClientId`, `baseUrl`, `tenant`
@@ -199,10 +266,17 @@ SELECT TOP 5 connectionreferencelogicalname,
   WHERE connectorid LIKE '%workday%'
 ```
 
-Check that all 3 Workday connection references exist and have
-`statuscode = 1` (Connected).
+Check the connection references based on `installPath`:
 
-If any show `statuscode != 1`, note which ones are broken.
+- **simplified** — expect the OAuthUser reference (`ff0df`) to exist
+  with `statuscode = 1` (Connected). `d6081`/`0786a` should NOT exist;
+  if they do, this is actually a legacy install — re-read step 1
+  detection.
+- **legacy** — expect all 3 Workday connection references
+  (`d6081`, `0786a`, `ff0df`) to exist with `statuscode = 1`.
+
+If any expected reference shows `statuscode != 1`, note which ones are
+broken.
 
 ### 3.5b — Verify flows are enabled
 
@@ -239,10 +313,16 @@ Type **done** when both flows are on.
 
 **End message.**
 
-### 3.5c — Verify environment variables
+### 3.5c — Verify environment variables (legacy path only)
 
-The environment variable `EmployeeContextRequestAccountName` must be
-set to the ISU_WQL account. This is the one that's usually missed.
+**Skip this entire sub-step if `installPath` is `simplified`.** The
+simplified install does not use the `EmployeeContextRequestAccountName`
+environment variable or the `WD_User_Context` RaaS report — user context
+comes from the REST `/workers/me` endpoint.
+
+For the **legacy** path: the environment variable
+`EmployeeContextRequestAccountName` must be set to the ISU_WQL account.
+This is the one that's usually missed.
 
 Try querying via Dataverse MCP:
 
@@ -280,8 +360,24 @@ Read the agent's `user-context-setup.mcs.yml` file:
 workspace/agents/{slug}/topics/user-context-setup.mcs.yml
 ```
 
-Check if it already contains a `BeginDialog` action pointing to
-`WorkdaySystemGetUserContext`.
+Check if it already contains a `BeginDialog` action pointing to the
+Workday user-context system topic.
+
+**Determine the correct redirect target based on `installPath`:**
+
+- **legacy** → the SOAP/RaaS user-context topic
+  `WorkdaySystemGetUserContext`.
+- **simplified** → the REST `/workers/me` user-context topic, which the
+  simplified extension pack ships as a V2 topic
+  (`WorkdaySystemGetUserContextV2`). Confirm the exact topic name by
+  listing the installed Workday system topics under
+  `my/agents/{slug}/topics/` (look for the Workday "Set User Context"
+  system topic) and use that topic's actual dialog id. Do NOT assume the
+  legacy name on a simplified install.
+
+Save the resolved dialog id as USER_CONTEXT_DIALOG
+(e.g. `{SCHEMA_NAME}.topic.WorkdaySystemGetUserContext` for legacy or
+`{SCHEMA_NAME}.topic.WorkdaySystemGetUserContextV2` for simplified).
 
 **If the redirect already exists:** Good, skip this step.
 
@@ -307,7 +403,8 @@ Create a checkpoint:
 python scripts/checkpoint.py "Add User Context redirect to Workday"
 ```
 
-Replace the file content with:
+Replace the file content with (use the USER_CONTEXT_DIALOG resolved
+above as the `dialog` value):
 
 ```yaml
 kind: AdaptiveDialog
@@ -319,7 +416,7 @@ beginDialog:
     - kind: BeginDialog
       id: bfT9Kx
       displayName: Redirect to Workday System Get User Context
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetUserContext
+      dialog: {USER_CONTEXT_DIALOG}
 ```
 
 Push the change:
@@ -342,7 +439,27 @@ python scripts/fetch_and_setup.py --url "{ENV_URL}" --bot-id "{BOT_ID}" --name "
 
 ### 3.5f — Show verification results
 
-Build a results table from all checks.
+Build a results table from all checks, based on `installPath`.
+
+**If INSTALL_PATH is `simplified`:**
+
+**Message:**
+
+Post-install verification:
+
+| Check | Status |
+|-------|--------|
+| Connection: OAuthUser SSO (`ff0df`) | {✅ or ❌} |
+| Connection: Dataverse | {✅ or ❌} |
+| Flow: ESS HR Workday Get User Context | {✅ Enabled or ❌ Disabled} |
+| Flow: ESS HR Workday | {✅ Enabled or ❌ Disabled} |
+| Topic redirect: User Context → Workday | {✅ Pushed or ❌ Missing} |
+
+{If any ❌ items, show specific fix instructions for each.}
+
+**End message.**
+
+**If INSTALL_PATH is `legacy`:**
 
 **Message:**
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
@@ -121,13 +121,16 @@ Do this silently — do not tell the user about app role assignments.
 Read `installPath` and `partialInstall` from `.local/connect/workday/config.json`.
 
 **If `partialInstall` is `true`**, the tenant has 1 or 2 legacy Workday
-connection refs (`d6081` and/or `0786a`) but not the full 3 — likely a
-prior install that errored out. Do NOT start a fresh simplified install
-on top. Use the **Legacy path** section below, walk the user through
-creating the missing connection(s) only, and skip the connections that
-already show as configured in Power Platform. Surface a brief note to
-the user that you detected a partial legacy install and are completing
-it rather than switching paths.
+connection refs (`d6081` and/or `0786a`) but not the full 3. Treat this
+as a **legacy repair**, not a fresh simplified install:
+
+- **Reuse** refs that already exist and show **Connected**.
+- **Repair or recreate** refs that exist but are not Connected.
+- **Create** only refs that are missing.
+
+Do NOT switch paths mid-repair. Use the **Legacy path** section below
+and surface a brief note to the user that you detected a partial legacy
+install and are completing that repair path.
 
 ### Simplified path (2 connections)
 
@@ -398,7 +401,7 @@ Workday user-context system topic.
   simplified extension pack ships as a V2 topic
   (`WorkdaySystemGetUserContextV2`). Confirm the exact topic name by
   listing the installed Workday system topics under
-  `my/agents/{slug}/topics/` (look for the Workday "Set User Context"
+  `.local/agents/{slug}/topics/` (look for the Workday "Set User Context"
   system topic) and use that topic's actual dialog id. Do NOT assume the
   legacy name on a simplified install.
 
@@ -468,6 +471,10 @@ python scripts/fetch_and_setup.py --url "{ENV_URL}" --bot-id "{BOT_ID}" --name "
 
 Build a results table from all checks, based on `installPath`.
 
+For the topic redirect check, do not hard-code a single topic name.
+Treat the check as pass when `user-context-setup.mcs.yml` contains a
+`BeginDialog` that points to the resolved `USER_CONTEXT_DIALOG`.
+
 **If INSTALL_PATH is `simplified`:**
 
 **Message:**
@@ -480,7 +487,8 @@ Post-install verification:
 | Connection: Dataverse | {✅ or ❌} |
 | Flow: ESS HR Workday Get User Context | {✅ Enabled or ❌ Disabled} |
 | Flow: ESS HR Workday | {✅ Enabled or ❌ Disabled} |
-| Topic redirect: User Context → Workday | {✅ Pushed or ❌ Missing} |
+| Environment variables (legacy-only) | ✅ N/A for simplified |
+| Topic redirect: User Context → Workday user-context topic | {✅ Pushed or ❌ Missing} |
 
 {If any ❌ items, show specific fix instructions for each.}
 
@@ -500,7 +508,7 @@ Post-install verification:
 | Flow: ESS HR Workday Get User Context | {✅ Enabled or ❌ Disabled} |
 | Flow: ESS HR Workday | {✅ Enabled or ❌ Disabled} |
 | Environment variable: AccountName | {✅ Set or ⚠️ Verify manually} |
-| Topic redirect: User Context → Workday | {✅ Pushed or ❌ Missing} |
+| Topic redirect: User Context → Workday user-context topic | {✅ Pushed or ❌ Missing} |
 
 {If any ❌ items, show specific fix instructions for each.}
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/step3.md
@@ -118,7 +118,7 @@ Do this silently — do not tell the user about app role assignments.
 
 ## 3.4 — Guide extension pack installation
 
-Read `installPath` and `partialInstall` from `my/connect/workday/config.json`.
+Read `installPath` and `partialInstall` from `.local/connect/workday/config.json`.
 
 **If `partialInstall` is `true`**, the tenant has 1 or 2 legacy Workday
 connection refs (`d6081` and/or `0786a`) but not the full 3 — likely a
@@ -184,7 +184,7 @@ Wait for the user. Then go to section 3.5.
 
 **If the user types `legacy` instead of `done`** (older extension pack
 without the REST base URL field), set `installPath = legacy` in
-`my/connect/workday/config.json`, then go back to step2 task 2 to run
+`.local/connect/workday/config.json`, then go back to step2 task 2 to run
 the legacy ISU/security-group/RaaS admin setup before retrying 3.4 on
 the Legacy path.
 

--- a/solutions/ess-maker-skills/src/skills/connect/workday/tasks.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/tasks.md
@@ -1,5 +1,5 @@
 # Workday Connect Checklist
 
 - [ ] **Environment configured** — Workday URL, tenant, and credentials captured
-- [ ] **Admin setup complete** — Entra SSO enabled (simplified), plus ISUs, security groups, permissions, and report (legacy only)
+- [ ] **Admin setup complete** — Entra SSO enabled (both paths) and Workday API client registered (both paths), plus ISUs, security groups, permissions, and report (legacy only)
 - [ ] **Connection verified** — Confirmed working end-to-end

--- a/solutions/ess-maker-skills/src/skills/connect/workday/tasks.md
+++ b/solutions/ess-maker-skills/src/skills/connect/workday/tasks.md
@@ -1,5 +1,5 @@
 # Workday Connect Checklist
 
 - [ ] **Environment configured** — Workday URL, tenant, and credentials captured
-- [ ] **Admin setup complete** — ISUs, security groups, permissions, and report created
+- [ ] **Admin setup complete** — Entra SSO enabled (simplified), plus ISUs, security groups, permissions, and report (legacy only)
 - [ ] **Connection verified** — Confirmed working end-to-end


### PR DESCRIPTION
## Summary

The `/connect workday` skill assumed the **legacy 3-connection install** (ISU service accounts, security groups, auth policies, API client, domain permissions, and the `WD_User_Context` RaaS report). Microsoft now ships a **simplified install** that needs only the OAuthUser connection (`ff0df`, Microsoft Entra ID Integrated) plus Dataverse, using the Workday REST `/workers/me` endpoint for user context.

This PR teaches the connect skill to detect which path a tenant is on and branch accordingly. Fresh installs default to **simplified**; existing **legacy** installs keep working unchanged.

Fixes #93.

## Changes

| File | Change |
|------|--------|
| `src/skills/connect/workday/step1.md` | Classify install path (simplified / legacy / fresh→simplified) from the detected connection references; derive the Workday **REST base URL**; gate RaaS-report detection to legacy; path-aware status table |
| `src/skills/connect/workday/step2.md` | Gate Tasks 2–6 (ISU accounts, security groups, auth policies, API client, domain permissions, RaaS report) to the **legacy** path. Task 1 (Entra SSO) stays mandatory on **both** paths — `ff0df` needs it |
| `src/skills/connect/workday/step3.md` | Add a **2-connection** install table (OAuthUser + Dataverse) with the new **Workday REST base URL** field; path-aware connection-ref + env-var verification; route the user-context topic redirect to the V2 (REST) topic on simplified installs |
| `src/skills/connect/workday/tasks.md` | Reword the admin-setup checklist item to cover both paths |
| `src/skills/connect/SKILL.md` | Rewrite the Workday routing + key-principles block to describe both paths |
| `.github/copilot-instructions.md` | Replace the "three connections" Workday bullet with a two-install-path description |
| `README.md` | Document both install paths in the Workday section |

## Key behavior preserved

- **Entra SSO stays mandatory** on both paths (the `ff0df` `runtimeSource: invoker` connection authenticates as the employee).
- **Existing legacy installs are untouched** — no forced migration.
- Verify-then-create and programmatic-verification patterns unchanged.

## Out of scope (intentionally)

- ❌ **FlightCheck** changes (`scripts/flightcheck/`) — owned by another team.
- ❌ **Vendoring** the new Microsoft Learn page into `src/reference/ess-docs/`.

## Note on the V2 redirect target

For the simplified path, step3 resolves the user-context topic dialog id by **discovering** the installed Workday "Set User Context" system topic from the extracted agent (rather than hardcoding an unverified schema name), defaulting to `WorkdaySystemGetUserContextV2`. A reviewer with a simplified-install tenant should confirm the exact topic name.

## Testing

These are agent instruction (Markdown) files — no automated tests. Reviewed for internal consistency across the branch points (step1 → step2 → step3) and against the existing legacy flow.