### PR TITLE
Evals: add quality gate to delete skill + fix stale Copilot API references

### DIFF
--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -315,14 +315,16 @@ JSON format", "something went wrong with Workday".
 "check my setup", "pre-flight", "deployment readiness", "run validation".
 
 **Quality validation invocation:** When quality validation is requested on
-eval files — at step 4.3 of the eval create flow OR step 4 of the eval
-update flow — invoke `runSubagent` (the VS Code Copilot Chat tool) pointing the subagent to read
+eval files — at step 4.3 of the eval create flow, step 4 of the eval
+update flow, OR step 5 of the eval delete flow (single test case deletion
+only) — invoke `runSubagent` (the VS Code Copilot Chat tool) pointing the subagent to read
 `src/skills/evaluations/validate/SKILL.md` as its first action, passing the
 paths of the newly written eval files and the agent folder path. Wait for
 the subagent to return with its quality report before continuing. If fixes
 are applied, re-invoke the subagent and wait for the updated report
 before continuing. Do NOT proceed to review and push until the subagent
-has returned. Do NOT invoke the validate subagent after delete operations.
+has returned. Do NOT invoke the validate subagent after entire test set
+delete operations or after deleting the last remaining case in a category.
 
 **When the user asks to modify, delete, rename, or otherwise change an agent
 component, ALWAYS load and follow the corresponding skill file.** The skill

--- a/solutions/ess-maker-skills/scripts/evaluate_evals.py
+++ b/solutions/ess-maker-skills/scripts/evaluate_evals.py
@@ -3,7 +3,7 @@
 evaluate_evals.py — Quality validation for generated evaluation test sets.
 
 Reads eval YAML files from an agent's evaluations/ folder, sends them to a
-LLM judge via GitHub Models API, and reports quality scores per dimension.
+LLM judge via GitHub Copilot API, and reports quality scores per dimension.
 
 Uses 'gh auth token' for credentials — no extra setup required.
 
@@ -178,7 +178,7 @@ def load_topic_context(topics_dir: Path) -> dict[str, str]:
     return context
 
 
-# ─── GitHub Models API ────────────────────────────────────────────────────────
+# ─── Copilot API ──────────────────────────────────────────────────────────────
 
 def get_gh_token() -> str:
     """Get the current GitHub token via gh auth token."""
@@ -205,7 +205,7 @@ def get_gh_token() -> str:
 
 
 def call_judge(prompt: str, token: str, _retry: bool = True) -> str:
-    """Call the GitHub Models LLM judge. Returns the response text."""
+    """Call the Copilot API LLM judge. Returns the response text."""
     payload = {
         "messages": [
             {
@@ -267,10 +267,10 @@ def call_judge(prompt: str, token: str, _retry: bool = True) -> str:
             print("\nERROR: Rate limited by Copilot API. Wait a moment and retry.", file=sys.stderr)
             sys.exit(1)
         else:
-            print(f"\nERROR: GitHub Models API returned {e.code}: {err_body}", file=sys.stderr)
+            print(f"\nERROR: Copilot API returned {e.code}: {err_body}", file=sys.stderr)
             sys.exit(1)
     except urllib.error.URLError as e:
-        print(f"\nERROR: Could not reach GitHub Models API: {e.reason}", file=sys.stderr)
+        print(f"\nERROR: Could not reach Copilot API: {e.reason}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
@@ -80,7 +80,40 @@ For an entire test set: delete the parent EvaluationSet file AND all child
 EvaluationData files that reference it (check `parentbotcomponentid` in the
 component map).
 
-## Step 5: Review before push
+## Step 5: Quality Validation (single test case deletion only)
+
+**Skip this step if deleting an entire test set** — there are no remaining
+cases to validate.
+
+**Also skip if this was the last test case in the category** — zero remaining
+cases means there is nothing to validate. In this situation, prompt the user:
+
+> This was the last test case in **{category}**. The parent EvaluationSet
+> file still exists but the set is now empty. Would you like to delete the
+> entire set as well?
+
+- If yes: follow the "entire test set" deletion path (Step 4) for the parent
+  EvaluationSet file, then proceed to Step 7 (dry run).
+- If no: proceed to Step 6 with a note that the set is empty.
+
+When deleting a single test case and cases remain, run quality validation on
+the remaining cases in the affected category. Removing a case can cause
+dimension scores to drop — for example, deleting the only negative case drops
+Failure Mode Coverage, or removing a keyword input shifts Diversity.
+
+Invoke the validate subagent on **all remaining** `.mcs.yml` files in the
+affected category (not just the deleted file). After it returns, paste its
+full quality report output verbatim to the user (do not summarize). Then
+follow the quality gate + fix flow defined in
+`src/skills/evaluations/quality-fix-flow.md`. The “review step” referred to
+there is Step 6 of this skill.
+
+**Do not proceed to Step 6 until quality validation has returned results and
+any fixes are complete.**
+
+---
+
+## Step 6: Review before push
 
 Show the user a summary of what will be deleted and ask for final confirmation:
 
@@ -96,19 +129,19 @@ Show the user a summary of what will be deleted and ask for final confirmation:
 - **If user confirms**: Proceed to dry run.
 - **If user cancels**: Revert local deletions via `python scripts/checkpoint.py --revert`.
 
-## Step 6: Dry Run
+## Step 7: Dry Run
 
 Run `python scripts/push.py --dry-run`. Confirm the expected files show as
 deleted.
 
-## Step 7: Push
+## Step 8: Push
 
 Run `python scripts/push.py`. The push script automatically orders
 evaluation deletions — children are deleted before parents.
 
 **If the push fails:** show the error and offer retry or revert.
 
-## Step 8: Verify
+## Step 9: Verify
 
 > ✅ Evaluation test {case/set} deleted from Copilot Studio.
 >

--- a/solutions/ess-maker-skills/src/skills/evaluations/quality-fix-flow.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/quality-fix-flow.md
@@ -1,8 +1,8 @@
 # Eval Quality Fix Flow
 
 This file is the single source of truth for the quality gate + fix flow.
-Both `create/SKILL.md` and `update/SKILL.md` reference it. Do not duplicate
-this logic in either file.
+`create/SKILL.md`, `update/SKILL.md`, and `delete/SKILL.md` reference it.
+Do not duplicate this logic in any of those files.
 
 ---
 


### PR DESCRIPTION

**Why:**
Two small fixes that were missed when the main eval quality validation related PR was merged:

- Delete skill was missing quality validation — when deleting a single test case, the remaining test cases in that category should be validated before push. Removing a case can silently drop dimension scores (e.g. deleting the only negative case drops Failure Mode Coverage; removing a keyword input shifts Diversity). Entire set deletions correctly skip validation since there are no remaining cases.

- [evaluate_evals.py](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) had stale "GitHub Models API" references — comments, section headers, and error messages still referenced GitHub Models even though the endpoint was already switched to api.githubcopilot.com (Copilot API) in the prior PR.

**What changed:**

delete/SKILL.md — new Step 5: run quality validation on remaining cases after single case deletion; skip for entire set deletion; references [quality-fix-flow.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Steps renumbered 6–9.

[quality-fix-flow.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — updated header to include delete/SKILL.md as a referencing skill alongside create and update.

[evaluate_evals.py](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — updated docstring, section header, and two error messages from "GitHub Models API" → "Copilot API" to match the actual endpoint in use.