### PR TITLE
Add FlightCheck-only installer and pip dependency fix

### DIFF
--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -654,16 +654,18 @@ if ($FlightCheckOnly) {
     if ($pythonExe) {
         Push-Location $workspace
         try {
+            # Run FlightCheck with EAP=Continue so stderr doesn't terminate,
+            # but let output stream directly to console (FlightCheck is interactive)
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
             if ($pythonExe -eq 'py -3.12') {
-                $fcArgs = @('-3.12', 'scripts/flightcheck/cli.py', '--scope', 'full')
-                $fcOutput = Invoke-Native { & py @fcArgs }
+                & py -3.12 scripts/flightcheck/cli.py --scope full
             } elseif ($pythonExe -eq 'py -3') {
-                $fcArgs = @('-3', 'scripts/flightcheck/cli.py', '--scope', 'full')
-                $fcOutput = Invoke-Native { & py @fcArgs }
+                & py -3 scripts/flightcheck/cli.py --scope full
             } else {
-                $fcOutput = Invoke-Native { & $pythonExe scripts/flightcheck/cli.py --scope full }
+                & $pythonExe scripts/flightcheck/cli.py --scope full
             }
-            foreach ($line in $fcOutput) { Write-Host $line }
+            $ErrorActionPreference = $prevEAP
         } finally { Pop-Location }
     } else {
         Write-Warn2 'Python not found. Open a new terminal and run:'

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -638,17 +638,24 @@ if ($FlightCheckOnly) {
         }
 
         # Match the structure setup.py produces: agents array + activeAgent slug
+        if ($botId) {
+            $agentsList = [System.Collections.ArrayList]@()
+            $agentsList.Add($agentEntry) | Out-Null
+        } else {
+            $agentsList = [System.Collections.ArrayList]@()
+        }
+
         $config = @{
             configVersion      = 1
             setup              = 'flightcheck-only'
             dataverseEndpoint  = $envUrl
             flightCheckOnly    = $true
             agent              = $agentEntry
-            agents             = if ($botId) { @(,$agentEntry) } else { @() }
+            agents             = $agentsList
             activeAgent        = if ($botId) { $slug } else { '' }
         }
 
-        $json = $config | ConvertTo-Json -Depth 4
+        $json = $config | ConvertTo-Json -Depth 4 -Compress:$false
         [System.IO.File]::WriteAllText($configPath, $json, (New-Object System.Text.UTF8Encoding $false))
         Write-Ok "Created $configPath"
     }

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -627,20 +627,24 @@ if ($FlightCheckOnly) {
         }
 
         # Write minimal config.json sufficient for FlightCheck
+        $slug = 'flightcheck-only'
+        $agentEntry = @{
+            name       = $agentName
+            botId      = $botId
+            schemaName = $schemaName
+            isManaged  = $isManaged
+            slug       = $slug
+            folder     = ''
+        }
+
+        # Match the structure setup.py produces: agents array + activeAgent slug
         $config = @{
             setup              = 'complete'
             dataverseEndpoint  = $envUrl
             flightCheckOnly    = $true
-            agent              = @{
-                name       = $agentName
-                botId      = $botId
-                schemaName = $schemaName
-                isManaged  = $isManaged
-                slug       = 'flightcheck-only'
-                folder     = ''
-            }
-            agents             = @()
-            activeAgent        = ''
+            agent              = $agentEntry
+            agents             = if ($botId) { @(,$agentEntry) } else { @() }
+            activeAgent        = if ($botId) { $slug } else { '' }
         }
 
         $json = $config | ConvertTo-Json -Depth 4

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -195,11 +195,8 @@ if (-not $wingetAvailable) {
     Write-Warn2 'winget not available. Checking for pre-installed tools...'
     $missingTools = @()
     foreach ($pkg in $packages) {
-        $cmd = Get-Command $pkg.Cmd -ErrorAction SilentlyContinue
-        if ($cmd) {
-            Write-Ok "$($pkg.Name) (already installed at $($cmd.Source))"
-        } elseif ($pkg.Cmd -eq 'python') {
-            # Use Resolve-Python for smarter detection
+        if ($pkg.Cmd -eq 'python') {
+            # Use Resolve-Python to exclude the non-functional Store alias
             $resolved = Resolve-Python
             if ($resolved) {
                 Write-Ok "$($pkg.Name) (found: $resolved)"
@@ -207,7 +204,12 @@ if (-not $wingetAvailable) {
                 $missingTools += $pkg.Name
             }
         } else {
-            $missingTools += $pkg.Name
+            $cmd = Get-Command $pkg.Cmd -ErrorAction SilentlyContinue
+            if ($cmd) {
+                Write-Ok "$($pkg.Name) (already installed at $($cmd.Source))"
+            } else {
+                $missingTools += $pkg.Name
+            }
         }
     }
     if ($missingTools.Count -gt 0) {
@@ -411,8 +413,22 @@ if (-not $SkipClone) {
         Push-Location $repoPath
         try {
             $gitOutput = Invoke-Native { & git fetch --quiet origin }
-            $gitOutput = Invoke-Native { & git checkout --quiet $Branch }
-            $gitOutput = Invoke-Native { & git pull --quiet --ff-only }
+            foreach ($line in $gitOutput) { if ($line) { Write-Host "      $line" } }
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warn2 "git fetch failed (exit $LASTEXITCODE). Continuing with local copy."
+            } else {
+                $gitOutput = Invoke-Native { & git checkout --quiet $Branch }
+                foreach ($line in $gitOutput) { if ($line) { Write-Host "      $line" } }
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Warn2 "git checkout $Branch failed (exit $LASTEXITCODE). Continuing on current branch."
+                } else {
+                    $gitOutput = Invoke-Native { & git pull --quiet --ff-only }
+                    foreach ($line in $gitOutput) { if ($line) { Write-Host "      $line" } }
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Warn2 "git pull failed (exit $LASTEXITCODE). Continuing with local copy."
+                    }
+                }
+            }
         } finally { Pop-Location }
     } else {
         $gitOutput = Invoke-Native { & git clone --branch $Branch --single-branch $RepoUrl $repoPath }
@@ -639,12 +655,15 @@ if ($FlightCheckOnly) {
         Push-Location $workspace
         try {
             if ($pythonExe -eq 'py -3.12') {
-                & py -3.12 scripts/flightcheck/cli.py --scope full
+                $fcArgs = @('-3.12', 'scripts/flightcheck/cli.py', '--scope', 'full')
+                $fcOutput = Invoke-Native { & py @fcArgs }
             } elseif ($pythonExe -eq 'py -3') {
-                & py -3 scripts/flightcheck/cli.py --scope full
+                $fcArgs = @('-3', 'scripts/flightcheck/cli.py', '--scope', 'full')
+                $fcOutput = Invoke-Native { & py @fcArgs }
             } else {
-                & $pythonExe scripts/flightcheck/cli.py --scope full
+                $fcOutput = Invoke-Native { & $pythonExe scripts/flightcheck/cli.py --scope full }
             }
+            foreach ($line in $fcOutput) { Write-Host $line }
         } finally { Pop-Location }
     } else {
         Write-Warn2 'Python not found. Open a new terminal and run:'

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -639,7 +639,8 @@ if ($FlightCheckOnly) {
 
         # Match the structure setup.py produces: agents array + activeAgent slug
         $config = @{
-            setup              = 'complete'
+            configVersion      = 1
+            setup              = 'flightcheck-only'
             dataverseEndpoint  = $envUrl
             flightCheckOnly    = $true
             agent              = $agentEntry

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -85,6 +85,57 @@ function Write-Ok    { param([string]$m) Write-Host "    [ok]   $m" -ForegroundC
 function Write-Warn2 { param([string]$m) Write-Host "    [warn] $m" -ForegroundColor Yellow }
 function Write-Err2  { param([string]$m) Write-Host "    [err]  $m" -ForegroundColor Red }
 
+# Helper: run a native command safely without $ErrorActionPreference = 'Stop'
+# terminating on stderr output (PS 5.1 bug). Returns combined output as string[].
+function Invoke-Native {
+    param([scriptblock]$Command)
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = & $Command 2>&1
+        return $output
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+# Helper: resolve Python executable robustly.
+# Checks py launcher, python on PATH (excluding Store alias), and known install paths.
+function Resolve-Python {
+    # 1. py launcher (most reliable on Windows)
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        $null = Invoke-Native { & py -3.12 --version }
+        if ($LASTEXITCODE -eq 0) { return 'py -3.12' }
+        $null = Invoke-Native { & py -3 --version }
+        if ($LASTEXITCODE -eq 0) { return 'py -3' }
+    }
+
+    # 2. python on PATH (validate it's real, not the Store alias)
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        # Store alias lives in WindowsApps and outputs nothing useful
+        if ($python.Source -notmatch 'WindowsApps') {
+            $null = Invoke-Native { & $python.Source --version }
+            if ($LASTEXITCODE -eq 0) { return $python.Source }
+        }
+    }
+
+    # 3. Known install paths
+    $knownPaths = @(
+        "$env:LOCALAPPDATA\Programs\Python\Python312\python.exe",
+        "$env:ProgramFiles\Python312\python.exe",
+        "${env:ProgramFiles(x86)}\Python312\python.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python311\python.exe",
+        "$env:ProgramFiles\Python311\python.exe"
+    )
+    foreach ($p in $knownPaths) {
+        if (Test-Path $p) { return $p }
+    }
+
+    return $null
+}
+
 # ---------------------------------------------------------------------------
 # 1. Preflight
 # ---------------------------------------------------------------------------
@@ -102,11 +153,20 @@ if ($os.Platform -ne 'Win32NT' -or $os.Version.Build -lt 17763) {
 Write-Ok "Windows build $($os.Version.Build)"
 
 $winget = Get-Command winget -ErrorAction SilentlyContinue
-if (-not $winget) {
-    Write-Err2 'winget not found. Install "App Installer" from the Microsoft Store, then re-run.'
-    throw 'winget is required.'
+$wingetAvailable = [bool]$winget
+
+if (-not $wingetAvailable) {
+    if ($FlightCheckOnly) {
+        # In FlightCheck-only mode, winget is preferred but not mandatory.
+        # If Python and Git are already installed, we can skip winget entirely.
+        Write-Warn2 'winget not found. Will check if Python and Git are already available.'
+    } else {
+        Write-Err2 'winget not found. Install "App Installer" from the Microsoft Store, then re-run.'
+        throw 'winget is required for the full ADK install.'
+    }
+} else {
+    Write-Ok "winget at $($winget.Source)"
 }
-Write-Ok "winget at $($winget.Source)"
 
 # ---------------------------------------------------------------------------
 # 2. Toolchain install (winget)
@@ -117,20 +177,52 @@ Write-Step 'Installing toolchain via winget'
 if ($FlightCheckOnly) {
     # Minimal set: just Python + Git (no VS Code, PowerShell 7, or GH CLI)
     $packages = @(
-        @{ Id = 'Python.Python.3.12'; Name = 'Python 3.12'     },
-        @{ Id = 'Git.Git';            Name = 'Git for Windows' }
+        @{ Id = 'Python.Python.3.12'; Name = 'Python 3.12'; Cmd = 'python' },
+        @{ Id = 'Git.Git';            Name = 'Git for Windows'; Cmd = 'git' }
     )
 } else {
     $packages = @(
-        @{ Id = 'Microsoft.VisualStudioCode'; Name = 'Visual Studio Code' },
-        @{ Id = 'Python.Python.3.12';         Name = 'Python 3.12'        },
-        @{ Id = 'Microsoft.PowerShell';       Name = 'PowerShell 7'       },
-        @{ Id = 'Git.Git';                    Name = 'Git for Windows'    },
-        @{ Id = 'GitHub.cli';                 Name = 'GitHub CLI'         }
+        @{ Id = 'Microsoft.VisualStudioCode'; Name = 'Visual Studio Code'; Cmd = 'code' },
+        @{ Id = 'Python.Python.3.12';         Name = 'Python 3.12'; Cmd = 'python'      },
+        @{ Id = 'Microsoft.PowerShell';       Name = 'PowerShell 7'; Cmd = 'pwsh'       },
+        @{ Id = 'Git.Git';                    Name = 'Git for Windows'; Cmd = 'git'     },
+        @{ Id = 'GitHub.cli';                 Name = 'GitHub CLI'; Cmd = 'gh'           }
     )
 }
 
-if ($UseDsc) {
+if (-not $wingetAvailable) {
+    # winget not present - check if required tools are already installed
+    Write-Warn2 'winget not available. Checking for pre-installed tools...'
+    $missingTools = @()
+    foreach ($pkg in $packages) {
+        $cmd = Get-Command $pkg.Cmd -ErrorAction SilentlyContinue
+        if ($cmd) {
+            Write-Ok "$($pkg.Name) (already installed at $($cmd.Source))"
+        } elseif ($pkg.Cmd -eq 'python') {
+            # Use Resolve-Python for smarter detection
+            $resolved = Resolve-Python
+            if ($resolved) {
+                Write-Ok "$($pkg.Name) (found: $resolved)"
+            } else {
+                $missingTools += $pkg.Name
+            }
+        } else {
+            $missingTools += $pkg.Name
+        }
+    }
+    if ($missingTools.Count -gt 0) {
+        Write-Err2 "Missing tools that cannot be auto-installed without winget: $($missingTools -join ', ')"
+        Write-Err2 'Please install them manually:'
+        Write-Err2 '  Python 3.12: https://www.python.org/downloads/'
+        Write-Err2 '  Git: https://git-scm.com/download/win'
+        if (-not $FlightCheckOnly) {
+            Write-Err2 '  VS Code: https://code.visualstudio.com/download'
+            Write-Err2 '  PowerShell 7: https://aka.ms/powershell-release?tag=stable'
+            Write-Err2 '  GitHub CLI: https://cli.github.com/'
+        }
+        throw "Required tools are missing and winget is not available to install them."
+    }
+} elseif ($UseDsc) {
     # Declarative path - requires `winget configure --enable` (one-time opt-in
     # that pulls DSC modules from the Microsoft Store). Provided for IT shops
     # that prefer the auditable YAML manifest.
@@ -150,16 +242,27 @@ if ($UseDsc) {
     # winget without enabling extended features. Idempotent: re-running just
     # logs "already installed" for present packages.
     foreach ($pkg in $packages) {
+        # Skip if already installed (avoids unnecessary winget calls + elevation prompts)
+        if ($FlightCheckOnly) {
+            $existing = if ($pkg.Cmd -eq 'python') { Resolve-Python } else { Get-Command $pkg.Cmd -ErrorAction SilentlyContinue }
+            if ($existing) {
+                Write-Ok "$($pkg.Name) (already installed)"
+                continue
+            }
+        }
+
         Write-Host "    installing $($pkg.Name) ($($pkg.Id))"
-        & winget install --id $pkg.Id `
-                         --source winget `
-                         --exact `
-                         --silent `
-                         --accept-package-agreements `
-                         --accept-source-agreements `
-                         --disable-interactivity 2>&1 | ForEach-Object {
-            $line = "$_".Trim()
-            # Skip empty lines, spinner frames, and progress bar garbage
+        $wingetOutput = Invoke-Native {
+            & winget install --id $pkg.Id `
+                             --source winget `
+                             --exact `
+                             --silent `
+                             --accept-package-agreements `
+                             --accept-source-agreements `
+                             --disable-interactivity
+        }
+        foreach ($rawLine in $wingetOutput) {
+            $line = "$rawLine".Trim()
             if ($line -and $line -notmatch '^[\\/\|\-]$' -and $line -notmatch '[^\x20-\x7E]') {
                 Write-Host "      $line"
             }
@@ -174,7 +277,11 @@ if ($UseDsc) {
         if ($code -eq 0 -or $code -eq -1978335189) {
             Write-Ok "$($pkg.Name)"
         } else {
-            throw "winget install $($pkg.Id) failed with exit code $code"
+            if ($FlightCheckOnly) {
+                Write-Warn2 "$($pkg.Name) install exited $code. Will check if usable anyway."
+            } else {
+                throw "winget install $($pkg.Id) failed with exit code $code"
+            }
         }
     }
 }
@@ -190,43 +297,31 @@ $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' +
 Write-Step 'Installing Python pip dependencies'
 
 $deferPip = $false
-$pip = Get-Command pip -ErrorAction SilentlyContinue
-if (-not $pip) {
-    # Try python -m pip as a fallback (pip not on PATH yet after fresh install)
-    $python = Get-Command python -ErrorAction SilentlyContinue
-    if ($python) {
-        $requirementsFile = Join-Path $PSScriptRoot '..\solutions\ess-maker-skills\scripts\requirements.txt'
-        if (-not (Test-Path $requirementsFile)) {
-            # If running from a temp dir (bootstrap), the repo hasn't been cloned yet.
-            # Defer pip install to after clone (section 5b below).
-            Write-Warn2 'requirements.txt not yet available (pre-clone). Will install after clone.'
-            $deferPip = $true
-        } else {
-            & $python.Source -m pip install --quiet --disable-pip-version-check -r $requirementsFile 2>&1 | ForEach-Object { Write-Host "      $_" }
-            if ($LASTEXITCODE -eq 0) {
-                Write-Ok 'pip dependencies installed'
-            } else {
-                Write-Warn2 "pip install returned exit code $LASTEXITCODE (non-fatal, /setup will retry)"
-            }
-            $deferPip = $false
-        }
-    } else {
-        Write-Warn2 'python not on PATH yet. Pip dependencies will be installed when you run /setup.'
-        $deferPip = $false
-    }
+$pythonExe = Resolve-Python
+
+if (-not $pythonExe) {
+    Write-Warn2 'Python not found on PATH or known locations. Pip dependencies will be installed when you run /setup.'
+    $deferPip = $false
 } else {
+    Write-Ok "Using Python: $pythonExe"
     $requirementsFile = Join-Path $PSScriptRoot '..\solutions\ess-maker-skills\scripts\requirements.txt'
     if (-not (Test-Path $requirementsFile)) {
         Write-Warn2 'requirements.txt not yet available (pre-clone). Will install after clone.'
         $deferPip = $true
     } else {
-        & $pip.Source install --quiet --disable-pip-version-check -r $requirementsFile 2>&1 | ForEach-Object { Write-Host "      $_" }
+        # Use Invoke-Native to avoid PS 5.1 stderr termination
+        if ($pythonExe -eq 'py -3.12' -or $pythonExe -eq 'py -3') {
+            $pyArgs = ($pythonExe -split ' ')[1]
+            $pipOutput = Invoke-Native { & py $pyArgs -m pip install --quiet --disable-pip-version-check -r $requirementsFile }
+        } else {
+            $pipOutput = Invoke-Native { & $pythonExe -m pip install --quiet --disable-pip-version-check -r $requirementsFile }
+        }
+        foreach ($line in $pipOutput) { Write-Host "      $line" }
         if ($LASTEXITCODE -eq 0) {
             Write-Ok 'pip dependencies installed'
         } else {
             Write-Warn2 "pip install returned exit code $LASTEXITCODE (non-fatal, /setup will retry)"
         }
-        $deferPip = $false
     }
 }
 
@@ -303,6 +398,10 @@ $repoPath = Join-Path $InstallRoot $repoName
 if (-not $SkipClone) {
     Write-Step "Cloning $RepoUrl"
 
+    # Prevent git from hanging waiting for credentials or host-key prompts
+    $env:GIT_TERMINAL_PROMPT = '0'
+    $env:GCM_INTERACTIVE = 'never'
+
     if (-not (Test-Path $InstallRoot)) {
         New-Item -ItemType Directory -Path $InstallRoot -Force | Out-Null
     }
@@ -311,13 +410,17 @@ if (-not $SkipClone) {
         Write-Ok "Repo already cloned at $repoPath - pulling latest"
         Push-Location $repoPath
         try {
-            & git fetch --quiet origin
-            & git checkout --quiet $Branch
-            & git pull --quiet --ff-only
+            $gitOutput = Invoke-Native { & git fetch --quiet origin }
+            $gitOutput = Invoke-Native { & git checkout --quiet $Branch }
+            $gitOutput = Invoke-Native { & git pull --quiet --ff-only }
         } finally { Pop-Location }
     } else {
-        & git clone --branch $Branch --single-branch $RepoUrl $repoPath
+        $gitOutput = Invoke-Native { & git clone --branch $Branch --single-branch $RepoUrl $repoPath }
+        foreach ($line in $gitOutput) { Write-Host "      $line" }
         if ($LASTEXITCODE -ne 0) {
+            Write-Err2 "git clone failed with exit code $LASTEXITCODE"
+            Write-Err2 "If this is a network/firewall issue, you can download the repo manually:"
+            Write-Err2 "  https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/archive/refs/heads/$Branch.zip"
             throw "git clone failed with exit code $LASTEXITCODE"
         }
         Write-Ok "Cloned to $repoPath"
@@ -333,16 +436,22 @@ if ($deferPip) {
     $requirementsFile = Join-Path $repoPath 'solutions\ess-maker-skills\scripts\requirements.txt'
     if (Test-Path $requirementsFile) {
         Write-Step 'Installing Python pip dependencies (deferred)'
-        $python = Get-Command python -ErrorAction SilentlyContinue
-        if ($python) {
-            & $python.Source -m pip install --quiet --disable-pip-version-check -r $requirementsFile 2>&1 | ForEach-Object { Write-Host "      $_" }
+        $pythonExe = Resolve-Python
+        if ($pythonExe) {
+            if ($pythonExe -eq 'py -3.12' -or $pythonExe -eq 'py -3') {
+                $pyArgs = ($pythonExe -split ' ')[1]
+                $pipOutput = Invoke-Native { & py $pyArgs -m pip install --quiet --disable-pip-version-check -r $requirementsFile }
+            } else {
+                $pipOutput = Invoke-Native { & $pythonExe -m pip install --quiet --disable-pip-version-check -r $requirementsFile }
+            }
+            foreach ($line in $pipOutput) { Write-Host "      $line" }
             if ($LASTEXITCODE -eq 0) {
                 Write-Ok 'pip dependencies installed'
             } else {
                 Write-Warn2 "pip install returned exit code $LASTEXITCODE (non-fatal, /setup will retry)"
             }
         } else {
-            Write-Warn2 'python still not on PATH. Run: pip install -r solutions/ess-maker-skills/scripts/requirements.txt'
+            Write-Warn2 'Python still not found. Run: pip install -r solutions/ess-maker-skills/scripts/requirements.txt'
         }
     } else {
         Write-Warn2 'requirements.txt not found in cloned repo - pip dependencies not installed'
@@ -382,13 +491,22 @@ if ($FlightCheckOnly) {
     if (-not (Test-Path $configPath)) {
         $scriptsDir = Join-Path $workspace 'scripts'
         $discoverPy = Join-Path $scriptsDir 'discover.py'
-        $python = Get-Command python -ErrorAction SilentlyContinue
+        $pythonExe = Resolve-Python
 
-        if (-not $python) {
-            throw 'python not found on PATH. Cannot run environment discovery.'
+        if (-not $pythonExe) {
+            throw 'Python not found on PATH or known locations. Cannot run environment discovery.'
         }
         if (-not (Test-Path $discoverPy)) {
             throw "discover.py not found at $discoverPy. Was the repo cloned correctly?"
+        }
+
+        # Build the base python command components for consistent invocation
+        if ($pythonExe -eq 'py -3.12') {
+            $pyCmd = 'py'; $pyBaseArgs = @('-3.12')
+        } elseif ($pythonExe -eq 'py -3') {
+            $pyCmd = 'py'; $pyBaseArgs = @('-3')
+        } else {
+            $pyCmd = $pythonExe; $pyBaseArgs = @()
         }
 
         # --- Step 1: List environments and let user pick ---
@@ -400,7 +518,9 @@ if ($FlightCheckOnly) {
         # Run discover.py --list-environments (interactive - shows table to user)
         Push-Location $workspace
         try {
-            & $python.Source $discoverPy --list-environments
+            $discoverArgs = $pyBaseArgs + @($discoverPy, '--list-environments')
+            $output = Invoke-Native { & $pyCmd @discoverArgs }
+            foreach ($line in $output) { Write-Host $line }
             if ($LASTEXITCODE -ne 0) {
                 throw 'Environment listing failed.'
             }
@@ -413,7 +533,8 @@ if ($FlightCheckOnly) {
             }
 
             # Re-run with --select to get machine-parseable JSON
-            $envOutput = & $python.Source $discoverPy --list-environments --select $envChoice 2>&1
+            $selectArgs = $pyBaseArgs + @($discoverPy, '--list-environments', '--select', $envChoice)
+            $envOutput = Invoke-Native { & $pyCmd @selectArgs }
             if ($LASTEXITCODE -ne 0) {
                 throw "Environment selection failed: $envOutput"
             }
@@ -435,7 +556,9 @@ if ($FlightCheckOnly) {
             Write-Host '    Discovering agents in this environment...' -ForegroundColor White
             Write-Host ''
 
-            & $python.Source $discoverPy --url $envUrl
+            $agentListArgs = $pyBaseArgs + @($discoverPy, '--url', $envUrl)
+            $output = Invoke-Native { & $pyCmd @agentListArgs }
+            foreach ($line in $output) { Write-Host $line }
             if ($LASTEXITCODE -ne 0) {
                 Write-Warn2 'Agent discovery failed. Config will be created without a bot ID.'
                 $botId = ''
@@ -448,7 +571,8 @@ if ($FlightCheckOnly) {
                 $agentChoice = $agentChoice.Trim()
 
                 if ($agentChoice -and $agentChoice -match '^\d+$') {
-                    $agentOutput = & $python.Source $discoverPy --url $envUrl --select $agentChoice 2>&1
+                    $agentSelectArgs = $pyBaseArgs + @($discoverPy, '--url', $envUrl, '--select', $agentChoice)
+                    $agentOutput = Invoke-Native { & $pyCmd @agentSelectArgs }
                     if ($LASTEXITCODE -ne 0) {
                         Write-Warn2 "Agent selection failed. Continuing without bot ID."
                         $botId = ''
@@ -510,14 +634,20 @@ if ($FlightCheckOnly) {
 
     # --- Run FlightCheck ---
     Write-Step 'Running FlightCheck'
-    $python = Get-Command python -ErrorAction SilentlyContinue
-    if ($python) {
+    $pythonExe = Resolve-Python
+    if ($pythonExe) {
         Push-Location $workspace
         try {
-            & $python.Source scripts/flightcheck/cli.py --scope full
+            if ($pythonExe -eq 'py -3.12') {
+                & py -3.12 scripts/flightcheck/cli.py --scope full
+            } elseif ($pythonExe -eq 'py -3') {
+                & py -3 scripts/flightcheck/cli.py --scope full
+            } else {
+                & $pythonExe scripts/flightcheck/cli.py --scope full
+            }
         } finally { Pop-Location }
     } else {
-        Write-Warn2 'python not found on PATH. Open a new terminal and run:'
+        Write-Warn2 'Python not found. Open a new terminal and run:'
         Write-Warn2 "  cd $workspace"
         Write-Warn2 '  python scripts/flightcheck/cli.py --scope full'
     }

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -543,7 +543,7 @@ if ($FlightCheckOnly) {
 
             Write-Host ''
             $envChoice = Read-Host '    Select environment number from the list above'
-            $envChoice = $envChoice.Trim()
+            if ($envChoice) { $envChoice = $envChoice.Trim() }
             if (-not $envChoice -or $envChoice -notmatch '^\d+$') {
                 throw 'Invalid selection. Please re-run and pick a number from the list.'
             }
@@ -584,7 +584,7 @@ if ($FlightCheckOnly) {
             } else {
                 Write-Host ''
                 $agentChoice = Read-Host '    Select agent number (or press Enter to run environment-wide checks only)'
-                $agentChoice = $agentChoice.Trim()
+                if ($agentChoice) { $agentChoice = $agentChoice.Trim() }
 
                 if ($agentChoice -and $agentChoice -match '^\d+$') {
                     $agentSelectArgs = $pyBaseArgs + @($discoverPy, '--url', $envUrl, '--select', $agentChoice)

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -366,8 +366,20 @@ if ($FlightCheckOnly) {
     $configPath = Join-Path $localDir 'config.json'
 
     if (Test-Path $configPath) {
-        Write-Ok "Config already exists at $configPath - skipping generation"
-    } else {
+        Write-Host ''
+        Write-Host "    Config already exists at $configPath" -ForegroundColor White
+        Write-Host '    Would you like to reconfigure? (Y/N)' -ForegroundColor Gray
+        Write-Host ''
+        $reconfigure = Read-Host '    Reconfigure'
+        if ($reconfigure -notmatch '^[Yy]') {
+            Write-Ok 'Keeping existing config'
+        } else {
+            Remove-Item $configPath -Force
+            Write-Ok 'Removed existing config - starting fresh'
+        }
+    }
+
+    if (-not (Test-Path $configPath)) {
         $scriptsDir = Join-Path $workspace 'scripts'
         $discoverPy = Join-Path $scriptsDir 'discover.py'
         $python = Get-Command python -ErrorAction SilentlyContinue
@@ -432,7 +444,7 @@ if ($FlightCheckOnly) {
                 $isManaged = $true
             } else {
                 Write-Host ''
-                $agentChoice = Read-Host '    Select agent number from the list above (or press Enter to skip)'
+                $agentChoice = Read-Host '    Select agent number (or press Enter to run environment-wide checks only)'
                 $agentChoice = $agentChoice.Trim()
 
                 if ($agentChoice -and $agentChoice -match '^\d+$') {

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -503,7 +503,8 @@ if ($FlightCheckOnly) {
             activeAgent        = ''
         }
 
-        $config | ConvertTo-Json -Depth 4 | Set-Content -Path $configPath -Encoding utf8
+        $json = $config | ConvertTo-Json -Depth 4
+        [System.IO.File]::WriteAllText($configPath, $json, (New-Object System.Text.UTF8Encoding $false))
         Write-Ok "Created $configPath"
     }
 

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -339,7 +339,7 @@ if ($deferPip) {
             Write-Warn2 'python still not on PATH. Run: pip install -r solutions/ess-maker-skills/scripts/requirements.txt'
         }
     } else {
-        Write-Warn2 'requirements.txt not found in cloned repo — pip dependencies not installed'
+        Write-Warn2 'requirements.txt not found in cloned repo - pip dependencies not installed'
     }
 }
 
@@ -360,7 +360,7 @@ if ($FlightCheckOnly) {
     $configPath = Join-Path $localDir 'config.json'
 
     if (Test-Path $configPath) {
-        Write-Ok "Config already exists at $configPath — skipping generation"
+        Write-Ok "Config already exists at $configPath - skipping generation"
     } else {
         $scriptsDir = Join-Path $workspace 'scripts'
         $discoverPy = Join-Path $scriptsDir 'discover.py'
@@ -379,7 +379,7 @@ if ($FlightCheckOnly) {
         Write-Host '    A browser window will open for sign-in.' -ForegroundColor Gray
         Write-Host ''
 
-        # Run discover.py --list-environments (interactive — shows table to user)
+        # Run discover.py --list-environments (interactive - shows table to user)
         Push-Location $workspace
         try {
             & $python.Source $discoverPy --list-environments

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -10,11 +10,13 @@
       1. Verifies prerequisites (Windows 10/11, winget present).
       2. Runs `winget configure` against ess-adk-setup.winget.yaml to install
          VS Code, Python 3.12, PowerShell 7, Git, and GitHub CLI.
-      3. Installs the VS Code extensions required by the maker kit
+      3. Installs Python pip dependencies from requirements.txt (msal, requests,
+         PyYAML, defusedxml, etc.) so that /setup scripts work immediately.
+      4. Installs the VS Code extensions required by the maker kit
          (GitHub.copilot, GitHub.copilot-chat, ms-python.python).
-      4. Clones the Employee-Self-Service-Agent-Developer-Kit repo to a known
+      5. Clones the Employee-Self-Service-Agent-Developer-Kit repo to a known
          location (default: $env:USERPROFILE\source\Employee-Self-Service-Agent-Developer-Kit).
-      5. Opens the ess-maker-skills workspace in VS Code.
+      6. Opens the ess-maker-skills workspace in VS Code.
 
     The script is idempotent: re-run to repair a partial install.
 
@@ -44,6 +46,12 @@
     PowerShell modules from the Microsoft Store). Default is the direct install
     path, which works on any GA winget without that opt-in.
 
+.PARAMETER FlightCheckOnly
+    Install only the minimal toolchain needed to run FlightCheck (Python + Git +
+    pip dependencies). Skips VS Code, extensions, and the full maker kit setup.
+    Prompts for your Dataverse environment URL and creates a minimal
+    .local/config.json so FlightCheck can authenticate without running /setup.
+
 .EXAMPLE
     # Default invocation. May fail on stock Windows due to PowerShell
     # ExecutionPolicy=Restricted. If so, use the form below instead.
@@ -66,7 +74,8 @@ param(
     [switch] $SkipExtensions,
     [switch] $SkipClone,
     [switch] $SkipLaunch,
-    [switch] $UseDsc
+    [switch] $UseDsc,
+    [switch] $FlightCheckOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -105,13 +114,21 @@ Write-Ok "winget at $($winget.Source)"
 Write-Step 'Installing toolchain via winget'
 
 # Packages must match ess-adk-setup.winget.yaml. Keep these two in sync.
-$packages = @(
-    @{ Id = 'Microsoft.VisualStudioCode'; Name = 'Visual Studio Code' },
-    @{ Id = 'Python.Python.3.12';         Name = 'Python 3.12'        },
-    @{ Id = 'Microsoft.PowerShell';       Name = 'PowerShell 7'       },
-    @{ Id = 'Git.Git';                    Name = 'Git for Windows'    },
-    @{ Id = 'GitHub.cli';                 Name = 'GitHub CLI'         }
-)
+if ($FlightCheckOnly) {
+    # Minimal set: just Python + Git (no VS Code, PowerShell 7, or GH CLI)
+    $packages = @(
+        @{ Id = 'Python.Python.3.12'; Name = 'Python 3.12'     },
+        @{ Id = 'Git.Git';            Name = 'Git for Windows' }
+    )
+} else {
+    $packages = @(
+        @{ Id = 'Microsoft.VisualStudioCode'; Name = 'Visual Studio Code' },
+        @{ Id = 'Python.Python.3.12';         Name = 'Python 3.12'        },
+        @{ Id = 'Microsoft.PowerShell';       Name = 'PowerShell 7'       },
+        @{ Id = 'Git.Git';                    Name = 'Git for Windows'    },
+        @{ Id = 'GitHub.cli';                 Name = 'GitHub CLI'         }
+    )
+}
 
 if ($UseDsc) {
     # Declarative path - requires `winget configure --enable` (one-time opt-in
@@ -162,9 +179,57 @@ $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' +
             [Environment]::GetEnvironmentVariable('Path','User')
 
 # ---------------------------------------------------------------------------
-# 3. VS Code extensions
+# 3. Python pip dependencies
 # ---------------------------------------------------------------------------
-if (-not $SkipExtensions) {
+Write-Step 'Installing Python pip dependencies'
+
+$deferPip = $false
+$pip = Get-Command pip -ErrorAction SilentlyContinue
+if (-not $pip) {
+    # Try python -m pip as a fallback (pip not on PATH yet after fresh install)
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        $requirementsFile = Join-Path $PSScriptRoot '..\solutions\ess-maker-skills\scripts\requirements.txt'
+        if (-not (Test-Path $requirementsFile)) {
+            # If running from a temp dir (bootstrap), the repo hasn't been cloned yet.
+            # Defer pip install to after clone (section 5b below).
+            Write-Warn2 'requirements.txt not yet available (pre-clone). Will install after clone.'
+            $deferPip = $true
+        } else {
+            & $python.Source -m pip install --quiet --disable-pip-version-check -r $requirementsFile 2>&1 | ForEach-Object { Write-Host "      $_" }
+            if ($LASTEXITCODE -eq 0) {
+                Write-Ok 'pip dependencies installed'
+            } else {
+                Write-Warn2 "pip install returned exit code $LASTEXITCODE (non-fatal, /setup will retry)"
+            }
+            $deferPip = $false
+        }
+    } else {
+        Write-Warn2 'python not on PATH yet. Pip dependencies will be installed when you run /setup.'
+        $deferPip = $false
+    }
+} else {
+    $requirementsFile = Join-Path $PSScriptRoot '..\solutions\ess-maker-skills\scripts\requirements.txt'
+    if (-not (Test-Path $requirementsFile)) {
+        Write-Warn2 'requirements.txt not yet available (pre-clone). Will install after clone.'
+        $deferPip = $true
+    } else {
+        & $pip.Source install --quiet --disable-pip-version-check -r $requirementsFile 2>&1 | ForEach-Object { Write-Host "      $_" }
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok 'pip dependencies installed'
+        } else {
+            Write-Warn2 "pip install returned exit code $LASTEXITCODE (non-fatal, /setup will retry)"
+        }
+        $deferPip = $false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 4. VS Code extensions
+# ---------------------------------------------------------------------------
+if ($FlightCheckOnly) {
+    Write-Warn2 'Skipping VS Code extensions (FlightCheck-only mode)'
+} elseif (-not $SkipExtensions) {
     Write-Step 'Installing VS Code extensions'
 
     $code = Get-Command code -ErrorAction SilentlyContinue
@@ -224,7 +289,7 @@ if (-not $SkipExtensions) {
 }
 
 # ---------------------------------------------------------------------------
-# 4. Clone repo
+# 5. Clone repo
 # ---------------------------------------------------------------------------
 $repoName = [IO.Path]::GetFileNameWithoutExtension(($RepoUrl -split '/')[-1])
 $repoPath = Join-Path $InstallRoot $repoName
@@ -256,15 +321,184 @@ if (-not $SkipClone) {
 }
 
 # ---------------------------------------------------------------------------
-# 5. Launch
+# 5b. Deferred pip install (if requirements.txt was not available pre-clone)
+# ---------------------------------------------------------------------------
+if ($deferPip) {
+    $requirementsFile = Join-Path $repoPath 'solutions\ess-maker-skills\scripts\requirements.txt'
+    if (Test-Path $requirementsFile) {
+        Write-Step 'Installing Python pip dependencies (deferred)'
+        $python = Get-Command python -ErrorAction SilentlyContinue
+        if ($python) {
+            & $python.Source -m pip install --quiet --disable-pip-version-check -r $requirementsFile 2>&1 | ForEach-Object { Write-Host "      $_" }
+            if ($LASTEXITCODE -eq 0) {
+                Write-Ok 'pip dependencies installed'
+            } else {
+                Write-Warn2 "pip install returned exit code $LASTEXITCODE (non-fatal, /setup will retry)"
+            }
+        } else {
+            Write-Warn2 'python still not on PATH. Run: pip install -r solutions/ess-maker-skills/scripts/requirements.txt'
+        }
+    } else {
+        Write-Warn2 'requirements.txt not found in cloned repo — pip dependencies not installed'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 6. FlightCheck config generation (FlightCheckOnly mode)
 # ---------------------------------------------------------------------------
 $workspace = Join-Path $repoPath 'solutions\ess-maker-skills'
 if (-not (Test-Path $workspace)) {
     Write-Warn2 "Expected workspace not found: $workspace"
-    Write-Warn2 'Repo layout may have changed; opening repo root instead.'
+    Write-Warn2 'Repo layout may have changed; using repo root instead.'
     $workspace = $repoPath
 }
 
+if ($FlightCheckOnly) {
+    Write-Step 'Configuring FlightCheck environment'
+
+    $localDir = Join-Path $workspace '.local'
+    $configPath = Join-Path $localDir 'config.json'
+
+    if (Test-Path $configPath) {
+        Write-Ok "Config already exists at $configPath — skipping generation"
+    } else {
+        $scriptsDir = Join-Path $workspace 'scripts'
+        $discoverPy = Join-Path $scriptsDir 'discover.py'
+        $python = Get-Command python -ErrorAction SilentlyContinue
+
+        if (-not $python) {
+            throw 'python not found on PATH. Cannot run environment discovery.'
+        }
+        if (-not (Test-Path $discoverPy)) {
+            throw "discover.py not found at $discoverPy. Was the repo cloned correctly?"
+        }
+
+        # --- Step 1: List environments and let user pick ---
+        Write-Host ''
+        Write-Host '    Listing Power Platform environments in your tenant...' -ForegroundColor White
+        Write-Host '    A browser window will open for sign-in.' -ForegroundColor Gray
+        Write-Host ''
+
+        # Run discover.py --list-environments (interactive — shows table to user)
+        Push-Location $workspace
+        try {
+            & $python.Source $discoverPy --list-environments
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Environment listing failed.'
+            }
+
+            Write-Host ''
+            $envChoice = Read-Host '    Select environment number from the list above'
+            $envChoice = $envChoice.Trim()
+            if (-not $envChoice -or $envChoice -notmatch '^\d+$') {
+                throw 'Invalid selection. Please re-run and pick a number from the list.'
+            }
+
+            # Re-run with --select to get machine-parseable JSON
+            $envOutput = & $python.Source $discoverPy --list-environments --select $envChoice 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Environment selection failed: $envOutput"
+            }
+            $envJsonLine = ($envOutput | Where-Object { $_ -match '^SELECTED_ENV_JSON:' }) -replace '^SELECTED_ENV_JSON:', ''
+            if (-not $envJsonLine) {
+                throw 'Could not parse environment selection output.'
+            }
+            $selectedEnv = $envJsonLine | ConvertFrom-Json
+            $envUrl = $selectedEnv.instanceUrl.TrimEnd('/')
+
+            if (-not $envUrl) {
+                throw 'Selected environment has no linked Dataverse URL.'
+            }
+            Write-Ok "Environment: $($selectedEnv.displayName)"
+            Write-Ok "URL: $envUrl"
+
+            # --- Step 2: List agents and let user pick ---
+            Write-Host ''
+            Write-Host '    Discovering agents in this environment...' -ForegroundColor White
+            Write-Host ''
+
+            & $python.Source $discoverPy --url $envUrl
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warn2 'Agent discovery failed. Config will be created without a bot ID.'
+                $botId = ''
+                $agentName = 'FlightCheck-only (no agent selected)'
+                $schemaName = ''
+                $isManaged = $true
+            } else {
+                Write-Host ''
+                $agentChoice = Read-Host '    Select agent number from the list above (or press Enter to skip)'
+                $agentChoice = $agentChoice.Trim()
+
+                if ($agentChoice -and $agentChoice -match '^\d+$') {
+                    $agentOutput = & $python.Source $discoverPy --url $envUrl --select $agentChoice 2>&1
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Warn2 "Agent selection failed. Continuing without bot ID."
+                        $botId = ''
+                        $agentName = 'FlightCheck-only (no agent selected)'
+                        $schemaName = ''
+                        $isManaged = $true
+                    } else {
+                        $agentJsonLine = ($agentOutput | Where-Object { $_ -match '^SELECTED_AGENT_JSON:' }) -replace '^SELECTED_AGENT_JSON:', ''
+                        if ($agentJsonLine) {
+                            $selectedAgent = $agentJsonLine | ConvertFrom-Json
+                            $botId = $selectedAgent.botid
+                            $agentName = $selectedAgent.name
+                            $schemaName = $selectedAgent.schemaname
+                            $isManaged = [bool]$selectedAgent.ismanaged
+                            Write-Ok "Agent: $agentName"
+                        } else {
+                            $botId = ''
+                            $agentName = 'FlightCheck-only (no agent selected)'
+                            $schemaName = ''
+                            $isManaged = $true
+                        }
+                    }
+                } else {
+                    Write-Warn2 'Skipping agent selection. Some agent-specific checks will be skipped.'
+                    $botId = ''
+                    $agentName = 'FlightCheck-only (no agent selected)'
+                    $schemaName = ''
+                    $isManaged = $true
+                }
+            }
+        } finally { Pop-Location }
+
+        # Create .local directory
+        if (-not (Test-Path $localDir)) {
+            New-Item -ItemType Directory -Path $localDir -Force | Out-Null
+        }
+
+        # Write minimal config.json sufficient for FlightCheck
+        $config = @{
+            setup              = 'complete'
+            dataverseEndpoint  = $envUrl
+            flightCheckOnly    = $true
+            agent              = @{
+                name       = $agentName
+                botId      = $botId
+                schemaName = $schemaName
+                isManaged  = $isManaged
+                slug       = 'flightcheck-only'
+                folder     = ''
+            }
+            agents             = @()
+            activeAgent        = ''
+        }
+
+        $config | ConvertTo-Json -Depth 4 | Set-Content -Path $configPath -Encoding utf8
+        Write-Ok "Created $configPath"
+    }
+
+    Write-Host "`nDone. FlightCheck is ready." -ForegroundColor Green
+    Write-Host "Next: cd into $workspace and run:" -ForegroundColor Green
+    Write-Host "  python scripts/flightcheck/cli.py --scope full" -ForegroundColor Yellow
+    Write-Host "  python scripts/flightcheck/environment_picker.py  (to pick a different environment)" -ForegroundColor Yellow
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# 7. Launch
+# ---------------------------------------------------------------------------
 if (-not $SkipLaunch) {
     Write-Step 'Opening workspace in VS Code'
     $code = Get-Command code -ErrorAction SilentlyContinue

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -507,10 +507,19 @@ if ($FlightCheckOnly) {
         Write-Ok "Created $configPath"
     }
 
-    Write-Host "`nDone. FlightCheck is ready." -ForegroundColor Green
-    Write-Host "Next: cd into $workspace and run:" -ForegroundColor Green
-    Write-Host "  python scripts/flightcheck/cli.py --scope full" -ForegroundColor Yellow
-    Write-Host "  python scripts/flightcheck/environment_picker.py  (to pick a different environment)" -ForegroundColor Yellow
+    # --- Run FlightCheck ---
+    Write-Step 'Running FlightCheck'
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        Push-Location $workspace
+        try {
+            & $python.Source scripts/flightcheck/cli.py --scope full
+        } finally { Pop-Location }
+    } else {
+        Write-Warn2 'python not found on PATH. Open a new terminal and run:'
+        Write-Warn2 "  cd $workspace"
+        Write-Warn2 '  python scripts/flightcheck/cli.py --scope full'
+    }
     exit 0
 }
 

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -157,7 +157,13 @@ if ($UseDsc) {
                          --silent `
                          --accept-package-agreements `
                          --accept-source-agreements `
-                         --disable-interactivity 2>&1 | ForEach-Object { Write-Host "      $_" }
+                         --disable-interactivity 2>&1 | ForEach-Object {
+            $line = "$_".Trim()
+            # Skip empty lines, spinner frames, and progress bar garbage
+            if ($line -and $line -notmatch '^[\\/\|\-]$' -and $line -notmatch '[^\x20-\x7E]') {
+                Write-Host "      $line"
+            }
+        }
 
         # winget exit codes:
         #   0                = installed OK

--- a/setup/README.md
+++ b/setup/README.md
@@ -2,8 +2,6 @@
 
 A single PowerShell command that takes a customer from a clean Windows machine to a ready-to-use ESS Maker Kit workspace in VS Code.
 
-> **Status:** Prototype for review. The `aka.ms/ess-adk-setup` short link in the customer command below assumes the files are eventually published under `bootstrap/` in [microsoft/Employee-Self-Service-Agent-Developer-Kit](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit).
-
 ## What this delivers
 
 The customer experience goes from:
@@ -13,21 +11,19 @@ The customer experience goes from:
 to:
 
 ```powershell
-iex (irm https://aka.ms/ess-adk-setup)
+iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap.ps1)
 ```
 
-…and they land in VS Code at `solutions/ess-maker-skills/` with everything wired up except the final Dataverse auth step (`/setup` in Copilot Chat).
+...and they land in VS Code at `solutions/ess-maker-skills/` with everything wired up except the final Dataverse auth step (`/setup` in Copilot Chat).
 
-> **GitHub Copilot subscription is still required** for the in-editor maker experience — see the parent proposal for context. This script installs and signs the customer into the extension scaffolding; it does not (and cannot) grant the entitlement.
+> **GitHub Copilot subscription is still required** for the in-editor maker experience. This script installs the toolchain and extension scaffolding; it does not (and cannot) grant the Copilot entitlement.
 
 ## FlightCheck-Only Mode
 
 For users who only need to run FlightCheck (pre-deployment readiness validation) without the full maker kit experience:
 
 ```powershell
-# Download and run (no local clone required):
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/Install-EssAdk.ps1" -OutFile "$env:TEMP\Install-EssAdk.ps1" -UseBasicParsing
-powershell -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\Install-EssAdk.ps1" -FlightCheckOnly
+iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
 ```
 
 Or, if you already have the repo cloned:
@@ -51,10 +47,10 @@ python scripts/flightcheck/cli.py --scope full
 
 ### Changing your environment or agent
 
-Re-run the installer with `-FlightCheckOnly` — it will detect the existing config and ask if you want to reconfigure:
+Re-run the FlightCheck bootstrap — it will detect the existing config and ask if you want to reconfigure:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -FlightCheckOnly
+iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
 ```
 
 Since the toolchain is already installed, it skips straight to the environment/agent picker. You can select a different environment, a different agent, or skip the agent entirely.
@@ -65,7 +61,8 @@ Since the toolchain is already installed, it skips straight to the environment/a
 |---|---|
 | `ess-adk-setup.winget.yaml` | Declarative DSC config consumed by `winget configure`. Installs VS Code, Python 3.12, PowerShell 7, Git, GitHub CLI. |
 | `Install-EssAdk.ps1` | Orchestrator. Installs toolchain via winget, installs pip dependencies, clones the repo, installs VS Code extensions, launches VS Code. Idempotent. With `-FlightCheckOnly`, installs minimal toolchain and runs interactive environment/agent discovery. |
-| `bootstrap.ps1` | The thing behind `aka.ms/ess-adk-setup`. Downloads the two files above into `$env:TEMP` and runs the installer. |
+| `bootstrap.ps1` | One-liner entry point for the full maker kit install. Downloads the installer into `$env:TEMP` and runs it. |
+| `bootstrap-flightcheck.ps1` | One-liner entry point for FlightCheck-only install. Downloads the installer and runs it with `-FlightCheckOnly`. |
 
 ## How to test it locally (without publishing anything)
 
@@ -84,7 +81,7 @@ Since the toolchain is already installed, it skips straight to the environment/a
 > iex (Get-Content .\bootstrap.ps1 -Raw)
 > ```
 >
-> The published customer entry point (`iex (irm https://aka.ms/ess-adk-setup)`) uses the third pattern, so end users will not hit this error.
+> The published customer entry point (`iex (irm ...)`) uses the third pattern, so end users will not hit this error.
 
 From this folder:
 
@@ -105,24 +102,29 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -SkipLa
 powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -FlightCheckOnly     # minimal install for FlightCheck only
 ```
 
-## How it will look once published
+## Customer-facing commands
 
-After the files are placed under `bootstrap/` in the upstream repo, the customer-facing command becomes:
+Full maker kit install (VS Code + Copilot + everything):
 
 ```powershell
-# Public one-liner (needs aka.ms short link or raw GitHub URL):
-iex (irm https://aka.ms/ess-adk-setup)
+iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap.ps1)
 ```
 
-Or, for customers who prefer to inspect first:
+FlightCheck-only (no VS Code or Copilot required):
 
 ```powershell
-irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/bootstrap/bootstrap.ps1 -OutFile bootstrap.ps1
+iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
+```
+
+For customers who prefer to inspect first:
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap.ps1" -OutFile bootstrap.ps1 -UseBasicParsing
 # review bootstrap.ps1
 .\bootstrap.ps1
 ```
 
-For air-gapped / locked-down environments, IT can mirror the three files internally and serve them from an intranet URL by passing `-SourceBaseUrl`.
+For air-gapped / locked-down environments, IT can mirror the files internally and serve them from an intranet URL by passing `-SourceBaseUrl`.
 
 ## Design choices worth flagging in review
 
@@ -136,6 +138,4 @@ For air-gapped / locked-down environments, IT can mirror the three files interna
 
 - [ ] Confirm exact Python version the kit pins to (3.11 vs 3.12).
 - [ ] Decide if we ship a VS Code workspace file in the repo so we can open `.code-workspace` instead of a folder.
-- [ ] Get `aka.ms/ess-adk-setup` registered and pointed at the raw `bootstrap.ps1` URL.
 - [ ] Add an MSRC-aligned signing story for `Install-EssAdk.ps1` (or document `-ExecutionPolicy Bypass` invocation).
-- [ ] Decide where in the upstream repo the files live (`/bootstrap/` is suggested above; could also be `/solutions/ess-maker-skills/bootstrap/`).

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,4 +1,4 @@
-# ESS ADK — `winget configure` one-shot installer (Option 3)
+# ESS ADK — One-Shot Installer
 
 Companion artifact to [`../adk-onboarding-friction-reduction.md`](../adk-onboarding-friction-reduction.md). This folder is a **working prototype** of Option 3 from that proposal — a single PowerShell command that takes a customer from a clean Windows machine to a ready-to-use ESS Maker Kit workspace in VS Code.
 
@@ -20,12 +20,43 @@ iex (irm https://aka.ms/ess-adk-setup)
 
 > **GitHub Copilot subscription is still required** for the in-editor maker experience — see the parent proposal for context. This script installs and signs the customer into the extension scaffolding; it does not (and cannot) grant the entitlement.
 
+## FlightCheck-Only Mode
+
+For users who only need to run FlightCheck (pre-deployment readiness validation) without the full maker kit experience:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -FlightCheckOnly
+```
+
+This installs a **minimal toolchain** (Python + Git only — no VS Code, PowerShell 7, or GitHub CLI), installs pip dependencies, clones the repo, and then walks you through an interactive setup:
+
+1. **Environment selection** — Lists all Power Platform environments in your tenant (authenticates via browser) and lets you pick one by number.
+2. **Agent selection** — Lists all agents in the selected environment and lets you pick one (or press Enter to skip for environment-wide checks only).
+3. **Config generation** — Creates `.local/config.json` with the selected environment and agent.
+
+After setup, run FlightCheck with:
+
+```powershell
+cd solutions\ess-maker-skills
+python scripts/flightcheck/cli.py --scope full
+```
+
+### Changing your environment or agent
+
+Re-run the installer with `-FlightCheckOnly` — it will detect the existing config and ask if you want to reconfigure:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -FlightCheckOnly
+```
+
+Since the toolchain is already installed, it skips straight to the environment/agent picker. You can select a different environment, a different agent, or skip the agent entirely.
+
 ## Files
 
 | File | Purpose |
 |---|---|
 | `ess-adk-setup.winget.yaml` | Declarative DSC config consumed by `winget configure`. Installs VS Code, Python 3.12, PowerShell 7, Git, GitHub CLI. |
-| `Install-EssAdk.ps1` | Orchestrator. Runs `winget configure`, installs VS Code extensions, clones the repo, launches VS Code. Idempotent. |
+| `Install-EssAdk.ps1` | Orchestrator. Installs toolchain via winget, installs pip dependencies, clones the repo, installs VS Code extensions, launches VS Code. Idempotent. With `-FlightCheckOnly`, installs minimal toolchain and runs interactive environment/agent discovery. |
 | `bootstrap.ps1` | The thing behind `aka.ms/ess-adk-setup`. Downloads the two files above into `$env:TEMP` and runs the installer. |
 
 ## How to test it locally (without publishing anything)
@@ -60,9 +91,10 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -Instal
 Useful flags during testing:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -SkipExtensions   # skip code --install-extension calls
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -SkipClone        # skip git clone (toolchain only)
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -SkipLaunch       # don't open VS Code at the end
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -SkipExtensions      # skip code --install-extension calls
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -SkipClone           # skip git clone (toolchain only)
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -SkipLaunch          # don't open VS Code at the end
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -FlightCheckOnly     # minimal install for FlightCheck only
 ```
 
 ## How it will look once published

--- a/setup/README.md
+++ b/setup/README.md
@@ -25,7 +25,15 @@ iex (irm https://aka.ms/ess-adk-setup)
 For users who only need to run FlightCheck (pre-deployment readiness validation) without the full maker kit experience:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -FlightCheckOnly
+# Download and run (no local clone required):
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/Install-EssAdk.ps1" -OutFile "$env:TEMP\Install-EssAdk.ps1" -UseBasicParsing
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\Install-EssAdk.ps1" -FlightCheckOnly
+```
+
+Or, if you already have the repo cloned:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\setup\Install-EssAdk.ps1 -FlightCheckOnly
 ```
 
 This installs a **minimal toolchain** (Python + Git only — no VS Code, PowerShell 7, or GitHub CLI), installs pip dependencies, clones the repo, and then walks you through an interactive setup:

--- a/setup/README.md
+++ b/setup/README.md
@@ -20,40 +20,36 @@ iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent
 
 ## FlightCheck-Only Mode
 
-For users who only need to run FlightCheck (pre-deployment readiness validation) without the full maker kit experience:
+For users who want to run a pre-deployment readiness check on their Power Platform environment — no coding tools or VS Code required. Just run this command in PowerShell:
 
 ```powershell
 iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
 ```
 
-Or, if you already have the repo cloned:
+That's it. The script handles everything automatically:
 
-```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\setup\Install-EssAdk.ps1 -FlightCheckOnly
-```
-
-This installs a **minimal toolchain** (Python + Git only — no VS Code, PowerShell 7, or GitHub CLI), installs pip dependencies, clones the repo, and then walks you through an interactive setup:
-
-1. **Environment selection** — Lists all Power Platform environments in your tenant (authenticates via browser) and lets you pick one by number.
-2. **Agent selection** — Lists all agents in the selected environment and lets you pick one (or press Enter to skip for environment-wide checks only).
-3. **Config generation** — Creates `.local/config.json` with the selected environment and agent.
-
-After setup, run FlightCheck with:
-
-```powershell
-cd solutions\ess-maker-skills
-python scripts/flightcheck/cli.py --scope full
-```
+1. Installs Python and Git (if not already present)
+2. Opens a browser window for you to sign in with your Microsoft work account
+3. Shows your available environments — pick one by number
+4. Shows the agents in that environment — pick one (or skip)
+5. Runs the full FlightCheck validation and displays results
 
 ### Changing your environment or agent
 
-Re-run the FlightCheck bootstrap — it will detect the existing config and ask if you want to reconfigure:
+Re-run the same command — it will ask if you want to reconfigure:
 
 ```powershell
 iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
 ```
 
-Since the toolchain is already installed, it skips straight to the environment/agent picker. You can select a different environment, a different agent, or skip the agent entirely.
+### Running FlightCheck again (after initial setup)
+
+Once you've run the installer once, you can re-run FlightCheck directly without going through setup again:
+
+```powershell
+cd $env:USERPROFILE\source\Employee-Self-Service-Agent-Developer-Kit\solutions\ess-maker-skills
+python scripts/flightcheck/cli.py --scope full
+```
 
 ## Files
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,8 +1,8 @@
 # ESS ADK — One-Shot Installer
 
-Companion artifact to [`../adk-onboarding-friction-reduction.md`](../adk-onboarding-friction-reduction.md). This folder is a **working prototype** of Option 3 from that proposal — a single PowerShell command that takes a customer from a clean Windows machine to a ready-to-use ESS Maker Kit workspace in VS Code.
+A single PowerShell command that takes a customer from a clean Windows machine to a ready-to-use ESS Maker Kit workspace in VS Code.
 
-> **Status:** Prototype for review. Not yet pushed to the upstream ADK repo. The `aka.ms/ess-adk-setup` short link in the customer command below assumes the files are eventually published under `bootstrap/` in [microsoft/Employee-Self-Service-Agent-Developer-Kit](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit).
+> **Status:** Prototype for review. The `aka.ms/ess-adk-setup` short link in the customer command below assumes the files are eventually published under `bootstrap/` in [microsoft/Employee-Self-Service-Agent-Developer-Kit](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit).
 
 ## What this delivers
 

--- a/setup/bootstrap-flightcheck.ps1
+++ b/setup/bootstrap-flightcheck.ps1
@@ -1,15 +1,18 @@
 <#
 .SYNOPSIS
-    Irreducible one-liner bootstrap for the ESS Agent Developer Kit.
+    One-liner bootstrap for FlightCheck-only installation.
 
 .DESCRIPTION
-    Downloads the winget config + installer script into a temp folder and runs them.
-    Designed to be invoked from a single command (see README.md):
+    Downloads the installer script into a temp folder and runs it with
+    -FlightCheckOnly. Installs only Python + Git, pip dependencies, and
+    walks through interactive environment/agent discovery.
 
-        iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap.ps1)
+    Designed to be invoked from a single command:
+
+        iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
 
     All real work happens in Install-EssAdk.ps1; this file just gets the bits
-    onto the customer's machine first.
+    onto the customer's machine and passes the -FlightCheckOnly flag.
 
 .PARAMETER InstallRoot
     Forwarded to Install-EssAdk.ps1. See that script for details.
@@ -19,7 +22,7 @@
 
 .PARAMETER SourceBaseUrl
     Where to fetch the installer files from. Defaults to the raw GitHub URL of
-    this folder once it lands in the upstream repo. Override for testing.
+    the setup folder. Override for testing.
 #>
 
 [CmdletBinding()]
@@ -49,7 +52,7 @@ foreach ($f in $files) {
 }
 
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'
-$installerArgs = @{ Branch = $Branch }
+$installerArgs = @{ Branch = $Branch; FlightCheckOnly = $true }
 if ($InstallRoot) { $installerArgs.InstallRoot = $InstallRoot }
 
 & $installer @installerArgs

--- a/setup/bootstrap-flightcheck.ps1
+++ b/setup/bootstrap-flightcheck.ps1
@@ -48,7 +48,15 @@ foreach ($f in $files) {
     $url = "$SourceBaseUrl/$f"
     $dst = Join-Path $tempDir $f
     Write-Host "  $url"
-    Invoke-WebRequest -Uri $url -OutFile $dst -UseBasicParsing
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $dst -UseBasicParsing -TimeoutSec 60
+    } catch {
+        Write-Host "  [ERR] Failed to download: $url" -ForegroundColor Red
+        Write-Host "  If raw.githubusercontent.com is blocked by your firewall/proxy," -ForegroundColor Yellow
+        Write-Host "  download the repo manually and run:" -ForegroundColor Yellow
+        Write-Host "    .\setup\Install-EssAdk.ps1 -FlightCheckOnly" -ForegroundColor Yellow
+        throw $_
+    }
 }
 
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'

--- a/setup/bootstrap-flightcheck.ps1
+++ b/setup/bootstrap-flightcheck.ps1
@@ -39,7 +39,6 @@ $tempDir = Join-Path $env:TEMP "ess-adk-bootstrap-$([Guid]::NewGuid().ToString('
 New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
 $files = @(
-    'ess-adk-setup.winget.yaml',
     'Install-EssAdk.ps1'
 )
 

--- a/setup/bootstrap.ps1
+++ b/setup/bootstrap.ps1
@@ -45,7 +45,15 @@ foreach ($f in $files) {
     $url = "$SourceBaseUrl/$f"
     $dst = Join-Path $tempDir $f
     Write-Host "  $url"
-    Invoke-WebRequest -Uri $url -OutFile $dst -UseBasicParsing
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $dst -UseBasicParsing -TimeoutSec 60
+    } catch {
+        Write-Host "  [ERR] Failed to download: $url" -ForegroundColor Red
+        Write-Host "  If raw.githubusercontent.com is blocked by your firewall/proxy," -ForegroundColor Yellow
+        Write-Host "  download the repo manually and run:" -ForegroundColor Yellow
+        Write-Host "    .\setup\Install-EssAdk.ps1" -ForegroundColor Yellow
+        throw $_
+    }
 }
 
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -98,6 +98,16 @@ cd solutions/ess-maker-skills
 python scripts/flightcheck/cli.py --scope full
 ```
 
+**Standalone install (no VS Code or Copilot required):**
+
+If you only need FlightCheck without the full maker kit, use the one-shot installer with `-FlightCheckOnly`:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\setup\Install-EssAdk.ps1 -FlightCheckOnly
+```
+
+This installs just Python + Git, pip dependencies, and walks you through selecting your environment and agent interactively. Re-run the same command to change your environment or agent. See [`setup/README.md`](../../setup/README.md) for details.
+
 **What it checks (41+ automated checks across 8 categories):**
 
 | Category | What's validated |

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -100,13 +100,13 @@ python scripts/flightcheck/cli.py --scope full
 
 **Standalone install (no VS Code or Copilot required):**
 
-If you only need FlightCheck without the full maker kit, use the one-liner bootstrap:
+If you only need to run FlightCheck, this single command handles everything — installs dependencies, signs you in, lets you pick your environment, and runs the check:
 
 ```powershell
 iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
 ```
 
-This installs just Python + Git, pip dependencies, and walks you through selecting your environment and agent interactively. Re-run the same command to change your environment or agent. See [`setup/README.md`](../../setup/README.md) for details.
+Re-run the same command to change your environment or agent. See [`setup/README.md`](../../setup/README.md) for details.
 
 **What it checks (41+ automated checks across 8 categories):**
 

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -103,7 +103,9 @@ python scripts/flightcheck/cli.py --scope full
 If you only need FlightCheck without the full maker kit, use the one-shot installer with `-FlightCheckOnly`:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\setup\Install-EssAdk.ps1 -FlightCheckOnly
+# Download and run (no local clone required):
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/Install-EssAdk.ps1" -OutFile "$env:TEMP\Install-EssAdk.ps1" -UseBasicParsing
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\Install-EssAdk.ps1" -FlightCheckOnly
 ```
 
 This installs just Python + Git, pip dependencies, and walks you through selecting your environment and agent interactively. Re-run the same command to change your environment or agent. See [`setup/README.md`](../../setup/README.md) for details.

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -100,12 +100,10 @@ python scripts/flightcheck/cli.py --scope full
 
 **Standalone install (no VS Code or Copilot required):**
 
-If you only need FlightCheck without the full maker kit, use the one-shot installer with `-FlightCheckOnly`:
+If you only need FlightCheck without the full maker kit, use the one-liner bootstrap:
 
 ```powershell
-# Download and run (no local clone required):
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/Install-EssAdk.ps1" -OutFile "$env:TEMP\Install-EssAdk.ps1" -UseBasicParsing
-powershell -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\Install-EssAdk.ps1" -FlightCheckOnly
+iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
 ```
 
 This installs just Python + Git, pip dependencies, and walks you through selecting your environment and agent interactively. Re-run the same command to change your environment or agent. See [`setup/README.md`](../../setup/README.md) for details.

--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -211,9 +211,9 @@ def query_all(env_url, token, entity_set, select, filter_expr=None):
         if page == 1:
             print(f"  Page {page}: {len(records)} records", end="")
         elif records:
-            print(f" → Page {page}: {len(records)}", end="")
+            print(f" -> Page {page}: {len(records)}", end="")
 
-    print(f" → Total: {len(all_records)}")
+    print(f" -> Total: {len(all_records)}")
     return all_records
 
 

--- a/solutions/ess-maker-skills/scripts/discover.py
+++ b/solutions/ess-maker-skills/scripts/discover.py
@@ -60,7 +60,7 @@ def print_agent_table(agents):
     schema_width = max(schema_width, 11)
 
     header = f"  {'#':<4} {'Agent Name':<{name_width}}  {'Schema Name':<{schema_width}}  {'Managed'}"
-    sep = f"  {'─'*4} {'─'*name_width}  {'─'*schema_width}  {'─'*7}"
+    sep = f"  {'-'*4} {'-'*name_width}  {'-'*schema_width}  {'-'*7}"
     print()
     print(header)
     print(sep)

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -127,7 +127,7 @@ def main():
     else:
         print(f"  Agents:      {len(agents)} discovered")
         for a in agents:
-            marker = "→" if a.get("slug") == active else " "
+            marker = "->" if a.get("slug") == active else "  "
             print(f"    {marker} {a.get('name', 'Unknown')}")
     print(f"  Environment: {env_url}")
     print(f"  Scope:       {args.scope}")


### PR DESCRIPTION
## Summary

Adds a `-FlightCheckOnly` flag to the one-shot installer (`setup/Install-EssAdk.ps1`) that installs only the minimal toolchain needed to run FlightCheck without requiring VS Code, GitHub Copilot, or the full `/setup` flow.

Also fixes a gap where pip dependencies (msal, requests, PyYAML, defusedxml) were never installed by the installer, causing `/setup` to fail on fresh machines.

ADO task: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7439972 

##  Demo video
https://github.com/user-attachments/assets/44e7fae8-6427-452c-a5da-ec533140e9a8

## User Commands

### Full ADK Maker Kit install (developers customizing ESS agents)

```powershell
iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap.ps1)
```

Installs Python, Git, GitHub CLI, PowerShell 7, VS Code + extensions, clones the repo, installs pip dependencies, and opens VS Code in the maker workspace.

### FlightCheck only (validating a deployed environment)

```powershell
iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
```

Single command that handles everything: installs Python + Git, signs you in, walks you through picking your environment and agent, then runs FlightCheck automatically. Re-run the same command to change your environment or agent.

## Changes

### Installer (`setup/Install-EssAdk.ps1`)
- **Pip dependency install** — New step installs from requirements.txt after Python is available (deferred to post-clone when running via bootstrap)
- **`-FlightCheckOnly` flag** — Minimal toolchain (Python + Git only), interactive environment/agent discovery via discover.py, generates `.local/config.json` for FlightCheck
- **Auto-run FlightCheck** — After config generation, FlightCheck runs immediately so users see results without a second command
- **Reconfigure support** — Re-running with `-FlightCheckOnly` detects existing config and offers to reconfigure (change environment or agent)

### Robustness improvements
- **`Invoke-Native` helper** — Prevents PowerShell 5.1 from terminating the script when native commands (winget, pip, git, python) write to stderr under `$ErrorActionPreference = 'Stop'`
- **`Resolve-Python` helper** — Robust Python detection: tries `py -3.12`, `py -3`, validated `python` on PATH (excluding the Windows Store alias), and known install paths (`%LOCALAPPDATA%\Programs\Python\Python312\`)
- **Git hang prevention** — Sets `GIT_TERMINAL_PROMPT=0` and `GCM_INTERACTIVE=never` to prevent git clone from blocking on credential/host-key prompts
- **winget optional for FlightCheckOnly** — If Python and Git are already installed, continues without winget (supports Windows Server, LTSC, and Store-disabled environments)
- **Pre-installed tool detection** — Skips winget install for already-present packages (avoids unnecessary elevation prompts)
- **Network resilience** — Bootstrap downloads use `-TimeoutSec 60` with actionable guidance when blocked by firewalls/proxies
- **Manual install fallback** — When winget is unavailable or fails, provides direct download URLs for Python, Git, etc.
- **Output filtering** — Suppresses winget progress bar Unicode garbage and spinner frames that corrupt terminal output

### New files
- **`setup/bootstrap-flightcheck.ps1`** — One-liner entry point that downloads the installer and passes `-FlightCheckOnly`

### Unicode/encoding fixes
- **`scripts/auth.py`** — Replace Unicode arrows with ASCII (fixes crash on CP1252 consoles)
- **`scripts/discover.py`** — Replace box-drawing chars with ASCII hyphens
- **Config JSON** — Write without UTF-8 BOM (PS 5.1's `-Encoding utf8` adds BOM; Python's `json.load()` rejects it)

### Documentation
- **`setup/README.md`** — Rewritten to document both install modes with user-friendly language
- **`solutions/ess-maker-skills/README.md`** — Added standalone install section to FlightCheck docs

## Testing

Tested end-to-end on a clean Windows machine (no Python/Git pre-installed):
1. Bootstrap downloads installer from raw GitHub URL
2. Installs Python 3.12 + Git via winget
3. Clones repo from branch
4. Installs pip dependencies successfully
5. Interactive environment picker lists environments, user selects one
6. Agent discovery lists agents, user selects one (or skips)
7. Config written (BOM-free UTF-8), FlightCheck runs automatically and displays results

Also validated:
- Re-run detects existing config and offers reconfigure prompt
- Script works in both PowerShell 5.1 (Windows PowerShell) and PowerShell 7
- Output is clean (no Unicode garbage from winget progress bars)