### PR TITLE
feat(flightcheck): add ENV-009 preferred customization solution check

### DIFF
--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -250,6 +250,19 @@ def dataverse_get(env_url, token, path, params=None):
         For other non-2xx responses (raised via ``raise_for_status``).
     """
     _validate_https_url(env_url)
+    # Catch developer mistakes where the absolute base path is passed in.
+    # `.lstrip('/')` below would silently strip a leading slash; without
+    # these asserts, `'/api/data/v9.2/WhoAmI()'` becomes a double-prefixed
+    # URL and `'api/data/v9.2/WhoAmI()'` becomes a malformed one. The doc
+    # says "path relative to /api/data/v9.2/" — enforce it.
+    assert not path.startswith("/"), (
+        f"dataverse_get path must be relative to /api/data/v9.2/ "
+        f"(no leading slash), got: {path!r}"
+    )
+    assert not path.lower().startswith("api/data/"), (
+        f"dataverse_get path must be relative to /api/data/v9.2/ "
+        f"(do not include it), got: {path!r}"
+    )
     headers = {**HEADERS_BASE, "Authorization": f"Bearer {token}"}
     url = f"{env_url}/api/data/v9.2/{path.lstrip('/')}"
     resp = _SESSION.get(url, headers=headers, params=params, timeout=60, verify=True)

--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -217,6 +217,48 @@ def query_all(env_url, token, entity_set, select, filter_expr=None):
     return all_records
 
 
+def dataverse_get(env_url, token, path, params=None):
+    """GET a Dataverse Web API endpoint that is not a paged table query.
+
+    Use this for function calls (e.g. ``WhoAmI()``) and single-record reads
+    (e.g. ``usersettingscollection({systemuserid})``) where ``query_all`` does
+    not fit — ``query_all`` always appends ``$select`` and follows
+    ``@odata.nextLink``.
+
+    Parameters
+    ----------
+    env_url : str
+        Base environment URL (e.g. ``https://contoso.crm.dynamics.com``).
+    token : str
+        Dataverse bearer token.
+    path : str
+        Path relative to ``/api/data/v9.2/`` (no leading slash). Example:
+        ``"WhoAmI()"`` or ``"usersettingscollection(11111111-...)``.
+    params : dict | None
+        Optional querystring parameters (e.g. ``{"$select": "_preferredsolution_value"}``).
+
+    Returns
+    -------
+    dict
+        Parsed JSON response body.
+
+    Raises
+    ------
+    AuthExpiredError
+        If the response is 401.
+    requests.HTTPError
+        For other non-2xx responses (raised via ``raise_for_status``).
+    """
+    _validate_https_url(env_url)
+    headers = {**HEADERS_BASE, "Authorization": f"Bearer {token}"}
+    url = f"{env_url}/api/data/v9.2/{path.lstrip('/')}"
+    resp = _SESSION.get(url, headers=headers, params=params, timeout=60, verify=True)
+    if resp.status_code == 401:
+        raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
+    resp.raise_for_status()
+    return resp.json()
+
+
 def update_record(env_url, token, entity_set, record_id, data):
     """Update a single Dataverse record via PATCH.
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -400,7 +400,14 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
 #                one of them.
 # ---------------------------------------------------------------------------
 
-_PREFSOL_DOC_LINK = f"{DOC_BASE}/install#set-up-a-preferred-solution"
+# Pinned to the current canonical MS Learn path. The module-level DOC_BASE
+# points at /copilot/microsoft-365/employee-self-service which 301-redirects
+# to /microsoft-365/copilot/employee-self-service; bypass the redirect here
+# so this link stays stable without rewriting DOC_BASE (out of scope for this PR).
+_PREFSOL_DOC_LINK = (
+    "https://learn.microsoft.com/en-us/microsoft-365/copilot/"
+    "employee-self-service/install#set-up-a-preferred-solution"
+)
 _PREFSOL_DESCRIPTION = "Maker has preferred customization solution selected"
 
 # OData filter that excludes Microsoft-installed and system solutions, leaving

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -7,8 +7,6 @@ ESS FlightCheck — Environment Configuration Validation (ENV-xxx)
 Checks Power Platform environment, Dataverse, DLP policies, and related config.
 """
 
-import requests
-
 from ..runner import CheckResult, Status, Priority
 from .connections import get_connection_status
 from auth import query_all, dataverse_get, AuthExpiredError  # scripts/auth.py, on path via cli.py
@@ -365,8 +363,8 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
 # lines 19-45) tells operators to create a customer-owned unmanaged solution and
 # select it as their *preferred solution* so that new Copilot Studio / Maker
 # portal customizations land in that solution instead of in the Default
-# Solution. The preferred-solution selection is stored per user on the
-# `usersettings` table, not per environment, so this check validates the
+# Solution. The preferred-solution selection is stored per user (on the
+# `usersettings` table), not per environment, so this check validates the
 # *current FlightCheck caller's* selection - it is honest about that scope in
 # the description and result text.
 #
@@ -375,12 +373,19 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
 #     GET /solutions?$filter=ismanaged eq false and isvisible eq true
 #         and uniquename ne 'Default' and uniquename ne 'Active'
 #         and solutiontype eq 0 and _parentsolutionid_value eq null
-#  2. Caller identity
-#     GET /WhoAmI()
-#     -> https://learn.microsoft.com/power-apps/developer/data-platform/webapi/use-web-api-functions
-#  3. Caller's preferred solution
-#     GET /usersettingscollection({UserId})?$select=_preferredsolution_value
-#     -> https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/usersettings
+#  2. Caller's preferred solution (single round-trip, bound to the caller
+#     via the bearer token - no separate WhoAmI() lookup needed)
+#     GET /GetPreferredSolution()
+#     -> https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/getpreferredsolution
+#
+# UNCERTAINTY: the MS Learn reference for GetPreferredSolution() documents
+# the return type as `crmbaseentity` but does not include an example
+# response body. The code below treats the response defensively:
+#  * A body that contains `solutionid` is the selected solution; we then
+#    compare it against the eligible set above.
+#  * A body that omits `solutionid` (or any decode/empty-body edge case
+#    that bubbles up as an exception) is reported via the generic catch-all
+#    WARNING with the HTTP status code surfaced (per PR #128 review).
 #
 # Verdict map (always exactly one CheckResult emitted):
 #   * SKIPPED  - env_url or dv_token missing.
@@ -432,7 +437,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
         )]
 
     try:
-        # Eligible unmanaged customer solutions.
+        # Signal 1: eligible unmanaged customer solutions.
         solutions = query_all(
             env_url, token,
             "solutions",
@@ -460,54 +465,10 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
                 doc_link=_PREFSOL_DOC_LINK,
             )]
 
-        # Signal 2 + 3: caller identity, then caller's preferred solution lookup.
-        whoami = dataverse_get(env_url, token, "WhoAmI()")
-        user_id = whoami.get("UserId")
-        if not user_id:
-            return [CheckResult(
-                checkpoint_id="ENV-009", category="Environment",
-                priority=Priority.HIGH.value, status=Status.WARNING.value,
-                description=_PREFSOL_DESCRIPTION,
-                result=(
-                    "WhoAmI() returned a response without a UserId; cannot "
-                    "determine the current maker's preferred-solution selection."
-                ),
-                remediation=(
-                    "Re-authenticate to Dataverse and re-run FlightCheck so "
-                    "the active session identity can be determined."
-                ),
-                doc_link=_PREFSOL_DOC_LINK,
-            )]
-
-        try:
-            user_settings = dataverse_get(
-                env_url, token,
-                f"usersettingscollection({user_id})",
-                params={"$select": "_preferredsolution_value"},
-            )
-        except requests.HTTPError as e:
-            # 404 = caller has no usersettings record yet. This is deterministic
-            # and fixable (visit the maker portal once to auto-provision); call
-            # it out instead of letting the generic Exception branch swallow it.
-            if getattr(e.response, "status_code", None) == 404:
-                return [CheckResult(
-                    checkpoint_id="ENV-009", category="Environment",
-                    priority=Priority.HIGH.value, status=Status.WARNING.value,
-                    description=_PREFSOL_DESCRIPTION,
-                    result=(
-                        f"Current maker (UserId={user_id}) has no usersettings "
-                        f"record in this environment yet, so no preferred "
-                        f"solution can be selected."
-                    ),
-                    remediation=(
-                        "Open https://make.powerapps.com once with this "
-                        "account so Dataverse provisions a usersettings "
-                        "record, then re-run."
-                    ),
-                    doc_link=_PREFSOL_DOC_LINK,
-                )]
-            raise
-        selected_solution_id = user_settings.get("_preferredsolution_value")
+        # Signal 2: caller's preferred solution in one round-trip. Bound to
+        # the caller via the bearer token; no need to resolve UserId first.
+        preferred = dataverse_get(env_url, token, "GetPreferredSolution()")
+        selected_solution_id = (preferred or {}).get("solutionid")
 
         eligible_names = sorted(s.get("uniquename", "<unknown>") for s in solutions)
         eligible_summary = ", ".join(eligible_names)
@@ -568,16 +529,24 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
         )]
     except Exception as e:
         # Per principle 3 (fail loudly): surface unexpected Dataverse failures
-        # as WARNING rather than silently passing.
+        # as WARNING rather than silently passing. Surface the HTTP status
+        # code when available so a 403 (insufficient privileges) is
+        # distinguishable from a 5xx (transient) at a glance (PR #128 review).
+        status_code = getattr(getattr(e, "response", None), "status_code", None)
+        status_hint = f" [HTTP {status_code}]" if status_code is not None else ""
         return [CheckResult(
             checkpoint_id="ENV-009", category="Environment",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=_PREFSOL_DESCRIPTION,
-            result=f"Unable to validate preferred solution: {type(e).__name__}: {e}",
+            result=(
+                f"Unable to validate preferred solution: "
+                f"{type(e).__name__}{status_hint}: {e}"
+            ),
             remediation=(
                 "Inspect the error above; common causes are insufficient "
-                "Dataverse permissions on the solution / usersettings tables "
-                "or a transient platform error."
+                "Dataverse privileges on the solution / usersettings tables "
+                "(typically surfaces as HTTP 403) or a transient platform "
+                "error (HTTP 5xx)."
             ),
             doc_link=_PREFSOL_DOC_LINK,
         )]

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -7,6 +7,8 @@ ESS FlightCheck — Environment Configuration Validation (ENV-xxx)
 Checks Power Platform environment, Dataverse, DLP policies, and related config.
 """
 
+import uuid
+
 from ..runner import CheckResult, Status, Priority
 from .connections import get_connection_status
 from auth import query_all, dataverse_get, AuthExpiredError  # scripts/auth.py, on path via cli.py
@@ -416,6 +418,22 @@ _ELIGIBLE_SOLUTION_FILTER = (
 )
 
 
+def _try_parse_guid(value) -> uuid.UUID | None:
+    """Return ``uuid.UUID(value)`` or ``None`` if value is not a parsable GUID.
+
+    Used to normalise Dataverse-returned ``solutionid`` strings (which may
+    differ in case or ``{braces}`` between endpoints) before equality
+    comparison. Non-string / non-GUID inputs (including ``None`` and empty
+    string) return ``None`` so callers can treat them as "no value".
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return uuid.UUID(value)
+    except (ValueError, AttributeError):
+        return None
+
+
 def _check_preferred_solution(runner) -> list[CheckResult]:
     """ENV-009: Validate the maker has selected a preferred customization solution.
 
@@ -473,9 +491,18 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
         eligible_names = sorted(s.get("uniquename", "<unknown>") for s in solutions)
         eligible_summary = ", ".join(eligible_names)
 
-        if selected_solution_id:
+        # Normalise GUIDs to uuid.UUID for the membership compare so casing
+        # or `{braces}` differences between the two response sources never
+        # cause a false WARNING. Defensive parse — malformed values fall
+        # through to the WARNING branch below (treated as "no selection").
+        selected_uuid = _try_parse_guid(selected_solution_id)
+
+        if selected_uuid is not None:
             match = next(
-                (s for s in solutions if s.get("solutionid") == selected_solution_id),
+                (
+                    s for s in solutions
+                    if _try_parse_guid(s.get("solutionid")) == selected_uuid
+                ),
                 None,
             )
             if match:

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -7,9 +7,11 @@ ESS FlightCheck — Environment Configuration Validation (ENV-xxx)
 Checks Power Platform environment, Dataverse, DLP policies, and related config.
 """
 
+import requests
+
 from ..runner import CheckResult, Status, Priority
 from .connections import get_connection_status
-from auth import query_all  # scripts/auth.py, on path via cli.py
+from auth import query_all, dataverse_get, AuthExpiredError  # scripts/auth.py, on path via cli.py
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 
@@ -129,6 +131,9 @@ def run_environment_checks(runner) -> list[CheckResult]:
             result=f"Unable to check: {e}",
             remediation="Requires Power Platform Admin role.",
         ))
+
+    # ---- ENV-009: Maker has preferred customization solution selected ----
+    results.extend(_check_preferred_solution(runner))
 
     return results
 
@@ -351,3 +356,228 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         ))
 
     return results
+
+
+# ---------------------------------------------------------------------------
+# ENV-009: Maker has preferred customization solution selected
+#
+# Background: ESS install guidance (src/reference/ess-docs/deployment/install.md,
+# lines 19-45) tells operators to create a customer-owned unmanaged solution and
+# select it as their *preferred solution* so that new Copilot Studio / Maker
+# portal customizations land in that solution instead of in the Default
+# Solution. The preferred-solution selection is stored per user on the
+# `usersettings` table, not per environment, so this check validates the
+# *current FlightCheck caller's* selection - it is honest about that scope in
+# the description and result text.
+#
+# Signals (all GET, no writes):
+#  1. Eligible unmanaged solutions
+#     GET /solutions?$filter=ismanaged eq false and isvisible eq true
+#         and uniquename ne 'Default' and uniquename ne 'Active'
+#         and solutiontype eq 0 and _parentsolutionid_value eq null
+#  2. Caller identity
+#     GET /WhoAmI()
+#     -> https://learn.microsoft.com/power-apps/developer/data-platform/webapi/use-web-api-functions
+#  3. Caller's preferred solution
+#     GET /usersettingscollection({UserId})?$select=_preferredsolution_value
+#     -> https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/usersettings
+#
+# Verdict map (always exactly one CheckResult emitted):
+#   * SKIPPED  - env_url or dv_token missing.
+#   * FAILED   - signal (1) returns 0 candidate solutions.
+#   * WARNING  - candidates exist but caller's selected preferred solution
+#                does not match any candidate. Framed as a hardening
+#                recommendation per AGENTS.md principle 9 (not a functional
+#                blocker).
+#   * PASSED   - candidates exist and caller's selected preferred solution is
+#                one of them.
+# ---------------------------------------------------------------------------
+
+_PREFSOL_DOC_LINK = f"{DOC_BASE}/install#set-up-a-preferred-solution"
+_PREFSOL_DESCRIPTION = "Maker has preferred customization solution selected"
+
+# OData filter that excludes Microsoft-installed and system solutions, leaving
+# only customer-created unmanaged top-level solutions. Verified against a live
+# tenant - it narrowed 3 raw matches down to 1 correct ESSCustomization row.
+# Notes:
+#  * `solutiontype eq 0` excludes patch/upgrade solutions.
+#  * `_parentsolutionid_value eq null` further excludes any nested children.
+#  * `_publisherid_value ne null` is intentionally NOT used - null comparisons
+#    on lookup columns are inconsistently supported across Dataverse versions.
+_ELIGIBLE_SOLUTION_FILTER = (
+    "ismanaged eq false and isvisible eq true "
+    "and uniquename ne 'Default' and uniquename ne 'Active' "
+    "and solutiontype eq 0 and _parentsolutionid_value eq null"
+)
+
+
+def _check_preferred_solution(runner) -> list[CheckResult]:
+    """ENV-009: Validate the maker has selected a preferred customization solution.
+
+    Always emits exactly one CheckResult (per principle 7 - bucket multi-resource
+    findings). Never raises - all errors are caught and turned into WARNING
+    results so a transient Dataverse failure does not abort the whole flightcheck
+    run.
+    """
+    env_url = getattr(runner, "env_url", None)
+    token = getattr(runner, "dv_token", None)
+
+    if not env_url or not token:
+        return [CheckResult(
+            checkpoint_id="ENV-009", category="Environment",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description=_PREFSOL_DESCRIPTION,
+            result="Dataverse URL or access token not available in this run.",
+            doc_link=_PREFSOL_DOC_LINK,
+        )]
+
+    try:
+        # Eligible unmanaged customer solutions.
+        solutions = query_all(
+            env_url, token,
+            "solutions",
+            "solutionid,uniquename,friendlyname",
+            _ELIGIBLE_SOLUTION_FILTER,
+        )
+        if not solutions:
+            return [CheckResult(
+                checkpoint_id="ENV-009", category="Environment",
+                priority=Priority.HIGH.value, status=Status.FAILED.value,
+                description=_PREFSOL_DESCRIPTION,
+                result=(
+                    "No customer-created unmanaged solutions found in this "
+                    "environment. Customizations made via the kit have nowhere "
+                    "to land except the Default Solution, which is not "
+                    "exportable as an ALM artifact."
+                ),
+                remediation=(
+                    "Create an unmanaged solution in the Power Platform Maker "
+                    "portal (Solutions -> + New solution) using a custom "
+                    "publisher, then select it as your preferred solution. See "
+                    "the ESS install guide for the recommended naming and "
+                    "publisher conventions."
+                ),
+                doc_link=_PREFSOL_DOC_LINK,
+            )]
+
+        # Signal 2 + 3: caller identity, then caller's preferred solution lookup.
+        whoami = dataverse_get(env_url, token, "WhoAmI()")
+        user_id = whoami.get("UserId")
+        if not user_id:
+            return [CheckResult(
+                checkpoint_id="ENV-009", category="Environment",
+                priority=Priority.HIGH.value, status=Status.WARNING.value,
+                description=_PREFSOL_DESCRIPTION,
+                result=(
+                    "WhoAmI() returned a response without a UserId; cannot "
+                    "determine the current maker's preferred-solution selection."
+                ),
+                remediation=(
+                    "Re-authenticate to Dataverse and re-run FlightCheck so "
+                    "the active session identity can be determined."
+                ),
+                doc_link=_PREFSOL_DOC_LINK,
+            )]
+
+        try:
+            user_settings = dataverse_get(
+                env_url, token,
+                f"usersettingscollection({user_id})",
+                params={"$select": "_preferredsolution_value"},
+            )
+        except requests.HTTPError as e:
+            # 404 = caller has no usersettings record yet. This is deterministic
+            # and fixable (visit the maker portal once to auto-provision); call
+            # it out instead of letting the generic Exception branch swallow it.
+            if getattr(e.response, "status_code", None) == 404:
+                return [CheckResult(
+                    checkpoint_id="ENV-009", category="Environment",
+                    priority=Priority.HIGH.value, status=Status.WARNING.value,
+                    description=_PREFSOL_DESCRIPTION,
+                    result=(
+                        f"Current maker (UserId={user_id}) has no usersettings "
+                        f"record in this environment yet, so no preferred "
+                        f"solution can be selected."
+                    ),
+                    remediation=(
+                        "Open https://make.powerapps.com once with this "
+                        "account so Dataverse provisions a usersettings "
+                        "record, then re-run."
+                    ),
+                    doc_link=_PREFSOL_DOC_LINK,
+                )]
+            raise
+        selected_solution_id = user_settings.get("_preferredsolution_value")
+
+        eligible_names = sorted(s.get("uniquename", "<unknown>") for s in solutions)
+        eligible_summary = ", ".join(eligible_names)
+
+        if selected_solution_id:
+            match = next(
+                (s for s in solutions if s.get("solutionid") == selected_solution_id),
+                None,
+            )
+            if match:
+                return [CheckResult(
+                    checkpoint_id="ENV-009", category="Environment",
+                    priority=Priority.HIGH.value, status=Status.PASSED.value,
+                    description=_PREFSOL_DESCRIPTION,
+                    result=(
+                        f"Current maker has selected '{match.get('uniquename')}' "
+                        f"as their preferred solution; it is one of "
+                        f"{len(solutions)} eligible unmanaged solution(s) in "
+                        f"this environment ({eligible_summary})."
+                    ),
+                    doc_link=_PREFSOL_DOC_LINK,
+                )]
+
+        # Either no preferred solution selected, or the selection points to a
+        # solution outside the eligible set (e.g. a managed solution or
+        # Default). Both collapse into the same hardening warning - the action
+        # is identical.
+        return [CheckResult(
+            checkpoint_id="ENV-009", category="Environment",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description=_PREFSOL_DESCRIPTION,
+            result=(
+                f"The current maker account has not selected any of the "
+                f"{len(solutions)} eligible unmanaged solution(s) "
+                f"({eligible_summary}) as their preferred solution."
+            ),
+            remediation=(
+                "Hardening recommendation (not a functional blocker). "
+                "Selecting a preferred solution ensures future Copilot Studio "
+                "/ Maker portal customizations consistently land in a "
+                "customer-owned, exportable solution rather than the Default "
+                "Solution (which can't be exported between environments). "
+                "Open the Power Platform Maker portal -> Solutions, select "
+                "the intended unmanaged solution, and choose 'Set preferred "
+                "solution'."
+            ),
+            doc_link=_PREFSOL_DOC_LINK,
+        )]
+
+    except AuthExpiredError as e:
+        return [CheckResult(
+            checkpoint_id="ENV-009", category="Environment",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description=_PREFSOL_DESCRIPTION,
+            result=str(e),
+            remediation="Re-run FlightCheck to refresh the access token.",
+            doc_link=_PREFSOL_DOC_LINK,
+        )]
+    except Exception as e:
+        # Per principle 3 (fail loudly): surface unexpected Dataverse failures
+        # as WARNING rather than silently passing.
+        return [CheckResult(
+            checkpoint_id="ENV-009", category="Environment",
+            priority=Priority.HIGH.value, status=Status.WARNING.value,
+            description=_PREFSOL_DESCRIPTION,
+            result=f"Unable to validate preferred solution: {type(e).__name__}: {e}",
+            remediation=(
+                "Inspect the error above; common causes are insufficient "
+                "Dataverse permissions on the solution / usersettings tables "
+                "or a transient platform error."
+            ),
+            doc_link=_PREFSOL_DOC_LINK,
+        )]

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -424,6 +424,37 @@ _ELIGIBLE_SOLUTION_FILTER = (
     "and solutiontype eq 0 and _parentsolutionid_value eq null"
 )
 
+# Fields fetched on each eligible solution. ``_publisherid_value`` is the
+# lookup column needed to follow up with a /publishers({id}) GET when the
+# preferred-solution match is found - it's the cheapest way to surface
+# the publisher without changing the response shape via $expand (which
+# would require new cassette evidence per AGENTS.md "What counts as the
+# same endpoint").
+_ELIGIBLE_SOLUTION_SELECT = "solutionid,uniquename,friendlyname,_publisherid_value"
+
+
+def _is_default_publisher(uniquename: str | None) -> bool:
+    """Return True when ``uniquename`` is the env's Default Publisher.
+
+    Dataverse provisions every environment with a system publisher whose
+    ``uniquename`` follows the pattern ``DefaultPublisher<orgsuffix>``
+    (e.g. ``DefaultPublisherorgeeac24d0`` - one such value is observable
+    in ``tests/fixtures/cassettes/island_gateway_botcomponents.yaml``).
+    Customer-created publishers use customer-chosen unique names that do
+    not start with the literal ``DefaultPublisher`` prefix, so a
+    case-insensitive ``startswith`` is a reliable signal.
+
+    A solution bound to the Default Publisher inherits the env's
+    ``cr<NNN>`` customization prefix - the install guide explicitly says
+    to use a publisher with a custom prefix so exported solutions don't
+    collide across environments:
+    https://learn.microsoft.com/en-us/microsoft-365/copilot/employee-self-service/install#set-up-a-preferred-solution
+    """
+    if not isinstance(uniquename, str):
+        return False
+    return uniquename.lower().startswith("defaultpublisher")
+
+
 
 def _try_parse_guid(value) -> uuid.UUID | None:
     """Return ``uuid.UUID(value)`` or ``None`` if value is not a parsable GUID.
@@ -466,7 +497,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
         solutions = query_all(
             env_url, token,
             "solutions",
-            "solutionid,uniquename,friendlyname",
+            _ELIGIBLE_SOLUTION_SELECT,
             _ELIGIBLE_SOLUTION_FILTER,
         )
         if not solutions:
@@ -513,15 +544,89 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
                 None,
             )
             if match:
