### PR TITLE
Evals: add quality validation flow to create/update eval skills

### DIFF
--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -296,6 +296,7 @@ After a successful push, `.baseline/` is updated to match the new state.
 | Generate evaluation test sets | `src/skills/evaluations/create/SKILL.md` |
 | Update/modify evaluation test cases | `src/skills/evaluations/update/SKILL.md` |
 | Delete evaluation test sets/cases | `src/skills/evaluations/delete/SKILL.md` |
+| Validate / quality-check evaluation test sets | `src/skills/evaluations/validate/SKILL.md` |
 | Troubleshoot connectivity/auth issues | `src/skills/troubleshoot/SKILL.md` |
 | Debug Workday ISU errors | `src/skills/troubleshoot/SKILL.md` |
 
@@ -312,6 +313,16 @@ JSON format", "something went wrong with Workday".
 **Trigger phrases for flightcheck:** "readiness check", "pre-deployment check",
 "flightcheck", "flight check", "is my agent ready", "validate my environment",
 "check my setup", "pre-flight", "deployment readiness", "run validation".
+
+**Quality validation invocation:** When quality validation is requested on
+eval files — at step 4.3 of the eval create flow OR step 4 of the eval
+update flow — invoke `runSubagent` (the VS Code Copilot Chat tool) pointing the subagent to read
+`src/skills/evaluations/validate/SKILL.md` as its first action, passing the
+paths of the newly written eval files and the agent folder path. Wait for
+the subagent to return with its quality report before continuing. If fixes
+are applied, re-invoke the subagent and wait for the updated report
+before continuing. Do NOT proceed to review and push until the subagent
+has returned. Do NOT invoke the validate subagent after delete operations.
 
 **When the user asks to modify, delete, rename, or otherwise change an agent
 component, ALWAYS load and follow the corresponding skill file.** The skill

--- a/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
@@ -267,6 +267,25 @@ and negative variants (≥1 of each type per topic):
 | Write-on-read-only | "Update my hire date" / "Change my employee ID" |
 | Multi-intent confusion | "Check my PTO balance and also reset my password" |
 
+**Utterance type rule — natural language vs. keyword:**
+
+Every test set needs two kinds of utterances. Apply this rule across all three
+case types (positive, boundary, negative):
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Natural language** | A complete sentence a real employee would say | "Can you show me all my open IT support tickets?" |
+| **Keyword** | Short, sparse input with no grammar | "open tkts" |
+
+Rules:
+- **Never generate two natural-language paraphrases for the same intent.** Near-synonyms
+  like "Show me my email" / "What's my email address on file?" test the same routing and
+  inflate redundancy scores without adding coverage.
+- **Positives**: if a topic gets 2 positive cases, make one natural language and one
+  keyword (e.g., "List my open IT tickets" + "open tkts").
+- **Boundaries**: the boundary types (typos, abbreviations, very short input) already
+  lean keyword by nature — continue this pattern, do not add full-sentence boundaries.
+
 **Step 1 — Positive cases (≥1 per topic):**
 1. Read the topic's `triggerQueries` list from the YAML file.
 2. Pick **1-2 representative trigger queries** per topic — not all of them:
@@ -298,12 +317,24 @@ Pick the most relevant boundary type for each topic and generate 1 test case:
 
 **Step 3 — Negative cases (≥1 per topic, where applicable):**
 Pick the most relevant negative type for each topic:
+
+**CRITICAL — vary utterance type across negatives.** If you generate privacy-boundary
+negatives for multiple topics, do NOT write them all as "Show me [person]'s [X]"
+natural-language sentences — they will all share the same structure and score low on
+Redundancy. Apply the utterance type rule:
+- First privacy negative in the set → natural language: "What is Sarah's salary?"
+- Second privacy negative → keyword: "Sarah tkts" / "John salary" / "manager ticket"
+- Third+ → different failure mode entirely (write-on-read-only, cross-domain, out-of-scope)
+
 - For **read-only data topics** (Get Employee ID, Get Hire Date): add a
   **write-on-read-only** case — "Update my hire date" / "Change my employee ID"
+  - Use keyword format: "change hire date" / "update employee ID"
   - `expectedOutput`: The agent should explain it cannot modify this data or
     offer an alternative path
 - For **employee-scoped topics** (My Salary, My PTO): add a **privacy boundary**
