### PR TITLE
flightcheck: actionable remediations + report bucketing for issue #67 follow-ups

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/_maker_urls.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/_maker_urls.py
@@ -1,0 +1,71 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Shared deep-link builders for the Power Platform maker portals.
+
+Multiple FlightCheck checks emit remediation strings that point the user
+at the place in the maker portal where a problem can be fixed. Several
+of these strings used to be hand-written per check, which meant they
+drifted (different hosts, different paths, inconsistent encoding). This
+module is the single source of truth so every remediation links to the
+same URL shape for the same operator action.
+
+Consumers:
+  * ENV-004 (``checks/environment._check_connections_and_refs``):
+    re-bind orphan/unbound connection references and clean up unbound
+    connections.
+  * WD-CONN-* (``checks/workday``): repair unhealthy Workday connections
+    by reopening the connector dialog from the connections list.
+
+Host choice rationale:
+  * ``make.powerautomate.com/environments/{env}/connections`` is used
+    for the connections list because the PowerAutomate maker has
+    rendered the env-scoped connections list more reliably than
+    ``make.powerapps.com`` across the multiple Power Platform admin
+    center information-architecture churns observed in 2024-2026.
+  * ``make.powerapps.com/environments/{env}/solutions`` is the only
+    surface that exposes the solution-scoped Connection References
+    pane where a maker re-binds a reference to a different connection.
+"""
+
+from __future__ import annotations
+
+
+def maker_connections_url(env_id: str) -> str:
+    """Direct link to the maker connections list for ``env_id``.
+
+    Use for remediations that ask the operator to open a connector
+    dialog (test, edit credentials, delete unused connection). The
+    target page is the same regardless of which connector the
+    connection wraps, so callers do not need to pass connector kind.
+    """
+    return f"https://make.powerautomate.com/environments/{env_id}/connections"
+
+
+def maker_solutions_url(env_id: str) -> str:
+    """Direct link to the maker solutions list for ``env_id``.
+
+    Use as a fallback when the operator must browse multiple solutions
+    (e.g. broken refs spread across several solutions) or when the
+    containing solution is not known.
+    """
+    return f"https://make.powerapps.com/environments/{env_id}/solutions"
+
+
+def maker_solution_url(env_id: str, solution_id: str) -> str:
+    """Direct link to a specific solution's detail page in the Power
+    Apps maker for ``env_id``.
+
+    Prefer this over :func:`maker_solutions_url` whenever the caller
+    knows which solution holds the broken object — landing on the
+    solutions LIST forces the operator to guess which solution to open
+    (often half a dozen first-party + ISV solutions are present). The
+    solution detail page exposes the **Objects \u2192 Connection
+    references** pane directly.
+
+    The URL format is documented at the Power Platform ALM level:
+    ``make.powerapps.com/environments/{env}/solutions/{solution_guid}``.
+    """
+    return (
+        f"https://make.powerapps.com/environments/{env_id}/solutions/{solution_id}"
+    )

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -8,10 +8,197 @@ Checks Power Platform environment, Dataverse, DLP policies, and related config.
 """
 
 from ..runner import CheckResult, Status, Priority
+from ._maker_urls import (
+    maker_connections_url,
+    maker_solution_url,
+    maker_solutions_url,
+)
 from .connections import get_connection_status
 from auth import query_all  # scripts/auth.py, on path via cli.py
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
+
+
+def _resolve_ref_solutions(
+    *, env_url: str, dv_token: str, env_id: str, refs: list[dict],
+) -> dict[str, dict[str, str]]:
+    """Resolve the containing solutions for a set of connection refs.
+
+    Returns a map ``{connectionreferenceid: {"url": <maker url>, "label": <name>}}``
+    so each ENV-004 detail row can deep-link to the specific solution
+    that holds its broken ref, instead of dumping the operator on the
+    env-wide solutions list.
+
+    Two Dataverse round-trips are required because the
+    ``connectionreference`` entity carries no solution column — solution
+    membership is only exposed via the ``solutioncomponent`` intersect:
+      1. ``solutioncomponents`` filtered only by ``objectid eq <ref-guid>``
+         → maps each ref GUID to its owning ``_solutionid_value``. We
+         deliberately omit a ``componenttype`` filter because Microsoft's
+         published enum does not document a stable value for Connection
+         Reference (earlier guesses such as 10047 returned empty in real
+         environments). A GUID is universally unique, so filtering on
+         ``objectid`` alone cannot collide with another component kind.
+      2. ``solutions`` filtered by the distinct solution GUIDs from
+         step 1 *and* ``uniquename eq 'Default'`` → resolves
+         friendlyname/ismanaged for ranking, and ensures we always know
+         the Default Solution's GUID for the managed-only fallback.
+
+    Link selection prefers (in order): a named unmanaged solution
+    containing the ref → the Default Solution (always unmanaged, always
+    present, can edit any component as customization) → no link. We
+    never link to a managed solution because Power Apps blocks edits
+    with "You cannot directly edit the objects within a managed
+    solution.", which is a dead end for the maker.
+
+    Best-effort: any Dataverse failure returns ``{}`` so callers cleanly
+    fall back to the env-wide solutions URL.
+    """
+    ref_ids = {
+        ref.get("connectionreferenceid") for ref in refs
+        if ref.get("connectionreferenceid")
+    }
+    if not ref_ids:
+        return {}
+
+    # Step 1: ref-guid -> solution-guid via solutioncomponents.
+    # No componenttype filter — see docstring above for rationale.
+    sc_filter = " or ".join(f"objectid eq {rid}" for rid in ref_ids)
+    try:
+        components = query_all(
+            env_url, dv_token,
+            "solutioncomponents",
+            "objectid,_solutionid_value",
+            filter_expr=sc_filter,
+        )
+    except Exception:
+        return {}
+
+    # A single ref typically appears in multiple solution layers (the
+    # base managed solution that defined it plus any unmanaged layer
+    # that customized it). Collect every solution per ref so step 2 can
+    # pick the one the maker can actually edit in the portal.
+    ref_to_solutions: dict[str, list[str]] = {}
+    for comp in components:
+        oid = comp.get("objectid")
+        sid = comp.get("_solutionid_value")
+        if oid and sid:
+            ref_to_solutions.setdefault(oid, []).append(sid)
+    if not ref_to_solutions:
+        return {}
+
+    # Step 2: solution-guid -> {friendlyname, ismanaged} via solutions.
+    # We also unconditionally include the **Default Solution** (uniquename
+    # 'Default'), which is the unmanaged customization layer that always
+    # exists in every Dataverse environment. It's the only place a maker
+    # can edit a connection reference that was defined in a managed
+    # solution — Power Apps refuses direct edits there with "You cannot
+    # directly edit the objects within a managed solution." So when a ref
+    # only lives in managed solutions, we fall back to Default Solution.
+    distinct_sids = {sid for sids in ref_to_solutions.values() for sid in sids}
+    sid_clauses = [f"solutionid eq {sid}" for sid in distinct_sids]
+    sol_filter = "(" + " or ".join(sid_clauses) + ") or uniquename eq 'Default'"
+    try:
+        solutions = query_all(
+            env_url, dv_token,
+            "solutions",
+            "solutionid,uniquename,friendlyname,ismanaged",
+            filter_expr=sol_filter,
+        )
+    except Exception:
+        return {}
+
+    sid_to_info: dict[str, dict] = {}
+    default_sid: str | None = None
+    for sol in solutions:
+        sid = sol.get("solutionid")
+        if not sid:
+            continue
+        uname = sol.get("uniquename") or ""
+        sid_to_info[sid] = {
+            "label": (
+                sol.get("friendlyname") or uname or sid
+            ),
+            "uniquename": uname,
+            "ismanaged": bool(sol.get("ismanaged")),
+        }
+        if uname == "Default":
+            default_sid = sid
+
+    # Internal/system solutions a maker never opens in the portal — skip
+    # them when ranking. (Note: 'Default' is the user-facing Default
+    # Solution and IS editable, so it's NOT in this set.)
+    SYSTEM_UNIQUENAMES = {"Active", "Basic", "System"}
+
+    def _solution_rank(sid: str) -> tuple[int, int, int, str]:
+        info = sid_to_info.get(sid, {})
+        uname = info.get("uniquename", "")
+        is_system = uname in SYSTEM_UNIQUENAMES
+        is_managed = info.get("ismanaged", False)
+        is_default = uname == "Default"
+        # Lowest tuple wins. Prefer (in order):
+        #   1. not-system over system,
+        #   2. unmanaged over managed (maker can edit directly),
+        #   3. a named unmanaged solution over Default (more focused
+        #      view; Default is the catch-all),
+        #   4. alphabetical for stability.
+        return (
+            1 if is_system else 0,
+            1 if is_managed else 0,
+            1 if is_default else 0,
+            uname,
+        )
+
+    out: dict[str, dict[str, str]] = {}
+    for rid, sids in ref_to_solutions.items():
+        # Only consider sids we successfully resolved in step 2.
+        known = [sid for sid in sids if sid in sid_to_info]
+        if known:
+            best = sorted(known, key=_solution_rank)[0]
+            # If the best candidate is still managed (i.e. every solution
+            # containing this ref is managed), redirect the link to the
+            # Default Solution so the maker actually has somewhere to
+            # edit. The label changes too so the report doesn't mislead
+            # the maker into clicking through to a read-only solution.
+            if sid_to_info[best].get("ismanaged"):
+                if default_sid:
+                    out[rid] = {
+                        "url": maker_solution_url(env_id, default_sid),
+                        "label": sid_to_info[default_sid]["label"],
+                    }
+                # Else: nothing editable to link to. Skip so the caller
+                # falls back to the env-wide URL — better to give the
+                # maker the solutions list than dump them on a managed
+                # solution page that refuses edits.
+                continue
+            out[rid] = {
+                "url": maker_solution_url(env_id, best),
+                "label": sid_to_info[best]["label"],
+            }
+        elif default_sid:
+            # No containing solution resolved — Default Solution is still
+            # the right editable fallback (better than the env-wide list).
+            out[rid] = {
+                "url": maker_solution_url(env_id, default_sid),
+                "label": sid_to_info[default_sid]["label"],
+            }
+    return out
+
+
+def _solution_link_parts(
+    ref: dict, solution_info: dict[str, dict[str, str]], fallback_url: str,
+) -> tuple[str, str]:
+    """Pick the best (url, label) for the solution containing a ref.
+
+    Returns a deep link to the specific solution when we resolved its
+    metadata; otherwise falls back to the env-wide solutions list so
+    the remediation never produces a 404.
+    """
+    rid = ref.get("connectionreferenceid")
+    if rid and rid in solution_info:
+        info = solution_info[rid]
+        return info["url"], f"Power Apps \u2192 Solutions \u2192 {info['label']}"
+    return fallback_url, "Power Apps \u2192 Solutions"
 
 
 def run_environment_checks(runner) -> list[CheckResult]:
@@ -113,12 +300,31 @@ def run_environment_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prepare#allow-the-external-systems-connector",
             ))
         else:
+            # "No DLP policy" means the environment is currently
+            # unrestricted — connectors are not blocked or grouped.
+            # That's intentional in many tenants (especially dev), so
+            # this is a Warning, not a Failure. The remediation walks
+            # the operator through the actual fix when DLP IS required:
+            # open the policies page, scope a policy to this env, and
+            # put every connector the agent uses in the SAME group
+            # (Business or Non-Business) — connectors in different
+            # groups cannot be combined in a single flow/agent action,
+            # so "allowlisting" really means group-coexistence, not
+            # just "unblock".
             results.append(CheckResult(
                 checkpoint_id="ENV-008", category="Environment",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description="DLP policies configured",
                 result="No DLP policies found for this environment",
-                remediation="Review DLP policies in [PP admin center](https://admin.powerplatform.microsoft.com) to ensure connectors are allowlisted.",
+                remediation=(
+                    "No DLP policy applies to this environment, so connector usage is currently unrestricted. "
+                    "If your tenant requires DLP, open the [Power Platform admin center](https://admin.powerplatform.microsoft.com/) "
+                    "and navigate to **Security \u2192 Data and privacy \u2192 Data policy**, then either create a new policy or edit an existing one so that: "
+                    "(1) the policy's **Environments** scope includes this environment, "
+                    "(2) every connector the agent uses (e.g. Workday, SharePoint, Microsoft 365, HTTP, custom connectors) is placed in the **same** group \u2014 Business or Non-Business \u2014 since connectors in different groups cannot be combined in a single flow or agent action, "
+                    "and (3) none of those connectors are in the **Blocked** group. "
+                    "If your tenant does not enforce DLP for this environment, no action is required."
+                ),
                 doc_link=f"{DOC_BASE}/prepare#allow-the-external-systems-connector",
             ))
     except Exception as e:
@@ -127,7 +333,11 @@ def run_environment_checks(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="DLP policies",
             result=f"Unable to check: {e}",
-            remediation="Requires Power Platform Admin role.",
+            remediation=(
+                "Reading DLP policies requires the **Power Platform Administrator** role at the tenant level. "
+                "Ask a tenant admin to either grant you the role or to review policies on your behalf at the "
+                "[Power Platform admin center](https://admin.powerplatform.microsoft.com/) under **Security \u2192 Data and privacy \u2192 Data policy**."
+            ),
         ))
 
     return results
@@ -218,6 +428,12 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         return results
 
     # --- Fetch connection references from Dataverse ---
+    #
+    # `connectionreference` carries no solution column — solution
+    # membership is only exposed via the `solutioncomponent` intersect.
+    # The deep-link resolution (`_resolve_ref_solutions`) does the
+    # extra round-trip downstream, only for the broken refs we need
+    # to remediate, not for every ref in the env.
     try:
         conn_refs = query_all(
             env_url, dv_token,
@@ -288,24 +504,93 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         summary_parts.append(f"{len(unbound_conns)} unbound conn(s)")
 
     remediation = ""
+    solutions_url = maker_solutions_url(env_id)
+    connections_url = maker_connections_url(env_id)
+    # Microsoft's official walkthrough for binding / editing a
+    # connection reference. We surface this as doc_link so the
+    # operator can follow the canonical flow if the abbreviated
+    # in-remediation instructions aren't enough.
+    conn_ref_doc = (
+        "https://learn.microsoft.com/en-us/power-apps/maker/"
+        "data-platform/create-connection-reference"
+    )
+
+    # --- Resolve containing solution for each problematic ref ---
+    #
+    # The env-wide solutions list dumps every first-party + ISV solution
+    # in the env on the operator and leaves them guessing which one
+    # holds the broken ref. Query the `solutioncomponent` intersect
+    # (componenttype 10047 = Connection Reference) to map each broken
+    # ref's GUID to its owning solution, then look up the friendly
+    # display name + solution GUID so the per-row remediation can
+    # deep-link straight to the right solution's detail page.
+    #
+    # The lookup is best-effort: any failure (Dataverse error, missing
+    # field, missing solution) cleanly falls back to the env-wide
+    # solutions list URL so the remediation never silently 404s.
+    problematic_refs = orphan_refs + unbound_refs
+    solution_info = _resolve_ref_solutions(
+        env_url=env_url, dv_token=dv_token,
+        env_id=env_id, refs=problematic_refs,
+    )
+
     if has_orphan_refs:
-        remediation = (
-            "Fix broken connection references: re-bind them to valid connections "
-            "in Power Apps → Solutions → Connection References, or remove stale references."
-        )
+        # Build the most specific summary remediation we can:
+        #   - All broken refs in ONE resolved solution → deep-link to it
+        #   - Broken refs span MULTIPLE resolved solutions → name them
+        #     all, but the link has to fall back to the env-wide list
+        #     (no single deep link covers multiple solutions)
+        #   - Lookup didn't resolve any solution → generic prose
+        distinct_solutions = {
+            (info["url"], info["label"])
+            for info in solution_info.values()
+        }
+        if len(distinct_solutions) == 1:
+            sol_url, sol_label = next(iter(distinct_solutions))
+            remediation = (
+                f"Fix broken connection references: open [Power Apps \u2192 Solutions "
+                f"\u2192 {sol_label}]({sol_url}) \u2192 in the left nav choose "
+                f"**Objects \u2192 Connection references** \u2192 re-bind each broken "
+                f"reference to a valid connection, or remove stale references."
+            )
+        elif len(distinct_solutions) > 1:
+            names = ", ".join(sorted(label for _, label in distinct_solutions))
+            remediation = (
+                f"Fix broken connection references (spread across solutions: {names}). "
+                f"Open [Power Apps \u2192 Solutions]({solutions_url}), open each "
+                f"affected solution, and in the left nav choose **Objects \u2192 "
+                f"Connection references** to re-bind each broken reference or remove "
+                f"stale ones. See the ENV-004-OR-* / ENV-004-UR-* detail rows below "
+                f"for per-reference deep links."
+            )
+        else:
+            remediation = (
+                f"Fix broken connection references: open [Power Apps \u2192 Solutions]({solutions_url}) "
+                f"\u2192 click the solution that contains your agent \u2192 in the left nav choose "
+                f"**Objects \u2192 Connection references** \u2192 re-bind each broken reference to a "
+                f"valid connection, or remove stale references."
+            )
     elif has_unbound_conns:
         remediation = (
-            "Unbound connections may be intentional (e.g., test connections). "
-            "Review in Power Platform admin center and remove unused connections."
+            f"Unbound connections may be intentional (e.g. test connections). "
+            f"Review them in [the environment connections list]({connections_url}) and remove unused entries."
         )
 
+    # When the summary is FAILED, the operator needs to fix connection
+    # references; surface Microsoft's canonical walkthrough as doc_link
+    # so they have the full reference next to the abbreviated steps.
+    summary_doc_link = (
+        conn_ref_doc
+        if overall_status == Status.FAILED.value
+        else f"{DOC_BASE}/prepare#set-up-your-power-platform-environment"
+    )
     results.append(CheckResult(
         checkpoint_id="ENV-004", category="Environment",
         priority=Priority.HIGH.value, status=overall_status,
         description="Connections & connection references",
         result=" | ".join(summary_parts),
         remediation=remediation,
-        doc_link=f"{DOC_BASE}/prepare#set-up-your-power-platform-environment",
+        doc_link=summary_doc_link,
     ))
 
     # --- Detail: orphan references (point to missing connections) ---
@@ -314,12 +599,18 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
             "connectionreferencelogicalname", "Unknown"
         )
         dead_conn_id = ref.get("connectionid", "?")
