### PR TITLE
FlightCheck installer: fetch agent solution before running checks

### DIFF
--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -521,6 +521,19 @@ if ($FlightCheckOnly) {
     $localDir = Join-Path $workspace '.local'
     $configPath = Join-Path $localDir 'config.json'
 
+    # Resolve python command early — needed for both discovery and fetch
+    $pythonExe = Resolve-Python
+    if (-not $pythonExe) {
+        throw 'Python not found on PATH or known locations. Cannot run FlightCheck.'
+    }
+    if ($pythonExe -eq 'py -3.12') {
+        $pyCmd = 'py'; $pyBaseArgs = @('-3.12')
+    } elseif ($pythonExe -eq 'py -3') {
+        $pyCmd = 'py'; $pyBaseArgs = @('-3')
+    } else {
+        $pyCmd = $pythonExe; $pyBaseArgs = @()
+    }
+
     if (Test-Path $configPath) {
         Write-Host ''
         Write-Host "    Config already exists at $configPath" -ForegroundColor White
@@ -538,22 +551,9 @@ if ($FlightCheckOnly) {
     if (-not (Test-Path $configPath)) {
         $scriptsDir = Join-Path $workspace 'scripts'
         $discoverPy = Join-Path $scriptsDir 'discover.py'
-        $pythonExe = Resolve-Python
 
-        if (-not $pythonExe) {
-            throw 'Python not found on PATH or known locations. Cannot run environment discovery.'
-        }
         if (-not (Test-Path $discoverPy)) {
             throw "discover.py not found at $discoverPy. Was the repo cloned correctly?"
-        }
-
-        # Build the base python command components for consistent invocation
-        if ($pythonExe -eq 'py -3.12') {
-            $pyCmd = 'py'; $pyBaseArgs = @('-3.12')
-        } elseif ($pythonExe -eq 'py -3') {
-            $pyCmd = 'py'; $pyBaseArgs = @('-3')
-        } else {
-            $pyCmd = $pythonExe; $pyBaseArgs = @()
         }
 
         # --- Step 1: List environments and let user pick ---
@@ -689,6 +689,52 @@ if ($FlightCheckOnly) {
         $json = $config | ConvertTo-Json -Depth 4 -Compress:$false
         [System.IO.File]::WriteAllText($configPath, $json, (New-Object System.Text.UTF8Encoding $false))
         Write-Ok "Created $configPath"
+    }
+
+    # --- Read config values if they came from an existing file ---
+    if (-not $botId -and (Test-Path $configPath)) {
+        $existingConfig = Get-Content $configPath -Raw | ConvertFrom-Json
+        $envUrl = $existingConfig.dataverseEndpoint
+        $botId = $existingConfig.agent.botId
+        $agentName = $existingConfig.agent.name
+        $schemaName = $existingConfig.agent.schemaName
+        $isManaged = $existingConfig.agent.isManaged
+    }
+
+    # --- Fetch solution snapshot for local file checks ---
+    if ($botId) {
+        Write-Step 'Fetching agent solution from Dataverse'
+        $fetchPy = Join-Path $workspace 'scripts\fetch_and_setup.py'
+        if (Test-Path $fetchPy) {
+            Push-Location $workspace
+            try {
+                $fetchArgs = $pyBaseArgs + @(
+                    $fetchPy,
+                    '--url', $envUrl,
+                    '--bot-id', $botId,
+                    '--name', $agentName,
+                    '--schema', $schemaName
+                )
+                if ($isManaged) { $fetchArgs += '--managed' }
+
+                Start-Spinner "fetching agent solution"
+                $fetchOutput = & $pyCmd @fetchArgs 2>&1
+                $fetchExit = $LASTEXITCODE
+                Stop-Spinner "fetching agent solution"
+
+                if ($fetchExit -eq 0) {
+                    Write-Ok 'Agent solution fetched and extracted'
+                } else {
+                    Write-Warn2 'fetch_and_setup.py exited with errors. Local file checks may be skipped.'
+                    foreach ($line in $fetchOutput) { Write-Host "      $line" }
+                }
+            } finally { Pop-Location }
+        } else {
+            Write-Warn2 "fetch_and_setup.py not found at $fetchPy. Local file checks will be skipped."
+        }
+    } else {
+        Write-Host ''
+        Write-Host '    [info] No agent selected — skipping solution fetch (local file checks will be skipped).' -ForegroundColor Gray
     }
 
     # --- Run FlightCheck ---

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -304,8 +304,7 @@ if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
         fi
 
         # Re-run with --select
-        SELECT_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --list-environments --select "$ENV_CHOICE" 2>&1)
-        if [[ $? -ne 0 ]]; then
+        if ! SELECT_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --list-environments --select "$ENV_CHOICE" 2>&1); then
             err "Environment selection failed."
             exit 1
         fi
@@ -331,8 +330,7 @@ if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
         echo "    Discovering agents in this environment..."
         echo ""
 
-        AGENT_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --url "$ENV_URL" 2>&1) || true
-        AGENT_EXIT=$?
+        AGENT_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --url "$ENV_URL" 2>&1) && AGENT_EXIT=0 || AGENT_EXIT=$?
         echo "$AGENT_OUTPUT"
 
         if [[ $AGENT_EXIT -ne 0 ]] || echo "$AGENT_OUTPUT" | grep -q "^ERROR:"; then