-  case — "What is Sarah's salary?" / "Show me John's PTO balance"
+  case — natural language for the first one, keyword for subsequent ones
+  - Natural language: "What is Sarah's salary?" / "Show me John's PTO balance"
+  - Keyword: "Sarah salary" / "John PTO"
   - `expectedOutput`: The agent should refuse to show another employee's data
 - For **domain-specific topics** (IT tickets, HR cases): add a **cross-domain**
   case — "Create a ticket and also show my pay stub"
@@ -547,19 +578,42 @@ Run `python scripts/checkpoint.py "before evaluation test set creation"` to save
 Create the `evaluations/` folder inside the agent folder if it doesn't exist.
 Write each EvaluationSet and EvaluationData file as described above.
 
-### 4.3 — Review before push
+### 4.3 — Quality validation
 
-Show the user a summary of what was generated and ask for confirmation:
+Run quality validation on the generated files.
+
+**After the subagent returns, display its full quality report output directly
+to the user — the complete dimension table, per-category scores, and any ⚠️
+callout blocks listing flagged files. Do NOT summarize or compress the report.
+Paste the subagent's output verbatim into the chat so the user sees it.**
+
+Follow the quality gate + fix flow defined in
+`src/skills/evaluations/quality-fix-flow.md`. The "review step" referred to
+there is step 4.4 of this skill.
+
+**Do not proceed to step 4.4 until quality validation has returned results and
+any fixes are complete.**
+
+---
+
+### 4.4 — Review before push
+
+> **STOP. Do not proceed to step 4.5 until the user has explicitly responded to this step.**
+> This step is mandatory. Do not skip it even if the quality gate passed cleanly.
+
+Count the positive, boundary, and negative cases generated per category. Then show the user this summary and wait for their response:
 
 > Here's what I generated:
 >
 > | Category | Positive | Boundary | Negative | Total |
-> |----------|----------|----------|----------|-------|
+> |----------|----------|----------|----------|---------|
 > | Topic Triggering | {n} | {n} | {n} | {n} |
 > | Integration Data | {n} | {n} | {n} | {n} |
 > | ... | ... | ... | ... | ... |
 >
 > Want to **review specific test cases** before pushing, or **push now**?
+
+Wait for the user's answer before continuing. Do not run the dry-run or push until the user explicitly says "push" or "proceed".
 
 **If IntegrationData tests were generated**, add a placeholder reminder:
 
@@ -577,26 +631,26 @@ Show the user a summary of what was generated and ask for confirmation:
 - **If user says now**: Walk through each placeholder and ask the user for
   the real value. Update the files before pushing.
 - **If user says after pushing**: Proceed, but remind them again in the
-  final summary (Step 4.6).
+  final summary (Step 4.7).
 
 - **If user says review**: Show the test cases they want to inspect, let them
   request edits, then re-confirm push.
 - **If user says push**: Proceed to dry run.
 
-### 4.4 — Dry run
+### 4.5 — Dry run
 
 Run `python scripts/push.py --dry-run` to preview what will be pushed. Confirm the
 evaluation files are detected as new botcomponent records.
 
 Show the user the dry run output and ask for confirmation.
 
-### 4.5 — Push
+### 4.6 — Push
 
 Run `python scripts/push.py` to push the evaluation test sets to Copilot Studio.
 The push script handles two-pass ordering automatically: parent EvaluationSet records
 are created first, then child EvaluationData records are linked via `parentbotcomponentid`.
 
-### 4.6 — Show summary
+### 4.7 — Show summary
 
 Print a summary table:
 