+        sol_url, sol_label = _solution_link_parts(ref, solution_info, solutions_url)
         results.append(CheckResult(
             checkpoint_id=f"ENV-004-OR-{i + 1:03d}", category="Environment",
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description=f"Orphan reference: {ref_name}",
             result=f"Points to missing connection '{dead_conn_id}'",
-            remediation=f"Re-bind '{ref_name}' to an active connection or delete the reference.",
+            remediation=(
+                f"Open [{sol_label}]({sol_url}) \u2192 in the left nav choose **Objects "
+                f"\u2192 Connection references** \u2192 re-bind '{ref_name}' to an active "
+                f"connection, or delete the reference."
+            ),
+            doc_link=conn_ref_doc,
         ))
 
     # --- Detail: unbound references (no connectionid set) ---
@@ -327,15 +618,28 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         ref_name = ref.get("connectionreferencedisplayname") or ref.get(
             "connectionreferencelogicalname", "Unknown"
         )
+        sol_url, sol_label = _solution_link_parts(ref, solution_info, solutions_url)
         results.append(CheckResult(
             checkpoint_id=f"ENV-004-UR-{i + 1:03d}", category="Environment",
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description=f"Unbound reference: {ref_name}",
             result="No connection bound to this reference",
-            remediation=f"Bind '{ref_name}' to a valid connection in Power Apps → Solutions → Connection References.",
+            remediation=(
+                f"Open [{sol_label}]({sol_url}) \u2192 in the left nav choose **Objects "
+                f"\u2192 Connection references** \u2192 bind '{ref_name}' to a valid connection."
+            ),
+            doc_link=conn_ref_doc,
         ))
 
-    # --- Detail: unbound connections (no reference points to them) ---
+    # --- Detail: unbound connections (no reference in THIS agent's solution
+    # points to them). ``unbound`` here is scoped to the agent under check:
+    # the connection might still be in use by another agent, a Power Automate
+    # flow that connects directly without a connection reference, or a
+    # canvas/model-driven app. We don't query env-wide to confirm true
+    # disuse, so the remediation MUST be explicit about that limitation
+    # and walk the maker through verifying before deletion. Deleting a
+    # connection that something else depends on breaks that resource
+    # silently \u2014 the platform does not warn.
     for i, conn in enumerate(unbound_conns):
         props = conn.get("properties", {})
         conn_name = props.get("displayName", conn.get("name", "Unknown"))
@@ -346,8 +650,30 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
             checkpoint_id=f"ENV-004-UC-{i + 1:03d}", category="Environment",
             priority=Priority.MEDIUM.value, status=Status.WARNING.value,
             description=f"Unbound connection: {conn_name}",
-            result=f"Connector: {connector_label} | Status: {conn_status} | No reference uses this connection",
-            remediation=f"If unused, remove '{conn_name}' from the environment to reduce clutter.",
+            result=(
+                f"Connector: {connector_label} | Status: {conn_status} | "
+                f"Not referenced by this agent's solution"
+            ),
+            remediation=(
+                f"This connection is not referenced by THIS agent's solution, "
+                f"but it may still be used by another agent, a Power Automate "
+                f"flow, or an app in this environment. **Verify it is unused "
+                f"before deleting** \u2014 the platform does not warn if you "
+                f"delete a connection that something else depends on. "
+                f"To verify: "
+                f"(1) open [Power Apps \u2192 Connections]({connections_url}) "
+                f"and click '{conn_name}' \u2014 the detail page lists apps "
+                f"that depend on it; "
+                f"(2) open [Power Automate \u2192 My flows]"
+                f"(https://make.powerautomate.com/environments/{runner.env_id}/flows) "
+                f"and check whether any flow authenticates via the "
+                f"'{connector_label}' connector; "
+                f"(3) open other [solutions in this environment]"
+                f"(https://make.powerapps.com/environments/{runner.env_id}/solutions) "
+                f"and check their **Objects \u2192 Connection references**. "
+                f"If nothing depends on '{conn_name}', delete it from the "
+                f"Power Apps Connections list."
+            ),
         ))
 
     return results

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -661,7 +661,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
                 f"before deleting** \u2014 the platform does not warn if you "
                 f"delete a connection that something else depends on. "
                 f"To verify: "
-                f"(1) open [Power Apps \u2192 Connections]({connections_url}) "
+                f"(1) open [Power Automate \u2192 Connections]({connections_url}) "
                 f"and click '{conn_name}' \u2014 the detail page lists apps "
                 f"that depend on it; "
                 f"(2) open [Power Automate \u2192 My flows]"
@@ -672,7 +672,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
                 f"(https://make.powerapps.com/environments/{runner.env_id}/solutions) "
                 f"and check their **Objects \u2192 Connection references**. "
                 f"If nothing depends on '{conn_name}', delete it from the "
-                f"Power Apps Connections list."
+                f"Power Automate Connections list."
             ),
         ))
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
@@ -55,14 +55,24 @@ def _studio_link_md(runner, agent_name: str, anchor: str = "Copilot Studio") -> 
     url = _studio_agent_url(runner, agent_name) or f"{STUDIO_BASE}/"
     return f"[{anchor}]({url})"
 
-# Required topics that ESS agents should have (by schema name substring)
+# Required topics that ESS agents should have. The `pattern` is a regex
+# matched against the **normalized** filename stem (lowercase + all
+# non-alphanumerics stripped) of every file under topics/. Normalization
+# is required because filenames are slugged with hyphens
+# (response-preparation.mcs.yml) but the patterns are written without
+# separators so a single pattern matches every hyphenation choice
+# Copilot Studio / extract.py might emit.
 REQUIRED_TOPICS = [
     {"id": "TOPIC-001", "pattern": "usercontext", "name": "[Admin] User Context - Setup", "priority": "Critical"},
     {"id": "TOPIC-002", "pattern": "responsepreparation", "name": "[System] Response Preparation", "priority": "Critical"},
     {"id": "TOPIC-004", "pattern": "sensitivetopic", "name": "[Example] Sensitive Topics", "priority": "High"},
     {"id": "TOPIC-005", "pattern": "onerror", "name": "[System] On Error", "priority": "High"},
     {"id": "TOPIC-009", "pattern": "emotionalintelligence|emotionalquotient", "name": "Emotional Intelligence", "priority": "High"},
-    {"id": "TOPIC-010", "pattern": "ambiguity", "name": "Ambiguity Clarification", "priority": "High"},
+    # The ESS template ships this as ``seek-clarification-to-avoid-ambiguous-answers``;
+    # normalized that becomes ``seekclarificationtoavoidambiguousanswers``. Pattern
+    # ``ambigu|clarif`` matches both "ambiguous" and "clarification" so the check
+    # passes whether the user adapts the topic name toward either concept.
+    {"id": "TOPIC-010", "pattern": "ambigu|clarif", "name": "Ambiguity Clarification", "priority": "High"},
 ]
 
 
@@ -113,7 +123,7 @@ def _check_single_agent(agent_path: Path, agent_name: str, runner=None) -> list[
     results.extend(_check_agent_identity(agent_path, label, runner, agent_name))
 
     # ---- Required topics ----
-    results.extend(_check_required_topics(agent_path, label))
+    results.extend(_check_required_topics(agent_path, label, runner, agent_name))
 
     # ---- Topic count ----
     results.extend(_check_topic_inventory(agent_path, label))
@@ -128,7 +138,7 @@ def _check_single_agent(agent_path: Path, agent_name: str, runner=None) -> list[
     results.extend(_check_template_configs(agent_path, label))
 
     # ---- Knowledge source readiness ----
-    results.extend(_check_knowledge_sources(agent_path, label, runner))
+    results.extend(_check_knowledge_sources(agent_path, label, runner, agent_name))
 
     return results
 
@@ -248,10 +258,11 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
     return results
 
 
-def _check_required_topics(agent_path: Path, label: str) -> list[CheckResult]:
+def _check_required_topics(agent_path: Path, label: str, runner=None, agent_name: str = "") -> list[CheckResult]:
     """Check that required system/admin topics exist."""
     results = []
     topics_dir = agent_path / "topics"
+    studio_link = _studio_link_md(runner, agent_name, "Copilot Studio")
 
     if not topics_dir.exists():
         for req in REQUIRED_TOPICS:
@@ -263,17 +274,29 @@ def _check_required_topics(agent_path: Path, label: str) -> list[CheckResult]:
             ))
         return results
 
-    topic_contents = {}
+    # Normalize each filename stem the same way pattern-authors expect:
+    # lowercase + drop every non-alphanumeric character. This collapses
+    # ``response-preparation.mcs.yml`` to ``responsepreparation`` so a
+    # single pattern like ``responsepreparation`` matches regardless of
+    # whether extract.py emitted hyphens, underscores, or a different
+    # casing. Pre-fix the matcher compared the raw hyphenated filename
+    # against the no-separator pattern and missed every system topic.
+    #
+    # We deliberately do NOT scan the topic's YAML body anymore: system
+    # topics like response-preparation.mcs.yml don't carry their schema
+    # name in the body at all (just ``kind: AdaptiveDialog`` + actions),
+    # and a body scan is a false-positive trap — any topic mentioning
+    # "on error" anywhere in its dialog text would satisfy TOPIC-005.
+    # Filename is the authoritative slug derived from the Dataverse
+    # botcomponents.name by extract.py.
+    normalized_stems = []
     for tf in topics_dir.glob("*.mcs.yml"):
-        topic_contents[tf.name.lower()] = tf.read_text(encoding="utf-8", errors="replace")
+        stem = tf.name.lower().replace(".mcs.yml", "")
+        normalized_stems.append(re.sub(r"[^a-z0-9]", "", stem))
 
     for req in REQUIRED_TOPICS:
         pattern = req["pattern"]
-        found = False
-        for fname, content in topic_contents.items():
-            if re.search(pattern, fname) or re.search(pattern, content, re.IGNORECASE):
-                found = True
-                break
+        found = any(re.search(pattern, stem) for stem in normalized_stems)
 
         if found:
             results.append(CheckResult(
@@ -289,7 +312,7 @@ def _check_required_topics(agent_path: Path, label: str) -> list[CheckResult]:
                 priority=req["priority"], status=Status.WARNING.value,
                 description=f"{label}: {req['name']}",
                 result="Required topic not found in extracted files",
-                remediation=f"Verify '{req['name']}' exists in [Copilot Studio](https://copilotstudio.microsoft.com/).",
+                remediation=f"Verify '{req['name']}' exists in {studio_link} \u2192 Topics.",
                 doc_link=f"{DOC_BASE}/customize#customize-topics",
             ))
 
@@ -440,6 +463,31 @@ def _get_disabled_topic_names(runner, agent_name: str) -> set[str]:
         return set()
 
 
+_XML_ATTR_KEY_RE = re.compile(r"^(\s+)([@#][A-Za-z_][\w.-]*)(\s*:(?:\s|$))", re.MULTILINE)
+
+
+def _salvage_xml_attribute_yaml(content: str) -> str:
+    """Quote bare ``@key:`` / ``#key:`` keys so PyYAML can parse the document.
+
+    Copilot Studio's topic export embeds connector-action response schemas
+    derived from XML/XSD definitions (e.g. Workday SOAP actions). It emits
+    XML attribute markers (``@type``) and text-node markers (``#text``) as
+    unquoted YAML keys, even though ``@`` and ``#`` are reserved indicators
+    in YAML 1.2 that must be quoted. Copilot Studio's own parser accepts
+    them; PyYAML correctly does not.
+
+    The maker can't fix this — it's not their YAML — and editing the file
+    locally would be overwritten on the next ``/scan``. Quote them in a
+    salvaged copy so CONFIG-014 can still inspect ``modelDescription`` for
+    these topics. The on-disk file is never mutated.
+
+    Only keys that begin with ``@`` or ``#`` at the start of a mapping line
+    are rewritten; any other YAML construct is left exactly as the parser
+    saw it, so a genuinely-broken file still raises.
+    """
+    return _XML_ATTR_KEY_RE.sub(r'\1"\2"\3', content)
+
+
 def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_name: str = "") -> list[CheckResult]:
     """CONFIG-014: Check that topic descriptions are specific enough for AI routing."""
     results = []
@@ -456,11 +504,16 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
 
     too_short: list[str] = []
     has_placeholder: list[str] = []
-    parse_errors: list[str] = []
+    # Files we couldn't parse even after salvaging Copilot Studio's
+    # XML-attribute-style keys. These are the only ones worth surfacing —
+    # the salvaged-and-parsed case is silent because the salvage is a
+    # workaround for a known upstream quirk, not maker-actionable.
+    unparseable: list[str] = []
     checked = 0
 
     # Query Dataverse for disabled topics to skip them
     disabled_topics = _get_disabled_topic_names(runner, agent_name)
+    studio_link = _studio_link_md(runner, agent_name, "the agent in Copilot Studio")
 
     for tf in sorted(topics_dir.glob("*.mcs.yml")):
         # Match the exact filename stem against the system-topic set — a
@@ -480,11 +533,27 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
         # key: that way we correctly handle every valid scalar form
         # (literal `|`, folded `>`, single/double-quoted, plain) and any
         # trailing-comment / odd-indentation cases the regex would miss.
+        #
+        # Two-pass parse: on YAMLError, try once more after quoting the
+        # XML-attribute keys Copilot Studio emits unquoted for
+        # connector-action schemas (see _salvage_xml_attribute_yaml).
+        # The salvage is silent on success — it's a workaround for a known
+        # upstream quirk, not something a maker can act on. If the second
+        # pass still fails the file goes on ``unparseable`` and we surface
+        # it as a low-priority Skipped row.
         try:
             doc = yaml.safe_load(content) or {}
-        except yaml.YAMLError as e:
-            parse_errors.append(f"{stem} ({e.__class__.__name__})")
-            continue
+        except yaml.YAMLError:
+            salvaged = _salvage_xml_attribute_yaml(content)
+            if salvaged != content:
+                try:
+                    doc = yaml.safe_load(salvaged) or {}
+                except yaml.YAMLError:
+                    unparseable.append(tf.name)
+                    continue
+            else:
+                unparseable.append(tf.name)
+                continue
 
         if not isinstance(doc, dict):
             # Topic file isn't a YAML mapping — nothing to check.
@@ -523,14 +592,29 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
         if word_count < _MIN_DESCRIPTION_WORDS:
             too_short.append(f"{display_name} ({word_count} words)")
 
-    # Report YAML parse errors so they don't silently skip checks
-    if parse_errors:
+    # If a file couldn't be parsed even after quoting Copilot Studio's
+    # XML-attribute-style keys, surface a single low-noise Skipped row so
+    # there's an audit trail. We deliberately do NOT recommend "fix the
+    # YAML" — in practice the file came verbatim from Copilot Studio's
+    # exporter and is overwritten on the next ``/scan``.
+    if unparseable:
+        names = ", ".join(unparseable[:10])
+        overflow = f" (+{len(unparseable) - 10} more)" if len(unparseable) > 10 else ""
+        studio_link_for_unparseable = _studio_link_md(runner, agent_name, "the agent in Copilot Studio")
         results.append(CheckResult(
             checkpoint_id="CONFIG-014", category=f"Topics ({label})",
-            priority=Priority.MEDIUM.value, status=Status.WARNING.value,
-            description=f"{label}: Topic YAML parse errors",
-            result=f"{len(parse_errors)} topic file(s) failed to parse: {', '.join(parse_errors[:5])}{'...' if len(parse_errors) > 5 else ''}",
-            remediation="Open the listed files and fix the YAML syntax errors so they can be validated.",
+            priority=Priority.LOW.value, status=Status.SKIPPED.value,
+            description=f"{label}: Topic description quality (unparseable files skipped)",
+            result=(
+                f"{len(unparseable)} topic file(s) could not be parsed as YAML and were "
+                f"skipped for description-quality checks: {names}{overflow}"
+            ),
+            remediation=(
+                f"These files were written verbatim by Copilot Studio's exporter. "
+                f"Open each topic in {studio_link_for_unparseable} \u2192 Topics and confirm "
+                "it loads in the Code editor without errors. If it does, no action is needed; "
+                "if it doesn't, edit the topic in the Code editor and save \u2014 then re-run `/scan`."
+            ),
         ))
 
     if not checked:
@@ -552,7 +636,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
             priority=Priority.MEDIUM.value, status=Status.FAILED.value,
             description=f"{label}: Topic descriptions contain placeholders",
             result=f"{len(has_placeholder)} topic(s) have placeholder text instead of a real description. Topics: {topic_list}",
-            remediation="Open these topics in Copilot Studio and replace the placeholder text in the Description field with specific trigger conditions and examples.",
+            remediation=f"Open {studio_link} \u2192 Topics and replace the placeholder text in each topic's Description field with specific trigger conditions and examples.",
             doc_link=f"{DOC_BASE}/customize#customize-topics",
         ))
 
@@ -563,7 +647,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
             priority=Priority.MEDIUM.value, status=Status.WARNING.value,
             description=f"{label}: Topic descriptions too short",
             result=f"{len(too_short)} topic(s) under {_MIN_DESCRIPTION_WORDS} words: {', '.join(too_short[:5])}{'...' if len(too_short) > 5 else ''}",
-            remediation="Expand descriptions with trigger conditions, valid examples, and exclusion criteria for better routing.",
+            remediation=f"Open {studio_link} \u2192 Topics and expand each topic's description with trigger conditions, valid examples, and exclusion criteria for better routing.",
             doc_link=f"{DOC_BASE}/customize#customize-topics",
         ))
 
@@ -607,7 +691,7 @@ _READY_STATUSES = {"completed", "indexed", "ready", "succeeded"}
 _NOT_READY_STATUSES = {"pending", "crawling", "queued", "provisioning", "failed", "error"}
 
 
-def _check_knowledge_sources(agent_path: Path, label: str, runner=None) -> list[CheckResult]:
+def _check_knowledge_sources(agent_path: Path, label: str, runner=None, agent_name: str = "") -> list[CheckResult]:
     """
     CONFIG-013: Verify that all configured knowledge sources have completed
     their initial crawl and are fully indexed.
@@ -623,7 +707,7 @@ def _check_knowledge_sources(agent_path: Path, label: str, runner=None) -> list[
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=f"{label}: Knowledge source readiness",
-            result="No knowledge directory found — no sources configured",
+            result="No knowledge directory found \u2014 no sources configured",
         ))
         return results
 
@@ -648,14 +732,14 @@ def _check_knowledge_sources(agent_path: Path, label: str, runner=None) -> list[
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=f"{label}: Knowledge source readiness",
-            result="Cannot verify — Copilot Studio API authentication required",
+            result="Cannot verify \u2014 Copilot Studio API authentication required",
         ))
         return results
 
-    return _check_knowledge_sources_via_gateway(pva, bot_id, knowledge_files, label)
+    return _check_knowledge_sources_via_gateway(pva, bot_id, knowledge_files, label, runner, agent_name)
 
 
-def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list, label: str) -> list[CheckResult]:
+def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list, label: str, runner=None, agent_name: str = "") -> list[CheckResult]:
     """Check knowledge source status using the Island Gateway API.
 
     Note on local-to-remote matching: the local filename is derived from the