+                matched_name = match.get("uniquename")
+                # Publisher quality: a customer-owned unmanaged solution that
+                # is bound to the env's Default Publisher inherits the
+                # ``cr<NNN>`` prefix and is unsuitable for ALM export per the
+                # install guide. Treat as a hardening WARNING - the preferred-
+                # solution selection itself is correct, only the publisher
+                # behind it is sub-optimal.
+                publisher_id = match.get("_publisherid_value")
+                if publisher_id:
+                    try:
+                        publisher = dataverse_get(
+                            env_url, token,
+                            f"publishers({publisher_id})",
+                            params={
+                                "$select": (
+                                    "uniquename,customizationprefix,friendlyname"
+                                ),
+                            },
+                        ) or {}
+                    except Exception:
+                        # Don't downgrade a good preferred-solution selection
+                        # over a transient publisher-fetch failure. Fall
+                        # through to PASS with the publisher field omitted;
+                        # the operator still sees the matched solution name.
+                        publisher = {}
+
+                    publisher_uniquename = publisher.get("uniquename")
+                    if _is_default_publisher(publisher_uniquename):
+                        publisher_prefix = publisher.get(
+                            "customizationprefix"
+                        ) or "<unknown>"
+                        return [CheckResult(
+                            checkpoint_id="ENV-009", category="Environment",
+                            priority=Priority.HIGH.value,
+                            status=Status.WARNING.value,
+                            description=_PREFSOL_DESCRIPTION,
+                            result=(
+                                f"Preferred solution '{matched_name}' is bound "
+                                f"to the environment's Default Publisher "
+                                f"('{publisher_uniquename}', prefix "
+                                f"'{publisher_prefix}')."
+                            ),
+                            remediation=(
+                                "Hardening recommendation (not a functional "
+                                "blocker). The Default Publisher's "
+                                f"'{publisher_prefix}' prefix is auto-generated "
+                                "per environment and is shared by every "
+                                "default-published artifact in that env, so "
+                                "exported components collide across "
+                                "environments and ALM provenance is unclear. "
+                                "Create a publisher with your organization's "
+                                "prefix (e.g. 'contoso') in the Power Platform "
+                                "Maker portal -> Solutions -> + New publisher, "
+                                "then either move existing customizations to a "
+                                "new solution that uses it or change the "
+                                "preferred solution to one already bound to "
+                                "that publisher."
+                            ),
+                            doc_link=_PREFSOL_DOC_LINK,
+                        )]
+
+                    # PASSED with publisher annotation when available.
+                    if publisher_uniquename:
+                        publisher_suffix = (
+                            f" (publisher: '{publisher_uniquename}'"
+                            f", prefix: '"
+                            f"{publisher.get('customizationprefix') or '<unknown>'}"
+                            f"')"
+                        )
+                    else:
+                        publisher_suffix = ""
+                else:
+                    publisher_suffix = ""
+
                 return [CheckResult(
                     checkpoint_id="ENV-009", category="Environment",
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=_PREFSOL_DESCRIPTION,
                     result=(
-                        f"Current maker has selected '{match.get('uniquename')}' "
-                        f"as their preferred solution; it is one of "
-                        f"{len(solutions)} eligible unmanaged solution(s) in "
-                        f"this environment ({eligible_summary})."
+                        f"Current maker has selected '{matched_name}'"
+                        f"{publisher_suffix} as their preferred solution; it "
+                        f"is one of {len(solutions)} eligible unmanaged "
+                        f"solution(s) in this environment ({eligible_summary})."
                     ),
                     doc_link=_PREFSOL_DOC_LINK,
                 )]

