### PR TITLE
Skip winget upgrade for already-installed tools & suppress parent-repo prompt

### DIFF
--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -245,12 +245,10 @@ if (-not $wingetAvailable) {
     # logs "already installed" for present packages.
     foreach ($pkg in $packages) {
         # Skip if already installed (avoids unnecessary winget calls + elevation prompts)
-        if ($FlightCheckOnly) {
-            $existing = if ($pkg.Cmd -eq 'python') { Resolve-Python } else { Get-Command $pkg.Cmd -ErrorAction SilentlyContinue }
-            if ($existing) {
-                Write-Ok "$($pkg.Name) (already installed)"
-                continue
-            }
+        $existing = if ($pkg.Cmd -eq 'python') { Resolve-Python } else { Get-Command $pkg.Cmd -ErrorAction SilentlyContinue }
+        if ($existing) {
+            Write-Ok "$($pkg.Name) (already installed)"
+            continue
         }
 
         Write-Host "    installing $($pkg.Name) ($($pkg.Id))"

--- a/solutions/ess-maker-skills/.vscode/settings.json
+++ b/solutions/ess-maker-skills/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "git.openRepositoryInParentFolders": "never",
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml",
     "editor.tabSize": 2


### PR DESCRIPTION
## Changes

1. **Skip winget install for already-present tools** — The pre-install check (`Resolve-Python` / `Get-Command`) was previously gated behind `-FlightCheckOnly`. In the full install path, winget always attempted an upgrade which throws if the upgrade fails (e.g. VS Code running or installed via a different channel). Now all modes skip tools that are already functional on PATH.

2. **Suppress VS Code parent-repo notification** — Set `git.openRepositoryInParentFolders` to `never` in the maker workspace settings so users aren't prompted to open the parent repo (which would break Copilot skills).

## Testing

Ran the full installer locally with VS Code already installed — installer correctly skips it with `[ok]` instead of attempting a winget upgrade that fails.