--- a/solutions/ess-maker-skills/src/skills/evaluations/quality-fix-flow.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/quality-fix-flow.md
@@ -1,0 +1,48 @@
+# Eval Quality Fix Flow
+
+This file is the single source of truth for the quality gate + fix flow.
+Both `create/SKILL.md` and `update/SKILL.md` reference it. Do not duplicate
+this logic in either file.
+
+---
+
+**If the gate returns Review (3/5) or Fail (1–2/5)**, the subagent's report
+will include the flagged cases table. Show the user this prompt and wait for
+their response:
+
+> What would you like to do?
+> - **A** — Fix all flagged cases
+> - **B** — Pick which ones to fix
+> - **C** — Push as-is and fix later
+
+When the user responds:
+
+- **A (fix all)**: Run the fix flow below for all flagged cases.
+- **B (pick some)**: Ask the user which case numbers to fix (e.g. `1, 3, 5`).
+  Run the fix flow below for only those cases.
+- **C (push as-is)**: Proceed to the review step.
+
+**Fix flow (A or B)**:
+1. For each selected case, read the current file and note the existing `input`
+   and `expectedOutput` values (these become the **Before** values in the summary).
+2. Devise a fix based on the issue description from the flagged cases table.
+   Edit the file with the new values.
+3. After all edits are done, show a summary of what changed:
+
+   > **Fixed {n} case(s):**
+   >
+   > | # | File | Dimension | Field | Before | After |
+   > |---|------|-----------|-------|--------|-------|
+   > | 1 | `{filename}.mcs.yml` | {dimension} | input | `{old input}` | `{new input}` |
+   > | 2 | `{filename}.mcs.yml` | {dimension} | expectedOutput | `{old output}` | `{new output}` |
+
+4. Re-invoke the validate subagent on all files in the category (not just
+   the edited ones — category-level dimensions need the full set) and display
+   the new quality report before proceeding.
+
+**If the gate passes (4–5/5)** with some dimensions at 3/5 or below, the
+subagent will note them as optional improvements but will not block. Proceed
+to the review step without running the fix flow.
+
+**Do not proceed to the review step until quality validation has returned
+results and any fixes are complete.**

--- a/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
@@ -80,7 +80,25 @@ extensionData:
 For new test cases, create new `.mcs.yml` files following the naming convention:
 `{set-name}-{short-slug}.mcs.yml`.
 
-## Step 4: Review before push
+## Step 4: Quality validation
+
+Run quality validation by invoking the validate subagent, passing the paths
+of **all `.mcs.yml` files in the affected category** (not just the modified
+ones — category-level dimensions need the full set) and the agent folder path.
+
+**After the subagent returns, display its full quality report output directly
+to the user — the complete dimension table, per-category scores, and any ⚠️
+callout blocks listing flagged files. Do NOT summarize or compress the report.
+Paste the subagent's output verbatim into the chat so the user sees it.**
+
+Follow the quality gate + fix flow defined in
+`src/skills/evaluations/quality-fix-flow.md`. The "review step" referred to
+there is Step 5 of this skill.
+
+**Do not proceed to Step 5 until quality validation has returned results and
+any fixes are complete.**
+
+## Step 5: Review before push
 
 Show the user a summary of what changed and ask for confirmation:
 
@@ -96,19 +114,19 @@ Show the user a summary of what changed and ask for confirmation:
 - **If user says review**: Show the full YAML of the changed file(s).
 - **If user says push**: Proceed to dry run.
 
-## Step 5: Dry Run
+## Step 6: Dry Run
 
 Run `python scripts/push.py --dry-run` to preview changes. Show the user the
 output confirming modified/new/deleted evaluation files.
 
-## Step 6: Push
+## Step 7: Push
 
 Run `python scripts/push.py` to push changes to Copilot Studio.
 
 **If the push fails:** show the error and offer retry or revert
 (`python scripts/checkpoint.py --revert`).
 
-## Step 7: Verify
+## Step 8: Verify
 
 > ✅ Evaluation test cases updated in Copilot Studio.
 >