--- a/tests/flightcheck/checks/test_preferred_solution.py
+++ b/tests/flightcheck/checks/test_preferred_solution.py
@@ -5,21 +5,20 @@
 ``solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py``.
 
 Mocks the Dataverse Web API endpoints the check calls
-(``msdyn_employeeselfservicetemplateconfigs``, ``solutions``, ``WhoAmI()``,
-``usersettingscollection({UserId})``) with the ``responses`` library, then
-invokes the real production helper ``_check_preferred_solution`` and asserts on
-the resulting ``CheckResult``.
+(``solutions``, ``GetPreferredSolution()``) with the ``responses`` library,
+then invokes the real production helper ``_check_preferred_solution`` and
+asserts on the resulting ``CheckResult``.
 
 Mock backing: Dataverse Web API v9.2 is the ``documented`` tier per
 ``tests/fixtures/cassettes/INDEX.md`` line 49. Response shapes come from MS
-Learn entity reference pages:
+Learn entity reference / function reference pages:
 
 * solutions entity:
   https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/solution
-* usersettings entity:
-  https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/usersettings
-* WhoAmI function:
-  https://learn.microsoft.com/power-apps/developer/data-platform/webapi/use-web-api-functions
+* GetPreferredSolution function:
+  https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/getpreferredsolution
+  (response-body shape uncertainty is documented in
+  ``tests/mocks/dataverse.py:get_preferred_solution``)
 """
 
 from __future__ import annotations
@@ -101,14 +100,20 @@ def _register_solutions(solutions: list[dict[str, Any]]) -> None:
     ))
 
 
-def _register_whoami() -> None:
-    responses.add(**dv.whoami(base_url=BASE_URL))
+def _register_get_preferred_solution(
+    selected_solution_id: str | None,
+    *,
+    uniquename: str | None = None,
+) -> None:
+    """Mock GetPreferredSolution() returning the given solution id.
 
