### PR TITLE
Add macOS one-shot installer (Homebrew-based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ There are several ways to set up your environment depending on your needs:
 | Option | Best for | Guide |
 |--------|----------|-------|
 | **One-shot installer** (Windows) | Full maker kit — installs VS Code, Python, Git, and all dependencies | [Setup README](setup/README.md) |
+| **One-shot installer** (macOS) | Same as above, using Homebrew | [Setup README](setup/README.md) |
 | **GitHub Codespaces** | Browser-based development — no local install required ([free tier available](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-codespaces/about-billing-for-github-codespaces#monthly-included-storage-and-core-hours-for-personal-accounts)) | [Setup README](setup/README.md#github-codespaces-no-local-install) |
 | **FlightCheck only** | Pre-deployment validation without the full ADK install | [Setup README](setup/README.md#flightcheck-only-mode) |
 | **Manual setup** | Clone the repo and configure your own environment | [Maker Kit README](solutions/ess-maker-skills/README.md#quick-start) |

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,9 +1,17 @@
 # ESS ADK — One-Shot Installer
 
-A single PowerShell command that installs everything needed for the ESS Maker Kit: VS Code, Python 3.12, Git, GitHub CLI, Copilot extensions, pip dependencies, and clones the repo.
+A single command that installs everything needed for the ESS Maker Kit: VS Code, Python 3.12, Git, GitHub CLI, Copilot extensions, pip dependencies, and clones the repo.
+
+**Windows** (PowerShell):
 
 ```powershell
 iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap.ps1)
+```
+
+**macOS** (Terminal):
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-mac.sh)"
 ```
 
 Once complete, VS Code opens at `solutions/ess-maker-skills/`. Run `/setup` in Copilot Chat to connect your Dataverse environment.
@@ -36,10 +44,18 @@ The same Codespace environment can be used to run FlightCheck without the full m
 
 ## FlightCheck-Only Mode
 
-For users who want to run a pre-deployment readiness check on their Power Platform environment — no coding tools or VS Code required. Just run this command in PowerShell:
+For users who want to run a pre-deployment readiness check on their Power Platform environment — no coding tools or VS Code required. Just run this command:
+
+**Windows** (PowerShell):
 
 ```powershell
 iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck.ps1)
+```
+
+**macOS** (Terminal):
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck-mac.sh)"
 ```
 
 That's it. The script handles everything automatically:
@@ -71,10 +87,13 @@ python scripts/flightcheck/cli.py --scope full
 
 | File | Purpose |
 |---|---|
-| `ess-adk-setup.winget.yaml` | Declarative DSC config consumed by `winget configure`. Installs VS Code, Python 3.12, PowerShell 7, Git, GitHub CLI. |
-| `Install-EssAdk.ps1` | Orchestrator. Installs toolchain via winget, installs pip dependencies, clones the repo, installs VS Code extensions, launches VS Code. Idempotent. With `-FlightCheckOnly`, installs minimal toolchain and runs interactive environment/agent discovery. |
-| `bootstrap.ps1` | One-liner entry point for the full maker kit install. Downloads the installer into `$env:TEMP` and runs it. |
-| `bootstrap-flightcheck.ps1` | One-liner entry point for FlightCheck-only install. Downloads the installer and runs it with `-FlightCheckOnly`. |
+| `Install-EssAdk.ps1` | Windows orchestrator. Installs toolchain via winget, pip dependencies, clones repo, installs extensions, launches VS Code. With `-FlightCheckOnly`, installs minimal toolchain and runs FlightCheck. |
+| `install-ess-adk.sh` | macOS orchestrator. Same as above but uses Homebrew. Set `FLIGHTCHECK_ONLY=true` for FlightCheck-only mode. |
+| `bootstrap.ps1` | Windows one-liner entry point (full maker kit). |
+| `bootstrap-flightcheck.ps1` | Windows one-liner entry point (FlightCheck only). |
+| `bootstrap-mac.sh` | macOS one-liner entry point (full maker kit). |
+| `bootstrap-flightcheck-mac.sh` | macOS one-liner entry point (FlightCheck only). |
+| `ess-adk-setup.winget.yaml` | Declarative DSC config consumed by `winget configure` (optional Windows path). |
 | `.devcontainer/devcontainer.json` | Codespace configuration. Pre-installs Python 3.12, pip dependencies, and Copilot extensions. |
 
 ## Dependencies

--- a/setup/README.md
+++ b/setup/README.md
@@ -78,9 +78,16 @@ iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent
 
 Once you've run the installer once, you can re-run FlightCheck directly without going through setup again:
 
+**Windows:**
 ```powershell
 cd $env:USERPROFILE\source\Employee-Self-Service-Agent-Developer-Kit\solutions\ess-maker-skills
 python scripts/flightcheck/cli.py --scope full
+```
+
+**macOS:**
+```bash
+cd ~/source/Employee-Self-Service-Agent-Developer-Kit/solutions/ess-maker-skills
+.venv/bin/python scripts/flightcheck/cli.py --scope full
 ```
 
 ## Files
@@ -106,7 +113,7 @@ The installer provisions the following dependencies. Users do not need to instal
 |------|---------|---------|:-----------------:|
 | Python | 3.12 | Runtime for FlightCheck and maker scripts | ✅ |
 | Git | Latest | Clone the repo, version control | ✅ |
-| GitHub CLI (`gh`) | Latest | Device-code auth flow for private repo clone | ✅ |
+| GitHub CLI (`gh`) | Latest | Device-code auth flow for private repo clone | ❌ |
 | VS Code | Latest | Editor and Copilot host | ❌ |
 | PowerShell 7 | Latest | Script execution (Windows only) | ❌ |
 
@@ -138,6 +145,8 @@ The devcontainer provides an equivalent pre-built environment:
 
 ## How to test it locally
 
+### Windows
+
 From this folder:
 
 ```powershell
@@ -155,3 +164,23 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\Install-EssAdk.ps1 -Flight
 ```
 
 For air-gapped / locked-down environments, IT can mirror the files internally and serve them from an intranet URL by passing `-SourceBaseUrl`.
+
+### macOS
+
+From this folder:
+
+```bash
+# Full installer:
+bash install-ess-adk.sh
+
+# FlightCheck only:
+FLIGHTCHECK_ONLY=true bash install-ess-adk.sh
+
+# Custom install location:
+ESS_ADK_INSTALL_ROOT=~/projects bash install-ess-adk.sh
+
+# Test against a branch:
+ESS_ADK_BRANCH=my-feature bash install-ess-adk.sh
+```
+
+For air-gapped environments, set `ESS_ADK_SOURCE_URL` in the bootstrap scripts to point at your internal mirror.

--- a/setup/README.md
+++ b/setup/README.md
@@ -87,7 +87,7 @@ python scripts/flightcheck/cli.py --scope full
 **macOS:**
 ```bash
 cd ~/source/Employee-Self-Service-Agent-Developer-Kit/solutions/ess-maker-skills
-.venv/bin/python scripts/flightcheck/cli.py --scope full
+../../.venv/bin/python scripts/flightcheck/cli.py --scope full
 ```
 
 ## Files

--- a/setup/bootstrap-flightcheck-mac.sh
+++ b/setup/bootstrap-flightcheck-mac.sh
@@ -25,5 +25,12 @@ if ! curl -fsSL "$INSTALLER_URL" -o "$TEMP_DIR/install-ess-adk.sh"; then
     exit 1
 fi
 
+# Verify the downloaded file looks like a valid script
+if [[ ! -s "$TEMP_DIR/install-ess-adk.sh" ]] || ! head -1 "$TEMP_DIR/install-ess-adk.sh" | grep -q '^#!/'; then
+    echo "  [ERR] Downloaded file appears invalid (empty or not a shell script)" >&2
+    echo "  A corporate proxy may be intercepting the request." >&2
+    exit 1
+fi
+
 # Run in-memory (source) to avoid any permission issues
 source "$TEMP_DIR/install-ess-adk.sh"

--- a/setup/bootstrap-flightcheck-mac.sh
+++ b/setup/bootstrap-flightcheck-mac.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# ESS ADK — macOS Bootstrap (FlightCheck Only)
+#
+# One-liner entry point:
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck-mac.sh)"
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+export FLIGHTCHECK_ONLY="true"
+
+SOURCE_BASE_URL="${ESS_ADK_SOURCE_URL:-https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup}"
+
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+echo "Fetching ESS ADK installer to $TEMP_DIR"
+INSTALLER_URL="$SOURCE_BASE_URL/install-ess-adk.sh"
+echo "  $INSTALLER_URL"
+
+if ! curl -fsSL "$INSTALLER_URL" -o "$TEMP_DIR/install-ess-adk.sh"; then
+    echo "  [ERR] Failed to download: $INSTALLER_URL" >&2
+    echo "  If raw.githubusercontent.com is blocked by your firewall/proxy," >&2
+    echo "  clone the repo manually and run: FLIGHTCHECK_ONLY=true setup/install-ess-adk.sh" >&2
+    exit 1
+fi
+
+# Run in-memory (source) to avoid any permission issues
+source "$TEMP_DIR/install-ess-adk.sh"

--- a/setup/bootstrap-mac.sh
+++ b/setup/bootstrap-mac.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# ESS ADK — macOS Bootstrap (Full Maker Kit)
+#
+# One-liner entry point:
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-mac.sh)"
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SOURCE_BASE_URL="${ESS_ADK_SOURCE_URL:-https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup}"
+
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+echo "Fetching ESS ADK installer to $TEMP_DIR"
+INSTALLER_URL="$SOURCE_BASE_URL/install-ess-adk.sh"
+echo "  $INSTALLER_URL"
+
+if ! curl -fsSL "$INSTALLER_URL" -o "$TEMP_DIR/install-ess-adk.sh"; then
+    echo "  [ERR] Failed to download: $INSTALLER_URL" >&2
+    echo "  If raw.githubusercontent.com is blocked by your firewall/proxy," >&2
+    echo "  clone the repo manually and run: setup/install-ess-adk.sh" >&2
+    exit 1
+fi
+
+# Run in-memory (source) to avoid any permission issues
+source "$TEMP_DIR/install-ess-adk.sh"

--- a/setup/bootstrap-mac.sh
+++ b/setup/bootstrap-mac.sh
@@ -23,5 +23,12 @@ if ! curl -fsSL "$INSTALLER_URL" -o "$TEMP_DIR/install-ess-adk.sh"; then
     exit 1
 fi
 
+# Verify the downloaded file looks like a valid script
+if [[ ! -s "$TEMP_DIR/install-ess-adk.sh" ]] || ! head -1 "$TEMP_DIR/install-ess-adk.sh" | grep -q '^#!/'; then
+    echo "  [ERR] Downloaded file appears invalid (empty or not a shell script)" >&2
+    echo "  A corporate proxy may be intercepting the request." >&2
+    exit 1
+fi
+
 # Run in-memory (source) to avoid any permission issues
 source "$TEMP_DIR/install-ess-adk.sh"

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -80,8 +80,13 @@ install_brew_pkg() {
         ok "$name (already installed)"
     else
         echo "    Installing $name ($pkg)..."
-        brew install "$pkg"
-        ok "$name"
+        brew install "$pkg" || true
+        if brew list "$pkg" &>/dev/null; then
+            ok "$name"
+        else
+            err "Failed to install $name. Try manually: brew install $pkg"
+            exit 1
+        fi
     fi
 }
 
@@ -94,14 +99,25 @@ install_brew_cask() {
         ok "$name (already installed outside Homebrew)"
     else
         echo "    Installing $name ($cask)..."
-        brew install --cask "$cask"
-        ok "$name"
+        brew install --cask "$cask" || true
+        if brew list --cask "$cask" &>/dev/null || [[ -d "/Applications/Visual Studio Code.app" ]]; then
+            ok "$name"
+        else
+            err "Failed to install $name. Try manually: brew install --cask $cask"
+            exit 1
+        fi
     fi
 }
 
 # Core tools (always needed)
 install_brew_pkg "python@3.12" "Python 3.12"
-install_brew_pkg "git" "Git"
+
+# Git: check if already available (e.g. via Xcode CLT) before installing via brew
+if command -v git &>/dev/null; then
+    ok "Git (already installed at $(command -v git))"
+else
+    install_brew_pkg "git" "Git"
+fi
 
 if [[ "$FLIGHTCHECK_ONLY" != "true" ]]; then
     # Full maker kit tools
@@ -158,15 +174,19 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Pip dependencies
+# 5. Pip dependencies (using virtualenv to avoid PEP 668 restrictions)
 # ---------------------------------------------------------------------------
 step "Installing Python pip dependencies"
 
 REQUIREMENTS_FILE="$REPO_PATH/solutions/ess-maker-skills/scripts/requirements.txt"
+VENV_PATH="$REPO_PATH/.venv"
 
 if [[ -f "$REQUIREMENTS_FILE" ]]; then
-    "$PYTHON" -m pip install --quiet --disable-pip-version-check -r "$REQUIREMENTS_FILE"
-    ok "pip dependencies installed"
+    if [[ ! -d "$VENV_PATH" ]]; then
+        "$PYTHON" -m venv "$VENV_PATH"
+    fi
+    "$VENV_PATH/bin/pip" install --quiet --disable-pip-version-check -r "$REQUIREMENTS_FILE"
+    ok "pip dependencies installed (virtualenv at .venv/)"
 else
     warn "requirements.txt not found at $REQUIREMENTS_FILE"
 fi
@@ -203,7 +223,11 @@ if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
 
     MAKER_KIT_PATH="$REPO_PATH/solutions/ess-maker-skills"
     cd "$MAKER_KIT_PATH"
-    "$PYTHON" scripts/flightcheck/cli.py --scope full
+    FLIGHTCHECK_PYTHON="$VENV_PATH/bin/python"
+    if [[ ! -x "$FLIGHTCHECK_PYTHON" ]]; then
+        FLIGHTCHECK_PYTHON="$PYTHON"
+    fi
+    "$FLIGHTCHECK_PYTHON" scripts/flightcheck/cli.py --scope full
     exit $?
 fi
 

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -22,6 +22,7 @@ INSTALL_ROOT="${ESS_ADK_INSTALL_ROOT:-$HOME/source}"
 FLIGHTCHECK_ONLY="${FLIGHTCHECK_ONLY:-false}"
 REPO_URL="https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit.git"
 REPO_NAME="Employee-Self-Service-Agent-Developer-Kit"
+CODE_CMD=""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -93,14 +94,15 @@ install_brew_pkg() {
 install_brew_cask() {
     local cask="$1"
     local name="${2:-$1}"
+    local app_path="${3:-}"
     if brew list --cask "$cask" &>/dev/null; then
         ok "$name (already installed)"
-    elif [[ -d "/Applications/Visual Studio Code.app" ]]; then
+    elif [[ -n "$app_path" && -d "$app_path" ]]; then
         ok "$name (already installed outside Homebrew)"
     else
         echo "    Installing $name ($cask)..."
         brew install --cask "$cask" || true
-        if brew list --cask "$cask" &>/dev/null || [[ -d "/Applications/Visual Studio Code.app" ]]; then
+        if brew list --cask "$cask" &>/dev/null || [[ -n "$app_path" && -d "$app_path" ]]; then
             ok "$name"
         else
             err "Failed to install $name. Try manually: brew install --cask $cask"
@@ -122,7 +124,7 @@ fi
 if [[ "$FLIGHTCHECK_ONLY" != "true" ]]; then
     # Full maker kit tools
     install_brew_pkg "gh" "GitHub CLI"
-    install_brew_cask "visual-studio-code" "Visual Studio Code"
+    install_brew_cask "visual-studio-code" "Visual Studio Code" "/Applications/Visual Studio Code.app"
 fi
 
 ok "Toolchain installed / verified"
@@ -142,7 +144,7 @@ elif command -v python3.12 &>/dev/null; then
     PYTHON="$(command -v python3.12)"
 elif command -v python3 &>/dev/null; then
     PY_VER="$(python3 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+')"
-    if [[ "$PY_VER" == "3.12" || "$PY_VER" > "3.12" ]]; then
+    if printf '%s\n' "3.12" "$PY_VER" | sort -V | head -n1 | grep -q "3.12"; then
         PYTHON="$(command -v python3)"
     fi
 fi
@@ -211,7 +213,10 @@ if [[ "$FLIGHTCHECK_ONLY" != "true" ]]; then
         for ext in "${REQUIRED_EXTENSIONS[@]}"; do
             if ! "$CODE_CMD" --install-extension "$ext" --force 2>/dev/null; then
                 err "Failed to install required extension: $ext"
-                err "Sign in to VS Code with a GitHub account that has Copilot access, then re-run this script."
+                err "Possible causes:"
+                err "  - VS Code marketplace is unreachable (corporate proxy/firewall)"
+                err "  - No GitHub account with Copilot access signed in to VS Code"
+                err "Re-run this script after resolving the issue."
                 exit 1
             fi
             ok "$ext"
@@ -234,6 +239,10 @@ if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
     step "Running FlightCheck"
 
     MAKER_KIT_PATH="$REPO_PATH/solutions/ess-maker-skills"
+    if [[ ! -d "$MAKER_KIT_PATH" ]]; then
+        err "Maker kit path not found at $MAKER_KIT_PATH. Was the clone successful?"
+        exit 1
+    fi
     cd "$MAKER_KIT_PATH"
     FLIGHTCHECK_PYTHON="$VENV_PATH/bin/python"
     if [[ ! -x "$FLIGHTCHECK_PYTHON" ]]; then

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -206,8 +206,20 @@ if [[ "$FLIGHTCHECK_ONLY" != "true" ]]; then
     fi
 
     if [[ -n "$CODE_CMD" ]]; then
-        EXTENSIONS=("GitHub.copilot" "GitHub.copilot-chat" "ms-python.python")
-        for ext in "${EXTENSIONS[@]}"; do
+        # Required extensions — fail if these can't be installed
+        REQUIRED_EXTENSIONS=("GitHub.copilot" "GitHub.copilot-chat")
+        for ext in "${REQUIRED_EXTENSIONS[@]}"; do
+            if ! "$CODE_CMD" --install-extension "$ext" --force 2>/dev/null; then
+                err "Failed to install required extension: $ext"
+                err "Sign in to VS Code with a GitHub account that has Copilot access, then re-run this script."
+                exit 1
+            fi
+            ok "$ext"
+        done
+
+        # Optional extensions — warn on failure
+        OPTIONAL_EXTENSIONS=("ms-python.python")
+        for ext in "${OPTIONAL_EXTENSIONS[@]}"; do
             "$CODE_CMD" --install-extension "$ext" --force 2>/dev/null && ok "$ext" || warn "Failed to install $ext"
         done
     else

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# ESS ADK — macOS One-Shot Installer
+#
+# Installs the full ESS Maker Kit toolchain on macOS:
+#   Homebrew, Python 3.12, Git, GitHub CLI, VS Code, Copilot extensions,
+#   pip dependencies, clones the repo, and launches VS Code.
+#
+# Usage (full maker kit):
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-mac.sh)"
+#
+# Usage (FlightCheck only):
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck-mac.sh)"
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+BRANCH="${ESS_ADK_BRANCH:-main}"
+INSTALL_ROOT="${ESS_ADK_INSTALL_ROOT:-$HOME/source}"
+FLIGHTCHECK_ONLY="${FLIGHTCHECK_ONLY:-false}"
+REPO_URL="https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit.git"
+REPO_NAME="Employee-Self-Service-Agent-Developer-Kit"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+ok()   { echo -e "    ${GREEN}[ok]${NC}   $1"; }
+warn() { echo -e "    ${YELLOW}[warn]${NC} $1"; }
+err()  { echo -e "    ${RED}[ERR]${NC}  $1"; }
+step() { echo -e "\n${CYAN}==> $1${NC}"; }
+
+# ---------------------------------------------------------------------------
+# 1. Homebrew
+# ---------------------------------------------------------------------------
+step "Checking Homebrew"
+
+ensure_brew_in_path() {
+    if [[ -x /opt/homebrew/bin/brew ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -x /usr/local/bin/brew ]]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+}
+
+if command -v brew &>/dev/null; then
+    ok "Homebrew already installed"
+else
+    ensure_brew_in_path
+    if command -v brew &>/dev/null; then
+        ok "Homebrew found after PATH update"
+    else
+        echo "    Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        ensure_brew_in_path
+        if ! command -v brew &>/dev/null; then
+            err "Homebrew installation failed. Please install manually: https://brew.sh"
+            exit 1
+        fi
+        ok "Homebrew installed"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Toolchain via Homebrew
+# ---------------------------------------------------------------------------
+step "Installing toolchain via Homebrew"
+
+install_brew_pkg() {
+    local pkg="$1"
+    local name="${2:-$1}"
+    if brew list "$pkg" &>/dev/null; then
+        ok "$name (already installed)"
+    else
+        echo "    Installing $name ($pkg)..."
+        brew install "$pkg"
+        ok "$name"
+    fi
+}
+
+install_brew_cask() {
+    local cask="$1"
+    local name="${2:-$1}"
+    if brew list --cask "$cask" &>/dev/null; then
+        ok "$name (already installed)"
+    elif [[ -d "/Applications/Visual Studio Code.app" ]]; then
+        ok "$name (already installed outside Homebrew)"
+    else
+        echo "    Installing $name ($cask)..."
+        brew install --cask "$cask"
+        ok "$name"
+    fi
+}
+
+# Core tools (always needed)
+install_brew_pkg "python@3.12" "Python 3.12"
+install_brew_pkg "git" "Git"
+
+if [[ "$FLIGHTCHECK_ONLY" != "true" ]]; then
+    # Full maker kit tools
+    install_brew_pkg "gh" "GitHub CLI"
+    install_brew_cask "visual-studio-code" "Visual Studio Code"
+fi
+
+ok "Toolchain installed / verified"
+
+# ---------------------------------------------------------------------------
+# 3. Resolve Python
+# ---------------------------------------------------------------------------
+step "Resolving Python"
+
+PYTHON=""
+BREW_PREFIX="$(brew --prefix)"
+
+# Try brew Python 3.12 first
+if [[ -x "$BREW_PREFIX/bin/python3.12" ]]; then
+    PYTHON="$BREW_PREFIX/bin/python3.12"
+elif command -v python3.12 &>/dev/null; then
+    PYTHON="$(command -v python3.12)"
+elif command -v python3 &>/dev/null; then
+    PY_VER="$(python3 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+')"
+    if [[ "$PY_VER" == "3.12" || "$PY_VER" > "3.12" ]]; then
+        PYTHON="$(command -v python3)"
+    fi
+fi
+
+if [[ -z "$PYTHON" ]]; then
+    err "Python 3.12+ not found after installation. Please check your PATH."
+    exit 1
+fi
+
+ok "Using Python: $PYTHON"
+
+# ---------------------------------------------------------------------------
+# 4. Clone repository
+# ---------------------------------------------------------------------------
+step "Cloning repository"
+
+REPO_PATH="$INSTALL_ROOT/$REPO_NAME"
+
+if [[ -d "$REPO_PATH/.git" ]]; then
+    ok "Repo already cloned at $REPO_PATH — pulling latest"
+    git -C "$REPO_PATH" fetch --quiet origin
+    git -C "$REPO_PATH" checkout "$BRANCH" 2>/dev/null || warn "git checkout $BRANCH failed. Continuing on current branch."
+    git -C "$REPO_PATH" pull --quiet origin "$BRANCH" 2>/dev/null || warn "git pull failed. Continuing with local copy."
+else
+    echo "    Cloning to $REPO_PATH..."
+    mkdir -p "$INSTALL_ROOT"
+    GIT_TERMINAL_PROMPT=0 git clone --branch "$BRANCH" "$REPO_URL" "$REPO_PATH"
+    ok "Cloned"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Pip dependencies
+# ---------------------------------------------------------------------------
+step "Installing Python pip dependencies"
+
+REQUIREMENTS_FILE="$REPO_PATH/solutions/ess-maker-skills/scripts/requirements.txt"
+
+if [[ -f "$REQUIREMENTS_FILE" ]]; then
+    "$PYTHON" -m pip install --quiet --disable-pip-version-check -r "$REQUIREMENTS_FILE"
+    ok "pip dependencies installed"
+else
+    warn "requirements.txt not found at $REQUIREMENTS_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. VS Code extensions (full install only)
+# ---------------------------------------------------------------------------
+if [[ "$FLIGHTCHECK_ONLY" != "true" ]]; then
+    step "Installing VS Code extensions"
+
+    # Resolve the code CLI
+    CODE_CMD=""
+    if command -v code &>/dev/null; then
+        CODE_CMD="code"
+    elif [[ -x "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]]; then
+        CODE_CMD="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    fi
+
+    if [[ -n "$CODE_CMD" ]]; then
+        EXTENSIONS=("GitHub.copilot" "GitHub.copilot-chat" "ms-python.python")
+        for ext in "${EXTENSIONS[@]}"; do
+            "$CODE_CMD" --install-extension "$ext" --force 2>/dev/null && ok "$ext" || warn "Failed to install $ext"
+        done
+    else
+        warn "VS Code 'code' CLI not found. Install extensions manually after launching VS Code."
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 7. FlightCheck-only: environment discovery
+# ---------------------------------------------------------------------------
+if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
+    step "Running FlightCheck"
+
+    MAKER_KIT_PATH="$REPO_PATH/solutions/ess-maker-skills"
+    cd "$MAKER_KIT_PATH"
+    "$PYTHON" scripts/flightcheck/cli.py --scope full
+    exit $?
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Launch VS Code
+# ---------------------------------------------------------------------------
+step "Launching VS Code"
+
+WORKSPACE_PATH="$REPO_PATH/solutions/ess-maker-skills"
+
+if [[ -n "$CODE_CMD" ]]; then
+    "$CODE_CMD" "$WORKSPACE_PATH"
+    ok "VS Code opened at $WORKSPACE_PATH"
+else
+    warn "Could not launch VS Code. Open manually: $WORKSPACE_PATH"
+fi
+
+echo ""
+echo -e "${GREEN}=== ESS Maker Kit ready! ===${NC}"
+echo "Open Copilot Chat in VS Code and run /setup to connect your Dataverse environment."
+echo ""


### PR DESCRIPTION
## Summary

Adds a macOS equivalent of the Windows one-shot installer, using Homebrew for toolchain management.

## New files

- `setup/install-ess-adk.sh` - Main orchestrator (installs Homebrew, Python 3.12, Git, gh, VS Code, pip deps, clones repo, launches VS Code)
- `setup/bootstrap-mac.sh` - One-liner entry point (full maker kit)
- `setup/bootstrap-flightcheck-mac.sh` - One-liner entry point (FlightCheck only)

## Usage

**Full maker kit:**
`ash
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-mac.sh)"
``n
**FlightCheck only:**
`ash
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-flightcheck-mac.sh)"
``n
## Key design decisions

- **PEP 668 compliance**: Uses a virtualenv (.venv/) instead of pip install --user to avoid externally-managed-environment errors on modern macOS
- **Apple Silicon + Intel**: Handles both Homebrew paths (/opt/homebrew vs /usr/local)
- **Git via Xcode CLT**: Skips brew install git if git is already available (common via Xcode Command Line Tools)
- **Copilot extensions as hard errors**: Fails the install if Copilot extensions can't be installed (user needs a valid subscription)
- **FlightCheck mode**: Installs only Python + Git, clones repo, runs cli.py --scope full

## README updates

- Root README: Added macOS row to Getting Started table
- setup/README: Added macOS testing section, fixed gh CLI dependency table, added macOS re-run command