--- a/solutions/ess-maker-skills/src/skills/evaluations/validate/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/validate/SKILL.md
@@ -1,0 +1,169 @@
+# ESS Eval Quality Validator
+
+You are the ESS evaluation quality validator. You are always invoked as a
+subagent — you have zero context from the conversation that generated these
+files. Your only inputs are the paths to the eval YAML files and the agent
+folder. Use your file-reading tools to load each file cold and score it.
+
+---
+
+## Step 1 — Read the files
+
+Read each YAML file at the provided paths. For EvaluationData files, extract:
+- `input` — the user utterance being tested
+- `expectedOutput` — the expected agent behavior
+- `kind` — must be `EvaluationData` to be scored
+
+**Skip any file where `kind` is `MultiTurnEvaluationCase`.** The 9 scoring
+dimensions are defined for single-turn `input`/`expectedOutput` pairs only.
+Multi-turn cases have a conversation-turn structure that requires separate
+guidance — they are out of scope for this validator. Note skipped files in
+your report:
+
+> ℹ️ Skipped {n} multi-turn file(s) — multi-turn scoring not supported by
+> this validator.
+
+Group remaining files by category (the subfolder they are in under `evaluations/`).
+
+---
+
+## Step 2 — Score each category
+
+Apply each quality dimension below to the full set of cases in the category.
+Score 1–5 per dimension. Then compute an overall holistic score (not a simple
+average — use judgment).
+
+**Topic Alignment applies only to: `topic-triggering` and `integration-data`
+categories.**
+
+### Quality Dimensions
+
+**Validity** — Each input is grammatically correct and plausible as a real
+user utterance.
+
+**Realism** — Inputs sound like things real employees would actually say — not
+textbook sentences or formal policy language.
+
+**Assertion Quality** — Each expectedOutput is specific, actionable, and
+testable — not vague like "agent should respond". It describes observable
+user-facing behavior, not implementation details.
+
+**Coverage** — The category covers a meaningful spread of sub-topics and
+scenario types (positive, boundary, negative) rather than clustering around
+one scenario.
+
+**Diversity** — Utterances cover two distinct types: (1) natural-language —
+complete sentences a real employee would say, and (2) keyword-style — short,
+sparse inputs with no grammar (e.g. "open tkts", "employee ID"). The ideal
+pattern is one natural-language input and one keyword-style input per topic.
+Score high when both types are present across the set. Score low when all
+inputs are natural-language near-synonyms of each other, or when keyword
+inputs dominate without any natural-language representation.
+
+**Redundancy** — No two cases test the exact same thing. Two cases are
+redundant if they have nearly identical inputs AND nearly identical expected
+outputs — changing only a single word does not make them distinct.
+IMPORTANT EXCEPTION: a boundary case (typo, abbreviation, very short input)
+intentionally shares its expectedOutput with the corresponding positive case —
+this is by design and is NOT redundant, because the inputs are meaningfully
+different (imperfect vs natural phrasing). Do NOT flag positive/boundary pairs
+as redundant. For negative cases specifically: also flag when multiple negatives
+share the same sentence structure (e.g. all written as "Show me [person]'s [X]")
+even if they test different failure modes — structural uniformity across
+negatives reduces discriminative value.
+
+**Failure Mode Coverage** — For negative/edge cases: the failures tested are
+realistic scenarios employees would actually trigger, not contrived or trivially
+obvious refusals.
+
+**Discriminative Power** — Inputs are clearly scoped to what the topic handles.
+Positive inputs would not accidentally trigger a different topic; negative inputs
+would not accidentally pass.
+
+**Topic Alignment** *(topic-triggering, integration-data only)* —
+Each case matches what its corresponding topic actually does.
+
+---
+
+## Step 3 — Present the quality report
+
+For each scored category, show this exact table format:
+
+> **Quality: `{category}`** — overall **{score}/5** ({label})
+>
+> **How is this scored?** Each of your test cases is reviewed against 8–9
+> dimensions and assigned a 1–5 score. The overall score is a holistic
+> judgment across all dimensions.
+>
+> | Dimension | Score | What it checks |
+> |-----------|-------|----------------|
+> | Validity | {n}/5 | Inputs are grammatically correct and plausible as real user utterances |
+> | Realism | {n}/5 | Inputs sound like things real employees would say, not formal policy language |
+> | Assertion Quality | {n}/5 | Expected outputs are specific and describe observable agent behavior |
+> | Coverage | {n}/5 | Cases span a meaningful spread of sub-topics and positive/boundary/negative types |
+> | Diversity | {n}/5 | Inputs use genuinely different vocabulary, structure, and formality levels |
+> | Redundancy | {n}/5 | No two cases test the exact same input and expected behavior |
+> | Failure Mode Coverage | {n}/5 | Negative/edge cases reflect realistic failure modes, not contrived refusals |
+> | Discriminative Power | {n}/5 | Inputs are clearly scoped so they won't accidentally trigger the wrong topic |
+> | Topic Alignment | {n}/5 | Each case matches what its corresponding topic actually does |
+
+Include the Topic Alignment row **only** for `topic-triggering` and
+`integration-data` categories. Omit the row entirely for all other categories —
+do not show it as N/A or blank.
+
+Score labels: 5 = ✓ Excellent, 4 = ✓ Good, 3 = ⚠ Fair, 2 = ✗ Weak, 1 = ✗ Poor
+
+For any dimension that scored **3/5 or below**, list the specific test cases
+that contributed to the low score directly under that row:
+
+> ⚠️ **`{dimension}`** scored **{n}/5** — test cases that caused this:
+> - `{filename}.mcs.yml` — {issue description}
+> - `{filename}.mcs.yml` — {issue description}
+
+---
+
+## Step 4 — Triage and gate
+
+Classify each category:
+
+- **Pass** (overall 4/5 or 5/5) — quality gate passed. If any individual
+  dimension scored **3/5 or below**, surface those dimensions and flagged
+  cases, then add:
+
+  > No fix required to push — but consider addressing before running live evaluations.
+
+- **Review** (overall 3/5) — has flagged cases, surface them to the user.
+- **Fail** (overall 1/5 or 2/5) — serious quality issues, do not push without fixes.
+
+If all categories **Pass** with no low-scoring dimensions, say:
+
+> ✅ All categories passed quality validation. Proceeding to review.
+
+If all pass but some dimensions scored 3/5 or below, say:
+
+> ✅ Quality gate passed. Some dimensions scored low — see details above.
+
+If any category is **Review** or **Fail**, show:
+
+> ⚠️ **`{category}`** scored **{score}/5** ({label}).
+>
+> These test cases were flagged:
+>
+> | # | File | Dimension | Issue |
+> |---|------|-----------|-------|
+> | 1 | `{filename}.mcs.yml` | {dimension} | {issue description} |
+> | 2 | `{filename}.mcs.yml` | {dimension} | {issue description} |
+>
+> **Recommendation:** {recommendation}
+>
+> Return this report to the parent agent. The parent create/update flow will
+> prompt the user for A/B/C and apply fixes in batch before re-validating.
+
+---
+
+## Step 5 — Return to parent
+
+Return the quality report to the parent agent. The parent will handle
+user interaction, fixes, and re-validation.
+
+This is a gate, not a hard blocker — the user can always choose to push as-is.