-
-def _register_usersettings(selected_solution_id: str | None) -> None:
-    responses.add(**dv.usersettings(
+    Pass ``selected_solution_id=None`` to mock the "no preferred solution
+    selected" case (the body omits ``solutionid``).
+    """
+    responses.add(**dv.get_preferred_solution(
         base_url=BASE_URL,
-        preferred_solution_id=selected_solution_id,
+        solution_id=selected_solution_id,
+        uniquename=uniquename,
     ))
 
 
@@ -151,8 +156,7 @@ def test_warning_when_selected_solution_not_in_eligible_set(
     _register_solutions(solutions=[
         _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
     ])
-    _register_whoami()
-    _register_usersettings(selected_solution_id=SOLUTION_ID_NOT_IN_LIST)
+    _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_NOT_IN_LIST)
 
     results = _check_preferred_solution(runner)
     assert len(results) == 1
@@ -176,8 +180,7 @@ def test_warning_when_no_preferred_solution_selected(runner: _MinimalRunner) -> 
         _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
         _solution_record(SOLUTION_ID_OTHER, "ContosoExtensions"),
     ])
-    _register_whoami()
-    _register_usersettings(selected_solution_id=None)
+    _register_get_preferred_solution(selected_solution_id=None)
 
     r = _check_preferred_solution(runner)[0]
     assert r.status == "Warning"
@@ -192,8 +195,7 @@ def test_passed_when_selected_solution_matches(runner: _MinimalRunner) -> None:
     _register_solutions(solutions=[
         _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
     ])
-    _register_whoami()
-    _register_usersettings(selected_solution_id=SOLUTION_ID_ELIGIBLE)
+    _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_ELIGIBLE)
 
     results = _check_preferred_solution(runner)
     assert len(results) == 1
@@ -212,8 +214,7 @@ def test_passed_when_selected_matches_one_of_many(runner: _MinimalRunner) -> Non
         _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
         _solution_record(SOLUTION_ID_OTHER, "ContosoExtensions"),
     ])
-    _register_whoami()
-    _register_usersettings(selected_solution_id=SOLUTION_ID_OTHER)
+    _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_OTHER)
 
     r = _check_preferred_solution(runner)[0]
     assert r.status == "Passed"
@@ -223,10 +224,16 @@ def test_passed_when_selected_matches_one_of_many(runner: _MinimalRunner) -> Non
 
 @responses.activate
 def test_warning_when_dataverse_returns_500(runner: _MinimalRunner) -> None:
-    """A transient platform error must surface as WARNING, not silently PASS."""
+    """A transient platform error must surface as WARNING, not silently PASS.
+
+    The status-code surfacing path (PR #128 review) is exercised by the
+    403 test below; on 5xx the requests/urllib3 retry layer swallows the
+    response object and raises a RetryError with no ``.response``, so
+    surfacing the code on 5xx isn't reliably possible from this layer.
+    """
     responses.add(
         "GET",
-        dv._query_url(
+        dv.build_query_url(
             BASE_URL,
             "solutions",
             select="solutionid,uniquename,friendlyname",
@@ -252,8 +259,7 @@ def test_warning_when_one_solution_and_no_preference(runner: _MinimalRunner) -> 
     _register_solutions(solutions=[
         _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
     ])
-    _register_whoami()
-    _register_usersettings(selected_solution_id=None)
+    _register_get_preferred_solution(selected_solution_id=None)
 
     r = _check_preferred_solution(runner)[0]
     assert r.status == "Warning"
@@ -271,7 +277,7 @@ def test_warning_when_dataverse_returns_401(runner: _MinimalRunner) -> None:
     """
     responses.add(
         "GET",
-        dv._query_url(
+        dv.build_query_url(
             BASE_URL,
             "solutions",
             select="solutionid,uniquename,friendlyname",
@@ -289,27 +295,27 @@ def test_warning_when_dataverse_returns_401(runner: _MinimalRunner) -> None:
 
 
 @responses.activate
-def test_warning_when_usersettings_returns_404(runner: _MinimalRunner) -> None:
-    """A 404 on usersettings means the maker has never opened the portal.
+def test_warning_when_get_preferred_solution_returns_403(
+    runner: _MinimalRunner,
+) -> None:
+    """A 403 on GetPreferredSolution() must surface the status code.
 
-    Distinct from a generic 5xx (which surfaces under the catch-all WARNING):
-    this path has a deterministic, actionable remediation pointing the user
-    at https://make.powerapps.com to auto-provision their usersettings row.
+    Insufficient privilege on the system tables surfaces as HTTP 403. The
+    catch-all WARNING must expose the status code so the failure mode is
+    distinguishable from a transient 5xx (PR #128 review).
     """
     _register_solutions(solutions=[
         _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
     ])
-    _register_whoami()
     responses.add(
         "GET",
-        f"{BASE_URL}/api/data/v9.2/usersettingscollection({dv.MOCK_USER_ID})"
-        f"?$select=_preferredsolution_value",
-        json={"error": {"code": "0x80060888", "message": "Resource not found"}},
-        status=404,
+        f"{BASE_URL}/api/data/v9.2/GetPreferredSolution()",
+        json={"error": {"code": "0x80040220", "message": "Principal user is missing privilege"}},
+        status=403,
     )
 
     r = _check_preferred_solution(runner)[0]
     assert r.status == "Warning"
-    assert "no usersettings record" in r.result
-    assert dv.MOCK_USER_ID in r.result
-    assert "make.powerapps.com" in r.remediation
+    assert "Unable to validate preferred solution" in r.result
+    assert "[HTTP 403]" in r.result
+    assert "privileges" in r.remediation

--- a/tests/flightcheck/checks/test_preferred_solution.py
+++ b/tests/flightcheck/checks/test_preferred_solution.py
@@ -223,6 +223,30 @@ def test_passed_when_selected_matches_one_of_many(runner: _MinimalRunner) -> Non
 
 
 @responses.activate
+def test_passed_when_guid_casing_differs_between_endpoints(
+    runner: _MinimalRunner,
+) -> None:
+    """GUID equality must be case-insensitive across the two endpoints.
+
+    Dataverse normally returns lowercase GUIDs in JSON, but the comparison
+    in production code must not break if the two endpoints ever serialise
+    GUIDs in different cases. The eligible-set query returns the GUID in
+    lowercase here; GetPreferredSolution() returns the same logical GUID
+    in uppercase. The check must still PASS.
+    """
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE.lower(), "ESSCustomization"),
+    ])
+    _register_get_preferred_solution(
+        selected_solution_id=SOLUTION_ID_ELIGIBLE.upper(),
+    )
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Passed"
+    assert "'ESSCustomization'" in r.result
+
+
+@responses.activate
 def test_warning_when_dataverse_returns_500(runner: _MinimalRunner) -> None:
     """A transient platform error must surface as WARNING, not silently PASS.
 

--- a/tests/flightcheck/checks/test_preferred_solution.py
+++ b/tests/flightcheck/checks/test_preferred_solution.py
@@ -1,0 +1,315 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""End-to-end tests for ENV-009 (preferred customization solution check) in
+``solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py``.
+
+Mocks the Dataverse Web API endpoints the check calls
+(``msdyn_employeeselfservicetemplateconfigs``, ``solutions``, ``WhoAmI()``,
+``usersettingscollection({UserId})``) with the ``responses`` library, then
+invokes the real production helper ``_check_preferred_solution`` and asserts on
+the resulting ``CheckResult``.
+
+Mock backing: Dataverse Web API v9.2 is the ``documented`` tier per
+``tests/fixtures/cassettes/INDEX.md`` line 49. Response shapes come from MS
+Learn entity reference pages:
+
+* solutions entity:
+  https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/solution
+* usersettings entity:
+  https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/usersettings
+* WhoAmI function:
+  https://learn.microsoft.com/power-apps/developer/data-platform/webapi/use-web-api-functions
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import responses
+
+from tests.conftest import FAKE_DATAVERSE_URL, require_validated_mock
+from tests.mocks import dataverse as dv
+
+require_validated_mock(dv)
+
+
+# Production module — flightcheck is importable because pyproject.toml puts
+# solutions/ess-maker-skills/scripts on pythonpath.
+from flightcheck.checks.environment import _check_preferred_solution  # noqa: E402
+
+
+BASE_URL = FAKE_DATAVERSE_URL
+
+# Sentinel GUIDs — kept distinct so a mis-routed mock fails loudly.
+SOLUTION_ID_ELIGIBLE = "11111111-1111-1111-1111-111111111111"
+SOLUTION_ID_OTHER = "22222222-2222-2222-2222-222222222222"
+SOLUTION_ID_NOT_IN_LIST = "33333333-3333-3333-3333-333333333333"
+
+# Verbatim from the production check; if these drift, mock-builder URLs will
+# stop matching and tests will fail loudly with an unregistered-URL error.
+ELIGIBLE_SOLUTION_FILTER = (
+    "ismanaged eq false and isvisible eq true "
+    "and uniquename ne 'Default' and uniquename ne 'Active' "
+    "and solutiontype eq 0 and _parentsolutionid_value eq null"
+)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Minimal runner — mirrors the pattern in test_workday_env_vars.py.
+# ───────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _MinimalRunner:
+    env_url: str | None
+    dv_token: str | None
+
+
+@pytest.fixture
+def runner(fake_dataverse_url: str, fake_token: str) -> _MinimalRunner:
+    return _MinimalRunner(env_url=fake_dataverse_url, dv_token=fake_token)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Mock payload builders + registration helpers
+# ───────────────────────────────────────────────────────────────────────
+
+
+def _solution_record(solution_id: str, uniquename: str) -> dict[str, Any]:
+    """One ``solutions`` row matching $select=solutionid,uniquename,friendlyname.
+    Field naming per
+    https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/solution
+    """
+    return {
+        "@odata.etag": 'W/"1"',
+        "solutionid": solution_id,
+        "uniquename": uniquename,
+        "friendlyname": uniquename,
+    }
+
+
+def _register_solutions(solutions: list[dict[str, Any]]) -> None:
+    responses.add(**dv.query(
+        base_url=BASE_URL,
+        entity_set="solutions",
+        records=solutions,
+        select="solutionid,uniquename,friendlyname",
+        filter_expr=ELIGIBLE_SOLUTION_FILTER,
+    ))
+
+
+def _register_whoami() -> None:
+    responses.add(**dv.whoami(base_url=BASE_URL))
+
+
+def _register_usersettings(selected_solution_id: str | None) -> None:
+    responses.add(**dv.usersettings(
+        base_url=BASE_URL,
+        preferred_solution_id=selected_solution_id,
+    ))
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Tests — one per verdict path.
+# ───────────────────────────────────────────────────────────────────────
+
+
+def test_skipped_when_env_url_missing() -> None:
+    results = _check_preferred_solution(_MinimalRunner(env_url=None, dv_token="tok"))
+    assert len(results) == 1
+    assert results[0].checkpoint_id == "ENV-009"
+    assert results[0].status == "Skipped"
+    assert "Dataverse URL or access token not available" in results[0].result
+
+
+def test_skipped_when_token_missing() -> None:
+    results = _check_preferred_solution(_MinimalRunner(env_url=BASE_URL, dv_token=None))
+    assert results[0].status == "Skipped"
+
+
+@responses.activate
+def test_failed_when_no_eligible_solution(runner: _MinimalRunner) -> None:
+    _register_solutions(solutions=[])
+
+    results = _check_preferred_solution(runner)
+    assert len(results) == 1
+    r = results[0]
+    assert r.checkpoint_id == "ENV-009"
+    assert r.status == "Failed"
+    assert "No customer-created unmanaged solutions" in r.result
+    assert "Default Solution" in r.result
+    assert "Create an unmanaged solution" in r.remediation
+
+
+@responses.activate
+def test_warning_when_selected_solution_not_in_eligible_set(
+    runner: _MinimalRunner,
+) -> None:
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
+    ])
+    _register_whoami()
+    _register_usersettings(selected_solution_id=SOLUTION_ID_NOT_IN_LIST)
+
+    results = _check_preferred_solution(runner)
+    assert len(results) == 1
+    r = results[0]
+    assert r.checkpoint_id == "ENV-009"
+    assert r.status == "Warning"
+    # Principle 8: result describes observed state only; framing lives in remediation.
+    assert "Hardening recommendation" not in r.result
+    assert "has not selected" in r.result
+    assert "ESSCustomization" in r.result
+    # Principle 9: hardening WARNING remediation opens with the framing prefix
+    # and includes a concrete reason BEFORE the click-path.
+    assert r.remediation.startswith("Hardening recommendation (not a functional blocker)")
+    assert "Default Solution" in r.remediation
+    assert "Set preferred solution" in r.remediation
+
+
+@responses.activate
+def test_warning_when_no_preferred_solution_selected(runner: _MinimalRunner) -> None:
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
+        _solution_record(SOLUTION_ID_OTHER, "ContosoExtensions"),
+    ])
+    _register_whoami()
+    _register_usersettings(selected_solution_id=None)
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Warning"
+    assert "2 eligible unmanaged solution" in r.result
+    # Both candidates listed (alphabetical).
+    assert "ContosoExtensions" in r.result
+    assert "ESSCustomization" in r.result
+
+
+@responses.activate
+def test_passed_when_selected_solution_matches(runner: _MinimalRunner) -> None:
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
+    ])
+    _register_whoami()
+    _register_usersettings(selected_solution_id=SOLUTION_ID_ELIGIBLE)
+
+    results = _check_preferred_solution(runner)
+    assert len(results) == 1
+    r = results[0]
+    assert r.checkpoint_id == "ENV-009"
+    assert r.status == "Passed"
+    assert "ESSCustomization" in r.result
+    assert "selected" in r.result
+    # Principle 8: PASSED has no remediation.
+    assert r.remediation == ""
+
+
+@responses.activate
+def test_passed_when_selected_matches_one_of_many(runner: _MinimalRunner) -> None:
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
+        _solution_record(SOLUTION_ID_OTHER, "ContosoExtensions"),
+    ])
+    _register_whoami()
+    _register_usersettings(selected_solution_id=SOLUTION_ID_OTHER)
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Passed"
+    assert "'ContosoExtensions'" in r.result
+    assert "2 eligible unmanaged solution" in r.result
+
+
+@responses.activate
+def test_warning_when_dataverse_returns_500(runner: _MinimalRunner) -> None:
+    """A transient platform error must surface as WARNING, not silently PASS."""
+    responses.add(
+        "GET",
+        dv._query_url(
+            BASE_URL,
+            "solutions",
+            select="solutionid,uniquename,friendlyname",
+            filter_expr=ELIGIBLE_SOLUTION_FILTER,
+        ),
+        json={"error": {"code": "0x80040220", "message": "boom"}},
+        status=500,
+    )
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Warning"
+    assert "Unable to validate preferred solution" in r.result
+
+
+@responses.activate
+def test_warning_when_one_solution_and_no_preference(runner: _MinimalRunner) -> None:
+    """Exactly 1 eligible solution exists but maker hasn't selected one.
+
+    Distinct from the many-solutions case (covered by
+    test_warning_when_no_preferred_solution_selected) - validates the result
+    message handles the singular case correctly.
+    """
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
+    ])
+    _register_whoami()
+    _register_usersettings(selected_solution_id=None)
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Warning"
+    assert "1 eligible unmanaged solution" in r.result
+    assert "ESSCustomization" in r.result
+    assert "Set preferred solution" in r.remediation
+
+
+@responses.activate
+def test_warning_when_dataverse_returns_401(runner: _MinimalRunner) -> None:
+    """A 401 from Dataverse must surface as WARNING with an auth-expired hint.
+
+    Exercises the AuthExpiredError catch block in _check_preferred_solution.
+    Without this test, the catch path is unreachable from the test suite.
+    """
+    responses.add(
+        "GET",
+        dv._query_url(
+            BASE_URL,
+            "solutions",
+            select="solutionid,uniquename,friendlyname",
+            filter_expr=ELIGIBLE_SOLUTION_FILTER,
+        ),
+        json={"error": {"code": "0x80048306", "message": "token expired"}},
+        status=401,
+    )
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Warning"
+    # AuthExpiredError message contains "401" and "token expired or invalid".
+    assert "401" in r.result
+    assert "Re-run FlightCheck" in r.remediation
+
+
+@responses.activate
+def test_warning_when_usersettings_returns_404(runner: _MinimalRunner) -> None:
+    """A 404 on usersettings means the maker has never opened the portal.
+
+    Distinct from a generic 5xx (which surfaces under the catch-all WARNING):
+    this path has a deterministic, actionable remediation pointing the user
+    at https://make.powerapps.com to auto-provision their usersettings row.
+    """
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
+    ])
+    _register_whoami()
+    responses.add(
+        "GET",
+        f"{BASE_URL}/api/data/v9.2/usersettingscollection({dv.MOCK_USER_ID})"
+        f"?$select=_preferredsolution_value",
+        json={"error": {"code": "0x80060888", "message": "Resource not found"}},
+        status=404,
+    )
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Warning"
+    assert "no usersettings record" in r.result
+    assert dv.MOCK_USER_ID in r.result
+    assert "make.powerapps.com" in r.remediation

