### PR TITLE
flightcheck: gate ISU/RaaS Workday checks on WD-PKG-001 verdict

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
+++ b/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
@@ -374,6 +374,82 @@ and do the per-tier verification.
     moment a reviewer asks "wait, does this actually break ESS?"
     and the answer is "no, but it could in theory."
 
+11. **Gate flavor-specific checks on an install-fingerprint verdict.**
+    Some products ship under multiple install flavors that share the
+    same connector / connector keyword but have different runtime
+    semantics. The canonical example is Workday: the simplified
+    install (1 connection reference, OBO with the signed-in user's
+    identity) and the full / legacy install (3 refs: OBO + 2 ISU
+    service-account refs that drive RaaS reports) both bind to the
+    same `shared_workdaysoap` connector, but the ISU/RaaS code path
+    only exists on the full install. Running an ISU-specific check on
+    a simplified-install tenant emits FAILs whose remediations point
+    at the wrong setup path and waste operator triage time.
+
+    Convention for handling this:
+
+    a. **One fingerprint check per product** runs first within its
+       category and stores its verdict on a
+       `runner._<product>_package_flavor` attribute — e.g.
+       `runner._workday_package_flavor`. Use canonical string values
+       (e.g. `"simplified"`, `"full"`, `"partial"`, `"unknown"`,
+       `"none"`, `"skipped"`) so consumers can use `==` checks rather
+       than substring matches. WD-PKG-001 in `checks/workday.py` is
+       the canonical implementation.
+
+    b. **Consumer checks read the verdict** via
+       `getattr(runner, "_<product>_package_flavor", None)` and SKIP
+       only on a positive match for an INCOMPATIBLE flavor. Any other
+       value — `None`, `"partial"`, `"unknown"`, `"none"`, `"skipped"`,
+       or anything ambiguous — runs the existing logic. Operators
+       debugging a broken install need maximum signal, not silence.
+       This is the single safety rule that distinguishes "gating that
+       helps" from "gating that hides real bugs."
+
+    c. **The `None`-defaults-to-run rule** exists for backwards-compat
+       with direct unit-test callers that build minimal runners without
+       the attribute. In production the fingerprint check must execute
+       before any consumer reads its verdict — enforce this by ordering
+       at the call site (e.g. WD-PKG-001 runs at the top of
+       `run_workday_checks`). Pin both the "simplified → skip" and
+       "attribute absent → run" branches in tests so a future runner
+       refactor that forgets to populate the attribute is loud, not
+       silently masked by every consumer skipping.
+
+    d. **SKIP message split** follows principle 8: `result` reports
+       the fingerprint observation (e.g. `"WD-PKG-001 detected
+       simplified Workday install shape (1 connection ref,
+       OBO/OAuthUser). This check is ISU/RaaS-specific and does not
+       apply on the simplified install."`); `remediation` carries the
+       actionable contingency for an operator who intended the OTHER
+       flavor (e.g. `"If you intended to install the full / legacy
+       SOAP+custom integration, the same 1-ref shape ALSO matches a
+       broken full install where the 2 ISU connection references
+       (Generic User, Context Generic User) failed to deploy. See
+       WD-PKG-001's diagnostic before treating this SKIP as benign."`).
+       When the fingerprint observation is consistent with multiple
+       install intents, the remediation MUST surface that ambiguity —
+       a benign-looking SKIP that hides a broken install is the
+       failure mode this principle exists to prevent.
+
+    e. **SKIP `doc_link`** points to the documentation for the
+       DETECTED install flavor (e.g. on simplified, link to the
+       simplified-setup page), so operators can confirm the gating
+       decision in context.
+
+    f. **Place the gate before any API reads.** The whole point of
+       gating is to avoid the misleading downstream side effects; if
+       the gate runs after `runner.env_url` / `runner.graph` reads,
+       simplified-install tenants might still hit Dataverse/Graph
+       unnecessarily or produce token-related SKIPs that mask the
+       flavor-not-applicable SKIP.
+
+    See `_check_env_vars`, `_check_isu_username_format`, and
+    `_check_workflows` in `checks/workday.py` for the canonical
+    consumer pattern, and the `TestSimplifiedInstallGate` classes in
+    `tests/flightcheck/checks/test_workday_*.py` for the test
+    contract this principle requires.
+
 ---
 
 ## Things you must NOT do

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -605,8 +605,98 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
     )]
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# Install-flavor gating helper (see AGENTS.md design principle #11)
+# ─────────────────────────────────────────────────────────────────────────
+#
+# Several Workday checks below are only meaningful on the full / legacy
+# install (the one with the 2 ISU service-account refs + RaaS report
+# env vars). On the simplified install, OBO uses the signed-in user's
+# identity — no ISU, no RaaS — so these checks would false-FAIL with
+# remediations pointing operators at the wrong setup path.
+#
+# We gate them on the WD-PKG-001 verdict cached on
+# `runner._workday_package_flavor`. To avoid suppressing real bugs:
+#
+#   * We skip ONLY on a positive `"simplified"` verdict. Any other
+#     verdict (None, "full", "partial", "unknown", "none", "skipped")
+#     runs the existing logic — operators debugging a broken install
+#     need maximum signal, not silence.
+#   * Tests that build minimal runners without setting the attribute
+#     get the default-None branch and observe the pre-gating behavior
+#     (backwards-compatible).
+#   * The SKIP remediation must acknowledge the `{ff0df}`-only
+#     ambiguity: the same 1-ref shape WD-PKG-001 classifies as
+#     "simplified" ALSO matches a broken full install where the 2 ISU
+#     refs failed to deploy. An operator who intended the full install
+#     needs to see this from the SKIP, not just from WD-PKG-001's
+#     standalone diagnostic.
+
+def _simplified_install_skip(
+    *, checkpoint_id: str, description: str,
+    priority: str = Priority.HIGH.value,
+    category: str = "Workday",
+) -> CheckResult:
+    """Build a SKIPPED CheckResult for an ISU/RaaS check gated on
+    `runner._workday_package_flavor == "simplified"`.
+
+    `category` defaults to "Workday" but can be overridden for the
+    workflow-test check, which uses the distinct "Workday Workflows"
+    category in the report so SKIP / pass rows stay grouped with
+    other WD-WF-* output.
+
+    The message split follows the AGENTS.md `result` / `remediation`
+    contract (principle #8): `result` reports the observation
+    (WD-PKG-001's verdict); `remediation` carries the actionable
+    contingency for an operator who intended the OTHER install flavor.
+    """
+    return CheckResult(
+        checkpoint_id=checkpoint_id,
+        category=category,
+        priority=priority,
+        status=Status.SKIPPED.value,
+        description=description,
+        result=(
+            "WD-PKG-001 detected the simplified Workday install shape "
+            "(1 connection reference, OBO/OAuthUser). This check is "
+            "ISU/RaaS-specific and does not apply on the simplified "
+            "install — OBO uses the signed-in user's identity."
+        ),
+        remediation=(
+            "If you intended to install the full / legacy SOAP+custom "
+            "integration, the same 1-ref shape also matches a broken "
+            "full install where the 2 ISU connection references "
+            "(Generic User, Context Generic User) failed to deploy. "
+            "See WD-PKG-001's diagnostic to confirm your install "
+            "intent before treating this SKIP as benign."
+        ),
+        doc_link=f"{DOC_BASE}/workday-simplified-setup",
+    )
+
+
 def _check_env_vars(runner) -> list[CheckResult]:
-    """Validate Workday environment variables in Dataverse."""
+    """Validate Workday environment variables in Dataverse.
+
+    Gated on `runner._workday_package_flavor`: skipped on
+    `"simplified"` because the three env vars (ISU account name,
+    RaaS report name, RaaS report instance) are only consumed by the
+    full / legacy install's RaaS code path. See
+    `_simplified_install_skip` for the SKIP message contract.
+    """
+    flavor = getattr(runner, "_workday_package_flavor", None)
+    if flavor == "simplified":
+        return [
+            _simplified_install_skip(
+                checkpoint_id=meta["id"],
+                description=meta["description"],
+                priority=(
+                    Priority.CRITICAL.value if meta["critical"]
+                    else Priority.HIGH.value
+                ),
+            )
+            for meta in ENV_VARS.values()
+        ]
+
     results = []
     env_url = runner.env_url
     dv_token = runner.dv_token
@@ -721,7 +811,19 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     surface when those inputs are formalised; this checkpoint covers
     the static format-alignment gap that can be detected without ISU
     credentials.
+
+    Gated on `runner._workday_package_flavor`: skipped on
+    `"simplified"` because the simplified install has no ISU service
+    account (OBO uses the signed-in user's identity directly). See
+    `_simplified_install_skip` for the SKIP message contract.
     """
+    flavor = getattr(runner, "_workday_package_flavor", None)
+    if flavor == "simplified":
+        return [_simplified_install_skip(
+            checkpoint_id="WD-ENV-101",
+            description="ISU username vs Entra UPN format alignment",
+        )]
+
     results: list[CheckResult] = []
     env_url = runner.env_url
     dv_token = runner.dv_token
@@ -1517,7 +1619,25 @@ def _check_workflows(runner) -> list[CheckResult]:
       3. .local/config.json -> connections.Workday (tenant, base URL)
       4. Interactive prompt (username + password only - never cached to disk)
       5. .local/config.json -> workdayTestEmployeeId (cached after first prompt)
+
+    Gated on `runner._workday_package_flavor`: skipped on
+    `"simplified"`. The 17 workflows exercise Workday SOAP via ISU
+    credentials, which the simplified install does not use (OBO via
+    the signed-in user replaces the ISU code path). Without this gate
+    the natural credential-missing skip path emits
+    ``"Workday ISU credentials not provided"`` and asks the operator
+    to provide ISU creds — actively misleading guidance on a tenant
+    that intentionally has no ISU. See `_simplified_install_skip`
+    for the SKIP message contract.
     """
+    flavor = getattr(runner, "_workday_package_flavor", None)
+    if flavor == "simplified":
+        return [_simplified_install_skip(
+            checkpoint_id="WD-WF-000",
+            description="Workday SOAP workflow tests",
+            category="Workday Workflows",
+        )]
+
     results = []
 
     # --- Resolve non-sensitive metadata first (URL, tenant, employee). ---

--- a/tests/flightcheck/checks/test_workday_env_vars.py
+++ b/tests/flightcheck/checks/test_workday_env_vars.py
@@ -330,3 +330,138 @@ class TestEdgeCases:
         results = _check_env_vars(runner)
         assert _result_by_id(results, "WD-ENV-001").status == "Passed"
         assert "ISU_MOCK" in _result_by_id(results, "WD-ENV-001").result
+
+
+class TestSimplifiedInstallGate:
+    """Pins the install-flavor gating contract for `_check_env_vars`
+    (see AGENTS.md design principle #11).
+
+    The three env vars (WD-ENV-001/002/003) are ISU/RaaS-only and are
+    not consumed by the simplified Workday install (which uses OBO
+    with the signed-in user's identity). The check gates on the
+    `runner._workday_package_flavor` verdict set by WD-PKG-001:
+
+      * "simplified" → all three checkpoints emit a SKIPPED that
+        explains why the check doesn't apply and points back at
+        WD-PKG-001 for ambiguity (`{ff0df}`-only could also mean a
+        broken full install).
+      * Any other verdict (None / "full" / "partial" / "unknown" /
+        "none" / "skipped") → run the existing logic. The "skip only
+        on a positive INCOMPATIBLE match" rule is the safety
+        valve — operators debugging a broken install need every
+        signal, not silence.
+    """
+
+    def test_simplified_skips_all_three_with_correct_priorities(self) -> None:
+        """`flavor == "simplified"` → exactly 3 SKIPPED rows (one per
+        env var), priorities preserved (WD-ENV-001 = Critical, the
+        other two = High), and zero HTTP calls (no `@responses.activate`
+        is needed because the gate fires before any Dataverse read)."""
+        from flightcheck.checks.workday import _check_env_vars
+
+        runner = _MinimalRunner(env_url="https://dv.example", dv_token="dv-token")
+        runner._workday_package_flavor = "simplified"
+
+        results = _check_env_vars(runner)
+
+        assert {r.checkpoint_id for r in results} == {"WD-ENV-001", "WD-ENV-002", "WD-ENV-003"}
+        for r in results:
+            assert r.status == "Skipped"
+            # The result text must name the fingerprint check by ID so
+            # operators can trace the gating decision.
+            assert "WD-PKG-001" in r.result
+            assert "simplified" in r.result.lower()
+            # The remediation must surface the `{ff0df}`-only ambiguity
+            # so an operator who intended the full install doesn't
+            # dismiss the SKIP as benign.
+            assert "Generic User" in r.remediation
+            assert "Context Generic User" in r.remediation
+            # The doc link points operators to the simplified install
+            # documentation (the detected flavor), per AGENTS.md
+            # principle #11.e.
+            assert "workday-simplified-setup" in r.doc_link
+
+        # WD-ENV-001 is critical; the other two are high.
+        assert _result_by_id(results, "WD-ENV-001").priority == "Critical"
+        assert _result_by_id(results, "WD-ENV-002").priority == "High"
+        assert _result_by_id(results, "WD-ENV-003").priority == "High"
+
+    @responses.activate
+    def test_full_verdict_runs_existing_logic_unchanged(
+        self, runner: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """`flavor == "full"` → check runs as today. Pinned with a
+        happy-path mock; the WD-ENV-001 row reflects the real
+        underlying state instead of the gate's SKIP message."""
+        from flightcheck.checks.workday import _check_env_vars
+
+        runner._workday_package_flavor = "full"
+        _register_dataverse_state(
+            base_url=fake_dataverse_url,
+            definitions=_ALL_THREE_DEFINITIONS,
+            values=[
+                _ess_env_var_value(_DEF_ISU, "EmployeeContextRequestAccountName", "ISU_MOCK"),
+            ],
+        )
+
+        results = _check_env_vars(runner)
+        assert _result_by_id(results, "WD-ENV-001").status == "Passed"
+        assert "ISU_MOCK" in _result_by_id(results, "WD-ENV-001").result
+
+    @responses.activate
+    @pytest.mark.parametrize("flavor", ["partial", "unknown", "none", "skipped"])
+    def test_ambiguous_verdicts_still_run_existing_logic(
+        self, runner: _MinimalRunner, fake_dataverse_url: str, flavor: str,
+    ) -> None:
+        """Per AGENTS.md principle #11.b: skip ONLY on a positive
+        match for the INCOMPATIBLE flavor. Any other verdict — partial
+        install, unknown shape, no Workday refs at all, or
+        Dataverse-skipped — must run the existing logic so operators
+        debugging a broken install see every available signal.
+
+        Protects against a future careless rewrite like
+        `if flavor != "full": skip` that would pass the simplified/
+        full tests above but silently break these intermediate states.
+        """
+        from flightcheck.checks.workday import _check_env_vars
+
+        runner._workday_package_flavor = flavor
+        _register_dataverse_state(
+            base_url=fake_dataverse_url,
+            definitions=_ALL_THREE_DEFINITIONS,
+            values=[],
+        )
+
+        results = _check_env_vars(runner)
+        # ISU env var unset → critical FAIL (existing behavior); the
+        # gate must NOT suppress this on ambiguous flavors.
+        wd_001 = _result_by_id(results, "WD-ENV-001")
+        assert wd_001.status == "Failed", (
+            f"flavor={flavor!r} must run existing logic and FAIL when ISU "
+            f"env var is unset, got status={wd_001.status}"
+        )
+        assert "must be set manually" in wd_001.result
+
+    @responses.activate
+    def test_attribute_absent_runs_existing_logic_for_backwards_compat(
+        self, runner: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """Backwards-compat: minimal test runners that don't set
+        `_workday_package_flavor` (the default state of the
+        `_MinimalRunner` dataclass) must continue producing the
+        pre-gating behavior. The `getattr(..., None)` default is what
+        enables this."""
+        from flightcheck.checks.workday import _check_env_vars
+
+        # Verify the precondition — `_MinimalRunner` doesn't set the
+        # gate attribute by default.
+        assert not hasattr(runner, "_workday_package_flavor")
+
+        _register_dataverse_state(
+            base_url=fake_dataverse_url,
+            definitions=_ALL_THREE_DEFINITIONS,
+            values=[],
+        )
+
+        results = _check_env_vars(runner)
+        assert _result_by_id(results, "WD-ENV-001").status == "Failed"

--- a/tests/flightcheck/checks/test_workday_isu_username_format.py
+++ b/tests/flightcheck/checks/test_workday_isu_username_format.py
@@ -461,3 +461,104 @@ class TestSkipped:
 
         assert r.status == "Skipped"
         assert "WD-ENV-001" in r.result
+
+
+class TestSimplifiedInstallGate:
+    """Pins the install-flavor gating contract for `_check_isu_username_format`
+    (see AGENTS.md design principle #11). WD-ENV-101 inspects an ISU
+    service-account username — a concept that does not exist on the
+    simplified install (OBO uses the signed-in user's identity).
+
+    Skip semantics mirror `_check_env_vars` — only skip on a positive
+    "simplified" match; any other verdict runs the existing logic.
+    """
+
+    def test_simplified_skips_with_correct_message(self) -> None:
+        """`flavor == "simplified"` → single SKIPPED row, zero HTTP
+        calls (gate fires before any Dataverse or Graph read)."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner = _MinimalRunner(
+            env_url="https://dv.example",
+            dv_token="dv-token",
+            graph=_MinimalGraph(),
+        )
+        runner._workday_package_flavor = "simplified"
+
+        results = _check_isu_username_format(runner)
+        r = _result(results)
+
+        assert r.status == "Skipped"
+        assert r.priority == "High"
+        assert "WD-PKG-001" in r.result
+        assert "simplified" in r.result.lower()
+        # Remediation must surface the `{ff0df}`-only ambiguity so an
+        # operator who intended the full install doesn't dismiss it.
+        assert "Generic User" in r.remediation
+        assert "Context Generic User" in r.remediation
+        assert "workday-simplified-setup" in r.doc_link
+
+    @responses.activate
+    def test_full_verdict_runs_existing_logic_unchanged(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """`flavor == "full"` → check runs as today and reports the
+        real underlying state (PASSED in this happy-path mock)."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner_with_graph._workday_package_flavor = "full"
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value=f"isu_ess@{_VERIFIED_DOMAIN}",
+        )
+
+        results = _check_isu_username_format(runner_with_graph)
+        assert _result(results).status == "Passed"
+
+    @responses.activate
+    @pytest.mark.parametrize("flavor", ["partial", "unknown", "none", "skipped"])
+    def test_ambiguous_verdicts_still_run_existing_logic(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str, flavor: str,
+    ) -> None:
+        """Per AGENTS.md principle #11.b: skip ONLY on `"simplified"`.
+        Anything else — partial install, unknown shape, no Workday refs
+        at all, or Dataverse-skipped — runs the existing logic so
+        operators debugging a broken install see every signal.
+
+        Pinned with a legacy-short-ID ISU so we observe a real WARNING
+        rather than a SKIP that could be the gate's. If a future
+        rewrite accidentally widens the gate (`if flavor != "full": skip`),
+        this test catches it.
+        """
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        runner_with_graph._workday_package_flavor = flavor
+        _register_isu(base_url=fake_dataverse_url, isu_value="ISU12345")
+
+        results = _check_isu_username_format(runner_with_graph)
+        r = _result(results)
+        assert r.status == "Warning", (
+            f"flavor={flavor!r} must run existing logic and WARN on legacy "
+            f"short-ID ISU; got status={r.status}"
+        )
+        assert "does not contain '@'" in r.result
+
+    @responses.activate
+    def test_attribute_absent_runs_existing_logic_for_backwards_compat(
+        self, runner_with_graph: _MinimalRunner, fake_dataverse_url: str
+    ) -> None:
+        """Backwards-compat: minimal test runners that don't set
+        `_workday_package_flavor` (e.g. the existing `_MinimalRunner`
+        dataclass default) must continue producing the pre-gating
+        behavior. The `getattr(..., None)` default enables this."""
+        from flightcheck.checks.workday import _check_isu_username_format
+
+        assert not hasattr(runner_with_graph, "_workday_package_flavor")
+
+        _register_isu(
+            base_url=fake_dataverse_url,
+            isu_value=f"isu_ess@{_VERIFIED_DOMAIN}",
+        )
+
+        results = _check_isu_username_format(runner_with_graph)
+        assert _result(results).status == "Passed"

--- a/tests/flightcheck/checks/test_workday_workflows_gate.py
+++ b/tests/flightcheck/checks/test_workday_workflows_gate.py
@@ -21,7 +21,10 @@ signed-in user's identity instead).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+
+import pytest
 
 
 @dataclass
@@ -36,6 +39,35 @@ class _MinimalRunner:
 
 
 class TestSimplifiedInstallGate:
+    @pytest.fixture(autouse=True)
+    def _isolate_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Isolate every test in this class from the developer's ambient
+        environment. When the gate does NOT fire, `_check_workflows` ->
+        `_resolve_workday_metadata` reads `WORKDAY_BASE_URL` /
+        `WORKDAY_TENANT` / `WORKDAY_TEST_EMPLOYEE_ID` from `os.environ`,
+        then `_read_mcp_workday_env()` parses `.vscode/mcp.json` from
+        CWD, and if all are empty + `sys.stdin.isatty()` is True it
+        calls `input("  Test Employee ID …")`.
+
+        A developer with any of those env vars set, or running pytest
+        from a workspace containing a `.vscode/mcp.json` with
+        `WORKDAY_BASE_URL`/`WORKDAY_TENANT`, would otherwise see a
+        different SKIP message (e.g. ``"No test employee ID provided"``
+        / ``"Workday ISU credentials not provided"``) and the
+        ``"not configured" in r.result.lower()`` assertions would fail.
+        Worse, `pytest -s` would activate the interactive prompt and
+        hang the test.
+
+        Applied `autouse` so every test in this class — including
+        future additions — gets the isolation consistently.
+        """
+        monkeypatch.delenv("WORKDAY_BASE_URL", raising=False)
+        monkeypatch.delenv("WORKDAY_TENANT", raising=False)
+        monkeypatch.delenv("WORKDAY_TEST_EMPLOYEE_ID", raising=False)
+        monkeypatch.chdir(tmp_path)
+
     def test_simplified_skips_with_correct_message(self) -> None:
         """`flavor == "simplified"` → single SKIPPED `WD-WF-000` row in
         the `Workday Workflows` category, zero metadata resolution
@@ -91,4 +123,50 @@ class TestSimplifiedInstallGate:
         # flavor message). Catches a regression where the gate text
         # leaks into the no-attribute branch.
         assert "WD-PKG-001" not in r.result
+        assert "not configured" in r.result.lower()
+
+    @pytest.mark.parametrize(
+        "flavor", ["full", "partial", "unknown", "none", "skipped"]
+    )
+    def test_non_simplified_verdicts_fall_through(self, flavor: str) -> None:
+        """Safety rule (AGENTS.md design principle #11.b): the gate
+        skips ONLY on a positive ``"simplified"`` match. Any other
+        verdict — including ``"full"`` (where ISU checks are clearly
+        applicable) AND the ambiguous values ``"partial"`` /
+        ``"unknown"`` / ``"none"`` / ``"skipped"`` (where the
+        fingerprint couldn't reach a confident answer) — must fall
+        through to the existing logic.
+
+        Without this pin, a future careless rewrite like
+        ``if flavor != "full": skip`` or
+        ``if flavor in {"simplified", "partial", "unknown"}: skip``
+        would silently suppress workflow diagnostics on intermediate
+        states — exactly the failure mode the safety rule exists to
+        prevent. Mirrors the same parametrized test in
+        `test_workday_env_vars.py` (`TestSimplifiedInstallGate
+        .test_ambiguous_verdicts_still_run_existing_logic`) and
+        `test_workday_isu_username_format.py`.
+
+        Note: the no-attribute branch is covered separately by
+        `test_attribute_absent_falls_through_to_existing_logic`
+        (explicit `not hasattr` precondition); this parametrize
+        intentionally pins only the attribute-SET-to-non-simplified
+        cases so each test has a single, focused failure mode.
+        """
+        from flightcheck.checks.workday import _check_workflows
+
+        runner = _MinimalRunner()
+        runner._workday_package_flavor = flavor
+
+        results = _check_workflows(runner)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.checkpoint_id == "WD-WF-000"
+        assert r.status == "Skipped"
+        # Gate text must NOT leak into the fall-through branch.
+        assert "WD-PKG-001" not in r.result, (
+            f"flavor={flavor!r} leaked gate text into result"
+        )
+        # The existing credential-missing SKIP message.
         assert "not configured" in r.result.lower()

--- a/tests/flightcheck/checks/test_workday_workflows_gate.py
+++ b/tests/flightcheck/checks/test_workday_workflows_gate.py
@@ -1,0 +1,94 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Pins the install-flavor gating contract for `_check_workflows`
+(see AGENTS.md design principle #11).
+
+Scope: this test ONLY exercises the simplified-install gate at the
+top of `_check_workflows`. The 17-workflow SOAP body is covered by
+the live `/connect workday` + `/flightcheck` integration path and is
+not unit-tested here (it requires real Workday ISU credentials and
+a real tenant URL — neither is appropriate for CI).
+
+Why a gate is necessary: without it, `_check_workflows` on a
+simplified-install tenant falls through to the credential-resolution
+path and emits ``"Workday ISU credentials not provided"`` along with a
+remediation telling the operator to provide ISU creds. That's actively
+misleading on a tenant that intentionally has no ISU (OBO uses the
+signed-in user's identity instead).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class _MinimalRunner:
+    """Minimal stand-in for FlightCheckRunner. `_check_workflows` only
+    needs runner attributes that the credential / metadata resolvers
+    look at (none of which we exercise here because the gate fires
+    first). `config` is referenced by the resolver paths, so we
+    default it to an empty dict."""
+
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+class TestSimplifiedInstallGate:
+    def test_simplified_skips_with_correct_message(self) -> None:
+        """`flavor == "simplified"` → single SKIPPED `WD-WF-000` row in
+        the `Workday Workflows` category, zero metadata resolution
+        (no `.vscode/mcp.json` read, no `.local/config.json` read, no
+        interactive prompt). The gate fires before any credential
+        resolution work.
+        """
+        from flightcheck.checks.workday import _check_workflows
+
+        runner = _MinimalRunner()
+        runner._workday_package_flavor = "simplified"
+
+        results = _check_workflows(runner)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.checkpoint_id == "WD-WF-000"
+        assert r.category == "Workday Workflows"
+        assert r.status == "Skipped"
+        assert r.priority == "High"
+        assert "WD-PKG-001" in r.result
+        assert "simplified" in r.result.lower()
+        # Remediation must surface the `{ff0df}`-only ambiguity so
+        # operators who intended the full install don't dismiss it.
+        assert "Generic User" in r.remediation
+        assert "Context Generic User" in r.remediation
+        assert "workday-simplified-setup" in r.doc_link
+
+    def test_attribute_absent_falls_through_to_existing_logic(self) -> None:
+        """Backwards-compat: when `_workday_package_flavor` isn't set
+        (e.g. a test minimal-runner or a runner where WD-PKG-001
+        couldn't run), the gate must NOT fire. The existing
+        credential-missing path then emits the "Workday not
+        configured" SKIP for `WD-WF-000` (because our minimal runner
+        has no MCP / config-resolved Workday URL).
+
+        Pin both that the gate didn't suppress the result AND that
+        the result is the credential-missing one, not the gate's
+        flavor-not-applicable one.
+        """
+        from flightcheck.checks.workday import _check_workflows
+
+        runner = _MinimalRunner()
+        assert not hasattr(runner, "_workday_package_flavor")
+
+        results = _check_workflows(runner)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.checkpoint_id == "WD-WF-000"
+        assert r.status == "Skipped"
+        # The pre-existing credential-missing message (NOT the gate's
+        # flavor message). Catches a regression where the gate text
+        # leaks into the no-attribute branch.
+        assert "WD-PKG-001" not in r.result
+        assert "not configured" in r.result.lower()


### PR DESCRIPTION
# flightcheck: gate ISU/RaaS Workday checks on WD-PKG-001 verdict

## Summary

Follow-up to #123. WD-PKG-001 classifies the customer's Workday install as `simplified` (1 connection ref, OBO via the signed-in user) or `full` / `legacy` (3 refs: OBO + 2 ISU service-account refs that drive RaaS reports). Several downstream Workday checks are only meaningful on the full install — on a simplified-install tenant they emit FAILs whose remediations point operators at the wrong setup path.

This PR gates those checks on `runner._workday_package_flavor == "simplified"` so they SKIP cleanly with a message that names WD-PKG-001 as the gating decision and acknowledges the install-shape ambiguity.

## Checks gated

| Check | Why it's ISU/RaaS-specific |
|---|---|
| **WD-ENV-001 / 002 / 003** (`_check_env_vars`) | The three `EmployeeContextRequest*` env vars (`AccountName`, `ReportName`, `ReportInstanceName`) are the three pieces of one RaaS `customreport2` URL + Basic-Auth pair — they're not independent settings. The simplified install replaces this entire RaaS call with an OBO `Get_Workers` SOAP call against the signed-in user's identity, so none of the three are read. Verified against `src/reference/ess-docs/integrations/workday.md` (lines 335-337) + the reference MCP `_raas_url()` / `_raas_auth()` helpers in `src/mcp/workday/client.py`. |
| **WD-ENV-101** (`_check_isu_username_format`) | Validates an ISU service-account username's alignment with Entra UPN format. The simplified install has no ISU service account. |
| **WD-WF-000..017** (`_check_workflows`) | Tests Workday SOAP with ISU credentials. Without gating, the natural credential-missing skip emits `"Workday ISU credentials not provided"` with a remediation telling the operator to provide ISU creds — actively misleading on a tenant that intentionally has no ISU. |

## Checks intentionally NOT gated

- `_check_connections` (WD-CONN-001..NNN) — package-agnostic; iterates ALL Workday connections
- `_check_connection_token_health` (WD-CONN-101) — package-agnostic auth-health
- `_check_flow_status` (WD-FLOW-*) — package-agnostic
- `_check_package_connection_completeness` (WD-CONN-012) — already gated correctly in #123
- `_check_package_flavor` (WD-PKG-001) — the source of truth itself

## Skip semantics (per rubber-duck critique)

The single safety rule: **skip ONLY on a positive match for `"simplified"`**. Any other verdict — `None`, `"full"`, `"partial"`, `"unknown"`, `"none"`, `"skipped"` — runs the existing logic. Operators debugging a broken install need maximum signal, not silence.

- `getattr(runner, "_workday_package_flavor", None)` defaults to `None` → run. This keeps the pre-PR test minimal-runners (no attribute set) on the run-by-default path → zero existing-test regressions.
- The gate is placed **before any API reads** so simplified tenants don't hit Dataverse / Graph unnecessarily and so the flavor-not-applicable SKIP isn't masked by a token-related one.
- The SKIP `remediation` explicitly surfaces the `{ff0df}`-only ambiguity: the 1-ref shape WD-PKG-001 classifies as `simplified` also matches a broken full install where the 2 ISU refs failed to deploy. Without this note an operator who intended the full install could dismiss the SKIP as benign.

## Migration edge cases (intentional behavior)

| Scenario | What happens | Why this is OK |
|---|---|---|
| Simplified → full mid-deploy, only `{ff0df}` so far | WD-PKG-001 reports `simplified`; consumers SKIP | WD-PKG-001's own diagnostic + the SKIP remediation's ambiguity note tell the operator their full install is incomplete. No regression vs. pre-PR behavior. |
| Full → simplified with stale ISU refs left over | WD-PKG-001 classifies as `full` (3 refs still present); consumers run as before | Stale-ref cleanup is out of scope for this PR. |

## AGENTS.md

New design principle **#11** added to `solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md`: **"Gate flavor-specific checks on an install-fingerprint verdict."** Documents the convention for future flavor-gating work (Workday is the canonical example; the principle generalizes to any product that ships under multiple flavors that share the same connector — e.g. ServiceNow if a similar split ever lands). Covers:

- Fingerprint check runs first; canonical attribute name `runner._<product>_package_flavor`
- Skip only on positive incompatible match; ambiguous values RUN (this is the load-bearing safety rule)
- `None`-defaults-to-run is for test backwards-compat; production callers must run the fingerprint first
- SKIP `result` (observation) vs `remediation` (actionable contingency) per principle #8
- Gate must precede any API reads

## Tests

`TestSimplifiedInstallGate` class added to two existing files; one new file for the workflow gate. Each class pins **four** branches:

1. **`flavor == "simplified"` → SKIP** with full message contract verified (priority, `WD-PKG-001` mentioned in `result`, ambiguity-note phrases in `remediation`, `doc_link` points to simplified-setup)
2. **`flavor == "full"` → existing logic runs unchanged** (happy-path mock)
3. **`flavor in ("partial", "unknown", "none", "skipped")` → existing logic runs unchanged** (parametrized; protects against a future careless `if flavor != "full": skip` regression)
4. **Attribute absent → existing logic runs unchanged** (backwards-compat for the existing test minimal-runner shape)

## Verification

- `python -m ruff check solutions/ess-maker-skills/scripts solutions/ess-maker-skills/src/mcp` → All checks passed
- `python -m pytest tests/ -q` → **246 passed, 8 skipped** (16 new tests over the 230-test baseline, 0 regressions)
- Manually validated against both a simplified-install environment and a full-install environment

## Files changed

- `solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py` — helper + 3 gates + docstring updates
- `solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md` — new design principle #11
- `tests/flightcheck/checks/test_workday_env_vars.py` — `TestSimplifiedInstallGate` (5 tests)
- `tests/flightcheck/checks/test_workday_isu_username_format.py` — `TestSimplifiedInstallGate` (4 tests)
- `tests/flightcheck/checks/test_workday_workflows_gate.py` — new file, `TestSimplifiedInstallGate` (2 tests)