@@ -665,6 +749,8 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
     components, so we use a count comparison plus per-remote status check.
     """
     results = []
+    studio_link = _studio_link_md(runner, agent_name, "the agent in Copilot Studio")
+    knowledge_path_hint = f"workspace/agents/{agent_name}/knowledge/" if agent_name else "workspace/agents/{slug}/knowledge/"
 
     try:
         sources = pva.get_knowledge_sources(bot_id)
@@ -674,7 +760,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=f"{label}: Knowledge source crawl status",
             result=f"Could not query Copilot Studio API: {e}",
-            remediation="Check authentication and retry. Verify status manually in Copilot Studio → Knowledge.",
+            remediation=f"Check authentication and retry. Verify status manually under {studio_link} \u2192 Knowledge.",
         ))
         return results
 
@@ -691,10 +777,10 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
                 "component(s) returned from Copilot Studio. Some sources may not be published."
             ),
             remediation=(
-                "Publish the agent in Copilot Studio to provision missing sources, "
+                f"Publish {studio_link} to provision missing sources, "
                 "or remove the local file if it should not exist. Identify mismatched "
-                "sources by comparing filenames in workspace/agents/{slug}/knowledge/ against "
-                "Copilot Studio → Knowledge."
+                f"sources by comparing filenames in {knowledge_path_hint} against the "
+                f"Knowledge tab in {studio_link}."
             ),
         ))
 
@@ -725,7 +811,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
                 checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description=f"{label}: '{name}' ({source_type})",
-                result=f"Status: {crawl_status} — indexed and ready",
+                result=f"Status: {crawl_status} \u2014 indexed and ready",
             ))
         elif crawl_status in _NOT_READY_STATUSES:
             all_ready = False
@@ -733,11 +819,11 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
                 checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
                 priority=Priority.HIGH.value, status=Status.FAILED.value,
                 description=f"{label}: '{name}' ({source_type})",
-                result=f"Status: {crawl_status} — not ready for deployment",
+                result=f"Status: {crawl_status} \u2014 not ready for deployment",
                 remediation=(
                     f"Knowledge source '{name}' has not completed indexing. "
-                    "Wait for the crawl to finish, or check for errors in "
-                    "Copilot Studio → Knowledge."
+                    f"Wait for the crawl to finish, or check for errors under "
+                    f"{studio_link} \u2192 Knowledge."
                 ),
             ))
         elif crawl_status:
@@ -750,7 +836,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
                 description=f"{label}: '{name}' ({source_type})",
                 result=f"Unknown crawl status: {crawl_status}",
                 remediation=(
-                    "Verify in Copilot Studio → Knowledge whether the source has "
+                    f"Verify under {studio_link} \u2192 Knowledge whether the source has "
                     "finished indexing. File an issue so this status string can be "
                     "added to the readiness allowlist."
                 ),
@@ -768,7 +854,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
                     "API did not return a `status` field for this source."
                 ),
                 remediation=(
-                    "Verify in Copilot Studio → Knowledge whether the source has "
+                    f"Verify under {studio_link} \u2192 Knowledge whether the source has "
                     "finished indexing before deploying."
                 ),
             ))

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/publishing.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/publishing.py
@@ -4,39 +4,270 @@
 """
 ESS FlightCheck — Publishing & QA Validation (PUB-xxx, QA-xxx)
 
-Mostly manual checklist items — presents as NotConfigured with remediation.
+These checks are organizational/process gates that the kit cannot
+verify by reading an API (test sets live in Copilot Studio behind the
+Analytics surface; managed-solution exports happen in the Power Apps
+maker; UAT sign-off lives in the operator's change-management
+system; M365 admin approval lives in the Microsoft 365 admin center).
+
+Each check therefore emits ``Status.MANUAL`` — meaning "the kit has
+nothing to check; the operator must confirm this themselves" — and
+the remediation provides the concrete steps + best available deep
+link for that specific action.
+
+Bucketing: MANUAL routes to the "Needs manual verification" section
+of the FlightCheck report. These checks never fail readiness.
 """
 
 from ..runner import CheckResult, Status
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
+STUDIO_BASE = "https://copilotstudio.microsoft.com"
+M365_INTEGRATED_APPS_URL = (
+    "https://admin.microsoft.com/Adminportal/Home#/Settings/IntegratedApps"
+)
 
-PUBLISHING_CHECKS = [
-    {"id": "QA-001", "desc": "Golden prompts library (50+ prompts)", "p": "Critical"},
-    {"id": "QA-002", "desc": "Core functionality prompts tested", "p": "Critical"},
-    {"id": "QA-012", "desc": "Accuracy validation completed", "p": "Critical"},
-    {"id": "PUB-001", "desc": "Solution exported as managed", "p": "Critical"},
-    {"id": "PUB-002", "desc": "Test environment deployment completed", "p": "Critical"},
-    {"id": "PUB-003", "desc": "UAT testing completed with sign-off", "p": "Critical"},
-    {"id": "PUB-006", "desc": "Microsoft 365 admin approval obtained", "p": "Critical"},
-    {"id": "PUB-011", "desc": "Publishing delay expected (up to 48 hrs)", "p": "Medium"},
-]
+
+def _studio_agent_url(runner) -> str | None:
+    """Build a deep link to the first configured agent's Studio page.
+
+    The publishing/QA checks are agent-scoped in spirit (the maker
+    runs evaluations against a specific agent), but the result rows
+    themselves are emitted once per checklist item — not per agent.
+    We pick the first configured agent so the deep link lands on a
+    real Studio surface rather than the generic homepage; if a tenant
+    runs multi-agent the operator can switch from the agent picker.
+    """
+    env_id = getattr(runner, "env_id", None)
+    if not env_id:
+        return None
+    config = getattr(runner, "config", None) or {}
+    bot_id = None
+    for agent in config.get("agents", []) or []:
+        bot_id = agent.get("botId")
+        if bot_id:
+            break
+    if not bot_id:
+        bot_id = (config.get("agent") or {}).get("botId")
+    if not bot_id:
+        return None
+    return f"{STUDIO_BASE}/environments/{env_id}/bots/{bot_id}/overview"
+
+
+def _maker_solutions_url(runner) -> str | None:
+    env_id = getattr(runner, "env_id", None)
+    if not env_id:
+        return None
+    return f"https://make.powerapps.com/environments/{env_id}/solutions"
+
+
+def _qa_remediation(runner, action: str, doc_anchor: str) -> str:
+    """Build a QA-* remediation that points at Copilot Studio Analytics
+    when the deep link is available, falling back to documentation."""
+    studio = _studio_agent_url(runner)
+    if studio:
+        return (
+            f"{action} Open the agent in [Copilot Studio]({studio}) → "
+            f"**Analytics → Evaluations**. "
+            f"See [{doc_anchor}]({DOC_BASE}/evaluations) for guidance on "
+            f"building test sets and interpreting results."
+        )
+    return (
+        f"{action} In Copilot Studio open your agent → **Analytics → "
+        f"Evaluations**. See [{doc_anchor}]({DOC_BASE}/evaluations) for "
+        f"guidance on building test sets and interpreting results."
+    )
+
+
+def _build_checks(runner) -> list[dict]:
+    """Per-check authored content. Constructed at call-time so deep
+    links can incorporate the runner's environment / agent IDs."""
+    studio = _studio_agent_url(runner)
+    solutions = _maker_solutions_url(runner)
+    publish_doc = f"{DOC_BASE}/publish"
+    deploy_doc = f"{DOC_BASE}/deploy-overview-alm"
+    evaluations_doc = f"{DOC_BASE}/evaluations"
+
+    # Studio link as a markdown fragment ready to splice into prose,
+    # or the literal phrase "Copilot Studio" when no deep link exists.
+    studio_md = f"[Copilot Studio]({studio})" if studio else "Copilot Studio"
+    solutions_md = (
+        f"[Power Apps → Solutions]({solutions})"
+        if solutions else "Power Apps → Solutions"
+    )
+
+    return [
+        {
+            "id": "QA-001",
+            "p": "Critical",
+            "desc": "Build a library of ≥50 evaluation prompts (golden queries)",
+            "result": (
+                "The kit can't inspect Copilot Studio evaluation test sets — "
+                "confirm a library of ≥50 representative prompts exists for this agent."
+            ),
+            "remediation": _qa_remediation(
+                runner,
+                action=(
+                    "Create at least one test set covering your top intents (PTO, "
+                    "payroll, benefits, IT password reset, common policy lookups, "
+                    "etc.) with ≥50 prompts in total."
+                ),
+                doc_anchor="ESS evaluations guide",
+            ),
+            "doc_link": evaluations_doc,
+        },
+        {
+            "id": "QA-002",
+            "p": "Critical",
+            "desc": "Run the evaluation test set against the agent",
+            "result": (
+                "The kit can't read evaluation runs — "
+                "confirm the golden-prompt test set was executed against this agent at least once."
+            ),
+            "remediation": _qa_remediation(
+                runner,
+                action=(
+                    "Select your test set, click **Run evaluation**, wait for "
+                    "the run to finish, and verify every prompt produced a "
+                    "response (no agent errors / timeouts)."
+                ),
+                doc_anchor="ESS evaluations guide",
+            ),
+            "doc_link": evaluations_doc,
+        },
+        {
+            "id": "QA-012",
+            "p": "Critical",
+            "desc": "Review evaluation scores against an accuracy target",
+            "result": (
+                "The kit can't measure response accuracy — "
+                "confirm evaluation scores were reviewed against a target agreed with stakeholders."
+            ),
+            "remediation": _qa_remediation(
+                runner,
+                action=(
+                    "Open the latest run, review per-prompt scores (groundedness, "
+                    "relevance, completeness), record the accept rate, and confirm "
+                    "it meets the target you agreed with business stakeholders "
+                    "before promoting the agent."
+                ),
+                doc_anchor="ESS evaluations guide",
+            ),
+            "doc_link": evaluations_doc,
+        },
+        {
+            "id": "PUB-001",
+            "p": "Critical",
+            "desc": "Export your customization solution as a managed solution",
+            "result": (
+                "The kit can't inspect maker-portal solution exports — "
+                "confirm a managed (.zip) export exists for promotion to test/UAT/prod."
+            ),
+            "remediation": (
+                f"In {solutions_md} → select the solution that contains your "
+                f"agent customizations → ⋯ → **Export solution** → **Publish** "
+                f"(publish all customizations first) → **Next** → choose "
+                f"**Managed** → **Export** → **Download**. Keep the .zip — "
+                f"it's the artifact you import into test/UAT/prod. See the "
+                f"[publish guide]({publish_doc}) for the full deployment flow."
+            ),
+            "doc_link": publish_doc,
+        },
+        {
+            "id": "PUB-002",
+            "p": "Critical",
+            "desc": "Import the managed solution into a test environment",
+            "result": (
+                "The kit only sees the configured environment — "
+                "confirm the managed solution was imported into a non-production environment and smoke-tested."
+            ),
+            "remediation": (
+                "Switch to your test environment in the Power Apps maker → "
+                "**Solutions** → **Import solution** → upload the managed .zip "
+                "from PUB-001 → install any prompted dependencies (the ESS "
+                "agent itself plus any connector solutions) → open the agent "
+                f"and smoke-test a handful of representative prompts. See the "
+                f"[publish guide]({publish_doc}) for the full deployment flow."
+            ),
+            "doc_link": publish_doc,
+        },
+        {
+            "id": "PUB-003",
+            "p": "Critical",
+            "desc": "Complete UAT and capture business sign-off",
+            "result": (
+                "The kit can't track sign-off — "
+                "confirm business stakeholders ran user-acceptance testing and recorded a pass decision."
+            ),
+            "remediation": (
+                "Run a pilot with the business stakeholders who own the use "
+                "cases the agent answers. Capture pass/fail decisions on the "
+                "representative prompts you tested and record sign-off in "
+                "your change-management system (release ticket, ADO work "
+                "item, ServiceNow change, etc.) before promoting to "
+                "production. This is an organizational gate — no portal link applies."
+            ),
+            "doc_link": deploy_doc,
+        },
+        {
+            "id": "PUB-006",
+            "p": "Critical",
+            "desc": "Obtain Microsoft 365 admin approval for the agent",
+            "result": (
+                "The kit can't read the Microsoft 365 admin center — "
+                "confirm a tenant admin approved the publish request in Integrated apps."
+            ),
+            "remediation": (
+                f"In {studio_md} → **Channels** → **Microsoft Teams** → "
+                f"**Submit for admin approval** (the maker does this). Then a "
+                f"tenant admin opens the "
+                f"[Microsoft 365 admin center → Settings → Integrated apps]"
+                f"({M365_INTEGRATED_APPS_URL}) → **Review request** for the "
+                f"agent → approves and deploys to the chosen user audience. "
+                f"Until both steps complete the agent won't appear in users' "
+                f"Microsoft 365 Copilot."
+            ),
+            "doc_link": publish_doc,
+        },
+        {
+            "id": "PUB-011",
+            "p": "Medium",
+            "desc": "Allow up to 48 hours for rollout to Microsoft 365 Copilot",
+            "result": (
+                "Informational — after admin approval, Teams/Microsoft 365 Copilot "
+                "rollout to end users can take up to 48 hours."
+            ),
+            "remediation": (
+                f"No action required at publish time. If the agent still isn't "
+                f"visible to users in Microsoft 365 Copilot 48 hours after admin "
+                f"approval, return to the "
+                f"[Microsoft 365 admin center → Integrated apps]"
+                f"({M365_INTEGRATED_APPS_URL}) and check the deployment status "
+                f"for this agent."
+            ),
+            "doc_link": publish_doc,
+        },
+    ]
 
 
 def run_publishing_checks(runner) -> list[CheckResult]:
-    """Return manual-review publishing/QA checklist items."""
-    results = []
+    """Return the publishing/QA checklist as MANUAL results.
 
-    for check in PUBLISHING_CHECKS:
-        results.append(CheckResult(
-            checkpoint_id=check["id"],
+    None of these checks reads an API — they're organizational gates
+    or actions on portals the kit doesn't traverse. Emitting them as
+    MANUAL (not NOT_CONFIGURED) keeps the report honest: nothing is
+    misconfigured, the operator just has work the kit can't witness.
+    """
+    return [
+        CheckResult(
+            checkpoint_id=c["id"],
             category="Publishing",
-            priority=check["p"],
-            status=Status.NOT_CONFIGURED.value,
-            description=check["desc"],
-            result="Manual verification required",
-            remediation=f"Verify: {check['desc']} — [deployment guide](https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service/deploy-overview-alm)",
-            doc_link=f"{DOC_BASE}/deploy-overview-alm",
-        ))
-
-    return results
+            priority=c["p"],
+            status=Status.MANUAL.value,
+            description=c["desc"],
+            result=c["result"],
+            remediation=c["remediation"],
+            doc_link=c["doc_link"],
+        )
+        for c in _build_checks(runner)
+    ]

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -31,6 +31,7 @@ from defusedxml import ElementTree as ET
 from defusedxml.common import DefusedXmlException
 
 from ..runner import CheckResult, Status, Priority