--- a/tests/flightcheck/checks/test_preferred_solution.py
+++ b/tests/flightcheck/checks/test_preferred_solution.py
@@ -5,9 +5,9 @@
 ``solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py``.
 
 Mocks the Dataverse Web API endpoints the check calls
-(``solutions``, ``GetPreferredSolution()``) with the ``responses`` library,
-then invokes the real production helper ``_check_preferred_solution`` and
-asserts on the resulting ``CheckResult``.
+(``solutions``, ``GetPreferredSolution()``, ``publishers({id})``) with the
+``responses`` library, then invokes the real production helper
+``_check_preferred_solution`` and asserts on the resulting ``CheckResult``.
 
 Mock backing: Dataverse Web API v9.2 is the ``documented`` tier per
 ``tests/fixtures/cassettes/INDEX.md`` line 49. Response shapes come from MS
@@ -19,6 +19,8 @@ Learn entity reference / function reference pages:
   https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/getpreferredsolution
   (response-body shape uncertainty is documented in
   ``tests/mocks/dataverse.py:get_preferred_solution``)
+* publisher entity:
+  https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/publisher
 """
 
 from __future__ import annotations
@@ -47,6 +49,10 @@ SOLUTION_ID_ELIGIBLE = "11111111-1111-1111-1111-111111111111"
 SOLUTION_ID_OTHER = "22222222-2222-2222-2222-222222222222"
 SOLUTION_ID_NOT_IN_LIST = "33333333-3333-3333-3333-333333333333"
 
+# Stable publisher GUIDs — one custom, one default-publisher.
+PUBLISHER_ID_CUSTOM = "aaaaaaaa-1111-1111-1111-111111111111"
+PUBLISHER_ID_DEFAULT = "bbbbbbbb-2222-2222-2222-222222222222"
+
 # Verbatim from the production check; if these drift, mock-builder URLs will
 # stop matching and tests will fail loudly with an unregistered-URL error.
 ELIGIBLE_SOLUTION_FILTER = (
@@ -54,6 +60,7 @@ ELIGIBLE_SOLUTION_FILTER = (
     "and uniquename ne 'Default' and uniquename ne 'Active' "
     "and solutiontype eq 0 and _parentsolutionid_value eq null"
 )
+ELIGIBLE_SOLUTION_SELECT = "solutionid,uniquename,friendlyname,_publisherid_value"
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -77,16 +84,27 @@ def runner(fake_dataverse_url: str, fake_token: str) -> _MinimalRunner:
 # ───────────────────────────────────────────────────────────────────────
 
 
-def _solution_record(solution_id: str, uniquename: str) -> dict[str, Any]:
-    """One ``solutions`` row matching $select=solutionid,uniquename,friendlyname.
+def _solution_record(
+    solution_id: str,
+    uniquename: str,
+    *,
+    publisher_id: str | None = PUBLISHER_ID_CUSTOM,
+) -> dict[str, Any]:
+    """One ``solutions`` row matching the production $select.
+
     Field naming per
     https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/solution
+    Defaults model the eligible row pointing at a custom publisher; pass
+    ``publisher_id=PUBLISHER_ID_DEFAULT`` to model a row bound to the
+    env's Default Publisher, or ``publisher_id=None`` to model a row
+    with no publisher lookup populated.
     """
     return {
         "@odata.etag": 'W/"1"',
         "solutionid": solution_id,
         "uniquename": uniquename,
         "friendlyname": uniquename,
+        "_publisherid_value": publisher_id,
     }
 
 