@@ -372,35 +370,37 @@ if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
             fi
         fi
 
-        # Create .local directory and write config
+        # Create .local directory and write config (use Python for safe JSON escaping)
         mkdir -p "$LOCAL_DIR"
 
-        if [[ -n "$BOT_ID" ]]; then
-            AGENTS_JSON="[{\"name\":\"$AGENT_NAME\",\"botId\":\"$BOT_ID\",\"schemaName\":\"$SCHEMA_NAME\",\"isManaged\":$IS_MANAGED,\"slug\":\"flightcheck-only\",\"folder\":\"\"}]"
-            ACTIVE_AGENT="\"flightcheck-only\""
-        else
-            AGENTS_JSON="[]"
-            ACTIVE_AGENT="\"\""
-        fi
-
-        cat > "$CONFIG_PATH" <<EOF
-{
-    "configVersion": 1,
-    "setup": "flightcheck-only",
-    "dataverseEndpoint": "$ENV_URL",
-    "flightCheckOnly": true,
-    "agent": {
-        "name": "$AGENT_NAME",
-        "botId": "$BOT_ID",
-        "schemaName": "$SCHEMA_NAME",
-        "isManaged": $IS_MANAGED,
-        "slug": "flightcheck-only",
-        "folder": ""
+        "$FLIGHTCHECK_PYTHON" -c "
+import json, sys
+config = {
+    'configVersion': 1,
+    'setup': 'flightcheck-only',
+    'dataverseEndpoint': sys.argv[1],
+    'flightCheckOnly': True,
+    'agent': {
+        'name': sys.argv[2],
+        'botId': sys.argv[3],
+        'schemaName': sys.argv[4],
+        'isManaged': sys.argv[5] == 'true',
+        'slug': 'flightcheck-only',
+        'folder': ''
     },
-    "agents": $AGENTS_JSON,
-    "activeAgent": $ACTIVE_AGENT
+    'agents': [{
+        'name': sys.argv[2],
+        'botId': sys.argv[3],
+        'schemaName': sys.argv[4],
+        'isManaged': sys.argv[5] == 'true',
+        'slug': 'flightcheck-only',
+        'folder': ''
+    }] if sys.argv[3] else [],
+    'activeAgent': 'flightcheck-only' if sys.argv[3] else ''
 }
-EOF
+with open(sys.argv[6], 'w', encoding='utf-8') as f:
+    json.dump(config, f, indent=4)
+" "$ENV_URL" "$AGENT_NAME" "$BOT_ID" "$SCHEMA_NAME" "$IS_MANAGED" "$CONFIG_PATH"
         ok "Created $CONFIG_PATH"
     fi
 

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -233,21 +233,210 @@ if [[ "$FLIGHTCHECK_ONLY" != "true" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 7. FlightCheck-only: environment discovery
+# 7. FlightCheck-only: environment discovery, config, fetch, and run
 # ---------------------------------------------------------------------------
 if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
-    step "Running FlightCheck"
-
     MAKER_KIT_PATH="$REPO_PATH/solutions/ess-maker-skills"
     if [[ ! -d "$MAKER_KIT_PATH" ]]; then
         err "Maker kit path not found at $MAKER_KIT_PATH. Was the clone successful?"
         exit 1
     fi
     cd "$MAKER_KIT_PATH"
+
+    # Resolve python for discovery/fetch/flightcheck
     FLIGHTCHECK_PYTHON="$VENV_PATH/bin/python"
     if [[ ! -x "$FLIGHTCHECK_PYTHON" ]]; then
         FLIGHTCHECK_PYTHON="$PYTHON"
     fi
+
+    LOCAL_DIR=".local"
+    CONFIG_PATH="$LOCAL_DIR/config.json"
+    DISCOVER_PY="scripts/discover.py"
+    FETCH_PY="scripts/fetch_and_setup.py"
+
+    # --- Config: reuse or create ---
+    BOT_ID=""
+    ENV_URL=""
+    AGENT_NAME=""
+    SCHEMA_NAME=""
+    IS_MANAGED="true"
+
+    if [[ -f "$CONFIG_PATH" ]]; then
+        echo ""
+        echo "    Config already exists at $CONFIG_PATH"
+        read -rp "    Reconfigure? (Y/N): " RECONFIGURE
+        if [[ "$RECONFIGURE" =~ ^[Yy] ]]; then
+            rm -f "$CONFIG_PATH"
+            ok "Removed existing config — starting fresh"
+        else
+            ok "Keeping existing config"
+        fi
+    fi
+
+    if [[ ! -f "$CONFIG_PATH" ]]; then
+        step "Configuring FlightCheck environment"
+
+        if [[ ! -f "$DISCOVER_PY" ]]; then
+            err "discover.py not found at $DISCOVER_PY. Was the repo cloned correctly?"
+            exit 1
+        fi
+
+        # --- Step 1: List environments ---
+        echo ""
+        echo "    Listing Power Platform environments in your tenant..."
+        echo "    A browser window will open for sign-in."
+        echo ""
+
+        ENV_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --list-environments 2>&1) || true
+        echo "$ENV_OUTPUT"
+
+        if echo "$ENV_OUTPUT" | grep -q "^ERROR:"; then
+            err "Environment listing failed."
+            exit 1
+        fi
+
+        echo ""
+        read -rp "    Select environment number from the list above: " ENV_CHOICE
+        ENV_CHOICE="${ENV_CHOICE// /}"
+        if [[ -z "$ENV_CHOICE" || ! "$ENV_CHOICE" =~ ^[0-9]+$ ]]; then
+            err "Invalid selection. Please re-run and pick a number."
+            exit 1
+        fi
+
+        # Re-run with --select
+        SELECT_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --list-environments --select "$ENV_CHOICE" 2>&1)
+        if [[ $? -ne 0 ]]; then
+            err "Environment selection failed."
+            exit 1
+        fi
+
+        ENV_JSON_LINE=$(echo "$SELECT_OUTPUT" | grep "^SELECTED_ENV_JSON:" | sed 's/^SELECTED_ENV_JSON://')
+        if [[ -z "$ENV_JSON_LINE" ]]; then
+            err "Could not parse environment selection output."
+            exit 1
+        fi
+
+        ENV_URL=$(echo "$ENV_JSON_LINE" | "$FLIGHTCHECK_PYTHON" -c "import sys,json; d=json.load(sys.stdin); print(d.get('instanceUrl','').rstrip('/'))")
+        ENV_DISPLAY=$(echo "$ENV_JSON_LINE" | "$FLIGHTCHECK_PYTHON" -c "import sys,json; d=json.load(sys.stdin); print(d.get('displayName',''))")
+
+        if [[ -z "$ENV_URL" ]]; then
+            err "Selected environment has no linked Dataverse URL."
+            exit 1
+        fi
+        ok "Environment: $ENV_DISPLAY"
+        ok "URL: $ENV_URL"
+
+        # --- Step 2: List agents ---
+        echo ""
+        echo "    Discovering agents in this environment..."
+        echo ""
+
+        AGENT_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --url "$ENV_URL" 2>&1) || true
+        AGENT_EXIT=$?
+        echo "$AGENT_OUTPUT"
+
+        if [[ $AGENT_EXIT -ne 0 ]] || echo "$AGENT_OUTPUT" | grep -q "^ERROR:"; then
+            warn "Agent discovery failed. Config will be created without a bot ID."
+            BOT_ID=""
+            AGENT_NAME="FlightCheck-only (no agent selected)"
+            SCHEMA_NAME=""
+            IS_MANAGED="true"
+        else
+            echo ""
+            read -rp "    Select agent number (or press Enter for environment-wide checks only): " AGENT_CHOICE
+            AGENT_CHOICE="${AGENT_CHOICE// /}"
+
+            if [[ -n "$AGENT_CHOICE" && "$AGENT_CHOICE" =~ ^[0-9]+$ ]]; then
+                AGENT_SELECT_OUTPUT=$("$FLIGHTCHECK_PYTHON" "$DISCOVER_PY" --url "$ENV_URL" --select "$AGENT_CHOICE" 2>&1) || true
+                AGENT_JSON_LINE=$(echo "$AGENT_SELECT_OUTPUT" | grep "^SELECTED_AGENT_JSON:" | sed 's/^SELECTED_AGENT_JSON://')
+
+                if [[ -n "$AGENT_JSON_LINE" ]]; then
+                    BOT_ID=$(echo "$AGENT_JSON_LINE" | "$FLIGHTCHECK_PYTHON" -c "import sys,json; d=json.load(sys.stdin); print(d.get('botid',''))")
+                    AGENT_NAME=$(echo "$AGENT_JSON_LINE" | "$FLIGHTCHECK_PYTHON" -c "import sys,json; d=json.load(sys.stdin); print(d.get('name',''))")
+                    SCHEMA_NAME=$(echo "$AGENT_JSON_LINE" | "$FLIGHTCHECK_PYTHON" -c "import sys,json; d=json.load(sys.stdin); print(d.get('schemaname',''))")
+                    IS_MANAGED=$(echo "$AGENT_JSON_LINE" | "$FLIGHTCHECK_PYTHON" -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('ismanaged') else 'false')")
+                    ok "Agent: $AGENT_NAME"
+                else
+                    warn "Agent selection failed. Continuing without bot ID."
+                    BOT_ID=""
+                    AGENT_NAME="FlightCheck-only (no agent selected)"
+                    SCHEMA_NAME=""
+                    IS_MANAGED="true"
+                fi
+            else
+                warn "Skipping agent selection. Some agent-specific checks will be skipped."
+                BOT_ID=""
+                AGENT_NAME="FlightCheck-only (no agent selected)"
+                SCHEMA_NAME=""
+                IS_MANAGED="true"
+            fi
+        fi
+
+        # Create .local directory and write config
+        mkdir -p "$LOCAL_DIR"
+
+        if [[ -n "$BOT_ID" ]]; then
+            AGENTS_JSON="[{\"name\":\"$AGENT_NAME\",\"botId\":\"$BOT_ID\",\"schemaName\":\"$SCHEMA_NAME\",\"isManaged\":$IS_MANAGED,\"slug\":\"flightcheck-only\",\"folder\":\"\"}]"
+            ACTIVE_AGENT="\"flightcheck-only\""
+        else
+            AGENTS_JSON="[]"
+            ACTIVE_AGENT="\"\""
+        fi
+
+        cat > "$CONFIG_PATH" <<EOF
+{
+    "configVersion": 1,
+    "setup": "flightcheck-only",
+    "dataverseEndpoint": "$ENV_URL",
+    "flightCheckOnly": true,
+    "agent": {
+        "name": "$AGENT_NAME",
+        "botId": "$BOT_ID",
+        "schemaName": "$SCHEMA_NAME",
+        "isManaged": $IS_MANAGED,
+        "slug": "flightcheck-only",
+        "folder": ""
+    },
+    "agents": $AGENTS_JSON,
+    "activeAgent": $ACTIVE_AGENT
+}
+EOF
+        ok "Created $CONFIG_PATH"
+    fi
+
+    # --- Read config values if they came from an existing file ---
+    if [[ -z "$BOT_ID" && -f "$CONFIG_PATH" ]]; then
+        ENV_URL=$("$FLIGHTCHECK_PYTHON" -c "import sys,json; c=json.load(open('$CONFIG_PATH')); print(c.get('dataverseEndpoint',''))")
+        BOT_ID=$("$FLIGHTCHECK_PYTHON" -c "import sys,json; c=json.load(open('$CONFIG_PATH')); print(c.get('agent',{}).get('botId',''))")
+        AGENT_NAME=$("$FLIGHTCHECK_PYTHON" -c "import sys,json; c=json.load(open('$CONFIG_PATH')); print(c.get('agent',{}).get('name',''))")
+        SCHEMA_NAME=$("$FLIGHTCHECK_PYTHON" -c "import sys,json; c=json.load(open('$CONFIG_PATH')); print(c.get('agent',{}).get('schemaName',''))")
+        IS_MANAGED=$("$FLIGHTCHECK_PYTHON" -c "import sys,json; c=json.load(open('$CONFIG_PATH')); print('true' if c.get('agent',{}).get('isManaged') else 'false')")
+    fi
+
+    # --- Fetch solution snapshot for local file checks ---
+    if [[ -n "$BOT_ID" ]]; then
+        step "Fetching agent solution from Dataverse"
+        if [[ -f "$FETCH_PY" ]]; then
+            FETCH_ARGS=("$FETCH_PY" "--url" "$ENV_URL" "--bot-id" "$BOT_ID" "--name" "$AGENT_NAME" "--schema" "$SCHEMA_NAME")
+            if [[ "$IS_MANAGED" == "true" ]]; then
+                FETCH_ARGS+=("--managed")
+            fi
+
+            if "$FLIGHTCHECK_PYTHON" "${FETCH_ARGS[@]}" 2>&1; then
+                ok "Agent solution fetched and extracted"
+            else
+                warn "fetch_and_setup.py exited with errors. Local file checks may be skipped."
+            fi
+        else
+            warn "fetch_and_setup.py not found at $FETCH_PY. Local file checks will be skipped."
+        fi
+    else
+        echo ""
+        echo "    [info] No agent selected — skipping solution fetch (local file checks will be skipped)."
+    fi
+
+    # --- Run FlightCheck ---
+    step "Running FlightCheck"
     "$FLIGHTCHECK_PYTHON" scripts/flightcheck/cli.py --scope full
     exit $?
 fi


### PR DESCRIPTION
## Summary

The FlightCheck-only installer now calls `fetch_and_setup.py` to download the agent solution from Dataverse before running FlightCheck. This enables the **Local Files** checks (topics, variables, agent identity) that previously always showed as SKIPPED.

Also fixes the environment listing table always showing "Unknown" for the Type column.

## Problem

1. FlightCheck has two categories of checks:
   - **API-based** (Dataverse, Graph, Power Platform) — always worked
   - **Local file checks** (inspect `workspace/agents/`) — always SKIPPED because the installer never downloaded the solution

2. The environment picker table showed "Unknown" for every environment type because it read `environmentType` instead of `environmentSku` from the BAP API response.

## Changes

- `setup/Install-EssAdk.ps1`: Added fetch_and_setup call between config creation and FlightCheck run. Refactored python command resolution to top of FlightCheckOnly block for reuse.
- `setup/install-ess-adk.sh`: Added full discovery + config + fetch flow to macOS FlightCheck-only mode (mirrors the Windows behavior). Uses Python `json.dump()` for safe config JSON generation.
- `scripts/list_environments.py`: Read `environmentSku` (the actual BAP API field) instead of `environmentType`.

## Testing

- Tested end-to-end on Windows: environment picker -> agent picker -> fetch solution -> FlightCheck runs with Local Files checks enabled (e.g. CONFIG-007 now fires instead of LOCAL-001 SKIPPED).
- macOS flow mirrors Windows structure (same discovery/config/fetch steps).