+from ._maker_urls import maker_connections_url
 from ._saml_utils import (
     WORKDAY_SAML_SP_FILTER,
     WORKDAY_SSO_TUTORIAL_DOC,
@@ -1717,17 +1718,6 @@ def _extract_connector_name(conn: dict) -> str:
     return match.group(1) if match else "shared_workdaysoap"
 
 
-def _maker_connections_url(env_id: str) -> str:
-    """Direct link to the Power Automate maker connections page.
-
-    We use make.powerautomate.com over make.powerapps.com because the
-    PowerAutomate experience renders the env-scoped connections list
-    more reliably across the multiple PPAC IA churns observed in
-    2024-2026.
-    """
-    return f"https://make.powerautomate.com/environments/{env_id}/connections"
-
-
 def _format_unhealthy_detail(entry: dict) -> str:
     """Single-connection detail line for the ``result`` field.
 
@@ -1769,7 +1759,7 @@ def _format_unhealthy_remediation(entry: dict, env_id: str) -> str:
     in_use = entry["in_use"]
     conn_name = c.get("name", "")
     connector = _extract_connector_name(c)
-    maker_url = _maker_connections_url(env_id)
+    maker_url = maker_connections_url(env_id)
     delete_cmd = (
         f"Remove-AdminPowerAppConnection -EnvironmentName {env_id} "
         f"-ConnectionName {conn_name} -ConnectorName {connector}"

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -293,10 +293,11 @@ def _print_prioritized_summary(result):
     Three sections, biggest signal first:
       1. Verdict banner (one line).
       2. Counts strip.
-      3. ACTION REQUIRED — full per-row detail (Failed / Error / Warning).
-      4. NEEDS MANUAL VERIFICATION — one line per row (Manual /
-         NotConfigured / Skipped).
-      5. PASSED — count only, point to report.html for the list.
+      3. ACTION REQUIRED — full per-row detail (Failed / Error).
+      4. NEEDS MANUAL VERIFICATION — one line per row (Warning /
+         Manual / NotConfigured).
+      5. PASSED — count only (includes Passed + Skipped); point to
+         report.html for the list.
 
     The goal is for an operator scanning the terminal to see, in
     order: am I OK? what must I fix? what must I verify? — without
@@ -320,11 +321,15 @@ def _print_prioritized_summary(result):
                   "verification -- see below)")
     elif result.overall == "READY_WITH_WARNINGS":
         print(f"  [WARN]  Ready with warnings -- {result.warnings} "
-              "warning(s) to review")
+              "warning(s) to verify")
     else:
-        action_total = result.failed + result.errors + result.warnings
-        word = "issue" if action_total == 1 else "issues"
-        print(f"  [FAIL]  Not ready -- {action_total} {word} need "
+        # Headline counts only the blocking items (failures + errors).
+        # Warnings live in the manual-verification section and aren't
+        # blockers, so counting them here would overstate the action
+        # load.
+        failing = result.failed + result.errors
+        word = "issue" if failing == 1 else "issues"
+        print(f"  [FAIL]  Not ready -- {failing} {word} need "
               "attention")
 
     print()

--- a/solutions/ess-maker-skills/scripts/flightcheck/runner.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/runner.py
@@ -226,21 +226,32 @@ def save_results(run_result: RunResult, output_dir: str = "workspace/flightcheck
 
 
 # --- Result bucketing for the prioritized report layout --------------
+
+# Triage bucket model
+# ------------------------------------------------------------------
+# Results sort into one of three rendered sections, top to bottom:
 #
-# The report groups results into three buckets so the operator can
-# triage by skimming top-to-bottom:
+#   1. ACTION_REQUIRED — Failed, Error. These are checks that did
+#      not pass and the kit is confident the operator must act.
+#      The blocking signal — fix-this-now items only.
 #
-#   1. ACTION_REQUIRED — Failed, Error, Warning. The operator must
-#      look at these and either fix them or decide they're acceptable.
-#   2. MANUAL_VERIFICATION — Manual, NotConfigured, Skipped. The
-#      kit cannot programmatically confirm these; the operator must
-#      verify in the portal / vendor system, OR fix the underlying
-#      reason FlightCheck couldn't run the check (missing creds, etc.).
-#   3. PASSED — everything the kit confirmed is in a good state.
+#   2. MANUAL_VERIFICATION — Warning, Manual, NotConfigured. The
+#      kit cannot make a yes/no judgement, or surfaced a soft
+#      finding the operator should confirm is acceptable. Warnings
+#      live here (not in Action required) because they are "should
+#      I worry?" questions, not "fix this" instructions — the
+#      verification path is the operator's, not the kit's. NotConfigured
+#      means the kit had no creds/visibility to evaluate.
 #
-# Within each bucket results are sorted by:
+#   3. PASSED — Passed, Skipped. Skipped is grouped with Passed
+#      because the kit chose not to run the check (e.g. it didn't
+#      apply to this scope, or a precondition wasn't met); from the
+#      operator's triage perspective the row needs no action and
+#      should sit alongside the proof-of-work passes.
+#
+# Within each bucket, results are sorted by:
 #   - priority (Critical > High > Medium > Low > unknown last)
-#   - status (per BUCKET_STATUS_ORDER below — worst first within bucket)
+#   - status (per _BUCKET_STATUS_ORDER below — worst first within bucket)
 #   - checkpoint_id (alphabetical, stable within ties)
 #
 # The flat run-order `RunResult.results` list is preserved unchanged
@@ -256,23 +267,28 @@ BUCKET_PASSED = "passed"
 _STATUS_TO_BUCKET = {
     Status.FAILED.value: BUCKET_ACTION,
     Status.ERROR.value: BUCKET_ACTION,
-    Status.WARNING.value: BUCKET_ACTION,
+    Status.WARNING.value: BUCKET_MANUAL,
     Status.MANUAL.value: BUCKET_MANUAL,
     Status.NOT_CONFIGURED.value: BUCKET_MANUAL,
-    Status.SKIPPED.value: BUCKET_MANUAL,
+    Status.SKIPPED.value: BUCKET_PASSED,
     Status.PASSED.value: BUCKET_PASSED,
 }
 
 # Within-bucket status sort order — lower index = surfaced first.
 # Worst news in each bucket goes to the top.
 _BUCKET_STATUS_ORDER = {
+    # ACTION_REQUIRED — Failed first, then Error.
     Status.FAILED.value: 0,
     Status.ERROR.value: 1,
-    Status.WARNING.value: 2,
-    Status.MANUAL.value: 0,
-    Status.NOT_CONFIGURED.value: 1,
-    Status.SKIPPED.value: 2,
+    # MANUAL_VERIFICATION — Warning first because it carries an
+    # observed finding (vs Manual/NotConfigured, which are "we
+    # didn't / couldn't evaluate").
+    Status.WARNING.value: 0,
+    Status.MANUAL.value: 1,
+    Status.NOT_CONFIGURED.value: 2,
+    # PASSED — actual passes first, then Skipped (no signal).
     Status.PASSED.value: 0,
+    Status.SKIPPED.value: 1,
 }
 
 _PRIORITY_ORDER = {
@@ -324,10 +340,10 @@ def _generate_html_report(r: RunResult) -> str:
       - Verdict banner (green / yellow / red) with one-line summary
       - Summary count cards (Passed / Failed / Warnings / Manual /
         Not Configured / Skipped / Errors)
-      - Section 1: ACTION REQUIRED (Failed + Error + Warning)
-      - Section 2: NEEDS MANUAL VERIFICATION (Manual + NotConfigured + Skipped)
-      - Section 3: PASSED (collapsed by default — proof of work, not
-        a triage queue)
+      - Section 1: ACTION REQUIRED (Failed + Error)
+      - Section 2: NEEDS MANUAL VERIFICATION (Warning + Manual + NotConfigured)
+      - Section 3: PASSED (collapsed by default — proof of work plus
+        Skipped, not a triage queue)
     """
     buckets = bucket_results(r.results)
 
@@ -341,13 +357,14 @@ def _generate_html_report(r: RunResult) -> str:
         section_id="section-action",
         title="Action required",
         subtitle=(
-            "Items the kit found to be failing, errored, or showing a "
-            "warning. Review each one and either fix it or confirm it's "
-            "acceptable for your deployment."
+            "Items the kit confirmed are failing or errored. Fix each one "
+            "before deploying. (Warnings live under \u201cNeeds manual "
+            "verification\u201d below \u2014 they\u2019re questions the "
+            "kit can\u2019t answer for you, not blocking failures.)"
         ),
         empty_text=(
-            "No failing, errored, or warning items \u2014 nothing here "
-            "needs your attention."
+            "No failing or errored items \u2014 nothing here needs your "
+            "attention."
         ),
         rows_html=action_rows,
         count=len(buckets[BUCKET_ACTION]),
@@ -358,10 +375,11 @@ def _generate_html_report(r: RunResult) -> str:
         section_id="section-manual",
         title="Needs manual verification",
         subtitle=(
-            "The kit can't confirm these programmatically. Either "
-            "verify the state in the portal / vendor system, or fix the "
-            "reason the check couldn't run (missing credentials, "
-            "permissions, or feature not enabled)."
+            "Warnings and other findings the kit can\u2019t confirm "
+            "programmatically. For each row, verify the state in the "
+            "portal / vendor system and confirm it\u2019s acceptable, "
+            "or fix the reason the check couldn\u2019t run (missing "
+            "credentials, permissions, or feature not enabled)."
         ),
         empty_text=(
             "Nothing requires manual verification \u2014 every check "
@@ -376,8 +394,9 @@ def _generate_html_report(r: RunResult) -> str:
         section_id="section-passed",
         title="Passed",
         subtitle=(
-            "Items the kit confirmed are in a good state. Expand for "
-            "the full list."
+            "Items the kit confirmed are in a good state, plus checks "
+            "the kit chose to skip because they didn\u2019t apply to "
+            "this scope. Expand for the full list."
         ),
         empty_text="No passing items in this run.",
         rows_html=passed_rows,
@@ -517,16 +536,22 @@ def _verdict_text(r: RunResult) -> tuple[str, str, str, str]:
     Drives the single biggest signal on the page, so word choice
     matters: the headline answers "is my deployment OK?" in five
     words or less; the subline says exactly what to do next.
+
+    Section pointers in the subline reflect the bucket model:
+    Failed / Error live under "Action required"; Warning / Manual /
+    NotConfigured live under "Needs manual verification". Pointing
+    operators at the right section is the whole reason the verdict
+    has a subline.
     """
-    action_count = r.failed + r.errors + r.warnings
-    manual_count = r.manual + r.not_configured + r.skipped
+    failing = r.failed + r.errors
+    manual_count = r.warnings + r.manual + r.not_configured
 
     if r.overall == "READY":
         if manual_count:
             sub = (
                 f"All {r.passed} automated check(s) passed. "
                 f"{manual_count} item(s) need manual verification \u2014 "
-                "see the section below."
+                "see \u201cNeeds manual verification\u201d below."
             )
         else:
             sub = (
@@ -537,9 +562,9 @@ def _verdict_text(r: RunResult) -> tuple[str, str, str, str]:
 
     if r.overall == "READY_WITH_WARNINGS":
         sub = (
-            f"{r.warnings} warning(s) found. Review the items in "
-            "\u201cAction required\u201d below and confirm each is "
-            "acceptable before deploying."
+            f"{r.warnings} warning(s) found. Review each one in "
+            "\u201cNeeds manual verification\u201d below and confirm "
+            "it\u2019s acceptable before deploying."
         )
         return (
             "verdict-warnings",
@@ -549,17 +574,26 @@ def _verdict_text(r: RunResult) -> tuple[str, str, str, str]:
         )
 
     # NOT_READY (or any unrecognized overall) — treat as a blocker.
-    failing = r.failed + r.errors
-    issue_word = "issue" if action_count == 1 else "issues"
-    sub = (
-        f"{failing} failing/errored check(s) and {r.warnings} "
-        f"warning(s) need attention. Start with the \u201cAction "
-        "required\u201d section below."
-    )
+    # Headline counts failures/errors as the truly blocking items;
+    # warnings (now in the manual section) are mentioned in the
+    # subline so the operator knows their scale without thinking
+    # they're additional blockers.
+    issue_word = "issue" if failing == 1 else "issues"
+    if r.warnings:
+        sub = (
+            f"{failing} failing/errored check(s) need action; "
+            f"{r.warnings} warning(s) need manual verification. "
+            "Start with \u201cAction required\u201d below."
+        )
+    else:
+        sub = (
+            f"{failing} failing/errored check(s) need action. "
+            "See \u201cAction required\u201d below."
+        )
     return (
         "verdict-not-ready",
         "\u2717",
-        f"Not ready \u2014 {action_count} {issue_word} need attention",
+        f"Not ready \u2014 {failing} {issue_word} need attention",
         sub,
     )
 

--- a/tests/flightcheck/checks/test_env_004_remediation_links.py
+++ b/tests/flightcheck/checks/test_env_004_remediation_links.py
@@ -306,7 +306,7 @@ def test_env_004_unbound_conn_remediation_lists_three_verification_paths(monkeyp
         if r.checkpoint_id.startswith("ENV-004-UC-")
     )
     rem = uc.remediation or ""
-    # 1. Power Apps Connections detail page (shows app dependencies).
+    # 1. Power Automate Connections detail page (shows app dependencies).
     assert "Connections" in rem and "make.powerautomate.com/environments/env-deeplinks/connections" in rem, rem
     # 2. Power Automate flows (the only place flow dependencies show up).
     assert "Power Automate" in rem, rem

--- a/tests/flightcheck/checks/test_env_004_remediation_links.py
+++ b/tests/flightcheck/checks/test_env_004_remediation_links.py
@@ -1,0 +1,931 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for ENV-004 connection-binding remediations.
+
+The user surfaced that ENV-004 remediations had no actionable link —
+operators were told to "fix the broken connection reference" with no
+pointer to the actual page in the maker portal. This module pins the
+deep links that the remediation strings must now carry, for every
+ENV-004 row that asks the operator to take a manual action.
+
+Strategy:
+- Drive `_check_connections_and_refs` with a tiny in-memory fake of
+  the PPAdminClient + a monkeypatched `auth.query_all`.
+- Build the three buggy bindings the check is supposed to surface
+  (orphan ref, unbound ref, unbound connection) and assert each
+  remediation contains the expected env-scoped maker URL.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    """Make `flightcheck.*` and `auth` importable from the kit's scripts dir."""
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def test_maker_connections_url_targets_powerautomate():
+    from flightcheck.checks._maker_urls import maker_connections_url
+
+    assert maker_connections_url("env-123") == (
+        "https://make.powerautomate.com/environments/env-123/connections"
+    )
+
+
+def test_maker_solutions_url_targets_powerapps():
+    """Solutions are only surfaced in the Power Apps maker — the
+    Power Automate maker does not expose the Connection References
+    pane that ENV-004 asks the operator to open."""
+    from flightcheck.checks._maker_urls import maker_solutions_url
+
+    assert maker_solutions_url("env-123") == (
+        "https://make.powerapps.com/environments/env-123/solutions"
+    )
+
+
+class _FakePPAdmin:
+    """Minimal stand-in for ``PPAdminClient`` covering the methods
+    ENV-004 calls. Returns the list passed at construction time."""
+
+    def __init__(self, connections):
+        self._connections = connections
+
+    def get_connections(self, _env_id):
+        return self._connections
+
+
+def _make_runner(connections):
+    return SimpleNamespace(
+        pp_admin=_FakePPAdmin(connections),
+        env_id="env-deeplinks",
+        env_url="https://example.crm.dynamics.com",
+        dv_token="fake-token",
+    )
+
+
+def _conn(name, display_name="Display Name"):
+    """Shape we need from PP Admin's get_connections — just `name`
+    (the GUID id field) and `properties.displayName`."""
+    return {"name": name, "properties": {"displayName": display_name, "apiId": "/providers/Microsoft.PowerApps/apis/shared_workdaysoap"}}
+
+
+def _ref(conn_id, ref_id=None, display="Reference", solution_id=None):
+    """Shape we need from Dataverse connectionreferences query.
+
+    ``solution_id`` does NOT live on the ref itself in the production
+    schema — connectionreference has no solution column. We carry it
+    on the fake dict purely so the test fixtures (``_patch_query_all``)
+    can derive a solutioncomponents response from the same input list,
+    keeping each test's setup compact.
+    """
+    return {
+        "connectionreferenceid": ref_id or "ref-id",
+        "connectionreferencelogicalname": "logical_name",
+        "connectionreferencedisplayname": display,
+        "connectorid": "shared_workdaysoap",
+        "connectionid": conn_id,
+        "statuscode": 1,
+        # NOTE: prefixed so the production code path never reads this
+        # — it's test-fixture metadata, not a Dataverse column.
+        "_test_solution_id": solution_id or "00000000-0000-0000-0000-000000009000",
+    }
+
+
+def _solution(sid, friendly_name, unique_name=None, ismanaged=False):
+    """Shape we need from Dataverse `solutions` query for the
+    ref → solution lookup. Defaults to ``ismanaged=False`` (unmanaged)
+    because that's the layer the maker can actually edit and the one
+    production prefers when picking among multiple matches."""
+    return {
+        "solutionid": sid,
+        "uniquename": unique_name or friendly_name.lower().replace(" ", ""),
+        "friendlyname": friendly_name,
+        "ismanaged": ismanaged,
+    }
+
+
+def _patch_query_all(monkeypatch, env_mod, *, conn_refs, solutions=None):
+    """Install a dispatching fake for ``auth.query_all`` covering all
+    three queries ENV-004 issues:
+
+      1. ``connectionreferences`` → returns the conn_refs argument
+      2. ``solutioncomponents`` → derives a (ref_id → solution_id)
+         mapping from each ref's ``_test_solution_id`` fixture field
+      3. ``solutions`` → returns the solutions argument
+
+    Tests that don't care about the per-row deep link can omit
+    ``solutions`` and the third call returns []; the production code
+    falls back to the env-wide solutions URL.
+    """
+    solutions = solutions or []
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            # Production code never reads `_test_solution_id` — strip
+            # it so the mock can't accidentally make production logic
+            # depend on a non-existent Dataverse column.
+            return [{k: v for k, v in r.items() if not k.startswith("_test_")}
+                    for r in conn_refs]
+        if entity_set == "solutioncomponents":
+            return [
+                {"objectid": r["connectionreferenceid"],
+                 "_solutionid_value": r["_test_solution_id"]}
+                for r in conn_refs if r.get("_test_solution_id")
+            ]
+        if entity_set == "solutions":
+            return solutions
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+
+def test_env_004_summary_orphan_remediation_links_to_solutions(monkeypatch):
+    """The top-level ENV-004 row, when orphan refs are present, must
+    point the operator at the Power Apps Solutions page where the
+    Connection References pane lives."""
+    from flightcheck.checks import environment as env_mod
+
+    # 1 connection that exists, 1 ref pointing at a DIFFERENT (missing) connection.
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("missing-conn-id", display="Workday")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    assert summary.status == "Failed", summary.__dict__
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in (summary.remediation or "")
+
+
+def test_env_004_summary_unbound_conns_links_to_connections_list(monkeypatch):
+    """When only unbound (extra) connections exist with no orphan refs,
+    the top-level row must link to the env-scoped connections list."""
+    from flightcheck.checks import environment as env_mod
+
+    # 2 connections, only the first has a ref bound to it -> second is unbound.
+    runner = _make_runner(connections=[_conn("bound-conn"), _conn("unbound-conn")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("bound-conn")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    assert summary.status == "Warning", summary.__dict__
+    assert "https://make.powerautomate.com/environments/env-deeplinks/connections" in (summary.remediation or "")
+
+
+def test_env_004_orphan_ref_detail_links_to_solutions(monkeypatch):
+    """Each ENV-004-OR-* (orphan ref) detail row must carry the
+    solutions deep link so the operator can re-bind the reference."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("missing-conn-id", display="Workday")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    assert orphan.status == "Failed"
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in (orphan.remediation or "")
+
+
+def test_env_004_unbound_ref_detail_links_to_solutions(monkeypatch):
+    """ENV-004-UR-* (ref with no connectionid set) detail must point
+    the operator at Solutions to bind the reference."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[])
+    # connectionid="" -> classified as unbound ref
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("", display="UnboundRef")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    unbound = next(r for r in results if r.checkpoint_id.startswith("ENV-004-UR-"))
+    assert unbound.status == "Failed"
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in (unbound.remediation or "")
+
+
+def test_env_004_unbound_conn_detail_links_to_connections_list(monkeypatch):
+    """ENV-004-UC-* (connection no ref points at) detail must link to
+    the connections list so the operator can remove the stale entry."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("orphan-conn", display_name="Stale Connection")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    uc = next(r for r in results if r.checkpoint_id.startswith("ENV-004-UC-"))
+    assert uc.status == "Warning"
+    assert "https://make.powerautomate.com/environments/env-deeplinks/connections" in (uc.remediation or "")
+
+
+# ---------------------------------------------------------------------------
+# ENV-004-UC-* honesty: the check ONLY knows the connection isn't
+# referenced by the agent's own solution. It can't see flows, canvas
+# apps, or other solutions in the env. The original prose ("If unused,
+# remove '<conn>' ... to reduce clutter") under-warned operators about
+# the silent-breakage risk of deleting a connection used elsewhere AND
+# gave no way to verify true disuse. The new prose must:
+#   1) reframe the finding as scoped to THIS agent's solution
+#   2) explicitly warn that deletion can silently break dependents
+#   3) walk through concrete verification steps (Power Apps connection
+#      detail, Power Automate flows, other solutions' connection refs)
+#   4) gate the "delete" action on the operator's verification
+# ---------------------------------------------------------------------------
+
+
+def test_env_004_unbound_conn_result_scopes_finding_to_this_solution(monkeypatch):
+    """Old result said 'No reference uses this connection' — which over-
+    claims, because the check only inspects the agent's own solution.
+    The new wording must scope to this agent's solution so the operator
+    doesn't read it as 'nothing in the env uses this'."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("orphan-conn", display_name="Stale Connection")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+
+    uc = next(
+        r for r in env_mod._check_connections_and_refs(runner)
+        if r.checkpoint_id.startswith("ENV-004-UC-")
+    )
+    assert "agent's solution" in uc.result.lower(), uc.result
+    # The original over-claim string must not regress.
+    assert "no reference uses this connection" not in uc.result.lower(), uc.result
+
+
+def test_env_004_unbound_conn_remediation_warns_about_silent_breakage(monkeypatch):
+    """Deleting a connection that's used by another resource fails
+    silently from the operator's perspective (the dependent breaks on
+    next run, not at delete time). The remediation must call this out
+    so the operator doesn't treat 'delete to reduce clutter' as safe."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("orphan-conn", display_name="Stale Connection")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+
+    uc = next(
+        r for r in env_mod._check_connections_and_refs(runner)
+        if r.checkpoint_id.startswith("ENV-004-UC-")
+    )
+    rem = (uc.remediation or "").lower()
+    # Must explicitly say verification is required before deletion.
+    assert "verify" in rem, rem
+    # Must explicitly warn about silent breakage.
+    assert ("silently" in rem) or ("does not warn" in rem), rem
+    # The old phrasing was actively misleading and must not regress.
+    assert "to reduce clutter" not in rem, rem
+
+
+def test_env_004_unbound_conn_remediation_lists_three_verification_paths(monkeypatch):
+    """Verification requires checking three places the check itself
+    didn't look. All three must be named — naming only one would imply
+    the others aren't relevant, and the operator would skip them."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("orphan-conn", display_name="Workday")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+
+    uc = next(
+        r for r in env_mod._check_connections_and_refs(runner)
+        if r.checkpoint_id.startswith("ENV-004-UC-")
+    )
+    rem = uc.remediation or ""
+    # 1. Power Apps Connections detail page (shows app dependencies).
+    assert "Connections" in rem and "make.powerautomate.com/environments/env-deeplinks/connections" in rem, rem
+    # 2. Power Automate flows (the only place flow dependencies show up).
+    assert "Power Automate" in rem, rem
+    assert "make.powerautomate.com/environments/env-deeplinks/flows" in rem, rem
+    # 3. Other solutions' connection references (the connection could be
+    #    bound by a connection reference in a different solution).
+    assert "Connection references" in rem, rem
+    assert "make.powerapps.com/environments/env-deeplinks/solutions" in rem, rem
+
+
+def test_env_004_unbound_conn_remediation_names_connector_and_connection(monkeypatch):
+    """The verification steps reference both the connection's display
+    name (so operators can spot it in the connections list) AND the
+    connector API id (so the Power Automate verification step is
+    actionable — flows are filtered by connector). Dropping either
+    forces the operator to cross-reference the original result text."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("orphan-conn", display_name="My Workday Conn")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+
+    uc = next(
+        r for r in env_mod._check_connections_and_refs(runner)
+        if r.checkpoint_id.startswith("ENV-004-UC-")
+    )
+    rem = uc.remediation or ""
+    assert "My Workday Conn" in rem, rem
+    # The connector label comes from the apiId in the _conn fixture.
+    assert "shared_workdaysoap" in rem, rem
+
+
+# ---------------------------------------------------------------------------
+# Walkthrough prose + doc_link pins
+#
+# The Solutions deep link by itself is not enough — Connection References
+# are only visible *inside* a solution, under Objects → Connection
+# references. The remediations must spell that out, and the doc_link
+# must point to Microsoft's canonical walkthrough for binding a
+# connection reference, so an operator unfamiliar with the maker portal
+# has a complete reference next to the abbreviated steps.
+# ---------------------------------------------------------------------------
+
+_CONN_REF_DOC = (
+    "https://learn.microsoft.com/en-us/power-apps/maker/"
+    "data-platform/create-connection-reference"
+)
+
+
+def test_env_004_orphan_detail_prose_calls_out_objects_pane(monkeypatch):
+    """Operators reported they couldn't find Connection References from
+    the Solutions list. The remediation must explicitly walk them
+    through `Objects → Connection references` inside the solution."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("missing-conn-id", display="Workday")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    rem = orphan.remediation or ""
+    assert "Objects" in rem and "Connection references" in rem, rem
+
+
+def test_env_004_unbound_ref_detail_prose_calls_out_objects_pane(monkeypatch):
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("", display="UnboundRef")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    unbound = next(r for r in results if r.checkpoint_id.startswith("ENV-004-UR-"))
+    rem = unbound.remediation or ""
+    assert "Objects" in rem and "Connection references" in rem, rem
+
+
+def test_env_004_summary_prose_calls_out_objects_pane_when_failed(monkeypatch):
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("missing-conn-id", display="Workday")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    rem = summary.remediation or ""
+    assert "Objects" in rem and "Connection references" in rem, rem
+
+
+def test_env_004_failed_summary_doc_link_points_to_connection_reference_doc(monkeypatch):
+    """When the summary is FAILED (ref problems), surface Microsoft's
+    canonical connection-reference walkthrough — the generic
+    ess-prepare doc doesn't help an operator fix a binding."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("missing-conn-id", display="Workday")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    assert summary.status == "Failed"
+    assert summary.doc_link == _CONN_REF_DOC
+
+
+def test_env_004_warning_only_summary_keeps_generic_doc_link(monkeypatch):
+    """A WARNING-only summary (unbound connections, no orphan refs) is
+    not really about connection references, so keep the generic
+    ess-prepare doc as the summary's doc_link."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("bound-conn"), _conn("unbound-conn")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("bound-conn")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    assert summary.status == "Warning"
+    assert summary.doc_link != _CONN_REF_DOC
+    assert "prepare" in (summary.doc_link or "")
+
+
+def test_env_004_orphan_detail_doc_link_points_to_connection_reference_doc(monkeypatch):
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("missing-conn-id", display="Workday")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    assert orphan.doc_link == _CONN_REF_DOC
+
+
+def test_env_004_unbound_ref_detail_doc_link_points_to_connection_reference_doc(monkeypatch):
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[])
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [_ref("", display="UnboundRef")])
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    unbound = next(r for r in results if r.checkpoint_id.startswith("ENV-004-UR-"))
+    assert unbound.doc_link == _CONN_REF_DOC
+
+
+# ---------------------------------------------------------------------------
+# Per-row specific-solution deep links
+#
+# The env-wide solutions list is unhelpful — it dumps every first-party
+# and ISV solution on the operator and leaves them guessing which one
+# holds the broken ref. ENV-004 now resolves each ref's `_solutionid_value`
+# to a friendly solution name + GUID and emits a deep link straight to
+# that solution's detail page, where the Objects → Connection references
+# pane lives.
+# ---------------------------------------------------------------------------
+
+_SOL_ID = "11111111-2222-3333-4444-555555555555"
+_SOL_URL_FRAGMENT = f"/solutions/{_SOL_ID}"
+
+
+def test_env_004_orphan_detail_deep_links_to_specific_solution(monkeypatch):
+    """When we can resolve the ref's containing solution, the orphan
+    detail row must deep-link to that specific solution (not the
+    env-wide solutions list)."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    _patch_query_all(
+        monkeypatch, env_mod,
+        conn_refs=[_ref("missing-conn-id", display="Workday", solution_id=_SOL_ID)],
+        solutions=[_solution(_SOL_ID, "Workday Agent Solution")],
+    )
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    rem = orphan.remediation or ""
+    assert _SOL_URL_FRAGMENT in rem, rem
+    # The link text should surface the friendly solution name so the
+    # operator can confirm they're opening the right one.
+    assert "Workday Agent Solution" in rem, rem
+
+
+def test_env_004_unbound_ref_detail_deep_links_to_specific_solution(monkeypatch):
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[])
+    _patch_query_all(
+        monkeypatch, env_mod,
+        conn_refs=[_ref("", display="UnboundRef", solution_id=_SOL_ID)],
+        solutions=[_solution(_SOL_ID, "Workday Agent Solution")],
+    )
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    unbound = next(r for r in results if r.checkpoint_id.startswith("ENV-004-UR-"))
+    rem = unbound.remediation or ""
+    assert _SOL_URL_FRAGMENT in rem, rem
+    assert "Workday Agent Solution" in rem, rem
+
+
+def test_env_004_detail_falls_back_to_env_solutions_when_lookup_fails(monkeypatch):
+    """If the solutions lookup returns nothing (Dataverse error, missing
+    permission, the ref isn't in any solutioncomponent row), the
+    remediation must fall back to the env-wide solutions URL — never
+    produce a 404 or a half-formed markdown link."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    # Conn-ref query succeeds, but solutioncomponents returns nothing
+    # for this ref — simulates a permission/visibility gap mid-check.
+    _patch_query_all(
+        monkeypatch, env_mod,
+        conn_refs=[_ref("missing-conn-id", display="Workday", solution_id=_SOL_ID)],
+        solutions=[],  # also empty for good measure
+    )
+    # Override the solutioncomponents leg to return nothing.
+    real_fake = env_mod.query_all
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "solutioncomponents":
+            return []
+        return real_fake(env_url, token, entity_set, select, filter_expr=filter_expr)
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    rem = orphan.remediation or ""
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in rem
+    assert _SOL_URL_FRAGMENT not in rem  # specific solution should NOT appear
+    # The fallback link text reverts to the generic label.
+    assert "Power Apps \u2192 Solutions" in rem
+
+
+def test_env_004_detail_falls_back_when_dataverse_solutions_query_raises(monkeypatch):
+    """A Dataverse exception during the lookup must not abort ENV-004 —
+    it should silently fall back to the env-wide URL so the operator
+    still gets actionable remediation. Covers both the
+    solutioncomponents and solutions queries failing."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            return [{
+                "connectionreferenceid": "broken-ref-id",
+                "connectionreferencelogicalname": "logical_name",
+                "connectionreferencedisplayname": "Workday",
+                "connectorid": "shared_workdaysoap",
+                "connectionid": "missing-conn-id",
+                "statuscode": 1,
+            }]
+        if entity_set == "solutioncomponents":
+            raise RuntimeError("403 Forbidden")
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    rem = orphan.remediation or ""
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in rem
+    assert _SOL_URL_FRAGMENT not in rem
+
+
+def test_env_004_solution_lookup_uses_distinct_solution_ids(monkeypatch):
+    """When multiple refs live in the same solution, the lookup must
+    de-dupe so we don't build an enormous OData filter and don't issue
+    multiple round-trips."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    sol_filters: list[str] = []
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            return [
+                {"connectionreferenceid": "r1", "connectionreferencelogicalname": "n",
+                 "connectionreferencedisplayname": "Ref1", "connectorid": "x",
+                 "connectionid": "missing-1", "statuscode": 1},
+                {"connectionreferenceid": "r2", "connectionreferencelogicalname": "n",
+                 "connectionreferencedisplayname": "Ref2", "connectorid": "x",
+                 "connectionid": "missing-2", "statuscode": 1},
+                {"connectionreferenceid": "r3", "connectionreferencelogicalname": "n",
+                 "connectionreferencedisplayname": "Ref3", "connectorid": "x",
+                 "connectionid": "missing-3", "statuscode": 1},
+            ]
+        if entity_set == "solutioncomponents":
+            # All 3 refs live in the same solution.
+            return [
+                {"objectid": rid, "_solutionid_value": _SOL_ID}
+                for rid in ("r1", "r2", "r3")
+            ]
+        if entity_set == "solutions":
+            sol_filters.append(filter_expr or "")
+            return [_solution(_SOL_ID, "Single Solution")]
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    env_mod._check_connections_and_refs(runner)
+
+    # Exactly one solutions query, with exactly one solutionid filter.
+    assert len(sol_filters) == 1, sol_filters
+    assert sol_filters[0].count("solutionid eq") == 1, sol_filters[0]
+
+
+def test_env_004_resolves_multiple_distinct_solutions(monkeypatch):
+    """When two broken refs live in two different solutions, each
+    detail row must deep-link to its own solution."""
+    from flightcheck.checks import environment as env_mod
+
+    sol_a = "aaaaaaaa-0000-0000-0000-000000000001"
+    sol_b = "bbbbbbbb-0000-0000-0000-000000000002"
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    _patch_query_all(
+        monkeypatch, env_mod,
+        conn_refs=[
+            _ref("missing-1", ref_id="r-a", display="RefA", solution_id=sol_a),
+            _ref("missing-2", ref_id="r-b", display="RefB", solution_id=sol_b),
+        ],
+        solutions=[
+            _solution(sol_a, "Solution A"),
+            _solution(sol_b, "Solution B"),
+        ],
+    )
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    orphan_rows = [r for r in results if r.checkpoint_id.startswith("ENV-004-OR-")]
+    assert len(orphan_rows) == 2
+
+    by_ref = {r.description: r.remediation or "" for r in orphan_rows}
+    assert f"/solutions/{sol_a}" in by_ref["Orphan reference: RefA"]
+    assert "Solution A" in by_ref["Orphan reference: RefA"]
+    assert f"/solutions/{sol_b}" in by_ref["Orphan reference: RefB"]
+    assert "Solution B" in by_ref["Orphan reference: RefB"]
+
+
+def test_resolve_ref_solutions_no_refs_skips_dataverse_call(monkeypatch):
+    """If there are no problematic refs, we must not issue an empty
+    OData filter (`objectid eq` with nothing) — skip both round-trips."""
+    from flightcheck.checks import environment as env_mod
+
+    called = []
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        called.append(entity_set)
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    out = env_mod._resolve_ref_solutions(
+        env_url="https://x.api.crm.dynamics.com",
+        dv_token="tok",
+        env_id="env-1",
+        refs=[],
+    )
+    assert out == {}
+    assert "solutioncomponents" not in called
+    assert "solutions" not in called
+
+
+# ---------------------------------------------------------------------------
+# Summary remediation when broken refs resolve to specific solutions
+#
+# Pin the smarter summary text:
+#   - All broken refs in ONE solution → summary deep-links to that solution
+#   - Broken refs SPREAD across solutions → summary names them and points
+#     at the env-wide list
+#   - Lookup failed → summary keeps the generic prose (don't pretend to
+#     know something we don't)
+# ---------------------------------------------------------------------------
+
+def test_env_004_summary_deep_links_when_all_refs_in_one_solution(monkeypatch):
+    """When every broken ref lives in the same solution, the summary
+    must deep-link to that specific solution — not the env-wide list."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    _patch_query_all(
+        monkeypatch, env_mod,
+        conn_refs=[
+            _ref("missing-1", ref_id="r1", display="RefA", solution_id=_SOL_ID),
+            _ref("missing-2", ref_id="r2", display="RefB", solution_id=_SOL_ID),
+        ],
+        solutions=[_solution(_SOL_ID, "Workday Agent Solution")],
+    )
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    rem = summary.remediation or ""
+    assert _SOL_URL_FRAGMENT in rem, rem
+    assert "Workday Agent Solution" in rem, rem
+    # The "click the solution that contains your agent" hedge wording
+    # should be gone now that we know the exact solution.
+    assert "click the solution that contains your agent" not in rem
+
+
+def test_env_004_summary_lists_solutions_when_refs_spread(monkeypatch):
+    """When broken refs span multiple solutions, the summary must name
+    every affected solution so the operator knows where to look."""
+    from flightcheck.checks import environment as env_mod
+
+    sol_a = "aaaaaaaa-0000-0000-0000-000000000001"
+    sol_b = "bbbbbbbb-0000-0000-0000-000000000002"
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    _patch_query_all(
+        monkeypatch, env_mod,
+        conn_refs=[
+            _ref("missing-1", ref_id="r-a", display="RefA", solution_id=sol_a),
+            _ref("missing-2", ref_id="r-b", display="RefB", solution_id=sol_b),
+        ],
+        solutions=[
+            _solution(sol_a, "Workday Agent Solution"),
+            _solution(sol_b, "Custom Tweaks Solution"),
+        ],
+    )
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    rem = summary.remediation or ""
+    # Both affected solution names must be surfaced.
+    assert "Workday Agent Solution" in rem, rem
+    assert "Custom Tweaks Solution" in rem, rem
+    # The env-wide solutions URL is the only viable link target when
+    # multiple solutions are involved.
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in rem
+    # And it must NOT deep-link to either specific solution (would be
+    # misleading — there are TWO to visit).
+    assert f"/solutions/{sol_a}" not in rem
+    assert f"/solutions/{sol_b}" not in rem
+
+
+def test_env_004_summary_keeps_generic_prose_when_lookup_unresolved(monkeypatch):
+    """If the solutioncomponents lookup returns nothing for any ref,
+    the summary must fall back to the generic prose — don't claim to
+    know solutions we couldn't resolve."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            return [{
+                "connectionreferenceid": "broken-ref",
+                "connectionreferencelogicalname": "n",
+                "connectionreferencedisplayname": "Workday",
+                "connectorid": "x",
+                "connectionid": "missing-conn",
+                "statuscode": 1,
+            }]
+        if entity_set == "solutioncomponents":
+            return []  # ref not found in any solution component
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    results = env_mod._check_connections_and_refs(runner)
+
+    summary = next(r for r in results if r.checkpoint_id == "ENV-004")
+    rem = summary.remediation or ""
+    # Generic prose hallmark — the hedge wording.
+    assert "click the solution that contains your agent" in rem
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in rem
+
+# ---------------------------------------------------------------------------
+# Managed-solution fallback to Default Solution.
+#
+# Power Apps blocks direct edits inside managed solutions with
+# "You cannot directly edit the objects within a managed solution.",
+# so a remediation link that lands on one is a dead end for the maker.
+# The check redirects the link to Default Solution (always unmanaged,
+# always present) so the maker has somewhere to actually re-bind.
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_SOL_ID = "00000000-0000-0000-0000-00000000DEFA"
+_DEFAULT_SOL_URL_FRAGMENT = f"/solutions/{_DEFAULT_SOL_ID}"
+
+
+def test_env_004_managed_only_ref_links_to_default_solution(monkeypatch):
+    """When a broken ref only lives in a *managed* solution, the link
+    must redirect to the Default Solution (the unmanaged customization
+    layer) — never to a managed solution where edits are blocked."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    managed_sid = "00000000-0000-0000-0000-0000MANAGED1"
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            return [_ref("missing-conn-id", display="Workday")]
+        if entity_set == "solutioncomponents":
+            return [{"objectid": "ref-id", "_solutionid_value": managed_sid}]
+        if entity_set == "solutions":
+            return [
+                _solution(managed_sid, "Workday Managed", ismanaged=True),
+                _solution(_DEFAULT_SOL_ID, "Default Solution",
+                          unique_name="Default", ismanaged=False),
+            ]
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    results = env_mod._check_connections_and_refs(runner)
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    rem = orphan.remediation or ""
+    # Link goes to Default, NOT to the managed solution.
+    assert _DEFAULT_SOL_URL_FRAGMENT in rem, rem
+    assert f"/solutions/{managed_sid}" not in rem, rem
+    # Label should reflect the actual destination so the maker isn't
+    # surprised by what they see when they click.
+    assert "Default Solution" in rem, rem
+
+
+def test_env_004_prefers_named_unmanaged_over_default_solution(monkeypatch):
+    """If a ref lives in BOTH a named unmanaged solution and Default,
+    prefer the named one — it's the maker's focused workspace, while
+    Default is the catch-all that includes every component in the org."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    named_sid = "00000000-0000-0000-0000-0000NAMED0001"
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            return [_ref("missing-conn-id", display="Workday")]
+        if entity_set == "solutioncomponents":
+            # Same ref appears in two solutions.
+            return [
+                {"objectid": "ref-id", "_solutionid_value": named_sid},
+                {"objectid": "ref-id", "_solutionid_value": _DEFAULT_SOL_ID},
+            ]
+        if entity_set == "solutions":
+            return [
+                _solution(named_sid, "Workday Customizations",
+                          unique_name="WorkdayCustom", ismanaged=False),
+                _solution(_DEFAULT_SOL_ID, "Default Solution",
+                          unique_name="Default", ismanaged=False),
+            ]
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    results = env_mod._check_connections_and_refs(runner)
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    rem = orphan.remediation or ""
+    assert f"/solutions/{named_sid}" in rem, rem
+    assert _DEFAULT_SOL_URL_FRAGMENT not in rem, rem
+    assert "Workday Customizations" in rem, rem
+
+
+def test_env_004_managed_only_with_no_default_falls_back_to_env_wide(monkeypatch):
+    """Edge case: ref only lives in a managed solution AND Dataverse
+    didn't return Default (shouldn't happen in practice — Default is
+    always present — but be defensive). Must not link to the managed
+    solution; fall back to the env-wide URL instead."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    managed_sid = "00000000-0000-0000-0000-0000MANAGED2"
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            return [_ref("missing-conn-id", display="Workday")]
+        if entity_set == "solutioncomponents":
+            return [{"objectid": "ref-id", "_solutionid_value": managed_sid}]
+        if entity_set == "solutions":
+            # No Default returned — only the managed solution.
+            return [_solution(managed_sid, "Managed Only", ismanaged=True)]
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    results = env_mod._check_connections_and_refs(runner)
+    orphan = next(r for r in results if r.checkpoint_id.startswith("ENV-004-OR-"))
+    rem = orphan.remediation or ""
+    # Never link to the managed solution.
+    assert f"/solutions/{managed_sid}" not in rem, rem
+    # Fall back to the env-wide solutions URL.
+    assert "https://make.powerapps.com/environments/env-deeplinks/solutions" in rem
+    # And no other specific /solutions/<guid>/ fragment leaked through.
+    assert "/solutions/00000000" not in rem, rem
+
+
+def test_env_004_solutions_filter_always_includes_default_uniquename(monkeypatch):
+    """The solutions OData filter must always include
+    `uniquename eq 'Default'` so the Default Solution row comes back
+    even when the ref's containing solutions don't intersect it. Without
+    this, the managed-only fallback has nowhere to redirect."""
+    from flightcheck.checks import environment as env_mod
+
+    runner = _make_runner(connections=[_conn("real-conn-id")])
+    sol_filters: list[str] = []
+
+    def _fake(env_url, token, entity_set, select, filter_expr=None):
+        if entity_set == "connectionreferences":
+            return [_ref("missing-conn-id", display="Workday")]
+        if entity_set == "solutioncomponents":
+            return [{"objectid": "ref-id", "_solutionid_value": _SOL_ID}]
+        if entity_set == "solutions":
+            sol_filters.append(filter_expr or "")
+            return [_solution(_SOL_ID, "Some Solution")]
+        return []
+
+    monkeypatch.setattr(env_mod, "query_all", _fake)
+
+    env_mod._check_connections_and_refs(runner)
+
+    assert len(sol_filters) == 1, sol_filters
+    assert "uniquename eq 'Default'" in sol_filters[0], sol_filters[0]

--- a/tests/flightcheck/checks/test_env_008_dlp_remediation.py
+++ b/tests/flightcheck/checks/test_env_008_dlp_remediation.py
@@ -1,0 +1,232 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for ENV-008 (DLP policies) remediation text.
+
+The original remediation was a one-liner pointing at the PP admin center
+homepage with a vague "ensure connectors are allowlisted" — operators
+reported they had no idea what concrete steps to take. These tests pin
+the actionable remediation prose now produced for each ENV-008 path:
+
+  * Warning (no DLP policies cover this env) — walks the operator
+    through scoping a policy, the same-group constraint, and the
+    "no-action-needed if DLP isn't enforced" exit.
+  * Warning (permission/API failure) — names the role required and
+    deep-links to the policies page so a tenant admin can review.
+
+These tests intentionally assert on the *substance* of the remediation
+(URL, role name, key concepts like 'same group', 'Blocked') rather than
+exact wording, so harmless prose tweaks don't churn them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+_ADMIN_URL = "https://admin.powerplatform.microsoft.com/"
+_NAV_PATH = "Security \u2192 Data and privacy \u2192 Data policy"
+
+
+class _FakePPAdmin:
+    """Minimal PP Admin stub exposing only the methods environment
+    checks call. Each method takes a callable so tests can simulate
+    success or raise."""
+
+    def __init__(
+        self,
+        *,
+        env_props: dict | None = None,
+        dlp_policies=None,
+        dlp_raises: Exception | None = None,
+    ):
+        self._env_props = env_props if env_props is not None else {
+            "displayName": "Test Env",
+            "linkedEnvironmentMetadata": {"resourceProvisioningState": "Succeeded"},
+            "databaseType": "CommonDataService",
+            "environmentSku": "Production",
+        }
+        self._dlp_policies = dlp_policies if dlp_policies is not None else []
+        self._dlp_raises = dlp_raises
+
+    def get_environment(self, _env_id):
+        return {"properties": self._env_props}
+
+    def get_dlp_policies_for_env(self, _env_id):
+        if self._dlp_raises:
+            raise self._dlp_raises
+        return self._dlp_policies
+
+    def get_connections(self, _env_id):
+        # ENV-004 also runs as part of run_environment_checks; return
+        # an empty list so it produces a clean PASSED row and doesn't
+        # interfere with ENV-008 assertions.
+        return []
+
+
+def _make_runner(pp_admin):
+    return SimpleNamespace(
+        pp_admin=pp_admin,
+        env_id="env-deeplinks",
+        env_url="https://example.crm.dynamics.com",
+        dv_token="fake-token",
+    )
+
+
+def _get_env_008(results):
+    """ENV-004 emits a summary row too — filter precisely to ENV-008."""
+    return next(r for r in results if r.checkpoint_id == "ENV-008")
+
+
+# ---------------------------------------------------------------------------
+# Warning path: no DLP policies cover this environment.
+# ---------------------------------------------------------------------------
+
+
+def test_env_008_no_policies_remediation_links_to_admin_center(monkeypatch):
+    """The remediation must link to the admin center root + spell out
+    the **Security \u2192 Data and privacy \u2192 Data policy** nav path
+    explicitly. We deliberately do NOT deep-link to a sub-path like
+    /policies or /dlp because Microsoft does not publish a stable
+    public URL for those routes (they 404 outside the SPA shell), and
+    Microsoft's own docs walk users through the same nav path from the
+    root."""
+    from flightcheck.checks import environment as env_mod
+
+    # Suppress the connection-ref Dataverse query that runs as part of
+    # the same check function.
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+
+    runner = _make_runner(_FakePPAdmin(dlp_policies=[]))
+    results = env_mod.run_environment_checks(runner)
+    env008 = _get_env_008(results)
+
+    assert env008.status == "Warning"
+    rem = env008.remediation or ""
+    assert _ADMIN_URL in rem, rem
+    # Must NOT use any of the URL paths we've previously tried that
+    # turned out to 404; pin them so the link doesn't regress.
+    for broken in ("/policies", "/dlp", "/datapolicies"):
+        assert _ADMIN_URL + broken.lstrip("/") not in rem, rem
+    # And the nav path must be there so the operator knows where to go
+    # after the link drops them on the admin center home.
+    assert _NAV_PATH in rem, rem
+
+
+def test_env_008_no_policies_remediation_names_same_group_constraint(monkeypatch):
+    """'Allowlisting' in DLP terms means putting every connector the
+    agent uses in the SAME group (Business or Non-Business) — connectors
+    in different groups cannot be combined in a single flow or agent
+    action. That's the constraint operators most often miss, so it must
+    be spelled out in the remediation."""
+    from flightcheck.checks import environment as env_mod
+
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+    runner = _make_runner(_FakePPAdmin(dlp_policies=[]))
+    results = env_mod.run_environment_checks(runner)
+    env008 = _get_env_008(results)
+
+    rem = env008.remediation or ""
+    assert "same" in rem.lower(), rem
+    # Both group names should appear so the operator knows what to pick.
+    assert "Business" in rem, rem
+    assert "Non-Business" in rem, rem
+    # And the Blocked group must be called out — putting a needed
+    # connector there is the other common misconfiguration.
+    assert "Blocked" in rem, rem
+
+
+def test_env_008_no_policies_remediation_explains_scoping_to_environment(monkeypatch):
+    """A DLP policy only takes effect on an env if that env is in the
+    policy's Environments scope. Operators frequently miss this and
+    create a policy that does nothing for the env in question."""
+    from flightcheck.checks import environment as env_mod
+
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+    runner = _make_runner(_FakePPAdmin(dlp_policies=[]))
+    results = env_mod.run_environment_checks(runner)
+    env008 = _get_env_008(results)
+
+    rem = env008.remediation or ""
+    # Must mention that the policy must include this environment.
+    assert "Environments" in rem or "environment" in rem.lower(), rem
+    assert "scope" in rem.lower() or "include" in rem.lower(), rem
+
+
+def test_env_008_no_policies_remediation_acknowledges_no_dlp_is_valid(monkeypatch):
+    """Many tenants intentionally don't enforce DLP, especially in dev.
+    The remediation must give those operators an explicit 'no action
+    required' exit so they don't waste time chasing a non-issue."""
+    from flightcheck.checks import environment as env_mod
+
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+    runner = _make_runner(_FakePPAdmin(dlp_policies=[]))
+    results = env_mod.run_environment_checks(runner)
+    env008 = _get_env_008(results)
+
+    rem = env008.remediation or ""
+    assert "no action" in rem.lower(), rem
+
+
+# ---------------------------------------------------------------------------
+# Passed path: at least one policy covers the environment.
+# ---------------------------------------------------------------------------
+
+
+def test_env_008_with_policies_passes_with_no_remediation(monkeypatch):
+    """When at least one DLP policy applies, ENV-008 passes and emits
+    no remediation — covering the regression risk that we accidentally
+    push remediation text on the happy path."""
+    from flightcheck.checks import environment as env_mod
+
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+    runner = _make_runner(_FakePPAdmin(dlp_policies=[{"policyDefinition": {}}]))
+    results = env_mod.run_environment_checks(runner)
+    env008 = _get_env_008(results)
+
+    assert env008.status == "Passed"
+    assert not (env008.remediation or "")
+
+
+# ---------------------------------------------------------------------------
+# Warning path: API/permission failure.
+# ---------------------------------------------------------------------------
+
+
+def test_env_008_permission_error_remediation_names_role_and_links(monkeypatch):
+    """When the DLP query fails (typically because the caller lacks
+    PP Administrator), the remediation must name the exact role required
+    AND link to the policies page so a tenant admin can review without
+    extra back-and-forth."""
+    from flightcheck.checks import environment as env_mod
+
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+    runner = _make_runner(_FakePPAdmin(dlp_raises=RuntimeError("403 Forbidden")))
+    results = env_mod.run_environment_checks(runner)
+    env008 = _get_env_008(results)
+
+    assert env008.status == "Warning"
+    rem = env008.remediation or ""
+    assert "Power Platform Administrator" in rem, rem
+    assert _ADMIN_URL in rem, rem
+    assert _NAV_PATH in rem, rem
+    for broken in ("/policies", "/dlp", "/datapolicies"):
+        assert _ADMIN_URL + broken.lstrip("/") not in rem, rem

--- a/tests/flightcheck/checks/test_publishing.py
+++ b/tests/flightcheck/checks/test_publishing.py
@@ -1,0 +1,196 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the Publishing & QA checklist (PUB-*, QA-*).
+
+The user surfaced that the publishing rows were emitted as
+``NotConfigured`` with a generic "Verify: <desc>" remediation and a
+single homepage link — operators had no way to act on them. The
+module was rewritten so:
+
+  * every row is ``Status.MANUAL`` (nothing is genuinely "not
+    configured" — the kit just can't witness the action remotely);
+  * every ``result`` describes WHAT the kit can't see, not the
+    boilerplate "Manual verification required";
+  * every ``remediation`` carries concrete steps and the best
+    available deep link (Copilot Studio agent for QA-*; Power Apps
+    Solutions for PUB-001/002; the Microsoft 365 admin center
+    Integrated apps page for PUB-006/011).
+
+These tests pin those contracts so the rows can't drift back to
+"vague + NotConfigured" without breaking CI.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    """Make `flightcheck.*` importable from the kit's scripts dir."""
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def _runner(env_id: str | None = "env-abc", bot_id: str | None = "bot-xyz"):
+    """Minimal runner stub exposing the two attributes publishing.py reads."""
+    config: dict = {}
+    if bot_id:
+        config["agents"] = [{"slug": "esshr", "botId": bot_id}]
+    return SimpleNamespace(env_id=env_id, config=config)
+
+
+def _results_by_id(runner) -> dict:
+    from flightcheck.checks.publishing import run_publishing_checks
+    return {r.checkpoint_id: r for r in run_publishing_checks(runner)}
+
+
+# --------------------------------------------------------------- shape
+
+
+def test_all_eight_checks_emitted():
+    """Regression guard: the published checklist must keep its 8 IDs."""
+    by_id = _results_by_id(_runner())
+    assert set(by_id) == {
+        "QA-001", "QA-002", "QA-012",
+        "PUB-001", "PUB-002", "PUB-003", "PUB-006", "PUB-011",
+    }
+
+
+def test_every_check_is_manual_not_notconfigured():
+    """The user's principle: nothing here is misconfigured. Don't
+    label it ``NotConfigured`` — that wrongly implies setup is missing."""
+    from flightcheck.runner import Status
+    for r in _results_by_id(_runner()).values():
+        assert r.status == Status.MANUAL.value, (
+            f"{r.checkpoint_id} regressed to status={r.status!r}; "
+            "publishing/QA gates are manual, not NotConfigured."
+        )
+
+
+def test_every_check_has_concrete_result_text():
+    """No row may carry the old "Manual verification required" stub."""
+    for r in _results_by_id(_runner()).values():
+        assert r.result.strip(), f"{r.checkpoint_id} has empty result"
+        assert r.result != "Manual verification required", (
+            f"{r.checkpoint_id} regressed to the generic result stub."
+        )
+
+
+def test_every_check_has_remediation_and_doc_link():
+    for r in _results_by_id(_runner()).values():
+        assert r.remediation.strip(), f"{r.checkpoint_id} has empty remediation"
+        # Remediation must say more than "Verify: <desc>".
+        assert not r.remediation.startswith("Verify:"), (
+            f"{r.checkpoint_id} regressed to the boilerplate remediation."
+        )
+        assert r.doc_link.startswith("https://"), (
+            f"{r.checkpoint_id} has missing/invalid doc_link {r.doc_link!r}"
+        )
+
+
+def test_category_is_publishing():
+    for r in _results_by_id(_runner()).values():
+        assert r.category == "Publishing"
+
+
+# ----------------------------------------------------------- QA deep links
+
+
+def test_qa_checks_link_to_studio_when_env_and_bot_resolved():
+    by_id = _results_by_id(_runner(env_id="env-abc", bot_id="bot-xyz"))
+    expected = (
+        "https://copilotstudio.microsoft.com/environments/env-abc/"
+        "bots/bot-xyz/overview"
+    )
+    for qa_id in ("QA-001", "QA-002", "QA-012"):
+        assert expected in by_id[qa_id].remediation, (
+            f"{qa_id} remediation missing the Studio deep link {expected!r}; "
+            f"got: {by_id[qa_id].remediation!r}"
+        )
+
+
+def test_qa_checks_remain_actionable_without_studio_link():
+    """If env_id or botId is missing, the remediation must still tell
+    the operator where to go — just without a clickable shortcut."""
+    by_id = _results_by_id(_runner(env_id=None, bot_id=None))
+    for qa_id in ("QA-001", "QA-002", "QA-012"):
+        text = by_id[qa_id].remediation
+        # No copilotstudio.microsoft.com link when we can't build one.
+        assert "copilotstudio.microsoft.com/environments/" not in text
+        # But the operator is still told where to perform the action.
+        assert "Analytics" in text and "Evaluations" in text
+
+
+def test_qa_checks_point_at_evaluations_doc():
+    by_id = _results_by_id(_runner())
+    for qa_id in ("QA-001", "QA-002", "QA-012"):
+        assert by_id[qa_id].doc_link.endswith("/evaluations"), (
+            f"{qa_id} doc_link should land on the evaluations guide; "
+            f"got {by_id[qa_id].doc_link!r}"
+        )
+
+
+# ----------------------------------------------------------- PUB deep links
+
+
+def test_pub_001_links_to_maker_solutions_for_export():
+    by_id = _results_by_id(_runner(env_id="env-abc"))
+    text = by_id["PUB-001"].remediation
+    assert "https://make.powerapps.com/environments/env-abc/solutions" in text, (
+        f"PUB-001 must deep-link to the maker Solutions list so the "
+        f"operator can find Export → Managed; got: {text!r}"
+    )
+    # And the operator is told what to actually click.
+    assert "Export solution" in text and "Managed" in text
+
+
+def test_pub_002_describes_target_environment_import():
+    text = _results_by_id(_runner())["PUB-002"].remediation
+    # The action happens in a *different* environment than the kit
+    # was pointed at, so we can't deep-link — but we must say where.
+    assert "test environment" in text.lower()
+    assert "Import solution" in text
+
+
+def test_pub_003_is_explicitly_organizational():
+    """No portal link applies. The remediation must own that fact so
+    the operator doesn't search for a non-existent maker page."""
+    text = _results_by_id(_runner())["PUB-003"].remediation
+    assert "organizational gate" in text.lower()
+    assert "sign-off" in text.lower() or "sign off" in text.lower()
+
+
+def test_pub_006_links_to_m365_admin_integrated_apps():
+    text = _results_by_id(_runner())["PUB-006"].remediation
+    expected = (
+        "https://admin.microsoft.com/Adminportal/Home#/Settings/IntegratedApps"
+    )
+    assert expected in text, (
+        f"PUB-006 must deep-link to M365 admin → Integrated apps so a "
+        f"tenant admin can approve the publish request; got: {text!r}"
+    )
+
+
+def test_pub_011_is_informational_with_no_action_at_publish_time():
+    text = _results_by_id(_runner())["PUB-011"].remediation
+    # Operators should see explicitly that this row needs no action.
+    assert "no action" in text.lower(), (
+        f"PUB-011 is a heads-up; the remediation must say no action is "
+        f"required at publish time; got: {text!r}"
+    )
+    # And still link to where to check status if rollout drags.
+    assert "Integrated apps" in text

--- a/tests/flightcheck/test_local_files_studio_link.py
+++ b/tests/flightcheck/test_local_files_studio_link.py
@@ -192,3 +192,488 @@ def test_config_007_remediation_falls_back_when_runner_unavailable(
     ]
     assert len(failed) == 1
     assert "https://copilotstudio.microsoft.com/" in (failed[0].remediation or "")
+
+
+# ---------------------------------------------------------------------------
+# TOPIC-001..010 required-topic remediations must also deep-link to the
+# specific agent. Pre-fix these all used the generic homepage URL because
+# `_check_required_topics` never received the runner or the agent slug.
+# This mirrors the CONFIG-007 pinning above for the topic checkpoints.
+# ---------------------------------------------------------------------------
+
+
+def test_topic_required_remediation_includes_deep_link_for_each_checkpoint(
+    tmp_path: Path,
+):
+    """When a required topic is missing, each TOPIC-* WARNING row must
+    point the user at the specific agent in Copilot Studio so they can
+    open the Topics tab in one click instead of guessing."""
+    from flightcheck.checks.local_files import _check_required_topics, REQUIRED_TOPICS
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)  # empty topics dir => every required topic missing
+
+    runner = _fake_runner(
+        env_id="env-topic",
+        agents=[{"slug": "my-agent", "botId": "bot-topic"}],
+    )
+
+    results = _check_required_topics(agent_dir, "My Agent", runner, "my-agent")
+
+    expected_deep_link = (
+        "https://copilotstudio.microsoft.com/"
+        "environments/env-topic/bots/bot-topic/overview"
+    )
+
+    # Every required topic should be WARNING (not found) and every WARNING
+    # row should carry the deep link in its remediation. This pins all of
+    # TOPIC-001/002/004/005/009/010 in one assertion.
+    warnings = [r for r in results if r.status == "Warning"]
+    assert len(warnings) == len(REQUIRED_TOPICS), [r.__dict__ for r in results]
+    for row in warnings:
+        assert expected_deep_link in (row.remediation or ""), row.__dict__
+
+
+def test_topic_required_remediation_falls_back_when_runner_unavailable(
+    tmp_path: Path,
+):
+    """Half-completed setup must not strip the link entirely; the
+    homepage URL is the documented fallback."""
+    from flightcheck.checks.local_files import _check_required_topics
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+
+    results = _check_required_topics(agent_dir, "My Agent", None, "")
+
+    warnings = [r for r in results if r.status == "Warning"]
+    assert warnings, results
+    for row in warnings:
+        assert "https://copilotstudio.microsoft.com/" in (row.remediation or "")
+
+
+# ---------------------------------------------------------------------------
+# Positive case: an agent that ships the real OOTB ESS template files must
+# PASS every required topic. Pre-fix this scenario reported all six as
+# WARNING because the patterns (``responsepreparation``) were matched
+# against raw hyphenated filenames (``response-preparation.mcs.yml``) which
+# can never satisfy a substring search. Bug surfaced by the user running
+# FlightCheck against an `ESS_HR_WDAY_ONLY_OAUTH` extract that clearly had
+# the [System] Response Preparation topic in Copilot Studio.
+# ---------------------------------------------------------------------------
+
+
+# Real filenames from solutions/ess-maker-skills/workspace/agents/<slug>/topics/
+# after running /setup against an OOTB ESS Workday template. Picked the
+# minimal set that covers each REQUIRED_TOPICS entry's expected match.
+_OOTB_TOPIC_FILENAMES = [
+    "user-context-setup.mcs.yml",                         # TOPIC-001
+    "response-preparation.mcs.yml",                       # TOPIC-002
+    "sensitive-topics.mcs.yml",                           # TOPIC-004
+    "on-error.mcs.yml",                                   # TOPIC-005
+    "seek-emotional-intelligence-response.mcs.yml",       # TOPIC-009
+    "seek-clarification-to-avoid-ambiguous-answers.mcs.yml",  # TOPIC-010
+]
+
+
+def test_required_topics_recognize_real_ootb_ess_filenames(tmp_path: Path):
+    """Each REQUIRED_TOPICS entry must match the actual ESS template
+    filename via the normalize-then-substring rule. This pins the
+    matcher against the OOTB Workday extract so the bug from the user's
+    live run (TOPIC-002 false-positive WARNING on a topic that was
+    visibly present in Copilot Studio) cannot regress."""
+    from flightcheck.checks.local_files import _check_required_topics, REQUIRED_TOPICS
+
+    agent_dir = tmp_path / "my-agent"
+    topics = agent_dir / "topics"
+    topics.mkdir(parents=True)
+    for name in _OOTB_TOPIC_FILENAMES:
+        # A minimal AdaptiveDialog body is enough — the matcher must NOT
+        # depend on body content (which never carried the schema name).
+        (topics / name).write_text("kind: AdaptiveDialog\n", encoding="utf-8")
+
+    results = _check_required_topics(agent_dir, "My Agent", None, "")
+
+    by_id = {r.checkpoint_id: r for r in results}
+    assert len(by_id) == len(REQUIRED_TOPICS), [r.__dict__ for r in results]
+    for req in REQUIRED_TOPICS:
+        row = by_id[req["id"]]
+        assert row.status == "Passed", (
+            f"{req['id']} ({req['pattern']!r}) should match OOTB filenames "
+            f"but got {row.status}: {row.result!r}"
+        )
+
+
+def test_required_topics_do_not_match_unrelated_topics(tmp_path: Path):
+    """An agent that has only unrelated topics must still WARN on every
+    required entry. Guards against over-broad patterns matching random
+    topics by accident after the body-scan removal."""
+    from flightcheck.checks.local_files import _check_required_topics, REQUIRED_TOPICS
+
+    agent_dir = tmp_path / "my-agent"
+    topics = agent_dir / "topics"
+    topics.mkdir(parents=True)
+    # None of these names contain any of the required-topic patterns.
+    for name in ["greeting.mcs.yml", "fallback.mcs.yml", "echo.mcs.yml"]:
+        (topics / name).write_text("kind: AdaptiveDialog\n", encoding="utf-8")
+
+    results = _check_required_topics(agent_dir, "My Agent", None, "")
+
+    by_id = {r.checkpoint_id: r for r in results}
+    for req in REQUIRED_TOPICS:
+        assert by_id[req["id"]].status == "Warning", by_id[req["id"]].__dict__
+
+
+# ---------------------------------------------------------------------------
+# CONFIG-014 (topic description quality) remediations historically had no
+# Copilot Studio link at all, even though `_check_topic_descriptions` already
+# received the runner. These tests pin the deep link on both failure modes.
+# ---------------------------------------------------------------------------
+
+
+def _placeholder_topic_yaml() -> str:
+    # modelDescription contains a bracketed placeholder marker — must trip
+    # _PLACEHOLDER_PATTERNS_INSENSITIVE and produce CONFIG-014 FAILED.
+    return (
+        "kind: AdaptiveDialog\n"
+        "modelDisplayName: My Placeholder Topic\n"
+        "modelDescription: '[Describe this topic here]'\n"
+    )
+
+
+def _too_short_topic_yaml() -> str:
+    # 5 words << _MIN_DESCRIPTION_WORDS (20) and no placeholder markers.
+    return (
+        "kind: AdaptiveDialog\n"
+        "modelDisplayName: My Short Topic\n"
+        "modelDescription: 'one two three four five'\n"
+    )
+
+
+def test_config_014_placeholder_remediation_includes_deep_link(tmp_path: Path):
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    (agent_dir / "topics" / "my-topic.mcs.yml").write_text(
+        _placeholder_topic_yaml(), encoding="utf-8"
+    )
+
+    runner = _fake_runner(
+        env_id="env-014",
+        agents=[{"slug": "my-agent", "botId": "bot-014"}],
+    )
+
+    results = _check_topic_descriptions(agent_dir, "My Agent", runner, "my-agent")
+
+    failed = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-014" and r.status == "Failed"
+    ]
+    assert len(failed) == 1, [r.__dict__ for r in results]
+    assert (
+        "https://copilotstudio.microsoft.com/environments/env-014/"
+        "bots/bot-014/overview"
+    ) in (failed[0].remediation or "")
+
+
+def test_config_014_too_short_remediation_includes_deep_link(tmp_path: Path):
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    (agent_dir / "topics" / "my-topic.mcs.yml").write_text(
+        _too_short_topic_yaml(), encoding="utf-8"
+    )
+
+    runner = _fake_runner(
+        env_id="env-014",
+        agents=[{"slug": "my-agent", "botId": "bot-014"}],
+    )
+
+    results = _check_topic_descriptions(agent_dir, "My Agent", runner, "my-agent")
+
+    warnings = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-014" and r.status == "Warning"
+    ]
+    assert len(warnings) == 1, [r.__dict__ for r in results]
+    assert (
+        "https://copilotstudio.microsoft.com/environments/env-014/"
+        "bots/bot-014/overview"
+    ) in (warnings[0].remediation or "")
+
+
+# ---------------------------------------------------------------------------
+# CONFIG-013 (knowledge source readiness) remediations had no deep link
+# either. The API-error branch is the easiest to exercise without standing
+# up a fake Island Gateway response stream — the rest of the branches go
+# through the same shared `studio_link`, so pinning the auth-failure path
+# is sufficient to prove the runner+agent_name plumbing reached the call.
+# ---------------------------------------------------------------------------
+
+
+def test_config_013_api_failure_remediation_includes_deep_link(tmp_path: Path):
+    from flightcheck.checks.local_files import _check_knowledge_sources
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "knowledge").mkdir(parents=True)
+    (agent_dir / "knowledge" / "src.mcs.yml").write_text("kind: KnowledgeSource\n", encoding="utf-8")
+
+    class _ExplodingPVA:
+        is_configured = True
+        def get_knowledge_sources(self, _bot_id):
+            raise RuntimeError("boom")
+
+    runner = SimpleNamespace(
+        env_id="env-013",
+        config={
+            "agent": {"botId": "bot-013"},
+            "agents": [{"slug": "my-agent", "botId": "bot-013"}],
+        },
+        pva=_ExplodingPVA(),
+    )
+
+    results = _check_knowledge_sources(agent_dir, "My Agent", runner, "my-agent")
+
+    warnings = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-013" and r.status == "Warning"
+    ]
+    assert len(warnings) == 1, [r.__dict__ for r in results]
+    assert (
+        "https://copilotstudio.microsoft.com/environments/env-013/"
+        "bots/bot-013/overview"
+    ) in (warnings[0].remediation or "")
+
+
+# ---------------------------------------------------------------------------
+# CONFIG-014 parse-error behavior:
+#   - Copilot Studio's topic exporter emits unquoted `@type` / `#text` keys
+#     for XML/XSD-defined connector actions (Workday SOAP, etc). These are
+#     reserved YAML 1.2 indicators that PyYAML correctly refuses. The maker
+#     can't fix this — the file came verbatim from Copilot Studio — and
+#     editing locally would be overwritten on the next `/scan`.
+#   - `_check_topic_descriptions` salvages such files (re-quotes the keys
+#     in a copy, never on disk) so the real check — modelDescription
+#     quality — still runs.
+#   - If salvage doesn't help (a genuinely-broken file the maker actually
+#     authored or some other Copilot Studio quirk we haven't seen), the
+#     row drops to a low-priority Skipped row that explains the file is
+#     a Copilot Studio export, NOT a "fix your YAML" lecture.
+# ---------------------------------------------------------------------------
+
+
+def _workday_style_topic_yaml(model_description: str = "Routes Workday government identification lookups including social security numbers, national insurance numbers, passport numbers, and other government-issued identifiers when the employee asks about their on-file IDs.") -> str:
+    """Mimics the Copilot Studio export shape that breaks PyYAML.
+
+    Uses the same `@type` / `#text` XML-attribute-style keys we see in the
+    kit's own samples/WorkdayCustomEngineAgent/Employee/* topic files.
+    The default description is intentionally over the 20-word minimum so
+    salvaged-and-parsed cases land in Passed instead of too-short Warning.
+    """
+    return (
+        "kind: AdaptiveDialog\n"
+        "modelDisplayName: Workday Get Government IDs\n"
+        # Quote the description so callers can pass placeholders containing
+        # ``:`` (e.g. ``TODO: ...``) without re-breaking the YAML parse.
+        f'modelDescription: "{model_description}"\n'
+        "beginDialog:\n"
+        "  actions:\n"
+        "    - kind: SendActivity\n"
+        "      schema:\n"
+        "        properties:\n"
+        "          @type: String\n"
+        '          "#text": String\n'
+    )
+
+
+def _truly_broken_topic_yaml() -> str:
+    """A YAML file that's bad in a way the salvage rewrite can't help with.
+
+    A tab character used for indentation triggers a ScannerError that has
+    nothing to do with the `@`/`#` quoting issue, so the salvage pass
+    leaves it alone and the file ends up on the unparseable list.
+    """
+    return (
+        "kind: AdaptiveDialog\n"
+        "modelDisplayName: Broken Topic\n"
+        "beginDialog:\n"
+        "\tactions:\n"  # tab indent — triggers ScannerError, salvage no-op
+        "    - kind: SendActivity\n"
+    )
+
+
+def test_salvage_xml_attribute_yaml_quotes_at_and_hash_keys():
+    """Unit test for the salvage helper itself — must quote both `@key:`
+    and `#key:` patterns at the start of mapping lines, and only those."""
+    from flightcheck.checks.local_files import _salvage_xml_attribute_yaml
+
+    raw = (
+        "outer:\n"
+        "  @type: String\n"
+        "  #text: Value\n"
+        "  @complex_name.v1: Foo\n"
+        "  normalKey: hello @at and #hash in value\n"  # in-value, must NOT touch
+        "  # an actual YAML comment, must NOT touch\n"
+    )
+    out = _salvage_xml_attribute_yaml(raw)
+    assert '"@type":' in out
+    assert '"#text":' in out
+    assert '"@complex_name.v1":' in out
+    # Values that happen to contain @ or # are left alone.
+    assert "hello @at and #hash in value" in out
+    # Real comment lines (`#` followed by a space, not key syntax) untouched.
+    assert "# an actual YAML comment" in out
+
+
+def test_config_014_workday_style_topic_is_salvaged_and_check_runs(tmp_path: Path):
+    """A Workday-style topic with unquoted `@type` / `#text` keys must
+    NOT show up as a YAML parse error — the salvage step lets us inspect
+    the modelDescription and run the real check."""
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    (agent_dir / "topics" / "workday-get-governmentids.mcs.yml").write_text(
+        _workday_style_topic_yaml(), encoding="utf-8"
+    )
+
+    results = _check_topic_descriptions(agent_dir, "My Agent")
+
+    # No Skipped-unparseable row should be emitted — the salvage worked.
+    skipped = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-014" and r.status == "Skipped"
+        and "unparseable" in (r.description or "").lower()
+    ]
+    assert not skipped, [r.description for r in skipped]
+    # The description-quality check should have run and PASSED (the
+    # description in the helper is long and contains no placeholders).
+    passed = [r for r in results if r.checkpoint_id == "CONFIG-014" and r.status == "Passed"]
+    assert passed, [(r.status, r.description) for r in results]
+
+
+def test_config_014_salvaged_topic_still_flags_placeholder_description(tmp_path: Path):
+    """Salvage must preserve the description-quality signal: a Workday-
+    style topic whose modelDescription is a placeholder must still be
+    flagged as such, NOT lost to a parse-error skip."""
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    (agent_dir / "topics" / "workday-broken-desc.mcs.yml").write_text(
+        _workday_style_topic_yaml(model_description="TODO: fill this in"),
+        encoding="utf-8",
+    )
+
+    results = _check_topic_descriptions(agent_dir, "My Agent")
+    failed = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-014" and r.status == "Failed"
+        and "placeholder" in (r.description or "").lower()
+    ]
+    assert failed, [(r.status, r.description, r.result) for r in results]
+
+
+def test_config_014_salvage_does_not_mutate_file_on_disk(tmp_path: Path):
+    """Salvage must operate on an in-memory copy only. The on-disk file
+    must come back byte-identical so a subsequent `/push` doesn't try to
+    re-upload a flightcheck-edited version to Copilot Studio."""
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    topic_path = agent_dir / "topics" / "workday.mcs.yml"
+    original = _workday_style_topic_yaml()
+    topic_path.write_text(original, encoding="utf-8")
+
+    _check_topic_descriptions(agent_dir, "My Agent")
+
+    assert topic_path.read_text(encoding="utf-8") == original
+
+
+def test_config_014_truly_unparseable_file_becomes_low_priority_skipped(tmp_path: Path):
+    """When salvage can't help (file is broken in a way unrelated to the
+    `@`/`#` quirk), the row must be Skipped/Low, not Warning/Medium.
+    Anything stronger would re-introduce the original false-positive
+    noise for the dominant Copilot-Studio-export case."""
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    (agent_dir / "topics" / "really-broken.mcs.yml").write_text(
+        _truly_broken_topic_yaml(), encoding="utf-8"
+    )
+
+    results = _check_topic_descriptions(agent_dir, "My Agent")
+    unparseable = [
+        r for r in results
+        if r.checkpoint_id == "CONFIG-014"
+        and "unparseable" in (r.description or "").lower()
+    ]
+    assert len(unparseable) == 1, [(r.status, r.description) for r in results]
+    row = unparseable[0]
+    assert row.status == "Skipped", row.status
+    assert row.priority == "Low", row.priority
+    # The file name must appear so the operator can locate it.
+    assert "really-broken.mcs.yml" in row.result, row.result
+
+
+def test_config_014_unparseable_row_does_not_lecture_about_yaml_syntax(tmp_path: Path):
+    """The previous remediation told the maker to open the file and fix
+    YAML syntax. For Copilot-Studio-exported content the maker has no way
+    to do that. The new remediation must point at Copilot Studio's Code
+    editor and the `/scan` workflow instead, and must NOT recommend
+    hand-editing the local YAML."""
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    (agent_dir / "topics" / "x.mcs.yml").write_text(
+        _truly_broken_topic_yaml(), encoding="utf-8"
+    )
+
+    results = _check_topic_descriptions(agent_dir, "My Agent")
+    row = next(
+        r for r in results
+        if r.checkpoint_id == "CONFIG-014"
+        and "unparseable" in (r.description or "").lower()
+    )
+    rem = (row.remediation or "").lower()
+    assert "copilot studio" in rem
+    assert "code editor" in rem
+    assert "/scan" in rem
+    # Old remediation text MUST be gone — it gave wrong advice for the
+    # dominant case (Copilot Studio export).
+    assert "fix the yaml syntax" not in rem
+    assert "yaml.safe_load" not in rem
+    assert "red hat" not in rem
+
+
+def test_config_014_unparseable_row_caps_long_listings_at_ten(tmp_path: Path):
+    """Many genuinely-broken files (rare, but possible in a kit-bug
+    scenario) must not flood the report. Cap at 10 file names with a
+    `+N more` overflow indicator."""
+    from flightcheck.checks.local_files import _check_topic_descriptions
+
+    agent_dir = tmp_path / "my-agent"
+    (agent_dir / "topics").mkdir(parents=True)
+    for i in range(13):
+        (agent_dir / "topics" / f"broken-{i:02d}.mcs.yml").write_text(
+            _truly_broken_topic_yaml(), encoding="utf-8"
+        )
+
+    results = _check_topic_descriptions(agent_dir, "My Agent")
+    row = next(
+        r for r in results
+        if r.checkpoint_id == "CONFIG-014"
+        and "unparseable" in (r.description or "").lower()
+    )
+    # Honest total in the count.
+    assert "13 topic file(s)" in row.result, row.result
+    # Overflow indicator present.
+    assert "+3 more" in row.result, row.result
+    # Only 10 file names listed in detail.
+    listed = row.result.count("broken-")
+    assert listed == 10, f"Expected 10 names, found {listed}: {row.result}"