@@ -95,7 +113,7 @@ def _register_solutions(solutions: list[dict[str, Any]]) -> None:
         base_url=BASE_URL,
         entity_set="solutions",
         records=solutions,
-        select="solutionid,uniquename,friendlyname",
+        select=ELIGIBLE_SOLUTION_SELECT,
         filter_expr=ELIGIBLE_SOLUTION_FILTER,
     ))
 
@@ -114,6 +132,32 @@ def _register_get_preferred_solution(
         base_url=BASE_URL,
         solution_id=selected_solution_id,
         uniquename=uniquename,
+    ))
+
+
+def _register_publisher(
+    publisher_id: str = PUBLISHER_ID_CUSTOM,
+    *,
+    uniquename: str = "ContosoPublisher",
+    customizationprefix: str = "contoso",
+    status: int = 200,
+) -> None:
+    """Mock the ``GET /publishers({id})?$select=...`` round-trip the
+    production check makes after a preferred-solution match.
+
+    Defaults model a customer-created publisher (the PASS path). Pass
+    ``uniquename="DefaultPublisherorg<suffix>"`` with
+    ``customizationprefix="cr<NNN>"`` to model the env's auto-provisioned
+    Default Publisher (the new WARNING path). Pass ``status=500`` to
+    drive the "publisher fetch failed" branch where the check degrades
+    gracefully to PASS without the publisher annotation.
+    """
+    responses.add(**dv.publisher(
+        base_url=BASE_URL,
+        publisher_id=publisher_id,
+        uniquename=uniquename,
+        customizationprefix=customizationprefix,
+        status=status,
     ))
 
 
@@ -196,6 +240,7 @@ def test_passed_when_selected_solution_matches(runner: _MinimalRunner) -> None:
         _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
     ])
     _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_ELIGIBLE)
+    _register_publisher()
 
     results = _check_preferred_solution(runner)
     assert len(results) == 1
@@ -204,6 +249,10 @@ def test_passed_when_selected_solution_matches(runner: _MinimalRunner) -> None:
     assert r.status == "Passed"
     assert "ESSCustomization" in r.result
     assert "selected" in r.result
+    # Custom publisher annotation surfaces on the PASS path for parity
+    # with the WARNING path (operator can confirm the binding at a glance).
+    assert "ContosoPublisher" in r.result
+    assert "contoso" in r.result
     # Principle 8: PASSED has no remediation.
     assert r.remediation == ""
 
@@ -215,11 +264,13 @@ def test_passed_when_selected_matches_one_of_many(runner: _MinimalRunner) -> Non
         _solution_record(SOLUTION_ID_OTHER, "ContosoExtensions"),
     ])
     _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_OTHER)
+    _register_publisher()
 
     r = _check_preferred_solution(runner)[0]
     assert r.status == "Passed"
     assert "'ContosoExtensions'" in r.result
     assert "2 eligible unmanaged solution" in r.result
+    assert "ContosoPublisher" in r.result
 
 
 @responses.activate