### PR DESCRIPTION
**Why**
The eval create and update flows had no quality gate — generated test cases were pushed without any review of whether they were realistic, diverse, or well-formed. When a gate did exist, the fix flow was clunky (per-case Y/N/Skip for every flagged case).

**How it works**

Quality validation uses a parent + subagent split:

- The validate subagent (validate/SKILL.md) is a stateless reviewer — it reads the eval files, applies the 9 dimension rubric, and returns a structured quality report. It has no knowledge of the create/update flow.

- The parent agent (create/update skill) invokes the subagent via **runSubagent** (inbuilt from vs code), displays its full report verbatim, then decides what to do next based on the gate result:
1. Pass (≥ 4/5) → proceed to review
2. Review/Fail (≤ 3/5) → run batch fix flow → re-invoke subagent → display new report → proceed to review

The subagent is re-invoked fresh after fixes (no shared state), so the second score is an independent re-evaluation, not a continuation of the first.

<img width="746" height="916" alt="image" src="https://github.com/user-attachments/assets/c9c8ce94-a908-4581-a68d-8fd44da24733" />


**What changed**

**New**: validate skill

Validate subagent that scores eval test sets across 9 quality dimensions (Validity, Realism, Assertion Quality, Coverage, Diversity, Redundancy, Failure Mode Coverage, Discriminative Power, Topic Alignment)
Outputs a dimension table with per-category scores and ⚠️ callouts for flagged cases
Pass ≥ 4/5 · Review = 3/5 · Fail ≤ 2/5

**Updated**:  create skill

Step 4.3: invoke validate subagent after writing files, display full dimension report verbatim
Fix flow: apply all (or selected) fixes in batch → show Before/After summary table → re-validate
Step 4.4 review is mandatory before push, even when gate passes cleanly

**Updated**:  update skill

Added new Step 4 (quality validation) with the same gate + batch fix flow
Old steps 4–7 renumbered to 5–8

**Updated**: [copilot-instructions.md]

Validate subagent routing now references step 4 of the update flow (was step 4.3)