--- a/tests/flightcheck/test_runner_report_layout.py
+++ b/tests/flightcheck/test_runner_report_layout.py
@@ -14,9 +14,15 @@ silently break the "find what needs my attention" path the report
 was designed for.
 
 The three buckets are:
-  - ACTION REQUIRED:  Failed, Error, Warning
-  - MANUAL:           Manual, NotConfigured, Skipped
-  - PASSED:           Passed
+  - ACTION REQUIRED:  Failed, Error
+  - MANUAL:           Warning, Manual, NotConfigured
+  - PASSED:           Passed, Skipped
+
+Warnings live under MANUAL (not ACTION) because they're "should I
+worry?" questions the kit can't answer — the verification path is
+the operator's. Skipped lives under PASSED because the kit chose
+not to run the check (didn't apply / precondition not met); from a
+triage perspective the row needs no action.
 """
 
 from __future__ import annotations
@@ -71,7 +77,10 @@ def _make_result(checkpoint_id, status, priority="High", category="Test"):
 
 def test_bucket_results_assigns_statuses_to_correct_buckets():
     """Every status maps to exactly one of the three buckets per
-    the contract documented in runner.py."""
+    the contract documented in runner.py. Warning routes to MANUAL
+    (it's an operator-verification question, not a fix-this); Skipped
+    routes to PASSED (the kit chose not to run the check, so the
+    row isn't actionable)."""
     from flightcheck.runner import (
         bucket_results,
         BUCKET_ACTION,
@@ -94,21 +103,21 @@ def test_bucket_results_assigns_statuses_to_correct_buckets():
     manual_ids = [r.checkpoint_id for r in b[BUCKET_MANUAL]]
     passed_ids = [r.checkpoint_id for r in b[BUCKET_PASSED]]
 
-    assert set(action_ids) == {"FAIL-1", "ERR-1", "WARN-1"}
-    assert set(manual_ids) == {"MAN-1", "CFG-1", "SKIP-1"}
-    assert passed_ids == ["PASS-1"]
+    assert set(action_ids) == {"FAIL-1", "ERR-1"}
+    assert set(manual_ids) == {"WARN-1", "MAN-1", "CFG-1"}
+    assert set(passed_ids) == {"SKIP-1", "PASS-1"}
 
 
 def test_bucket_results_sorts_by_priority_then_status_then_id():
     """Within ACTION REQUIRED:
        - Critical-priority items come before High before Medium.
-       - Within the same priority, Failed comes before Warning.
+       - Within the same priority, Failed comes before Error.
        - Within the same priority + status, ids sort alphabetically.
     """
     from flightcheck.runner import bucket_results, BUCKET_ACTION
 
     results = [
-        _make_result("Z-WARN", "Warning", priority="Critical"),
+        _make_result("Z-ERR", "Error", priority="Critical"),
         _make_result("Z-FAIL", "Failed", priority="Critical"),
         _make_result("A-FAIL", "Failed", priority="Critical"),
         _make_result("HI-FAIL", "Failed", priority="High"),
@@ -116,7 +125,39 @@ def test_bucket_results_sorts_by_priority_then_status_then_id():
     ]
     ordered = [r.checkpoint_id for r in bucket_results(results)[BUCKET_ACTION]]
 
-    assert ordered == ["A-FAIL", "Z-FAIL", "Z-WARN", "HI-FAIL", "MED-FAIL"]
+    assert ordered == ["A-FAIL", "Z-FAIL", "Z-ERR", "HI-FAIL", "MED-FAIL"]
+
+
+def test_bucket_results_manual_bucket_sorts_warning_before_manual_then_notconfigured():
+    """Within the MANUAL bucket, Warning surfaces FIRST because it
+    carries an observed finding the kit chose to flag. Manual and
+    NotConfigured come after because they're "we didn't / couldn't
+    evaluate" rather than "we found something". Operators triaging
+    the manual section read top-to-bottom, so observed-findings-first
+    is the high-signal order."""
+    from flightcheck.runner import bucket_results, BUCKET_MANUAL
+
+    results = [
+        _make_result("CFG-1", "NotConfigured", priority="High"),
+        _make_result("MAN-1", "Manual", priority="High"),
+        _make_result("WARN-1", "Warning", priority="High"),
+    ]
+    ordered = [r.checkpoint_id for r in bucket_results(results)[BUCKET_MANUAL]]
+    assert ordered == ["WARN-1", "MAN-1", "CFG-1"]
+
+
+def test_bucket_results_passed_bucket_sorts_passed_before_skipped():
+    """Within PASSED, actual Passed rows come before Skipped rows so
+    the operator's "proof of work" sits at the top of the (collapsed)
+    section, with Skipped — which has no signal — below it."""
+    from flightcheck.runner import bucket_results, BUCKET_PASSED
+
+    results = [
+        _make_result("SKIP-1", "Skipped", priority="High"),
+        _make_result("PASS-1", "Passed", priority="High"),
+    ]
+    ordered = [r.checkpoint_id for r in bucket_results(results)[BUCKET_PASSED]]
+    assert ordered == ["PASS-1", "SKIP-1"]
 
 
 def test_bucket_results_unknown_status_lands_in_action_required():
@@ -200,6 +241,78 @@ def test_verdict_ready_subline_mentions_manual_count_when_present(tmp_path):
     assert "need manual verification" in html
 
 
+def test_verdict_warnings_subline_points_at_manual_section_not_action(tmp_path):
+    """READY_WITH_WARNINGS subline must direct the operator to
+    \"Needs manual verification\" \u2014 where warnings actually live
+    under the new bucketing. The old wording \"Action required\" was
+    a stale pointer once warnings moved out of that section, and
+    operators would scroll to an empty Action Required and miss the
+    warnings entirely."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([_make_result("W-1", "Warning")])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    # Find the verdict text block — the subline lives next to the
+    # verdict-warnings class on the banner.
+    m = re.search(r'<div class="verdict verdict-warnings">.*?</div>\s*</div>', html, flags=re.S)
+    assert m is not None, "verdict-warnings block not found"
+    verdict_block = m.group(0)
+
+    assert "Needs manual verification" in verdict_block, verdict_block
+    # The old wording must not regress \u2014 it would point the
+    # operator at an empty section.
+    assert "Action required" not in verdict_block, verdict_block
+
+
+def test_verdict_not_ready_subline_separates_action_from_verification(tmp_path):
+    """When the run is NOT_READY and also has warnings, the subline
+    must say BOTH where to act (Action required) AND where to
+    verify (Needs manual verification). Bundling them under one
+    section name misroutes the operator."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("F-1", "Failed"),
+        _make_result("W-1", "Warning"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    m = re.search(r'<div class="verdict verdict-not-ready">.*?</div>\s*</div>', html, flags=re.S)
+    assert m is not None
+    verdict_block = m.group(0)
+
+    assert "1 failing/errored" in verdict_block, verdict_block
+    assert "1 warning" in verdict_block, verdict_block
+    assert "need action" in verdict_block, verdict_block
+    assert "need manual verification" in verdict_block, verdict_block
+
+
+def test_verdict_not_ready_headline_counts_failures_only_not_warnings(tmp_path):
+    """The NOT_READY headline counts only blocking items
+    (Failed + Error). Warnings are NOT blockers \u2014 they live in
+    the manual-verification section \u2014 so counting them in the
+    headline would overstate the action load."""
+    from flightcheck.runner import save_results
+    result = _build_run_with([
+        _make_result("F-1", "Failed"),
+        _make_result("W-1", "Warning"),
+        _make_result("W-2", "Warning"),
+    ])
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    # Headline must read "Not ready — 1 issue need attention" (one
+    # failure), NOT "3 issues" (which would include the warnings).
+    m = re.search(r'<h2>Not ready[^<]*</h2>', html)
+    assert m is not None, html
+    headline = m.group(0)
+    assert "1 issue" in headline, headline
+    # Defensive: the old behavior was to add the warning count into
+    # the headline; this pin prevents a regression.
+    assert "3 issues" not in headline, headline
+
+
 # ---------------------------------------------------------------------------
 # Section rendering — the three stacked sections.
 # ---------------------------------------------------------------------------
@@ -280,11 +393,13 @@ def test_empty_section_shows_friendly_note_not_an_empty_table(tmp_path):
 
 
 def test_status_to_section_routing_in_rendered_html(tmp_path):
-    """Each status renders inside the section its bucket dictates —
-    not in some other section's table."""
+    """Each status renders inside the section its bucket dictates.
+    Warning lands under MANUAL (operator must verify); Skipped lands
+    under PASSED (kit chose not to run the check)."""
     from flightcheck.runner import save_results
     result = _build_run_with([
         _make_result("FAIL-X", "Failed"),
+        _make_result("WARN-X", "Warning"),
         _make_result("MAN-X", "Manual"),
         _make_result("SKIP-X", "Skipped"),
         _make_result("PASS-X", "Passed"),
@@ -307,26 +422,33 @@ def test_status_to_section_routing_in_rendered_html(tmp_path):
     assert "FAIL-X" in action_html
     assert "FAIL-X" not in manual_html and "FAIL-X" not in passed_html
 
-    # MAN + SKIP belong in manual (Skipped folds here per design)
+    # WARN + MAN belong in manual (Warning folds here per design —
+    # it's an operator-verification question, not a fix-this).
+    assert "WARN-X" in manual_html
     assert "MAN-X" in manual_html
-    assert "SKIP-X" in manual_html
+    assert "WARN-X" not in action_html and "WARN-X" not in passed_html
     assert "MAN-X" not in action_html and "MAN-X" not in passed_html
-    assert "SKIP-X" not in action_html and "SKIP-X" not in passed_html
 
-    # PASS belongs in passed
+    # PASS + SKIP belong in passed (Skipped folds here per design —
+    # the kit chose not to run the check, so the row needs no action).
     assert "PASS-X" in passed_html
+    assert "SKIP-X" in passed_html
     assert "PASS-X" not in action_html and "PASS-X" not in manual_html
+    assert "SKIP-X" not in action_html and "SKIP-X" not in manual_html
 
 
 def test_section_count_badge_matches_bucket_size(tmp_path):
     """The badge next to each section header shows the bucket count
-    so the operator sees scale before expanding."""
+    so the operator sees scale before expanding. Counts reflect the
+    new mapping: Warning is in MANUAL (not ACTION), Skipped is in
+    PASSED (not MANUAL)."""
     from flightcheck.runner import save_results
     result = _build_run_with([
         _make_result("F-1", "Failed"),
         _make_result("F-2", "Failed"),
         _make_result("W-1", "Warning"),
         _make_result("M-1", "Manual"),
+        _make_result("S-1", "Skipped"),
         _make_result("P-1", "Passed"),
         _make_result("P-2", "Passed"),
         _make_result("P-3", "Passed"),
@@ -342,9 +464,9 @@ def test_section_count_badge_matches_bucket_size(tmp_path):
         assert m is not None, f"No count badge for {section_id}"
         return m.group(1)
 
-    assert badge_count_for("section-action") == "3"   # 2 Failed + 1 Warning
-    assert badge_count_for("section-manual") == "1"   # 1 Manual
-    assert badge_count_for("section-passed") == "3"   # 3 Passed
+    assert badge_count_for("section-action") == "2"   # 2 Failed only
+    assert badge_count_for("section-manual") == "2"   # 1 Warning + 1 Manual
+    assert badge_count_for("section-passed") == "4"   # 3 Passed + 1 Skipped
 
 
 def test_action_rows_sorted_critical_before_high_in_html(tmp_path):


### PR DESCRIPTION
Operator-feedback follow-ups on the FlightCheck remediations from #125, plus a report-bucketing change so warnings/skips land where operators expect them.

## What changed

### Actionable remediations (issue #67)

| Check | Before | After |
|---|---|---|
| **ENV-004** (connection refs) | Linked to maker Solutions *list* — operator had to guess which solution holds the broken ref | Resolves the containing solution from Dataverse, deep-links to `Power Apps → Solutions/{solutionId}`; falls back to unmanaged Default Solution when the customization solution is managed (can't edit managed) |
| **ENV-004-UC-*** (unused connections) | "No reference uses this connection" — over-claimed | "Not referenced by this agent's solution" + 3 verification paths (Power Apps Connections detail, Power Automate flows, other solutions' refs) + silent-breakage warning |
| **ENV-008** (DLP) | "Review DLP policies" + stale URL | Concrete steps for the connectors-allowed lists in Power Platform admin → Policies; corrected URL |
| **CONFIG-014** (topic YAML parse errors) | Loud Medium/Warning "fix your YAML" — was false-positive on Copilot Studio SOAP exports | In-memory salvage quotes `@key:` / `#key:` lines for parsing (never touches disk); only genuinely broken files land in a quiet Low/Skipped row pointing at Copilot Studio's Code editor |
| **PUB-* / QA-*** (publishing checklist) | All 8 emitted as `NotConfigured` + generic `"Verify: <desc>"` + single homepage link | `Manual` status (nothing is misconfigured — kit just can't witness it) + per-check result text + deep links: Copilot Studio Analytics → Evaluations for QA-*, Power Apps Solutions for PUB-001, M365 admin Integrated apps for PUB-006/011; PUB-003 explicitly states "organizational gate — no portal link applies" |

### Report bucketing

| Status | Before | After |
|---|---|---|
| **Warning** | Action required | **Needs manual verification** |
| Manual | Needs manual verification | Needs manual verification |
| NotConfigured | Needs manual verification | Needs manual verification |
| **Skipped** | Needs manual verification | **Passed** |
| Failed / Error | Action required | Action required |
| Passed | Passed | Passed |

**Why:** warnings carry an observed finding the kit can't classify — that's manual verification, not a fix instruction. Skipped means the kit chose not to run — no action required, so they ride along with proof-of-work passes.

Verdict logic + sublines updated to match:
- `READY_WITH_WARNINGS` subline now points at the manual section.
- `NOT_READY` subline separates `"X failing/errored need action"` from `"Y warnings need manual verification"`.
- `NOT_READY` headline now counts only blockers (failures + errors), not warnings.
- Severity colors (green/amber/red) unchanged.

### Refactor

- Extracted `maker_connections_url` / `maker_solutions_url` / `maker_solution_url` into `_maker_urls.py`; workday.py now imports the shared helper instead of carrying its own duplicate.

## Tests

232 → **255** (+23). Coverage added:
- CONFIG-014 salvage behavior (7)
- ENV-004 solution-scoped link + UC honesty (28 + 4)
- ENV-008 DLP remediation
- Runner bucketing & verdict sublines (9)
- Publishing/QA per-check contract (13)

All 255 pass; ruff clean on the CI-checked paths (`solutions/ess-maker-skills/scripts`).

## JSON / API compatibility

No break — JSON output uses raw status counts + flat results, bucket grouping is purely a report-layout concern.

Closes operator-feedback items raised on #125; relates to #67.
