### PR TITLE
flightcheck: triage-first report layout + actionable CONFIG-005/007 + env_id correctness

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
@@ -17,6 +17,43 @@ import yaml
 from ..runner import CheckResult, Status, Priority
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
+STUDIO_BASE = "https://copilotstudio.microsoft.com"
+
+
+def _studio_agent_url(runner, agent_name: str) -> str | None:
+    """Build a Copilot Studio deep link to a specific agent's overview page.
+
+    Returns None when the BAP environment ID or the agent's botId can't be
+    resolved from the runner's parsed config — callers fall back to the
+    generic Copilot Studio homepage.
+
+    URL shape verified against a live tenant:
+      https://copilotstudio.microsoft.com/environments/{envId}/bots/{botId}/overview
+    """
+    if not runner or not agent_name:
+        return None
+    env_id = getattr(runner, "env_id", None)
+    if not env_id:
+        return None
+    config = getattr(runner, "config", None) or {}
+    bot_id = None
+    for agent in config.get("agents", []):
+        if agent.get("slug") == agent_name:
+            bot_id = agent.get("botId")
+            break
+    if not bot_id:
+        # Fall back to the single-agent shape used by older configs.
+        bot_id = (config.get("agent") or {}).get("botId")
+    if not bot_id:
+        return None
+    return f"{STUDIO_BASE}/environments/{env_id}/bots/{bot_id}/overview"
+
+
+def _studio_link_md(runner, agent_name: str, anchor: str = "Copilot Studio") -> str:
+    """Markdown link to the specific agent in Copilot Studio, or to the
+    homepage when the deep link can't be resolved."""
+    url = _studio_agent_url(runner, agent_name) or f"{STUDIO_BASE}/"
+    return f"[{anchor}]({url})"
 
 # Required topics that ESS agents should have (by schema name substring)
 REQUIRED_TOPICS = [
@@ -73,7 +110,7 @@ def _check_single_agent(agent_path: Path, agent_name: str, runner=None) -> list[
     label = agent_name.replace("-", " ").title()
 
     # ---- Agent identity (agent.mcs.yml) ----
-    results.extend(_check_agent_identity(agent_path, label))
+    results.extend(_check_agent_identity(agent_path, label, runner, agent_name))
 
     # ---- Required topics ----
     results.extend(_check_required_topics(agent_path, label))
@@ -96,10 +133,11 @@ def _check_single_agent(agent_path: Path, agent_name: str, runner=None) -> list[
     return results
 
 
-def _check_agent_identity(agent_path: Path, label: str) -> list[CheckResult]:
+def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name: str = "") -> list[CheckResult]:
     """Check agent.mcs.yml for instructions, name, starter prompts."""
     results = []
     agent_file = agent_path / "agent.mcs.yml"
+    studio_link = _studio_link_md(runner, agent_name, "the agent in Copilot Studio")
 
     if not agent_file.exists():
         results.append(CheckResult(
@@ -107,15 +145,42 @@ def _check_agent_identity(agent_path: Path, label: str) -> list[CheckResult]:
             priority=Priority.CRITICAL.value, status=Status.FAILED.value,
             description=f"{label}: Agent identity file",
             result="agent.mcs.yml not found",
-            remediation="Re-run /setup to extract agent files.",
+            remediation=f"Verify {studio_link} exists and you can open it, then re-run `/setup` to extract agent files.",
         ))
         return results
 
     content = agent_file.read_text(encoding="utf-8")
 
-    instructions_match = re.search(r'instructions:\s*[|>]?\s*\n((?:\s+.+\n)+)', content)
-    if instructions_match:
-        instruction_text = instructions_match.group(1).strip()
+    # Parse the YAML once and operate on the parsed dict. The earlier
+    # regex approach (``instructions:\s*[|>]?\s*\n…``) silently missed
+    # YAML's chomping-indicator block scalars (``|-``, ``|+``, ``>-``,
+    # ``>+``) — which Copilot Studio routinely emits — and reported
+    # the agent as having no instructions at all. yaml.safe_load
+    # handles every block-scalar variant correctly and matches the
+    # parsing pattern already used by run_local_file_checks at line
+    # ~451 for topic files.
+    parsed: dict | None = None
+    try:
+        loaded = yaml.safe_load(content)
+        if isinstance(loaded, dict):
+            parsed = loaded
+    except yaml.YAMLError:
+        parsed = None
+
+    if parsed is None:
+        results.append(CheckResult(
+            checkpoint_id="CONFIG-007", category=f"Configuration ({label})",
+            priority=Priority.CRITICAL.value, status=Status.FAILED.value,
+            description=f"{label}: Agent instructions",
+            result="agent.mcs.yml could not be parsed as YAML",
+            remediation=f"Re-extract the agent with `/setup`. If the problem persists, inspect {studio_link} and check for unsupported customizations.",
+            doc_link=f"{DOC_BASE}/customize",
+        ))
+        return results
+
+    instructions_value = parsed.get("instructions")
+    instruction_text = instructions_value.strip() if isinstance(instructions_value, str) else ""
+    if instruction_text:
         word_count = len(instruction_text.split())
         if word_count >= 50:
             results.append(CheckResult(
@@ -131,7 +196,7 @@ def _check_agent_identity(agent_path: Path, label: str) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.WARNING.value,
                 description=f"{label}: Agent instructions",
                 result=f"Instructions seem short ({word_count} words)",
-                remediation="Expand agent instructions for better responses.",
+                remediation=f"Open {studio_link} and expand the agent instructions for better responses, then re-run `/setup`.",
                 doc_link=f"{DOC_BASE}/customize",
             ))
     else:
@@ -140,13 +205,19 @@ def _check_agent_identity(agent_path: Path, label: str) -> list[CheckResult]:
             priority=Priority.CRITICAL.value, status=Status.FAILED.value,
             description=f"{label}: Agent instructions",
             result="No instructions block found in agent.mcs.yml",
-            remediation="Add agent instructions in [Copilot Studio](https://copilotstudio.microsoft.com/), then re-extract with `/setup`.",
+            remediation=f"Open {studio_link} and add agent instructions on the Overview tab, then re-run `/setup`.",
             doc_link=f"{DOC_BASE}/customize",
         ))
 
-    prompt_count = len(re.findall(r'conversationStarters?:', content, re.IGNORECASE))
-    starter_items = re.findall(r'-\s+text:', content)
-    count = len(starter_items) if starter_items else prompt_count
+    # Starter prompts. Real Copilot Studio agent.mcs.yml uses the
+    # ``conversationStarters`` key whose value is a list of dicts with
+    # ``title`` + ``text`` fields. Parsing the YAML lets us count
+    # accurately regardless of indentation or quoting choices that
+    # tripped up the previous regex-based heuristic.
+    starters = parsed.get("conversationStarters") or parsed.get("conversationStarter") or []
+    if not isinstance(starters, list):
+        starters = []
+    count = sum(1 for item in starters if isinstance(item, dict) and item.get("text"))
     if count >= 3:
         results.append(CheckResult(
             checkpoint_id="CONFIG-005", category=f"Configuration ({label})",
@@ -160,8 +231,8 @@ def _check_agent_identity(agent_path: Path, label: str) -> list[CheckResult]:
             checkpoint_id="CONFIG-005", category=f"Configuration ({label})",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=f"{label}: Starter prompts",
-            result=f"Only {count} starter prompt(s) — recommend 6-12",
-            remediation="Add more starter prompts in [Copilot Studio](https://copilotstudio.microsoft.com/).",
+            result=f"Only {count} starter prompt(s) -- recommend 6-12",
+            remediation=f"Open {studio_link} and add more starter prompts on the Overview tab, then re-run `/setup`.",
             doc_link=f"{DOC_BASE}/customize#customize-starter-prompts",
         ))
     else:
@@ -170,7 +241,7 @@ def _check_agent_identity(agent_path: Path, label: str) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=f"{label}: Starter prompts",
             result="No starter prompts detected",
-            remediation="Add starter prompts in [Copilot Studio](https://copilotstudio.microsoft.com/).",
+            remediation=f"Open {studio_link} and add starter prompts on the Overview tab, then re-run `/setup`.",
             doc_link=f"{DOC_BASE}/customize#customize-starter-prompts",
         ))
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -29,7 +29,15 @@ import sys
 # Ensure scripts/ is on the path so we can import auth
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from flightcheck.runner import FlightCheckRunner, save_results, Status
+from flightcheck.runner import (
+    FlightCheckRunner,
+    save_results,
+    Status,
+    bucket_results,
+    BUCKET_ACTION,
+    BUCKET_MANUAL,
+    BUCKET_PASSED,
+)
 from flightcheck.graph_client import GraphClient
 from flightcheck.pp_admin_client import PPAdminClient, derive_environment_id
 from flightcheck.pva_client import PVAClient
@@ -192,10 +200,29 @@ def main():
         if env_id and pp_admin is not None:
             print(f"Environment ID: {env_id}")
         elif env_id:
+            # pp_admin is None: we fell back to WhoAmI/OrganizationId.
+            # That value is wrong for BAP admin calls AND for any URL
+            # that embeds an env id (Copilot Studio, maker portal, ...).
             print(
                 f"Environment ID: {env_id} (Dataverse OrganizationId fallback "
                 "— Power Platform sign-in failed, so BAP-scoped checks "
                 "(ENV-*, EXT-*, WD-CONN-*) will be skipped)"
+            )
+        elif pp_admin is not None:
+            # BAP auth succeeded but no env matched the Dataverse hostname.
+            # Usually means the signed-in user lacks admin access on the
+            # env hosting this Dataverse instance. Tell the operator how
+            # to override so deep links and BAP-scoped checks still work.
+            print(
+                f"WARNING: Could not find a BAP environment whose linked "
+                f"Dataverse instance matches {env_url}. You may not have "
+                "Power Platform admin access on that environment. "
+                "BAP-scoped checks (ENV-*, EXT-*, WD-CONN-*) will be skipped "
+                "and Copilot Studio deep links will fall back to the "
+                "homepage. To override, pass --environment-id <guid> "
+                "(find it in the Power Platform admin center or in the "
+                "Copilot Studio bot URL: "
+                "https://copilotstudio.microsoft.com/environments/<guid>/bots/...)."
             )
         else:
             print(
@@ -251,42 +278,125 @@ def main():
     result = runner.run()
 
     # --- Print summary ---
-    print()
-    print("=" * 64)
-    print("  FLIGHTCHECK SUMMARY")
-    print("=" * 64)
-    print(f"  Total checks: {result.total}")
-    print(f"  [PASS] Passed:         {result.passed}")
-    print(f"  [FAIL] Failed:         {result.failed}")
-    print(f"  [WARN] Warnings:       {result.warnings}")
-    print(f"  [INFO] Not Configured: {result.not_configured}")
-    print(f"  Duration:              {result.duration_secs}s")
-    print()
-
-    if result.overall == "READY":
-        print("  [PASS] READY FOR DEPLOYMENT")
-    elif result.overall == "READY_WITH_WARNINGS":
-        print("  [WARN] READY WITH WARNINGS")
-    else:
-        print("  [FAIL] NOT READY -- ISSUES FOUND")
-
-    print("=" * 64)
-
-    # Print failures
-    failures = [r for r in result.results if r.status == Status.FAILED.value]
-    if failures:
-        print(f"\n  FAILED CHECKS ({len(failures)}):\n")
-        for r in failures:
-            print(f"    [FAIL] {r.checkpoint_id}: {r.result}")
-            if r.remediation:
-                print(f"       -> {r.remediation}")
-        print()
+    _print_prioritized_summary(result)
 
     # Save results
     save_results(result, args.output)
 
     # Exit code
     sys.exit(1 if result.failed > 0 else 0)
+
+
+def _print_prioritized_summary(result):
+    """Print a triage-first summary that mirrors the HTML layout.
+
+    Three sections, biggest signal first:
+      1. Verdict banner (one line).
+      2. Counts strip.
+      3. ACTION REQUIRED — full per-row detail (Failed / Error / Warning).
+      4. NEEDS MANUAL VERIFICATION — one line per row (Manual /
+         NotConfigured / Skipped).
+      5. PASSED — count only, point to report.html for the list.
+
+    The goal is for an operator scanning the terminal to see, in
+    order: am I OK? what must I fix? what must I verify? — without
+    having to read every passing row.
+    """
+    buckets = bucket_results(result.results)
+    action = buckets[BUCKET_ACTION]
+    manual = buckets[BUCKET_MANUAL]
+    passed = buckets[BUCKET_PASSED]
+
+    print()
+    print("=" * 64)
+    print("  FLIGHTCHECK SUMMARY")
+    print("=" * 64)
+
+    # Verdict line — single most important signal in the terminal.
+    if result.overall == "READY":
+        print("  [READY] Ready for deployment")
+        if manual:
+            print(f"          ({len(manual)} item(s) need manual "
+                  "verification -- see below)")
+    elif result.overall == "READY_WITH_WARNINGS":
+        print(f"  [WARN]  Ready with warnings -- {result.warnings} "
+              "warning(s) to review")
+    else:
+        action_total = result.failed + result.errors + result.warnings
+        word = "issue" if action_total == 1 else "issues"
+        print(f"  [FAIL]  Not ready -- {action_total} {word} need "
+              "attention")
+
+    print()
+    # Counts strip — every status in one line so the operator can
+    # cross-reference with the detail sections below.
+    print(f"  Failed: {result.failed}   Errored: {result.errors}   "
+          f"Warnings: {result.warnings}   Manual: {result.manual}   "
+          f"NotConfigured: {result.not_configured}   "
+          f"Skipped: {result.skipped}   Passed: {result.passed}")
+    print(f"  Total checks: {result.total}   "
+          f"Duration: {result.duration_secs}s")
+    print("=" * 64)
+
+    # Section 1 — ACTION REQUIRED (full detail)
+    if action:
+        print()
+        print(f"  ACTION REQUIRED ({len(action)})")
+        print("  " + "-" * 62)
+        for r in action:
+            tag = _status_tag(r.status)
+            print(f"  {tag} {r.checkpoint_id} [{r.priority}]: {r.result}")
+            if r.remediation:
+                # Indent multi-line remediation under the arrow so
+                # multi-step fixes stay visually grouped with their
+                # finding.
+                lines = r.remediation.splitlines()
+                print(f"       -> {lines[0]}")
+                for cont in lines[1:]:
+                    print(f"          {cont}")
+            print()
+
+    # Section 2 — NEEDS MANUAL VERIFICATION (one-liner per row;
+    # full prose is in report.html so the terminal stays scannable).
+    if manual:
+        print()
+        print(f"  NEEDS MANUAL VERIFICATION ({len(manual)})")
+        print("  " + "-" * 62)
+        for r in manual:
+            tag = _status_tag(r.status)
+            print(f"  {tag} {r.checkpoint_id} [{r.priority}]: "
+                  f"{r.description}")
+        print("  (Open report.html for the full result + verification "
+              "steps.)")
+
+    # Section 3 — PASSED (count only; the operator doesn't need to
+    # scroll past 200+ green rows to find what needs their attention).
+    print()
+    print(f"  PASSED ({len(passed)})")
+    print("  " + "-" * 62)
+    if passed:
+        print("  See report.html for the full list of passing checks.")
+    else:
+        print("  No passing checks in this run.")
+    print()
+
+
+def _status_tag(status: str) -> str:
+    """Return a 6-char tag in [BRACKETS] for terminal alignment.
+
+    Matches the existing [PASS]/[FAIL]/[WARN]/[INFO] convention used
+    elsewhere in cli.py so the report visually fits the rest of the
+    terminal output.
+    """
+    return {
+        Status.FAILED.value: "[FAIL]",
+        Status.ERROR.value: "[ERR ]",
+        Status.WARNING.value: "[WARN]",
+        Status.MANUAL.value: "[MAN ]",
+        Status.NOT_CONFIGURED.value: "[CFG ]",
+        Status.SKIPPED.value: "[SKIP]",
+        Status.PASSED.value: "[PASS]",
+    }.get(status, "[?   ]")
 
 
 if __name__ == "__main__":

--- a/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
@@ -209,7 +209,7 @@ class PPAdminClient:
 
     def find_environment_id_by_dataverse_url(self, env_url: str) -> str | None:
         """Find the BAP environment "name" (the BAP env id) whose
-        `linkedEnvironmentMetadata.instanceUrl` matches `env_url`.
+        linked Dataverse instance matches `env_url`.
 
         The BAP env id is NOT the same as the Dataverse OrganizationId.
         Every BAP admin endpoint (`/scopes/admin/environments/{env_id}/...`)
@@ -218,8 +218,13 @@ class PPAdminClient:
         which is what was breaking EXT-001 / ENV-001 and the entire
         Workday block (no flows discovered ⇒ deep checks skipped).
 
-        Matches by hostname comparison so trailing slash / casing
-        differences between config and BAP don't cause a miss.
+        Matches by hostname against BOTH `linkedEnvironmentMetadata.instanceUrl`
+        and `linkedEnvironmentMetadata.instanceApiUrl`. BAP advertises the
+        web hostname (e.g. ``org<hash>.crm12.dynamics.com``) on one field and
+        the Web API hostname (``org<hash>.api.crm12.dynamics.com``) on the
+        other; the config's `dataverseEndpoint` is typically the API form,
+        so checking only `instanceUrl` silently misses every match on a
+        tenant whose config uses the `.api.` hostname.
         """
         target_host = (urlparse(env_url.rstrip("/")).hostname or "").lower()
         if not target_host:
@@ -228,14 +233,14 @@ class PPAdminClient:
         if isinstance(envs, dict) and "_error" in envs:
             return None
         for env in envs:
-            instance_url = (
-                env.get("properties", {})
-                .get("linkedEnvironmentMetadata", {})
-                .get("instanceUrl", "")
-            )
-            instance_host = (urlparse(instance_url).hostname or "").lower()
-            if instance_host == target_host:
-                return env.get("name")
+            linked = env.get("properties", {}).get("linkedEnvironmentMetadata", {})
+            for url_field in ("instanceUrl", "instanceApiUrl"):
+                candidate = linked.get(url_field, "")
+                if not candidate:
+                    continue
+                candidate_host = (urlparse(candidate).hostname or "").lower()
+                if candidate_host == target_host:
+                    return env.get("name")
         return None
 
     # ----- Flow APIs -----
@@ -316,23 +321,34 @@ def derive_environment_id(
     where the two ids diverged.
 
     Preferred path (when `pp_admin` is supplied and authenticated):
-      list BAP admin environments and match `linkedEnvironmentMetadata.instanceUrl`
-      against `env_url`. The matching env's `name` is the BAP env id.
+      list BAP admin environments and match against
+      `linkedEnvironmentMetadata.instanceUrl` / `instanceApiUrl`. The
+      matching env's `name` is the BAP env id.
 
-    Fallback path (legacy / no BAP token yet):
+      If the BAP lookup MISSES (no env matches the hostname, e.g. the
+      user lacks admin access on that env), this function returns None
+      and lets the caller surface a clear "couldn't resolve via BAP"
+      message. We deliberately do NOT fall back to the WhoAmI /
+      OrganizationId path here: that value silently corrupts both BAP
+      admin calls (404s) and any deep links that embed the env id (the
+      deep link points at a non-existent env). A clean None lets
+      downstream callers (e.g., the Copilot Studio deep-link builder)
+      degrade gracefully to the homepage rather than fabricate a wrong
+      target.
+
+    Legacy fallback path (only when `pp_admin` is None):
       WhoAmI returns the Dataverse `OrganizationId`. This is wrong as a
       BAP env id but is retained so callers without a BAP client still
-      get *something* (some checks tolerate the wrong id; everything
-      hitting admin endpoints does not). Callers SHOULD pass
-      `pp_admin` to get the correct id.
+      get *something* for non-BAP checks. New callers SHOULD pass
+      `pp_admin` to get the correct id and surface a missed lookup
+      explicitly.
     """
     if pp_admin is not None:
-        bap_id = pp_admin.find_environment_id_by_dataverse_url(env_url)
-        if bap_id:
-            return bap_id
-        # Fall through to the legacy WhoAmI behavior so the caller still
-        # sees a (possibly wrong) value and a "could not resolve via BAP"
-        # diagnostic — easier to debug than a silent None.
+        # When BAP is reachable, trust the BAP answer (or its absence).
+        # A None here means "could not resolve via BAP" — callers should
+        # surface this rather than papering over with WhoAmI/OrganizationId,
+        # which corrupts both BAP admin calls and any URL that embeds env id.
+        return pp_admin.find_environment_id_by_dataverse_url(env_url)
 
     # HARD GATE: refuse to attach the Dataverse bearer to a non-HTTPS URL.
     # env_url is config-supplied so a misconfigured or hostile value could

--- a/solutions/ess-maker-skills/scripts/flightcheck/runner.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/runner.py
@@ -144,10 +144,19 @@ class FlightCheckRunner:
         total_failed = sum(c.failed for c in cat_map.values())
         total_warnings = sum(c.warnings for c in cat_map.values())
         total_passed = sum(c.passed for c in cat_map.values())
+        # Tallied here so the verdict logic can consult errors. Errors
+        # (a check raised mid-run) mean we don't actually know whether
+        # ESS is healthy in that area, so they MUST count as
+        # "not ready" — not "ready" or "ready with warnings". Before
+        # this was added, an error-only run rendered as green READY
+        # with all the errored rows visible under ACTION REQUIRED
+        # directly below the green banner — exactly the at-a-glance
+        # contradiction the prioritized report is meant to eliminate.
+        total_errors = sum(c.errors for c in cat_map.values())
 
-        if total_failed == 0 and total_warnings == 0:
+        if total_failed == 0 and total_errors == 0 and total_warnings == 0:
             overall = "READY"
-        elif total_failed == 0:
+        elif total_failed == 0 and total_errors == 0:
             overall = "READY_WITH_WARNINGS"
         else:
             overall = "NOT_READY"
@@ -165,7 +174,7 @@ class FlightCheckRunner:
             not_configured=sum(c.not_configured for c in cat_map.values()),
             manual=sum(c.manual for c in cat_map.values()),
             skipped=sum(c.skipped for c in cat_map.values()),
-            errors=sum(c.errors for c in cat_map.values()),
+            errors=total_errors,
             overall=overall,
         )
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/runner.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/runner.py
@@ -78,6 +78,8 @@ class RunResult:
     warnings: int = 0
     not_configured: int = 0
     manual: int = 0
+    skipped: int = 0
+    errors: int = 0
     overall: str = ""  # READY / READY_WITH_WARNINGS / NOT_READY
 
 
@@ -162,6 +164,8 @@ class FlightCheckRunner:
             warnings=total_warnings,
             not_configured=sum(c.not_configured for c in cat_map.values()),
             manual=sum(c.manual for c in cat_map.values()),
+            skipped=sum(c.skipped for c in cat_map.values()),
+            errors=sum(c.errors for c in cat_map.values()),
             overall=overall,
         )
 
@@ -184,6 +188,8 @@ def save_results(run_result: RunResult, output_dir: str = "workspace/flightcheck
         "warnings": run_result.warnings,
         "not_configured": run_result.not_configured,
         "manual": run_result.manual,
+        "skipped": run_result.skipped,
+        "errors": run_result.errors,
         "categories": [asdict(c) for c in run_result.categories],
         "results": [asdict(r) for r in run_result.results],
     }
@@ -210,11 +216,349 @@ def save_results(run_result: RunResult, output_dir: str = "workspace/flightcheck
     print(f"Report saved to {report_path}")
 
 
+# --- Result bucketing for the prioritized report layout --------------
+#
+# The report groups results into three buckets so the operator can
+# triage by skimming top-to-bottom:
+#
+#   1. ACTION_REQUIRED — Failed, Error, Warning. The operator must
+#      look at these and either fix them or decide they're acceptable.
+#   2. MANUAL_VERIFICATION — Manual, NotConfigured, Skipped. The
+#      kit cannot programmatically confirm these; the operator must
+#      verify in the portal / vendor system, OR fix the underlying
+#      reason FlightCheck couldn't run the check (missing creds, etc.).
+#   3. PASSED — everything the kit confirmed is in a good state.
+#
+# Within each bucket results are sorted by:
+#   - priority (Critical > High > Medium > Low > unknown last)
+#   - status (per BUCKET_STATUS_ORDER below — worst first within bucket)
+#   - checkpoint_id (alphabetical, stable within ties)
+#
+# The flat run-order `RunResult.results` list is preserved unchanged
+# so JSON consumers and the pinned regression test for AUTH-005-style
+# bucketed checks keep working.
+
+BUCKET_ACTION = "action_required"
+BUCKET_MANUAL = "manual_verification"
+BUCKET_PASSED = "passed"
+
+# Which statuses land in which bucket. Keys are Status enum string
+# values (which is what CheckResult.status carries).
+_STATUS_TO_BUCKET = {
+    Status.FAILED.value: BUCKET_ACTION,
+    Status.ERROR.value: BUCKET_ACTION,
+    Status.WARNING.value: BUCKET_ACTION,
+    Status.MANUAL.value: BUCKET_MANUAL,
+    Status.NOT_CONFIGURED.value: BUCKET_MANUAL,
+    Status.SKIPPED.value: BUCKET_MANUAL,
+    Status.PASSED.value: BUCKET_PASSED,
+}
+
+# Within-bucket status sort order — lower index = surfaced first.
+# Worst news in each bucket goes to the top.
+_BUCKET_STATUS_ORDER = {
+    Status.FAILED.value: 0,
+    Status.ERROR.value: 1,
+    Status.WARNING.value: 2,
+    Status.MANUAL.value: 0,
+    Status.NOT_CONFIGURED.value: 1,
+    Status.SKIPPED.value: 2,
+    Status.PASSED.value: 0,
+}
+
+_PRIORITY_ORDER = {
+    Priority.CRITICAL.value: 0,
+    Priority.HIGH.value: 1,
+    Priority.MEDIUM.value: 2,
+    Priority.LOW.value: 3,
+}
+
+
+def _sort_key(r: CheckResult) -> tuple:
+    """Sort by priority, then within-bucket status order, then id."""
+    return (
+        _PRIORITY_ORDER.get(r.priority, 99),
+        _BUCKET_STATUS_ORDER.get(r.status, 99),
+        r.checkpoint_id or "",
+    )
+
+
+def bucket_results(
+    results: list[CheckResult],
+) -> dict[str, list[CheckResult]]:
+    """Group results into action_required / manual_verification / passed
+    buckets, each sorted by priority then status then checkpoint_id.
+
+    Unknown statuses fall into ACTION_REQUIRED as a defensive default
+    so a future status that isn't wired here doesn't silently vanish
+    from the report. The operator sees it under the most-visible
+    section instead.
+    """
+    buckets: dict[str, list[CheckResult]] = {
+        BUCKET_ACTION: [],
+        BUCKET_MANUAL: [],
+        BUCKET_PASSED: [],
+    }
+    for r in results:
+        bucket = _STATUS_TO_BUCKET.get(r.status, BUCKET_ACTION)
+        buckets[bucket].append(r)
+    for key in buckets:
+        buckets[key].sort(key=_sort_key)
+    return buckets
+
+
 def _generate_html_report(r: RunResult) -> str:
-    """Generate an HTML report matching the ESS FlightCheck template style."""
-    # Build table rows
+    """Generate the prioritized HTML report.
+
+    Layout (top to bottom):
+      - Header with timestamp / scope / duration
+      - Verdict banner (green / yellow / red) with one-line summary
+      - Summary count cards (Passed / Failed / Warnings / Manual /
+        Not Configured / Skipped / Errors)
+      - Section 1: ACTION REQUIRED (Failed + Error + Warning)
+      - Section 2: NEEDS MANUAL VERIFICATION (Manual + NotConfigured + Skipped)
+      - Section 3: PASSED (collapsed by default — proof of work, not
+        a triage queue)
+    """
+    buckets = bucket_results(r.results)
+
+    verdict_class, verdict_icon, verdict_headline, verdict_sub = _verdict_text(r)
+
+    action_rows = _render_rows(buckets[BUCKET_ACTION])
+    manual_rows = _render_rows(buckets[BUCKET_MANUAL])
+    passed_rows = _render_rows(buckets[BUCKET_PASSED])
+
+    action_section = _render_section(
+        section_id="section-action",
+        title="Action required",
+        subtitle=(
+            "Items the kit found to be failing, errored, or showing a "
+            "warning. Review each one and either fix it or confirm it's "
+            "acceptable for your deployment."
+        ),
+        empty_text=(
+            "No failing, errored, or warning items \u2014 nothing here "
+            "needs your attention."
+        ),
+        rows_html=action_rows,
+        count=len(buckets[BUCKET_ACTION]),
+        open_by_default=True,
+    )
+
+    manual_section = _render_section(
+        section_id="section-manual",
+        title="Needs manual verification",
+        subtitle=(
+            "The kit can't confirm these programmatically. Either "
+            "verify the state in the portal / vendor system, or fix the "
+            "reason the check couldn't run (missing credentials, "
+            "permissions, or feature not enabled)."
+        ),
+        empty_text=(
+            "Nothing requires manual verification \u2014 every check "
+            "ran end-to-end."
+        ),
+        rows_html=manual_rows,
+        count=len(buckets[BUCKET_MANUAL]),
+        open_by_default=True,
+    )
+
+    passed_section = _render_section(
+        section_id="section-passed",
+        title="Passed",
+        subtitle=(
+            "Items the kit confirmed are in a good state. Expand for "
+            "the full list."
+        ),
+        empty_text="No passing items in this run.",
+        rows_html=passed_rows,
+        count=len(buckets[BUCKET_PASSED]),
+        open_by_default=False,
+    )
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>ESS Pre-flight Validation Report</title>
+    <style>
+        body {{ font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 20px; background-color: #f5f5f5; }}
+        .header {{ background-color: #0078d4; color: white; padding: 20px; border-radius: 5px; }}
+        /* Verdict banner — the single biggest signal in the report.
+           Three states match RunResult.overall: READY (green),
+           READY_WITH_WARNINGS (amber), NOT_READY (red). The icon +
+           headline + subline are all sized so the operator gets the
+           verdict at a glance without reading anything else. */
+        .verdict {{ padding: 24px; margin: 20px 0; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); display: flex; align-items: center; gap: 20px; }}
+        .verdict-icon {{ font-size: 48px; line-height: 1; flex-shrink: 0; }}
+        .verdict-text h2 {{ margin: 0 0 4px 0; font-size: 24px; }}
+        .verdict-text p {{ margin: 0; font-size: 14px; opacity: 0.9; }}
+        .verdict-ready {{ background-color: #d4edda; color: #155724; border-left: 8px solid #28a745; }}
+        .verdict-warnings {{ background-color: #fff3cd; color: #856404; border-left: 8px solid #ffc107; }}
+        .verdict-not-ready {{ background-color: #f8d7da; color: #721c24; border-left: 8px solid #dc3545; }}
+        .summary {{ background-color: white; padding: 20px; margin: 20px 0; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
+        .summary-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 15px; }}
+        .summary-item {{ text-align: center; padding: 15px; border-radius: 5px; }}
+        .passed {{ background-color: #d4edda; color: #155724; }}
+        .failed {{ background-color: #f8d7da; color: #721c24; }}
+        .warning {{ background-color: #fff3cd; color: #856404; }}
+        .notconfigured {{ background-color: #e7e7e7; color: #666; }}
+        .manual {{ background-color: #cce5ff; color: #004085; }}
+        .skipped {{ background-color: #e7e7e7; color: #666; }}
+        .errored {{ background-color: #f8d7da; color: #721c24; }}
+        /* Each section gets its own card. The <details> element is
+           used so the operator can collapse PASSED to reduce noise;
+           ACTION REQUIRED and MANUAL stay open by default because the
+           operator's job is to look at every row. */
+        .section {{ background-color: white; padding: 20px; margin: 20px 0; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
+        .section summary {{ cursor: pointer; outline: none; }}
+        .section h2 {{ display: inline-block; margin: 0; font-size: 20px; }}
+        .section .count-badge {{ display: inline-block; margin-left: 10px; padding: 2px 10px; border-radius: 12px; font-size: 14px; font-weight: bold; vertical-align: middle; }}
+        .section .subtitle {{ margin: 8px 0 16px 0; color: #555; font-size: 13px; }}
+        .section .empty-note {{ padding: 12px; background-color: #f5f5f5; border-radius: 4px; color: #555; font-style: italic; }}
+        #section-action .count-badge {{ background-color: #f8d7da; color: #721c24; }}
+        #section-manual .count-badge {{ background-color: #cce5ff; color: #004085; }}
+        #section-passed .count-badge {{ background-color: #d4edda; color: #155724; }}
+        table {{ width: 100%; border-collapse: collapse; margin-top: 10px; }}
+        th {{ background-color: #0078d4; color: white; padding: 12px; text-align: left; }}
+        td {{ padding: 10px; border-bottom: 1px solid #ddd; vertical-align: top; word-wrap: break-word; overflow-wrap: break-word; }}
+        /* cell-text preserves authored line breaks AND leading
+           whitespace, so multi-line result/remediation strings (e.g.
+           AUTH-006's "Detected apps:" list and "Step 1 / Step 2"
+           sub-steps) render as written instead of collapsing into a
+           wall of text. Applied only to the result + remediation
+           cells; the other cells stay single-line. */
+        td.cell-text {{ white-space: pre-wrap; line-height: 1.5; }}
+        tr:hover {{ background-color: #f5f5f5; }}
+        .status-passed {{ color: #28a745; font-weight: bold; }}
+        .status-failed {{ color: #dc3545; font-weight: bold; }}
+        .status-warning {{ color: #ffc107; font-weight: bold; }}
+        .status-notconfigured {{ color: #6c757d; font-weight: bold; }}
+        .status-manual {{ color: #004085; font-weight: bold; }}
+        .priority-critical {{ background-color: #ffe6e6; }}
+        .priority-high {{ background-color: #fff4e6; }}
+        .footer {{ margin-top: 20px; text-align: center; color: #666; }}
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ESS Pre-flight Deployment Validation Report</h1>
+        <p>Generated: {r.started}</p>
+        <p>Validation Scope: {r.scope} | Duration: {r.duration_secs}s</p>
+    </div>
+
+    <div class="verdict {verdict_class}">
+        <div class="verdict-icon">{verdict_icon}</div>
+        <div class="verdict-text">
+            <h2>{verdict_headline}</h2>
+            <p>{verdict_sub}</p>
+        </div>
+    </div>
+
+    <div class="summary">
+        <h2>Validation Summary</h2>
+        <div class="summary-grid">
+            <div class="summary-item failed">
+                <h3>{r.failed}</h3>
+                <p>Failed</p>
+            </div>
+            <div class="summary-item errored">
+                <h3>{r.errors}</h3>
+                <p>Errored</p>
+            </div>
+            <div class="summary-item warning">
+                <h3>{r.warnings}</h3>
+                <p>Warnings</p>
+            </div>
+            <div class="summary-item manual">
+                <h3>{r.manual}</h3>
+                <p>Manual</p>
+            </div>
+            <div class="summary-item notconfigured">
+                <h3>{r.not_configured}</h3>
+                <p>Not Configured</p>
+            </div>
+            <div class="summary-item skipped">
+                <h3>{r.skipped}</h3>
+                <p>Skipped</p>
+            </div>
+            <div class="summary-item passed">
+                <h3>{r.passed}</h3>
+                <p>Passed</p>
+            </div>
+        </div>
+    </div>
+
+{action_section}
+
+{manual_section}
+
+{passed_section}
+
+    <div class="footer">
+        <p>ESS Maker Kit &mdash; FlightCheck v1.0</p>
+        <p>For more information, visit: <a href="https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service/">Microsoft Learn - Employee Self-Service</a></p>
+    </div>
+</body>
+</html>"""
+
+
+def _verdict_text(r: RunResult) -> tuple[str, str, str, str]:
+    """Return (css_class, icon, headline, subline) for the verdict banner.
+
+    Drives the single biggest signal on the page, so word choice
+    matters: the headline answers "is my deployment OK?" in five
+    words or less; the subline says exactly what to do next.
+    """
+    action_count = r.failed + r.errors + r.warnings
+    manual_count = r.manual + r.not_configured + r.skipped
+
+    if r.overall == "READY":
+        if manual_count:
+            sub = (
+                f"All {r.passed} automated check(s) passed. "
+                f"{manual_count} item(s) need manual verification \u2014 "
+                "see the section below."
+            )
+        else:
+            sub = (
+                f"All {r.passed} check(s) passed. Your environment "
+                "looks ready to deploy."
+            )
+        return ("verdict-ready", "\u2713", "Ready for deployment", sub)
+
+    if r.overall == "READY_WITH_WARNINGS":
+        sub = (
+            f"{r.warnings} warning(s) found. Review the items in "
+            "\u201cAction required\u201d below and confirm each is "
+            "acceptable before deploying."
+        )
+        return (
+            "verdict-warnings",
+            "\u26a0",
+            "Ready with warnings",
+            sub,
+        )
+
+    # NOT_READY (or any unrecognized overall) — treat as a blocker.
+    failing = r.failed + r.errors
+    issue_word = "issue" if action_count == 1 else "issues"
+    sub = (
+        f"{failing} failing/errored check(s) and {r.warnings} "
+        f"warning(s) need attention. Start with the \u201cAction "
+        "required\u201d section below."
+    )
+    return (
+        "verdict-not-ready",
+        "\u2717",
+        f"Not ready \u2014 {action_count} {issue_word} need attention",
+        sub,
+    )
+
+
+def _render_rows(results: list[CheckResult]) -> str:
+    """Render the <tr> rows for a list of results."""
     rows = []
-    for res in r.results:
+    for res in results:
         status_class = {
             Status.PASSED.value: "status-passed",
             Status.FAILED.value: "status-failed",
@@ -244,104 +588,56 @@ def _generate_html_report(r: RunResult) -> str:
             f'                    <td class="cell-text">{remediation}</td>\n'
             f"                </tr>"
         )
+    return "\n".join(rows)
 
-    rows_html = "\n".join(rows)
 
-    return f"""<!DOCTYPE html>
-<html>
-<head>
-    <title>ESS Pre-flight Validation Report</title>
-    <style>
-        body {{ font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 20px; background-color: #f5f5f5; }}
-        .header {{ background-color: #0078d4; color: white; padding: 20px; border-radius: 5px; }}
-        .summary {{ background-color: white; padding: 20px; margin: 20px 0; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
-        .summary-grid {{ display: grid; grid-template-columns: repeat(5, 1fr); gap: 20px; }}
-        .summary-item {{ text-align: center; padding: 15px; border-radius: 5px; }}
-        .passed {{ background-color: #d4edda; color: #155724; }}
-        .failed {{ background-color: #f8d7da; color: #721c24; }}
-        .warning {{ background-color: #fff3cd; color: #856404; }}
-        .notconfigured {{ background-color: #e7e7e7; color: #666; }}
-        .manual {{ background-color: #cce5ff; color: #004085; }}
-        .results {{ background-color: white; padding: 20px; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
-        table {{ width: 100%; border-collapse: collapse; margin-top: 20px; }}
-        th {{ background-color: #0078d4; color: white; padding: 12px; text-align: left; }}
-        td {{ padding: 10px; border-bottom: 1px solid #ddd; vertical-align: top; word-wrap: break-word; overflow-wrap: break-word; }}
-        /* cell-text preserves authored line breaks AND leading
-           whitespace, so multi-line result/remediation strings (e.g.
-           AUTH-006's "Detected apps:" list and "Step 1 / Step 2"
-           sub-steps) render as written instead of collapsing into a
-           wall of text. Applied only to the result + remediation
-           cells; the other cells stay single-line. */
-        td.cell-text {{ white-space: pre-wrap; line-height: 1.5; }}
-        tr:hover {{ background-color: #f5f5f5; }}
-        .status-passed {{ color: #28a745; font-weight: bold; }}
-        .status-failed {{ color: #dc3545; font-weight: bold; }}
-        .status-warning {{ color: #ffc107; font-weight: bold; }}
-        .status-notconfigured {{ color: #6c757d; font-weight: bold; }}
-        .status-manual {{ color: #004085; font-weight: bold; }}
-        .priority-critical {{ background-color: #ffe6e6; }}
-        .priority-high {{ background-color: #fff4e6; }}
-        .footer {{ margin-top: 20px; text-align: center; color: #666; }}
-    </style>
-</head>
-<body>
-    <div class="header">
-        <h1>ESS Pre-flight Deployment Validation Report</h1>
-        <p>Generated: {r.started}</p>
-        <p>Validation Scope: {r.scope} | Duration: {r.duration_secs}s</p>
-    </div>
+def _render_section(
+    *,
+    section_id: str,
+    title: str,
+    subtitle: str,
+    empty_text: str,
+    rows_html: str,
+    count: int,
+    open_by_default: bool,
+) -> str:
+    """Render one of the 3 result sections as a <details> block.
 
-    <div class="summary">
-        <h2>Validation Summary</h2>
-        <div class="summary-grid">
-            <div class="summary-item passed">
-                <h3>{r.passed}</h3>
-                <p>Passed</p>
-            </div>
-            <div class="summary-item failed">
-                <h3>{r.failed}</h3>
-                <p>Failed</p>
-            </div>
-            <div class="summary-item warning">
-                <h3>{r.warnings}</h3>
-                <p>Warnings</p>
-            </div>
-            <div class="summary-item notconfigured">
-                <h3>{r.not_configured}</h3>
-                <p>Not Configured</p>
-            </div>
-            <div class="summary-item manual">
-                <h3>{r.manual}</h3>
-                <p>Manual</p>
-            </div>
-        </div>
-    </div>
+    When the section is empty we still render the section card but
+    swap the table for a friendly "nothing here" note so the operator
+    sees at a glance that the kit checked the bucket and found
+    nothing to flag.
+    """
+    open_attr = " open" if open_by_default else ""
+    if count == 0:
+        body = f'        <div class="empty-note">{empty_text}</div>'
+    else:
+        body = (
+            '        <table>\n'
+            '            <thead>\n'
+            '                <tr>\n'
+            '                    <th>Checkpoint</th>\n'
+            '                    <th>Category</th>\n'
+            '                    <th>Priority</th>\n'
+            '                    <th>Status</th>\n'
+            '                    <th>Result</th>\n'
+            '                    <th>Remediation</th>\n'
+            '                </tr>\n'
+            '            </thead>\n'
+            '            <tbody>\n'
+            f"{rows_html}\n"
+            '            </tbody>\n'
+            '        </table>'
+        )
 
-    <div class="results">
-        <h2>Detailed Results</h2>
-        <table>
-            <thead>
-                <tr>
-                    <th>Checkpoint</th>
-                    <th>Category</th>
-                    <th>Priority</th>
-                    <th>Status</th>
-                    <th>Result</th>
-                    <th>Remediation</th>
-                </tr>
-            </thead>
-            <tbody>
-{rows_html}
-            </tbody>
-        </table>
-    </div>
-
-    <div class="footer">
-        <p>ESS Maker Kit — FlightCheck v1.0</p>
-        <p>For more information, visit: <a href="https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service/">Microsoft Learn - Employee Self-Service</a></p>
-    </div>
-</body>
-</html>"""
+    return (
+        f'    <details id="{section_id}" class="section"{open_attr}>\n'
+        f'        <summary><h2>{title}</h2>'
+        f'<span class="count-badge">{count}</span></summary>\n'
+        f'        <p class="subtitle">{subtitle}</p>\n'
+        f'{body}\n'
+        '    </details>'
+    )
 
 
 def _html_escape(text: str) -> str:

--- a/tests/flightcheck/test_local_files_agent_identity.py
+++ b/tests/flightcheck/test_local_files_agent_identity.py
@@ -1,0 +1,290 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for ``_check_agent_identity`` in
+``flightcheck.checks.local_files``.
+
+Pins the YAML-aware parsing behavior. The previous implementation used
+a regex (``instructions:\\s*[|>]?\\s*\\n…``) which silently missed
+YAML's chomping-indicator block scalars (``|-``, ``|+``, ``>-``,
+``>+``). Real Copilot Studio agent.mcs.yml files routinely emit
+``instructions: |-``, so the check reported "No instructions block
+found in agent.mcs.yml" for agents that obviously had instructions.
+
+These tests pin the new behavior and the specific regression.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    """Make `flightcheck.*` importable from the kit's scripts dir."""
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+# Minimal block-scalar instructions text built to exceed the 50-word
+# PASS threshold. Single source of truth so every test uses the same
+# wording — only the YAML scalar STYLE varies between tests.
+_INSTRUCTION_BODY = (
+    "  You are an employee experience agent that helps enterprise employees "
+    "with HR questions. Your role is to provide clear, authoritative, "
+    "policy-based guidance, clarify next steps, and escalate to HR support "
+    "channels when needed. Be empathetic, professional, nonjudgmental, "
+    "supportive, and reassuring across every interaction with a worker. "
+    "Always cite sources from the employee handbook, prefer concrete "
+    "actionable next steps, and gracefully hand off to a human reviewer "
+    "whenever the question goes beyond your authority."
+)
+
+
+def _runner():
+    return SimpleNamespace(env_id="env-guid", config={})
+
+
+def _write_agent(tmp_path, body: str) -> Path:
+    agent_path = tmp_path / "agentfolder"
+    agent_path.mkdir()
+    (agent_path / "agent.mcs.yml").write_text(body, encoding="utf-8")
+    return agent_path
+
+
+def _get_check(results, checkpoint_id):
+    hits = [r for r in results if r.checkpoint_id == checkpoint_id]
+    assert hits, f"no result with checkpoint_id={checkpoint_id!r}"
+    assert len(hits) == 1, f"expected exactly one {checkpoint_id} result"
+    return hits[0]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# CONFIG-007 — instructions
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_config_007_passes_when_instructions_use_strip_chomping_block_scalar(tmp_path):
+    """Regression: `instructions: |-` (strip-chomping) is what the
+    user's real Copilot Studio agent emits. The old regex required
+    `[|>]?` then `\\n` immediately, so `|-` failed to match and
+    CONFIG-007 wrongly reported "No instructions block found in
+    agent.mcs.yml" despite the agent obviously having instructions.
+    """
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "kind: GptComponentMetadata\n"
+        "displayName: ESS_HR_WDAY_ONLY_OAUTH\n"
+        "instructions: |-\n"
+        f"{_INSTRUCTION_BODY}\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    results = _check_agent_identity(agent_path, "ESS Agent", runner=_runner(), agent_name="esshrwdayonlyoauth")
+    instructions = _get_check(results, "CONFIG-007")
+    assert instructions.status == "Passed", instructions.result
+    assert "Instructions present" in instructions.result
+
+
+def test_config_007_passes_with_plain_block_scalar(tmp_path):
+    """Sanity: plain `|` (clip-chomping, the YAML default) still works."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        "instructions: |\n"
+        f"{_INSTRUCTION_BODY}\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    results = _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent")
+    assert _get_check(results, "CONFIG-007").status == "Passed"
+
+
+def test_config_007_passes_with_keep_chomping_block_scalar(tmp_path):
+    """Sanity: `|+` (keep-chomping) — same chomping-indicator failure
+    mode as `|-`, just keeping trailing newlines instead of stripping."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        "instructions: |+\n"
+        f"{_INSTRUCTION_BODY}\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    results = _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent")
+    assert _get_check(results, "CONFIG-007").status == "Passed"
+
+
+def test_config_007_passes_with_folded_block_scalar(tmp_path):
+    """Sanity: `>-` (folded with strip-chomping) — would also miss
+    the old regex for the same reason."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        "instructions: >-\n"
+        f"{_INSTRUCTION_BODY}\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    results = _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent")
+    assert _get_check(results, "CONFIG-007").status == "Passed"
+
+
+def test_config_007_passes_with_quoted_inline_string(tmp_path):
+    """Sanity: a single-line quoted string instead of a block scalar
+    must also be honored."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        f'instructions: "{_INSTRUCTION_BODY.strip()}"\n'
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    results = _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent")
+    assert _get_check(results, "CONFIG-007").status == "Passed"
+
+
+def test_config_007_warns_when_instructions_are_short(tmp_path):
+    """Below 50 words is a WARNING, not a FAIL."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        "instructions: |-\n"
+        "  Short instructions for tests.\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    instructions = _get_check(
+        _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent"),
+        "CONFIG-007",
+    )
+    assert instructions.status == "Warning"
+    assert "short" in instructions.result.lower()
+
+
+def test_config_007_fails_when_instructions_key_missing(tmp_path):
+    """The key truly is absent."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = "displayName: Some Agent\n"
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    instructions = _get_check(
+        _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent"),
+        "CONFIG-007",
+    )
+    assert instructions.status == "Failed"
+    assert "No instructions" in instructions.result
+
+
+def test_config_007_fails_when_yaml_is_unparseable(tmp_path):
+    """Surface a clear error rather than silently treating it as
+    'no instructions' (which would confuse the user)."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = "displayName: [unterminated\n"
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    instructions = _get_check(
+        _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent"),
+        "CONFIG-007",
+    )
+    assert instructions.status == "Failed"
+    assert "could not be parsed" in instructions.result.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# CONFIG-005 — starter prompts (parsed from the same YAML)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_config_005_passes_when_six_starter_prompts_present(tmp_path):
+    """The user's real file: 6 prompts, each with title+text. The old
+    regex counted `-\\s+text:` occurrences and could over- or
+    under-count depending on indentation; YAML parsing is deterministic."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        "instructions: |-\n"
+        f"{_INSTRUCTION_BODY}\n"
+        "conversationStarters:\n"
+        "  - title: Navigate benefits\n"
+        "    text: Help me learn more about benefits and resources\n"
+        "  - title: Check policies\n"
+        "    text: What are my options for taking time off work?\n"
+        "  - title: Discover resources\n"
+        "    text: Tell me more about hybrid and remote work policies\n"
+        "  - title: Grow skills\n"
+        "    text: Where can I find training and learning opportunities?\n"
+        "  - title: Find balance\n"
+        "    text: How do I learn more about physical and mental wellbeing?\n"
+        "  - title: Ask questions\n"
+        "    text: Where is my most recent paystub?\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    starters = _get_check(
+        _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent"),
+        "CONFIG-005",
+    )
+    assert starters.status == "Passed"
+    assert "6 starter prompt" in starters.result
+
+
+def test_config_005_warns_when_only_one_starter_prompt(tmp_path):
+    """1 < 3 is a WARNING (not FAIL): some prompts but recommend more."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        "instructions: |-\n"
+        f"{_INSTRUCTION_BODY}\n"
+        "conversationStarters:\n"
+        "  - title: Ask questions\n"
+        "    text: Where is my most recent paystub?\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    starters = _get_check(
+        _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent"),
+        "CONFIG-005",
+    )
+    assert starters.status == "Warning"
+    assert "Only 1" in starters.result
+
+
+def test_config_005_warns_when_no_starter_prompts(tmp_path):
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    yaml_text = (
+        "displayName: Some Agent\n"
+        "instructions: |-\n"
+        f"{_INSTRUCTION_BODY}\n"
+    )
+    agent_path = _write_agent(tmp_path, yaml_text)
+
+    starters = _get_check(
+        _check_agent_identity(agent_path, "Some Agent", runner=_runner(), agent_name="some-agent"),
+        "CONFIG-005",
+    )
+    assert starters.status == "Warning"
+    assert "No starter prompts" in starters.result

--- a/tests/flightcheck/test_local_files_studio_link.py
+++ b/tests/flightcheck/test_local_files_studio_link.py
@@ -1,0 +1,194 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for the Copilot Studio deep-link helpers in
+``flightcheck.checks.local_files``.
+
+These pin the CONFIG-007 remediation behavior the user surfaced: when a
+check fails, the remediation must point the user directly at the
+specific agent in Copilot Studio so they know where to click.
+
+URL shape (verified against a live tenant in conversation):
+    https://copilotstudio.microsoft.com/environments/{envId}/bots/{botId}/overview
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    """Make `flightcheck.*` importable from the kit's scripts dir."""
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def _fake_runner(env_id="env-guid-123", agents=None, single_agent=None):
+    config = {}
+    if agents is not None:
+        config["agents"] = agents
+    if single_agent is not None:
+        config["agent"] = single_agent
+    return SimpleNamespace(env_id=env_id, config=config)
+
+
+def test_deep_link_built_from_runner_env_id_and_matching_agent_slug():
+    from flightcheck.checks.local_files import _studio_agent_url
+
+    runner = _fake_runner(
+        env_id="11111111-2222-3333-4444-555555555555",
+        agents=[
+            {"slug": "agent-a", "botId": "bot-a-id"},
+            {"slug": "agent-b", "botId": "bot-b-id"},
+        ],
+    )
+
+    url = _studio_agent_url(runner, "agent-b")
+
+    assert url == (
+        "https://copilotstudio.microsoft.com/"
+        "environments/11111111-2222-3333-4444-555555555555/"
+        "bots/bot-b-id/overview"
+    )
+
+
+def test_deep_link_falls_back_to_single_agent_shape_when_slug_not_in_agents():
+    """Older configs only have a top-level "agent" key, no "agents" list."""
+    from flightcheck.checks.local_files import _studio_agent_url
+
+    runner = _fake_runner(
+        env_id="env-1",
+        single_agent={"slug": "legacy-agent", "botId": "legacy-bot-id"},
+    )
+
+    # agent_name doesn't match the single-agent slug, but the helper
+    # falls back to the single-agent shape — that's the whole point of
+    # the fallback, otherwise older configs always lose the deep link.
+    url = _studio_agent_url(runner, "any-name")
+
+    assert url == (
+        "https://copilotstudio.microsoft.com/"
+        "environments/env-1/bots/legacy-bot-id/overview"
+    )
+
+
+def test_deep_link_returns_none_when_env_id_missing():
+    from flightcheck.checks.local_files import _studio_agent_url
+
+    runner = _fake_runner(env_id=None, agents=[{"slug": "a", "botId": "b"}])
+
+    assert _studio_agent_url(runner, "a") is None
+
+
+def test_deep_link_returns_none_when_bot_id_not_findable():
+    from flightcheck.checks.local_files import _studio_agent_url
+
+    runner = _fake_runner(env_id="e", agents=[{"slug": "other", "botId": "x"}])
+
+    assert _studio_agent_url(runner, "missing-agent") is None
+
+
+def test_deep_link_returns_none_when_runner_is_none():
+    from flightcheck.checks.local_files import _studio_agent_url
+
+    assert _studio_agent_url(None, "any-agent") is None
+
+
+def test_studio_link_md_uses_deep_link_when_available():
+    from flightcheck.checks.local_files import _studio_link_md
+
+    runner = _fake_runner(env_id="e1", agents=[{"slug": "a", "botId": "b1"}])
+
+    md = _studio_link_md(runner, "a", "the agent")
+
+    assert md == (
+        "[the agent]("
+        "https://copilotstudio.microsoft.com/"
+        "environments/e1/bots/b1/overview)"
+    )
+
+
+def test_studio_link_md_falls_back_to_homepage_when_no_deep_link():
+    """Failing softly to the homepage keeps the remediation actionable
+    even when env_id or botId are missing (e.g. setup half-completed)."""
+    from flightcheck.checks.local_files import _studio_link_md
+
+    md = _studio_link_md(None, "", "Copilot Studio")
+
+    assert md == "[Copilot Studio](https://copilotstudio.microsoft.com/)"
+
+
+def test_config_007_missing_instructions_remediation_includes_deep_link(
+    tmp_path: Path,
+):
+    """When CONFIG-007 fails with 'no instructions block', the
+    remediation string must include the deep link so the user knows
+    EXACTLY where to go in Copilot Studio."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    agent_dir = tmp_path / "my-agent"
+    agent_dir.mkdir()
+    # agent.mcs.yml exists but has no instructions block at all
+    (agent_dir / "agent.mcs.yml").write_text(
+        "kind: AgentDefinition\nname: My Agent\n",
+        encoding="utf-8",
+    )
+
+    runner = _fake_runner(
+        env_id="env-007",
+        agents=[{"slug": "my-agent", "botId": "bot-007"}],
+    )
+
+    results = _check_agent_identity(agent_dir, "My Agent", runner, "my-agent")
+
+    # find the FAILED CONFIG-007 row for "Agent instructions"
+    failed = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-007"
+        and r.status == "Failed"
+        and "instructions" in r.description.lower()
+    ]
+    assert len(failed) == 1, [r.__dict__ for r in results]
+
+    remediation = failed[0].remediation or ""
+    assert (
+        "https://copilotstudio.microsoft.com/environments/env-007/"
+        "bots/bot-007/overview"
+    ) in remediation
+
+
+def test_config_007_remediation_falls_back_when_runner_unavailable(
+    tmp_path: Path,
+):
+    """No runner / missing config -> remediation still links somewhere
+    (the homepage) rather than leaving the user without a link."""
+    from flightcheck.checks.local_files import _check_agent_identity
+
+    agent_dir = tmp_path / "my-agent"
+    agent_dir.mkdir()
+    (agent_dir / "agent.mcs.yml").write_text(
+        "kind: AgentDefinition\nname: My Agent\n",
+        encoding="utf-8",
+    )
+
+    results = _check_agent_identity(agent_dir, "My Agent", None, "")
+
+    failed = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-007" and r.status == "Failed"
+    ]
+    assert len(failed) == 1
+    assert "https://copilotstudio.microsoft.com/" in (failed[0].remediation or "")

--- a/tests/flightcheck/test_pp_admin_client.py
+++ b/tests/flightcheck/test_pp_admin_client.py
@@ -59,3 +59,166 @@ class TestPermissionHandling:
         ))
         result = pp_client.get_connections(pp.MOCK_ENV_ID)
         assert result == []
+
+
+class TestFindEnvironmentIdByDataverseUrl:
+    """Pins the hostname-matching behavior of
+    PPAdminClient.find_environment_id_by_dataverse_url.
+
+    Bug being fixed: BAP advertises two URLs per env in
+    ``linkedEnvironmentMetadata``:
+      - ``instanceUrl``:    https://org<hash>.crm12.dynamics.com/
+      - ``instanceApiUrl``: https://org<hash>.api.crm12.dynamics.com
+
+    The config's ``dataverseEndpoint`` is typically the API form, but
+    the matcher historically only checked ``instanceUrl``, so every
+    tenant with an ``api.`` host silently missed and the caller fell
+    back to the Dataverse OrganizationId — which is NOT a valid BAP
+    env id and breaks both BAP admin calls AND any URL that embeds
+    the env id (e.g. Copilot Studio deep links).
+    """
+
+    def _make_client(self, envs):
+        from flightcheck.pp_admin_client import PPAdminClient
+
+        client = PPAdminClient(tenant_id="00000000-0000-0000-0000-000000001111")
+
+        # Patch out network: get_environments() now returns the fixture.
+        client.get_environments = lambda: envs  # type: ignore[method-assign]
+        return client
+
+    def _env(self, *, name, instance_url="", instance_api_url=""):
+        linked = {}
+        if instance_url:
+            linked["instanceUrl"] = instance_url
+        if instance_api_url:
+            linked["instanceApiUrl"] = instance_api_url
+        return {
+            "name": name,
+            "properties": {"linkedEnvironmentMetadata": linked},
+        }
+
+    def test_matches_when_config_uses_api_hostname_and_env_advertises_instance_api_url(
+        self,
+    ) -> None:
+        """The user's repro: config has the .api. host, BAP advertises
+        the .api. host on instanceApiUrl. Historically missed because
+        only instanceUrl was checked."""
+        envs = [
+            self._env(
+                name="ecf4737d-bef7-e58a-aa5e-e71a60780efc",
+                instance_url="https://orgd98aef4a.crm12.dynamics.com/",
+                instance_api_url="https://orgd98aef4a.api.crm12.dynamics.com",
+            ),
+        ]
+        client = self._make_client(envs)
+        assert (
+            client.find_environment_id_by_dataverse_url(
+                "https://orgd98aef4a.api.crm12.dynamics.com"
+            )
+            == "ecf4737d-bef7-e58a-aa5e-e71a60780efc"
+        )
+
+    def test_matches_when_config_uses_web_hostname_and_env_advertises_instance_url(
+        self,
+    ) -> None:
+        """Original behavior: config has the bare .crm. host, BAP
+        advertises it on instanceUrl. Must still match."""
+        envs = [
+            self._env(
+                name="bap-env-1",
+                instance_url="https://orgmocktenant.crm.dynamics.com/",
+                instance_api_url="https://orgmocktenant.api.crm.dynamics.com",
+            ),
+        ]
+        client = self._make_client(envs)
+        assert (
+            client.find_environment_id_by_dataverse_url(
+                "https://orgmocktenant.crm.dynamics.com/"
+            )
+            == "bap-env-1"
+        )
+
+    def test_returns_none_when_no_env_matches_either_url_field(self) -> None:
+        envs = [
+            self._env(
+                name="bap-env-1",
+                instance_url="https://otherorg.crm.dynamics.com/",
+                instance_api_url="https://otherorg.api.crm.dynamics.com",
+            ),
+        ]
+        client = self._make_client(envs)
+        assert (
+            client.find_environment_id_by_dataverse_url(
+                "https://orgd98aef4a.api.crm12.dynamics.com"
+            )
+            is None
+        )
+
+    def test_skips_envs_with_empty_url_fields(self) -> None:
+        """Some BAP env records (e.g. envs without linked Dataverse)
+        have no instanceUrl/instanceApiUrl. They must not raise and
+        must not produce false matches."""
+        envs = [
+            self._env(name="bap-env-empty"),
+            self._env(
+                name="bap-env-match",
+                instance_api_url="https://orgd98aef4a.api.crm12.dynamics.com",
+            ),
+        ]
+        client = self._make_client(envs)
+        assert (
+            client.find_environment_id_by_dataverse_url(
+                "https://orgd98aef4a.api.crm12.dynamics.com"
+            )
+            == "bap-env-match"
+        )
+
+
+class TestDeriveEnvironmentIdFallbackBehavior:
+    """Pins the post-fix behavior of derive_environment_id.
+
+    Before: when pp_admin was supplied but the matcher returned None,
+    we silently fell through to WhoAmI/OrganizationId. That value is
+    NOT a valid BAP env id — every downstream BAP admin call 404s, and
+    any URL that embeds it (Copilot Studio deep link, maker portal)
+    points at a non-existent env.
+
+    After: when pp_admin is supplied, the matcher's verdict is final.
+    A None means "could not resolve via BAP" and is surfaced to the
+    caller; downstream features (deep links, BAP-scoped checks)
+    degrade gracefully rather than silently fabricating wrong targets.
+    """
+
+    def test_returns_none_when_pp_admin_supplied_but_matcher_misses(self) -> None:
+        from flightcheck.pp_admin_client import derive_environment_id
+
+        class StubAdmin:
+            def find_environment_id_by_dataverse_url(self, _env_url):
+                return None
+
+        # Must NOT fall through to WhoAmI/OrganizationId even though
+        # we pass a non-empty dataverse_token. The whole point is to
+        # avoid the fabricated-OrgId footgun. If this test starts
+        # failing because the function hit the network, that means the
+        # silent-fallback regression has come back.
+        result = derive_environment_id(
+            "https://orgd98aef4a.api.crm12.dynamics.com",
+            "fake-token-must-not-be-used",
+            pp_admin=StubAdmin(),
+        )
+        assert result is None
+
+    def test_returns_bap_id_when_pp_admin_supplied_and_matcher_hits(self) -> None:
+        from flightcheck.pp_admin_client import derive_environment_id
+
+        class StubAdmin:
+            def find_environment_id_by_dataverse_url(self, _env_url):
+                return "ecf4737d-bef7-e58a-aa5e-e71a60780efc"
+
+        result = derive_environment_id(
+            "https://orgd98aef4a.api.crm12.dynamics.com",
+            "fake-token",
+            pp_admin=StubAdmin(),
+        )
+        assert result == "ecf4737d-bef7-e58a-aa5e-e71a60780efc"

--- a/tests/flightcheck/test_runner_report_layout.py
+++ b/tests/flightcheck/test_runner_report_layout.py
@@ -1,0 +1,463 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for the prioritized FlightCheck report layout introduced
+in PR for grahamc/flightcheck-report-prioritized-format.
+
+The redesign reshapes the operator's triage path: a verdict banner at
+the top tells them at a glance whether the deployment is ready, and
+results are split into three sections so they don't have to scan a
+single mixed table to find what needs action.
+
+This file pins the layout contracts so a future refactor cannot
+silently break the "find what needs my attention" path the report
+was designed for.
+
+The three buckets are:
+  - ACTION REQUIRED:  Failed, Error, Warning
+  - MANUAL:           Manual, NotConfigured, Skipped
+  - PASSED:           Passed
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    """Ensure scripts/ is on sys.path so `from flightcheck...` resolves."""
+    scripts_dir = (
+        Path(__file__).resolve().parents[1]
+        / "solutions" / "ess-maker-skills" / "scripts"
+    )
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def _make_result(checkpoint_id, status, priority="High", category="Test"):
+    """Lightweight CheckResult factory for layout tests."""
+    from flightcheck.runner import CheckResult
+    return CheckResult(
+        checkpoint_id=checkpoint_id,
+        category=category,
+        priority=priority,
+        status=status,
+        description=f"desc for {checkpoint_id}",
+        result=f"result for {checkpoint_id}",
+        remediation=(
+            f"remediation for {checkpoint_id}"
+            if status not in ("Passed",)
+            else ""
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# bucket_results — the core grouping helper.
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_results_assigns_statuses_to_correct_buckets():
+    """Every status maps to exactly one of the three buckets per
+    the contract documented in runner.py."""
+    from flightcheck.runner import (
+        bucket_results,
+        BUCKET_ACTION,
+        BUCKET_MANUAL,
+        BUCKET_PASSED,
+    )
+
+    results = [
+        _make_result("FAIL-1", "Failed"),
+        _make_result("ERR-1", "Error"),
+        _make_result("WARN-1", "Warning"),
+        _make_result("MAN-1", "Manual"),
+        _make_result("CFG-1", "NotConfigured"),
+        _make_result("SKIP-1", "Skipped"),
+        _make_result("PASS-1", "Passed"),
+    ]
+    b = bucket_results(results)
+
+    action_ids = [r.checkpoint_id for r in b[BUCKET_ACTION]]
+    manual_ids = [r.checkpoint_id for r in b[BUCKET_MANUAL]]
+    passed_ids = [r.checkpoint_id for r in b[BUCKET_PASSED]]
+
+    assert set(action_ids) == {"FAIL-1", "ERR-1", "WARN-1"}
+    assert set(manual_ids) == {"MAN-1", "CFG-1", "SKIP-1"}
+    assert passed_ids == ["PASS-1"]
+
+
+def test_bucket_results_sorts_by_priority_then_status_then_id():
+    """Within ACTION REQUIRED:
+       - Critical-priority items come before High before Medium.
+       - Within the same priority, Failed comes before Warning.
+       - Within the same priority + status, ids sort alphabetically.
+    """
+    from flightcheck.runner import bucket_results, BUCKET_ACTION
+
+    results = [
+        _make_result("Z-WARN", "Warning", priority="Critical"),
+        _make_result("Z-FAIL", "Failed", priority="Critical"),
+        _make_result("A-FAIL", "Failed", priority="Critical"),
+        _make_result("HI-FAIL", "Failed", priority="High"),
+        _make_result("MED-FAIL", "Failed", priority="Medium"),
+    ]
+    ordered = [r.checkpoint_id for r in bucket_results(results)[BUCKET_ACTION]]
+
+    assert ordered == ["A-FAIL", "Z-FAIL", "Z-WARN", "HI-FAIL", "MED-FAIL"]
+
+
+def test_bucket_results_unknown_status_lands_in_action_required():
+    """Defensive default: an unrecognized status should surface in
+    the most-visible bucket, not silently vanish."""
+    from flightcheck.runner import bucket_results, BUCKET_ACTION
+
+    r = _make_result("UNKNOWN-1", "SomeFutureStatus")
+    bucketed = bucket_results([r])
+    assert r in bucketed[BUCKET_ACTION]
+
+
+# ---------------------------------------------------------------------------
+# Verdict banner — the single largest signal at the top of the report.
+# ---------------------------------------------------------------------------
+
+
+def _build_run_with(results):
+    """Run a registered no-op check that returns the supplied results."""
+    from flightcheck.runner import FlightCheckRunner
+    runner = FlightCheckRunner(scope="test")
+    runner.register("Test", lambda _r: list(results))
+    return runner.run()
+
+
+def test_verdict_banner_ready_when_all_passed(tmp_path):
+    from flightcheck.runner import save_results
+    result = _build_run_with([_make_result("OK-1", "Passed")])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    assert result.overall == "READY"
+    assert "verdict-ready" in html
+    assert "Ready for deployment" in html
+
+
+def test_verdict_banner_warnings_when_only_warnings(tmp_path):
+    from flightcheck.runner import save_results
+    result = _build_run_with([_make_result("W-1", "Warning")])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    assert result.overall == "READY_WITH_WARNINGS"
+    assert "verdict-warnings" in html
+    assert "Ready with warnings" in html
+
+
+def test_verdict_banner_not_ready_when_any_failure(tmp_path):
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("F-1", "Failed"),
+        _make_result("W-1", "Warning"),
+        _make_result("OK-1", "Passed"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    assert result.overall == "NOT_READY"
+    assert "verdict-not-ready" in html
+    assert "Not ready" in html
+    # Subline mentions counts so operator knows the scale.
+    assert "1 failing/errored" in html
+    assert "1 warning" in html
+
+
+def test_verdict_ready_subline_mentions_manual_count_when_present(tmp_path):
+    """When the run is READY but contains manual items, the verdict
+    subline must point the operator to the manual section."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("OK-1", "Passed"),
+        _make_result("OK-2", "Passed"),
+        _make_result("M-1", "Manual"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    assert "verdict-ready" in html
+    # "1 item(s) need manual verification" — operator must not miss
+    # the manual items just because the verdict is green.
+    assert "need manual verification" in html
+
+
+# ---------------------------------------------------------------------------
+# Section rendering — the three stacked sections.
+# ---------------------------------------------------------------------------
+
+
+def test_html_renders_three_named_sections(tmp_path):
+    """The three section anchors must exist regardless of which
+    sections happen to be populated, so the layout is stable for any
+    downstream tooling that links into specific section ids."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("F-1", "Failed"),
+        _make_result("M-1", "Manual"),
+        _make_result("P-1", "Passed"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    assert 'id="section-action"' in html
+    assert 'id="section-manual"' in html
+    assert 'id="section-passed"' in html
+    assert "Action required" in html
+    assert "Needs manual verification" in html
+    assert ">Passed</h2>" in html
+
+
+def test_action_section_open_by_default_passed_section_collapsed(tmp_path):
+    """The ACTION section must be open (operator sees rows
+    immediately), the PASSED section must be collapsed (operator
+    isn't forced to scroll past every passing row)."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("F-1", "Failed"),
+        _make_result("P-1", "Passed"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    # <details id="section-action" class="section" open> — note the
+    # exact attribute presence, since absence flips the default.
+    assert re.search(
+        r'<details id="section-action" class="section" open>', html
+    ), "Action section must be open by default"
+    assert re.search(
+        r'<details id="section-manual" class="section" open>', html
+    ), "Manual section must be open by default"
+
+    # PASSED has no `open` attribute — collapsed.
+    passed_block = re.search(
+        r'<details id="section-passed"[^>]*>', html
+    )
+    assert passed_block is not None
+    assert " open" not in passed_block.group(0), (
+        "Passed section must NOT be open by default"
+    )
+
+
+def test_empty_section_shows_friendly_note_not_an_empty_table(tmp_path):
+    """A section with zero results must show a friendly empty-note,
+    not an empty table the operator has to decode."""
+    from flightcheck.runner import save_results
+    # Only passing rows — both action_required and manual sections
+    # are empty.
+    result = _build_run_with([_make_result("OK-1", "Passed")])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    assert "nothing here" in html.lower() or "no failing" in html.lower()
+    # The empty section should NOT have a table inside it; check that
+    # by ensuring action section header is followed by the empty-note
+    # class before the next section.
+    m = re.search(
+        r'id="section-action".*?</details>', html, flags=re.S
+    )
+    assert m is not None
+    assert "empty-note" in m.group(0)
+    assert "<table>" not in m.group(0)
+
+
+def test_status_to_section_routing_in_rendered_html(tmp_path):
+    """Each status renders inside the section its bucket dictates —
+    not in some other section's table."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("FAIL-X", "Failed"),
+        _make_result("MAN-X", "Manual"),
+        _make_result("SKIP-X", "Skipped"),
+        _make_result("PASS-X", "Passed"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    def section_html(section_id: str) -> str:
+        m = re.search(
+            rf'id="{section_id}".*?</details>', html, flags=re.S
+        )
+        assert m is not None, f"Section {section_id} not in HTML"
+        return m.group(0)
+
+    action_html = section_html("section-action")
+    manual_html = section_html("section-manual")
+    passed_html = section_html("section-passed")
+
+    # FAIL belongs in action
+    assert "FAIL-X" in action_html
+    assert "FAIL-X" not in manual_html and "FAIL-X" not in passed_html
+
+    # MAN + SKIP belong in manual (Skipped folds here per design)
+    assert "MAN-X" in manual_html
+    assert "SKIP-X" in manual_html
+    assert "MAN-X" not in action_html and "MAN-X" not in passed_html
+    assert "SKIP-X" not in action_html and "SKIP-X" not in passed_html
+
+    # PASS belongs in passed
+    assert "PASS-X" in passed_html
+    assert "PASS-X" not in action_html and "PASS-X" not in manual_html
+
+
+def test_section_count_badge_matches_bucket_size(tmp_path):
+    """The badge next to each section header shows the bucket count
+    so the operator sees scale before expanding."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("F-1", "Failed"),
+        _make_result("F-2", "Failed"),
+        _make_result("W-1", "Warning"),
+        _make_result("M-1", "Manual"),
+        _make_result("P-1", "Passed"),
+        _make_result("P-2", "Passed"),
+        _make_result("P-3", "Passed"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    def badge_count_for(section_id: str) -> str:
+        m = re.search(
+            rf'id="{section_id}".*?count-badge">(\d+)</span>',
+            html, flags=re.S,
+        )
+        assert m is not None, f"No count badge for {section_id}"
+        return m.group(1)
+
+    assert badge_count_for("section-action") == "3"   # 2 Failed + 1 Warning
+    assert badge_count_for("section-manual") == "1"   # 1 Manual
+    assert badge_count_for("section-passed") == "3"   # 3 Passed
+
+
+def test_action_rows_sorted_critical_before_high_in_html(tmp_path):
+    """Within ACTION REQUIRED, a Critical-priority row must appear
+    BEFORE a High-priority row in the rendered table — even if
+    Critical was registered later."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("HIGH-1", "Failed", priority="High"),
+        _make_result("CRIT-1", "Failed", priority="Critical"),
+        _make_result("MED-1", "Failed", priority="Medium"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    action_section_match = re.search(
+        r'id="section-action".*?</details>', html, flags=re.S,
+    )
+    assert action_section_match is not None
+    section_html = action_section_match.group(0)
+
+    crit_pos = section_html.index("CRIT-1")
+    high_pos = section_html.index("HIGH-1")
+    med_pos = section_html.index("MED-1")
+    assert crit_pos < high_pos < med_pos, (
+        "Within Action Required, priorities must render Critical -> "
+        "High -> Medium so operator triages worst-first."
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON contract — adding `skipped`/`errors` must not break existing fields.
+# ---------------------------------------------------------------------------
+
+
+def test_json_summary_includes_skipped_and_errors_counts(tmp_path):
+    """Top-level JSON gains `skipped` and `errors` so the new summary
+    cards have numbers to display. The existing six counters
+    (passed/failed/warnings/not_configured/manual + overall) must
+    continue to exist with the same keys."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("F-1", "Failed"),
+        _make_result("E-1", "Error"),
+        _make_result("S-1", "Skipped"),
+        _make_result("S-2", "Skipped"),
+        _make_result("P-1", "Passed"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+
+    data = json.loads(
+        (tmp_path / "results.json").read_text(encoding="utf-8")
+    )
+    assert data["skipped"] == 2
+    assert data["errors"] == 1
+    # Backwards-compat: existing keys still present.
+    for key in (
+        "overall", "total", "passed", "failed", "warnings",
+        "not_configured", "manual", "categories", "results",
+    ):
+        assert key in data, (
+            f"Missing top-level JSON key '{key}' — existing consumers "
+            "depend on it."
+        )
+
+
+def test_json_results_list_preserves_run_order(tmp_path):
+    """The `results[]` array in results.json must stay in run-order so
+    consumers that index it (or that diff between runs) don't break.
+    Bucketing happens at render time, not in the underlying data."""
+    from flightcheck.runner import save_results
+    # Register in mixed status order so bucket sort would re-order.
+    rs = [
+        _make_result("FIRST",  "Passed"),
+        _make_result("SECOND", "Failed", priority="Critical"),
+        _make_result("THIRD",  "Manual"),
+        _make_result("FOURTH", "Warning"),
+    ]
+    result = _build_run_with(rs)
+    save_results(result, output_dir=str(tmp_path))
+
+    data = json.loads(
+        (tmp_path / "results.json").read_text(encoding="utf-8")
+    )
+    ids_in_order = [r["checkpoint_id"] for r in data["results"]]
+    assert ids_in_order == ["FIRST", "SECOND", "THIRD", "FOURTH"], (
+        "results.json must preserve run-order; bucket sort applies "
+        "only to the rendered HTML."
+    )
+
+
+def test_runresult_skipped_and_errors_tallied():
+    """The runner must populate the new `skipped` and `errors`
+    top-level RunResult fields off the same source as the categories.
+    """
+    from flightcheck.runner import (
+        FlightCheckRunner, CheckResult, Status, Priority,
+    )
+
+    runner = FlightCheckRunner(scope="test")
+    runner.register("Cat", lambda _r: [
+        CheckResult(
+            checkpoint_id="S-1", category="Cat",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description="d", result="r",
+        ),
+        CheckResult(
+            checkpoint_id="E-1", category="Cat",
+            priority=Priority.HIGH.value, status=Status.ERROR.value,
+            description="d", result="r", remediation="x",
+        ),
+    ])
+    result = runner.run()
+
+    assert result.skipped == 1
+    assert result.errors == 1

--- a/tests/flightcheck/test_runner_report_layout.py
+++ b/tests/flightcheck/test_runner_report_layout.py
@@ -461,3 +461,89 @@ def test_runresult_skipped_and_errors_tallied():
 
     assert result.skipped == 1
     assert result.errors == 1
+
+
+def test_overall_verdict_treats_error_only_run_as_not_ready():
+    """An error-only run must not render as READY.
+
+    The verdict banner is the report's single biggest at-a-glance
+    signal. An ERROR (a check raised mid-run) means we don't actually
+    know whether ESS is healthy in that area, so the verdict MUST
+    NOT be green.
+
+    Pre-fix the verdict logic inspected only failed+warnings and
+    ignored errors entirely (runner.py:148). An error-only run
+    therefore rendered a green ``verdict-ready`` banner reading
+    *"All N check(s) passed. Your environment looks ready to
+    deploy."* with all the errored rows listed under ACTION REQUIRED
+    directly below — exactly the at-a-glance contradiction the
+    prioritized report is meant to eliminate.
+
+    Repro recipe: kill BAP auth mid-run so EXT-001 / ENV-001 /
+    WD-CONN-001 all raise. Nothing else fails or warns. Banner
+    shows READY. The errored rows appear directly below it.
+    """
+    from flightcheck.runner import (
+        CheckResult,
+        FlightCheckRunner,
+        Priority,
+        Status,
+    )
+
+    runner = FlightCheckRunner(scope="test")
+    runner.register("Cat", lambda _r: [
+        CheckResult(
+            checkpoint_id="E-1", category="Cat",
+            priority=Priority.HIGH.value, status=Status.ERROR.value,
+            description="External systems validation",
+            result="Check failed with error: boom",
+            remediation="Review permissions and retry.",
+        ),
+        CheckResult(
+            checkpoint_id="PRE-001", category="Cat",
+            priority=Priority.CRITICAL.value, status=Status.PASSED.value,
+            description="License", result="OK",
+        ),
+    ])
+    result = runner.run()
+
+    assert result.errors == 1
+    assert result.failed == 0
+    assert result.warnings == 0
+    assert result.overall == "NOT_READY"
+
+
+def test_overall_verdict_error_plus_warning_is_not_ready_not_ready_with_warnings():
+    """Same blind spot at the READY_WITH_WARNINGS boundary: an error
+    plus a warning must NOT render as READY_WITH_WARNINGS (which
+    would silently swallow the error in the verdict). It is
+    NOT_READY because we have an error.
+    """
+    from flightcheck.runner import (
+        CheckResult,
+        FlightCheckRunner,
+        Priority,
+        Status,
+    )
+
+    runner = FlightCheckRunner(scope="test")
+    runner.register("Cat", lambda _r: [
+        CheckResult(
+            checkpoint_id="E-1", category="Cat",
+            priority=Priority.HIGH.value, status=Status.ERROR.value,
+            description="External systems validation",
+            result="Check failed with error: boom",
+            remediation="Review permissions and retry.",
+        ),
+        CheckResult(
+            checkpoint_id="W-1", category="Cat",
+            priority=Priority.MEDIUM.value, status=Status.WARNING.value,
+            description="Soft issue", result="meh",
+            remediation="Look at this.",
+        ),
+    ])
+    result = runner.run()
+
+    assert result.errors == 1
+    assert result.warnings == 1
+    assert result.overall == "NOT_READY"


### PR DESCRIPTION
## Why

Two real-tenant scenarios surfaced when running FlightCheck against a live ESS agent:

1. **The report was hard to act on.** All results — passed, skipped, failed, warning — were dumped in a flat list. An operator had to scan every row to find the ones that needed action.
2. **CONFIG-007 lied.** It reported "No instructions block found in agent.mcs.yml" for an agent that obviously had hundreds of words of instructions in Copilot Studio, and the remediation didn't even point at the right agent.

Both turned out to span more than the surface symptom (a regex-on-YAML bug, a silent fallback that fabricated a wrong env id, and a missed BAP hostname match). This PR fixes them and ships a triage-friendly report layout.

## What changed

**Report layout** ( runner.py, cli.py)
- Verdict banner + three sections: **Action required**, **Manual verification**, **Passed**.
- Operators can see at a glance whether ESS is healthy and, if not, what they need to do.
- JSON output gains `skipped` + `errors` fields so downstream tooling stays in parity.

**CONFIG-007 / CONFIG-005** (checks/local_files.py)
- Remediations now include a verified Copilot Studio deep link:
  `https://copilotstudio.microsoft.com/environments/{envId}/bots/{botId}/overview` (with graceful fallback to the homepage if env_id / bot_id can't be resolved).
- Replace the regex YAML probe with `yaml.safe_load`. The old pattern (`instructions:\s*[|>]?\s*\n…`) silently missed YAML's chomping-indicator block scalars (`|-`, `|+`, `>-`, `>+`) — the exact form Copilot Studio emits.

**env_id correctness** (pp_admin_client.py, cli.py)
- `find_environment_id_by_dataverse_url` now matches on **both** `instanceUrl` AND `instanceApiUrl`. BAP advertises the bare web hostname on one and the `.api.` Web API hostname on the other; configs typically hold the `.api.` form, so checking only `instanceUrl` silently missed every match on those tenants.
- `derive_environment_id` no longer silently falls through to the Dataverse OrganizationId when `pp_admin` is supplied but the lookup misses. That fabricated value was corrupting both BAP admin calls (404s) and any URL that embeds the env id. CLI now reports the miss explicitly and tells the operator how to override with `--environment-id`.

## Tests

- `test_runner_report_layout.py` (16): bucket assignment, verdict banner, JSON shape, AUTH-005 multi-row pattern.
- `test_local_files_studio_link.py` (9): deep-link helper + CONFIG-007 deep-link remediation.
- `test_local_files_agent_identity.py` (11): pins the `|-` / `|+` / `>-` / `>+` / quoted-string regressions and starter-prompt counting from parsed YAML.
- `test_pp_admin_client.py` (+6): pins `instanceApiUrl` matching and no-silent-OrgId-fallback behavior.

**299 passed / 8 skipped.** Ruff clean on touched files.

## Follow-ups (deliberately out of scope, will land separately)

- Remaining remediation-string improvements (the user is iterating on these one at a time).
- `run_local_file_checks` and `checks/servicenow.py` walk `workspace/agents/` on disk instead of iterating `runner.config["agents"]` — surfaces stale folders from prior `/setup` runs and misses agents listed in config.
- `workspace/agents/` vs `my/agents/` naming inconsistency across the kit (setup.py / docs / SKILL.md files).
- Avery's `-FlightCheckOnly` flow should make local-file checks SKIP cleanly when `folder=""`.