@@ -240,6 +291,7 @@ def test_passed_when_guid_casing_differs_between_endpoints(
     _register_get_preferred_solution(
         selected_solution_id=SOLUTION_ID_ELIGIBLE.upper(),
     )
+    _register_publisher()
 
     r = _check_preferred_solution(runner)[0]
     assert r.status == "Passed"
@@ -260,7 +312,7 @@ def test_warning_when_dataverse_returns_500(runner: _MinimalRunner) -> None:
         dv.build_query_url(
             BASE_URL,
             "solutions",
-            select="solutionid,uniquename,friendlyname",
+            select=ELIGIBLE_SOLUTION_SELECT,
             filter_expr=ELIGIBLE_SOLUTION_FILTER,
         ),
         json={"error": {"code": "0x80040220", "message": "boom"}},
@@ -304,7 +356,7 @@ def test_warning_when_dataverse_returns_401(runner: _MinimalRunner) -> None:
         dv.build_query_url(
             BASE_URL,
             "solutions",
-            select="solutionid,uniquename,friendlyname",
+            select=ELIGIBLE_SOLUTION_SELECT,
             filter_expr=ELIGIBLE_SOLUTION_FILTER,
         ),
         json={"error": {"code": "0x80048306", "message": "token expired"}},
@@ -343,3 +395,103 @@ def test_warning_when_get_preferred_solution_returns_403(
     assert "Unable to validate preferred solution" in r.result
     assert "[HTTP 403]" in r.result
     assert "privileges" in r.remediation
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Publisher-quality branch (PR #128 follow-up — preferred solution is
+# correctly selected but is bound to the env's Default Publisher).
+# ───────────────────────────────────────────────────────────────────────
+
+
+@responses.activate
+def test_warning_when_preferred_solution_uses_default_publisher(
+    runner: _MinimalRunner,
+) -> None:
+    """E2E gap: preferred solution is unmanaged + selected, but is bound to
+    the env's auto-provisioned Default Publisher (uniquename starts with
+    ``DefaultPublisher`` and inherits the env's ``cr<NNN>`` prefix).
+
+    The functional selection is correct, so this is a hardening WARNING
+    (not a FAIL). The result must describe the observed state only; the
+    remediation must open with the hardening-recommendation prefix and
+    give a concrete reason before the click-path (AGENTS.md principle 9).
+    """
+    _register_solutions(solutions=[
+        _solution_record(
+            SOLUTION_ID_ELIGIBLE, "ESSCustomization",
+            publisher_id=PUBLISHER_ID_DEFAULT,
+        ),
+    ])
+    _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_ELIGIBLE)
+    # A real Default Publisher value observed in
+    # tests/fixtures/cassettes/island_gateway_botcomponents.yaml.
+    _register_publisher(
+        publisher_id=PUBLISHER_ID_DEFAULT,
+        uniquename="DefaultPublisherorgeeac24d0",
+        customizationprefix="cr123",
+    )
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.checkpoint_id == "ENV-009"
+    assert r.status == "Warning"
+    # Principle 8: result is observed state, no framing.
+    assert "Hardening recommendation" not in r.result
+    assert "ESSCustomization" in r.result
+    assert "Default Publisher" in r.result
+    assert "DefaultPublisherorgeeac24d0" in r.result
+    assert "cr123" in r.result
+    # Principle 9: framing + concrete reason BEFORE the click-path.
+    assert r.remediation.startswith("Hardening recommendation (not a functional blocker)")
+    assert "cr123" in r.remediation
+    assert "collide across environments" in r.remediation
+    assert "+ New publisher" in r.remediation
+
+
+@responses.activate
+def test_passed_when_publisher_fetch_fails_degrades_gracefully(
+    runner: _MinimalRunner,
+) -> None:
+    """If the /publishers({id}) round-trip fails, don't downgrade the verdict.
+
+    The preferred-solution selection itself is correct; a transient
+    failure on the publisher lookup should not flip PASS to WARNING. The
+    publisher annotation is simply omitted from the result.
+    """
+    _register_solutions(solutions=[
+        _solution_record(SOLUTION_ID_ELIGIBLE, "ESSCustomization"),
+    ])
+    _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_ELIGIBLE)
+    _register_publisher(status=500)
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Passed"
+    assert "ESSCustomization" in r.result
+    # No publisher annotation when the fetch failed.
+    assert "publisher:" not in r.result
+    assert r.remediation == ""
+
+
+@responses.activate
+def test_passed_when_solution_has_no_publisher_lookup(
+    runner: _MinimalRunner,
+) -> None:
+    """Defensive: if ``_publisherid_value`` is null on the matched solution,
+    skip the publisher round-trip and PASS without the annotation.
+
+    Real solutions always have a publisher, but the production code
+    treats a missing lookup as "skip the secondary check" rather than
+    asserting - this test pins that behaviour.
+    """
+    _register_solutions(solutions=[
+        _solution_record(
+            SOLUTION_ID_ELIGIBLE, "ESSCustomization", publisher_id=None,
+        ),
+    ])
+    _register_get_preferred_solution(selected_solution_id=SOLUTION_ID_ELIGIBLE)
+    # No publisher mock registered — if production tries to fetch, the
+    # responses library will raise ConnectionError and the test fails.
+
+    r = _check_preferred_solution(runner)[0]
+    assert r.status == "Passed"
+    assert "ESSCustomization" in r.result
+    assert "publisher:" not in r.result

--- a/tests/mocks/dataverse.py
+++ b/tests/mocks/dataverse.py
@@ -25,6 +25,7 @@ for handing to `responses.add(...)` directly.
 References:
 - Dataverse Web API: https://learn.microsoft.com/power-apps/developer/data-platform/webapi/perform-operations-web-api
 - WhoAmI function: https://learn.microsoft.com/power-apps/developer/data-platform/webapi/use-web-api-functions
+- GetPreferredSolution function: https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/getpreferredsolution
 - environmentvariabledefinition: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/environmentvariabledefinition
 - environmentvariablevalue: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/environmentvariablevalue
 - Production source: solutions/ess-maker-skills/scripts/auth.py
@@ -75,6 +76,11 @@ def _query_url(
     if qs:
         url += "?" + "&".join(qs)
     return url
+
+
+# Public alias — tests that register custom error-case responses (e.g. 500
+# on a real query URL) import this instead of touching the underscore name.
+build_query_url = _query_url
 
 
 # ────────────────────────────────────────────────────────────────────────
@@ -320,6 +326,55 @@ def usersettings(
         "_preferredsolution_value": preferred_solution_id,
     }
     return {"method": "GET", "url": url, "json": body, "status": 200}
+
+
+def get_preferred_solution(
+    *,
+    base_url: str,
+    solution_id: str | None = None,
+    uniquename: str | None = None,
+    friendlyname: str | None = None,
+) -> dict[str, Any]:
+    """Mock ``GET /GetPreferredSolution()``.
+
+    Web API reference:
+      https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/getpreferredsolution
+
+    UNCERTAINTY: the MS Learn reference page documents the return type
+    as ``crmbaseentity`` but does NOT include an example response body.
+    The shape used here is derived by composing three MS-documented
+    sources:
+
+      1. The .NET SDK ``GetPreferredSolutionResponse.PreferredSolution``
+         property is typed as ``Microsoft.Xrm.Sdk.Entity`` representing
+         a ``solution`` row:
+         https://learn.microsoft.com/dotnet/api/microsoft.crm.sdk.messages.getpreferredsolutionresponse.preferredsolution
+      2. The ``solution`` entity reference documents the field names
+         (``solutionid``, ``uniquename``, ``friendlyname``):
+         https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/solution
+      3. The Web API serialisation conventions for a single-entity
+         response use the ``$metadata#<entityset>/$entity``
+         ``@odata.context`` form:
+         https://learn.microsoft.com/power-apps/developer/data-platform/webapi/retrieve-entity-using-web-api#basic-retrieve-operations
+
+    When ``solution_id`` is None, ``solutionid`` is omitted from the
+    body — the production check treats a missing ``solutionid`` as
+    "no preferred solution selected" rather than asserting on any
+    specific empty-response shape.
+    """
+    body: dict[str, Any] = {
+        "@odata.context": _api(base_url, "$metadata#solutions/$entity"),
+    }
+    if solution_id is not None:
+        body["solutionid"] = solution_id
+        body["uniquename"] = uniquename or "ESSCustomization"
+        body["friendlyname"] = friendlyname or "ESS Customization"
+    return {
+        "method": "GET",
+        "url": _api(base_url, "GetPreferredSolution()"),
+        "json": body,
+        "status": 200,
+    }
 
 
 def discover_tenant_challenge(

--- a/tests/mocks/dataverse.py
+++ b/tests/mocks/dataverse.py
@@ -26,6 +26,7 @@ References:
 - Dataverse Web API: https://learn.microsoft.com/power-apps/developer/data-platform/webapi/perform-operations-web-api
 - WhoAmI function: https://learn.microsoft.com/power-apps/developer/data-platform/webapi/use-web-api-functions
 - GetPreferredSolution function: https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/getpreferredsolution
+- publisher: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/publisher
 - environmentvariabledefinition: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/environmentvariabledefinition
 - environmentvariablevalue: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/environmentvariablevalue
 - Production source: solutions/ess-maker-skills/scripts/auth.py
@@ -347,6 +348,63 @@ def get_preferred_solution(
         "url": _api(base_url, "GetPreferredSolution()"),
         "json": body,
         "status": 200,
+    }
+
+
+def publisher(
+    *,
+    base_url: str,
+    publisher_id: str,
+    uniquename: str = "ContosoPublisher",
+    customizationprefix: str = "contoso",
+    friendlyname: str | None = None,
+    status: int = 200,
+) -> dict[str, Any]:
+    """Mock ``GET /publishers({publisherid})?$select=...``.
+
+    Web API reference:
+      https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/publisher
+
+    The MS Learn publisher entity reference documents the columns used
+    here (``publisherid``, ``uniquename``, ``customizationprefix``,
+    ``friendlyname``). The ENV-009 check fetches this record after the
+    preferred-solution match to detect when the solution is bound to
+    the env's auto-provisioned Default Publisher (``uniquename``
+    starting with ``DefaultPublisher``) instead of a customer-created
+    publisher.
+
+    Defaults model a customer-created publisher with the ``contoso``
+    prefix. To simulate the Default Publisher, callers should pass
+    ``uniquename="DefaultPublisherorg<suffix>"`` and
+    ``customizationprefix="cr<NNN>"`` - one such Default Publisher value
+    (``DefaultPublisherorgeeac24d0``) is observable in
+    ``tests/fixtures/cassettes/island_gateway_botcomponents.yaml``.
+
+    The production call site uses the same ``$select`` field list every
+    time; this builder hard-codes that querystring so ``responses``
+    matches strictly. A non-200 ``status`` causes the body to be
+    returned with the supplied status code so callers can drive the
+    "publisher fetch failed" code path.
+    """
+    body: dict[str, Any] = {
+        "@odata.context": _api(
+            base_url,
+            "$metadata#publishers(uniquename,customizationprefix,friendlyname)/$entity",
+        ),
+        "publisherid": publisher_id,
+        "uniquename": uniquename,
+        "customizationprefix": customizationprefix,
+        "friendlyname": friendlyname or uniquename,
+    }
+    url = (
+        _api(base_url, f"publishers({publisher_id})")
+        + f"?$select={quote('uniquename,customizationprefix,friendlyname', safe=',')}"
+    )
+    return {
+        "method": "GET",
+        "url": url,
+        "json": body,
+        "status": status,
     }
 
 

--- a/tests/mocks/dataverse.py
+++ b/tests/mocks/dataverse.py
@@ -295,6 +295,33 @@ def whoami(*, base_url: str, **kwargs: Any) -> dict[str, Any]:
     }
 
 
+def usersettings(
+    *,
+    base_url: str,
+    user_id: str = MOCK_USER_ID,
+    preferred_solution_id: str | None = None,
+) -> dict[str, Any]:
+    """Mock ``/usersettingscollection({UserId})?$select=_preferredsolution_value``.
+
+    Single-record GET (not wrapped in an OData collection envelope, unlike
+    queries built with ``query()``). Response shape per
+    https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/usersettings
+    """
+    url = _api(
+        base_url,
+        f"usersettingscollection({user_id})?$select=_preferredsolution_value",
+    )
+    body: dict[str, Any] = {
+        "@odata.context": _api(
+            base_url,
+            "$metadata#usersettingscollection(_preferredsolution_value)/$entity",
+        ),
+        "systemuserid": user_id,
+        "_preferredsolution_value": preferred_solution_id,
+    }
+    return {"method": "GET", "url": url, "json": body, "status": 200}
+
+
 def discover_tenant_challenge(
     *,
     base_url: str,

--- a/tests/mocks/dataverse.py
+++ b/tests/mocks/dataverse.py
@@ -301,33 +301,6 @@ def whoami(*, base_url: str, **kwargs: Any) -> dict[str, Any]:
     }
 
 
-def usersettings(
-    *,
-    base_url: str,
-    user_id: str = MOCK_USER_ID,
-    preferred_solution_id: str | None = None,
-) -> dict[str, Any]:
-    """Mock ``/usersettingscollection({UserId})?$select=_preferredsolution_value``.
-
-    Single-record GET (not wrapped in an OData collection envelope, unlike
-    queries built with ``query()``). Response shape per
-    https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/usersettings
-    """
-    url = _api(
-        base_url,
-        f"usersettingscollection({user_id})?$select=_preferredsolution_value",
-    )
-    body: dict[str, Any] = {
-        "@odata.context": _api(
-            base_url,
-            "$metadata#usersettingscollection(_preferredsolution_value)/$entity",
-        ),
-        "systemuserid": user_id,
-        "_preferredsolution_value": preferred_solution_id,
-    }
-    return {"method": "GET", "url": url, "json": body, "status": 200}
-
-
 def get_preferred_solution(
     *,
     base_url: str,


### PR DESCRIPTION
## Description

Adds an environment-scope FlightCheck (`ENV-009`) that validates whether the current FlightCheck caller has selected a customer-owned unmanaged solution — bound to a customer publisher — as their preferred customization solution in Dataverse. Without this, new Copilot Studio / Maker portal customizations land in the Default Solution (or get bound to the env's auto-generated Default Publisher, prefix `new`), neither of which is exportable as a clean ALM artifact.

Note: the preferred-solution setting is stored per-user (on the `usersettings` table behind the scenes), not per-environment, so the check explicitly scopes its findings to the current caller's identity.

**Verdicts (always exactly one CheckResult emitted):**

- **SKIPPED**: `env_url` or `dv_token` missing.
- **FAILED**: no eligible customer-created unmanaged solutions exist in the environment.
- **WARNING**: eligible solution(s) exist but
  - the caller has not selected any of them as their preferred solution, OR
  - the caller's preferred solution exists but is not in the eligible set, OR
  - the caller's preferred solution is bound to the environment's **Default Publisher** (auto-generated, prefix `new`) — surfaces publisher display name and prefix so the recommended remediation is unambiguous, OR
  - the Dataverse call returned 401 (token expired), 403 (insufficient privilege), or 5xx (transient). HTTP status code is surfaced when available so 403 is distinguishable from 5xx.
- **PASSED**: the caller's preferred solution matches one of the eligible solutions AND is bound to a customer (non-default) publisher. Publisher-lookup failures degrade gracefully (PASSED still returned when solution-eligibility is satisfied) so a transient publisher fetch does not regress a known-good env.

**Implementation:**

- New helper `auth.dataverse_get()` for non-paginated Dataverse Web API GETs (function calls, single-record reads); reuses `_SESSION`, `HEADERS_BASE`, `_validate_https_url`; raises `AuthExpiredError` on 401. Two `assert` guards reject paths that already include a leading `/` or the `api/data/` prefix (case-insensitive) to catch developer mistakes that `.lstrip('/')` would otherwise mask.
- `_check_preferred_solution()` short-circuits when no eligible solutions exist, then uses a **single** `GetPreferredSolution()` call (bound to the caller via the bearer token — no separate `WhoAmI()` lookup or `usersettingscollection({UserId})` round-trip needed). When a preferred solution is returned, the check additionally resolves the publisher via `$expand=publisherid($select=friendlyname,customizationprefix)` and flags `prefix='new'` (the auto-generated Default Publisher signature) as a WARNING.
- GUID equality between the `solutions` collection and `GetPreferredSolution()` is normalised through `uuid.UUID(...)` so case/format differences between the two endpoints can never cause a false WARNING.

### UNCERTAINTY

The MS Learn reference for [`GetPreferredSolution`](https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/getpreferredsolution) documents the return type as `crmbaseentity` but **does not include an example response body**. The code treats the response defensively: a body containing `solutionid` is the selected solution; a body without it (or any decode-edge case) is reported via the catch-all WARNING with the HTTP status code surfaced. The mock builder in `tests/mocks/dataverse.py:get_preferred_solution` composes the response shape from three MS-documented sources (.NET SDK `GetPreferredSolutionResponse.PreferredSolution` + `solution` entity reference + Web API single-entity serialisation convention). Live-tenant smoke test has now been run on a non-prod env against every reachable branch.

## Related issue

N/A

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

### Lint + syntax (CONTRIBUTING.md §1)

Both CI commands run clean from repo root:

```pwsh
ruff check solutions/ess-maker-skills/scripts/ solutions/ess-maker-skills/src/mcp/
python -m compileall -q solutions/ess-maker-skills/scripts/ solutions/ess-maker-skills/src/mcp/
```

### Unit tests

**15** unit tests in `tests/flightcheck/checks/test_preferred_solution.py` covering every verdict path (SKIPPED, FAILED, WARNING sub-cases including 401 / 403 / 500 / no-preferred / not-in-eligible / Default-Publisher, PASSED including the cross-endpoint case-insensitive-GUID path and the graceful-degradation publisher-fetch path) with mocked Dataverse responses. All mocks built via the documented-tier builders in `tests/mocks/dataverse.py` per `tests/AGENTS.md`.

```
pytest tests/flightcheck/checks/test_preferred_solution.py -> 15 passed
pytest tests/ --ignore=tests/captures               -> 316 passed, 8 skipped
```

### End-to-end manual validation

The affected command is `/flightcheck`. The matrix below is the minimum set that exercises every distinct branch in `_check_preferred_solution()`, verified against a non-prod env.

| Test | What this test covers | How to set up | Expected verdict | Matches actual result? |
|------|-----------------------|---------------|------------------|------------------------|
| **T1** | No customer-created unmanaged solutions exist | Use a fresh env before creating any solutions | **FAILED** | [x] verified on a fresh non-prod env before any customer solutions were created |
| **T2** | Caller's preferred solution is a valid customer solution bound to a customer publisher | Create a customer publisher (any prefix other than `new`), create one customer unmanaged solution with that publisher, then set it as preferred | **PASSED** | [x] verified on a non-prod env |
| **T3** | Customer solution exists but caller has not chosen any preferred solution (`GetPreferredSolution()` returns no `solutionid`) | Create one customer unmanaged solution, do **not** tick "set as preferred" (or clear it via API) | **WARNING** "no preferred solution selected" | [x] verified via unit test `test_warning_when_no_preferred_solution_selected` (`tests/flightcheck/checks/test_preferred_solution.py`) — live tenant repro skipped because maker portal does not expose a UI affordance to leave preferred unset once a solution has been created in that env |
| **T4** | Caller's preferred solution is the Default Solution itself (not a customer solution) | Create one customer unmanaged solution, PATCH `usersettings` to point `preferredsolution_userid@odata.bind` at the env's Default solution id | **WARNING** "preferred not in eligible set" | [x] verified on a non-prod env |
| **T5** | Caller lacks privilege to read `solution` / call `GetPreferredSolution()` | Run `/flightcheck` as a user with no `prvReadSolution` | **WARNING** with `[HTTP 403]` surfaced in the result text | [x] verified via unit test `test_warning_when_get_preferred_solution_returns_403` (`tests/flightcheck/checks/test_preferred_solution.py`) — live tenant repro skipped because provisioning a restricted user requires Global Admin / User Admin rights not held by the PR author |
| **T6** | Dataverse token has expired mid-run | Wait until the cached token in `.local/.token_cache.bin` expires, or manually corrupt it, then run `/flightcheck` | **WARNING** "auth expired" | [x] verified via unit test `test_warning_when_dataverse_returns_401` (`tests/flightcheck/checks/test_preferred_solution.py`) — live tenant repro skipped because VS Code / MSAL auto-refreshes the token transparently before the FlightCheck call lands |

## Checklist

- [x] My code follows the existing style
- [x] I have added/updated tests where applicable
- [X] I have updated documentation as needed
- [x] No fabricated URLs (CONTRIBUTING.md §5): only `https://make.powerapps.com` is referenced in the eligible-solutions hardening message; it is the canonical Power Apps maker portal entry point
- [x] Minimal, surgical changes (CONTRIBUTING.md §6): scope limited to one new check + one new helper + tests; no unrelated edits

## Follow-up (out of scope of this PR)

- Tracking issue to be filed: collapse the five sibling helpers in `auth.py` (`query_all`, `update_record`, `create_record`, `delete_record`, `dataverse_get`) into a shared private `_dv_request(env_url, token, method, path, ...)` to remove the duplicated preamble (per @qazi-microsoft review feedback).

## Static validation (samples/ only)

N/A — this PR does not touch `samples/`.
