### PR TITLE
User-friendly HTTP error messages for API failures

### DIFF
--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -34,6 +34,8 @@ except ImportError:
     print("ERROR: 'urllib3' / 'requests' not found. Run: pip install requests")
     sys.exit(1)
 
+from http_errors import raise_api_error  # noqa: E402
+
 
 # Microsoft public client ID for Power Platform CLI / Dataverse delegated access.
 # Source: https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2
@@ -203,7 +205,7 @@ def query_all(env_url, token, entity_set, select, filter_expr=None):
         resp = _SESSION.get(url, headers=headers, timeout=120, verify=True)
         if resp.status_code == 401:
             raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
-        resp.raise_for_status()
+        raise_api_error(resp, resource_name=entity_set, operation="read")
         data = resp.json()
         records = data.get("value", [])
         all_records.extend(records)
@@ -324,7 +326,7 @@ def update_record(env_url, token, entity_set, record_id, data):
     resp = _SESSION.patch(url, headers=headers, json=data, timeout=60, verify=True)
     if resp.status_code == 401:
         raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
-    resp.raise_for_status()
+    raise_api_error(resp, resource_name=entity_set, operation="update")
     return True
 
 
@@ -341,7 +343,7 @@ def create_record(env_url, token, entity_set, data):
     resp = _SESSION.post(url, headers=headers, json=data, timeout=60, verify=True)
     if resp.status_code == 401:
         raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
-    resp.raise_for_status()
+    raise_api_error(resp, resource_name=entity_set, operation="create")
     result = resp.json()
     return result.get("botcomponentid", result.get("id"))
 
@@ -357,7 +359,7 @@ def delete_record(env_url, token, entity_set, record_id):
     resp = _SESSION.delete(url, headers=headers, timeout=60, verify=True)
     if resp.status_code == 401:
         raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
-    resp.raise_for_status()
+    raise_api_error(resp, resource_name=entity_set, operation="delete")
     return True
 
 

--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -34,7 +34,7 @@ except ImportError:
     print("ERROR: 'urllib3' / 'requests' not found. Run: pip install requests")
     sys.exit(1)
 
-from http_errors import raise_api_error  # noqa: E402
+from http_errors import APIError, raise_api_error  # noqa: E402
 
 
 # Microsoft public client ID for Power Platform CLI / Dataverse delegated access.
@@ -61,9 +61,27 @@ HEADERS_BASE = {
 }
 
 
-class AuthExpiredError(RuntimeError):
+class AuthExpiredError(APIError):
     """Raised when a Dataverse call returns 401. Callers can catch this and
-    re-authenticate without losing in-flight push state."""
+    re-authenticate without losing in-flight push state.
+
+    Subclasses APIError so generic ``except APIError`` handlers (e.g. in
+    discover.py, fetch_and_setup.py) also catch 401s and render the friendly
+    "session expired" message. Code that wants to specifically intercept 401
+    for re-auth (push.py) keeps using ``except AuthExpiredError``.
+    """
+
+    def __init__(self, message=None, response=None):
+        # Preserve the legacy positional ``message`` argument for callers and
+        # tests that construct AuthExpiredError("...") directly. When a real
+        # Response is available, pass it through so URL / method / request_id
+        # show up in format_for_terminal() output.
+        super().__init__(
+            response=response,
+            status_code=401,
+            operation="access",
+            message=message,
+        )
 
 
 # Module-level requests Session with bounded retry-with-backoff for 429/5xx.
@@ -204,7 +222,7 @@ def query_all(env_url, token, entity_set, select, filter_expr=None):
         page += 1
         resp = _SESSION.get(url, headers=headers, timeout=120, verify=True)
         if resp.status_code == 401:
-            raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
+            raise AuthExpiredError(response=resp)
         raise_api_error(resp, resource_name=entity_set, operation="read")
         data = resp.json()
         records = data.get("value", [])
@@ -248,7 +266,7 @@ def retrieve_shared_principals_and_access(env_url, token, bot_id):
     headers = {**HEADERS_BASE, "Authorization": f"Bearer {token}"}
     resp = _SESSION.get(url, headers=headers, timeout=120, verify=True)
     if resp.status_code == 401:
-        raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
+        raise AuthExpiredError(response=resp)
     resp.raise_for_status()
     return resp.json()
 
@@ -303,7 +321,7 @@ def dataverse_get(env_url, token, path, params=None):
     url = f"{env_url}/api/data/v9.2/{path.lstrip('/')}"
     resp = _SESSION.get(url, headers=headers, params=params, timeout=60, verify=True)
     if resp.status_code == 401:
-        raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
+        raise AuthExpiredError(response=resp)
     resp.raise_for_status()
     return resp.json()
 
@@ -325,7 +343,7 @@ def update_record(env_url, token, entity_set, record_id, data):
     url = f"{env_url}/api/data/v9.2/{entity_set}({record_id})"
     resp = _SESSION.patch(url, headers=headers, json=data, timeout=60, verify=True)
     if resp.status_code == 401:
-        raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
+        raise AuthExpiredError(response=resp)
     raise_api_error(resp, resource_name=entity_set, operation="update")
     return True
 
@@ -342,7 +360,7 @@ def create_record(env_url, token, entity_set, data):
     url = f"{env_url}/api/data/v9.2/{entity_set}"
     resp = _SESSION.post(url, headers=headers, json=data, timeout=60, verify=True)
     if resp.status_code == 401:
-        raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
+        raise AuthExpiredError(response=resp)
     raise_api_error(resp, resource_name=entity_set, operation="create")
     result = resp.json()
     return result.get("botcomponentid", result.get("id"))
@@ -358,7 +376,7 @@ def delete_record(env_url, token, entity_set, record_id):
     url = f"{env_url}/api/data/v9.2/{entity_set}({record_id})"
     resp = _SESSION.delete(url, headers=headers, timeout=60, verify=True)
     if resp.status_code == 401:
-        raise AuthExpiredError("Dataverse returned 401 (token expired or invalid)")
+        raise AuthExpiredError(response=resp)
     raise_api_error(resp, resource_name=entity_set, operation="delete")
     return True
 

--- a/solutions/ess-maker-skills/scripts/discover.py
+++ b/solutions/ess-maker-skills/scripts/discover.py
@@ -31,6 +31,7 @@ import os
 # Add scripts/ to path so we can import auth
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from auth import authenticate, query_all
+from http_errors import APIError
 
 
 def discover_agents(env_url, token):
@@ -124,7 +125,11 @@ def main():
     print("Authenticated.\n")
 
     print("Discovering agents...")
-    agents = discover_agents(env_url, token)
+    try:
+        agents = discover_agents(env_url, token)
+    except APIError as e:
+        print(e.format_for_terminal())
+        sys.exit(1)
 
     if not agents:
         print("No agents found in this environment.")

--- a/solutions/ess-maker-skills/scripts/fetch_and_setup.py
+++ b/solutions/ess-maker-skills/scripts/fetch_and_setup.py
@@ -34,6 +34,7 @@ import sys
 # Add scripts/ to path so we can import auth
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from auth import authenticate, load_config, query_all
+from http_errors import APIError
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +123,6 @@ def fetch_all(env_url, token, bot_id, components=None):
 
     Returns (components, template_configs, workflows).
     """
-    import requests as _requests  # local import to avoid top-level dep
 
     # --- Fetch components ---
     if components is None:
@@ -151,8 +151,8 @@ def fetch_all(env_url, token, bot_id, components=None):
         )
         template_configs = normalize_template_configs(raw_configs)
         print(f"  {len(template_configs)} template configs fetched.\n")
-    except _requests.exceptions.HTTPError as e:
-        if e.response is not None and e.response.status_code == 404:
+    except APIError as e:
+        if e.status_code == 404:
             print("  Table not found (ESS template configs not deployed). "
                   "Skipping.\n")
         else:
@@ -282,8 +282,12 @@ def main():
         token = authenticate(env_url)
         print("Authenticated.\n")
 
-        components, template_configs, workflows = fetch_all(
-            env_url, token, bot_id)
+        try:
+            components, template_configs, workflows = fetch_all(
+                env_url, token, bot_id)
+        except APIError as e:
+            print(e.format_for_terminal())
+            sys.exit(1)
         paths = save_temp_files(components, template_configs, workflows)
         rc = run_setup(env_url, bot_id, name, schema, managed,
                        paths, extra_flags=["--refresh"])
@@ -301,8 +305,12 @@ def main():
     token = authenticate(env_url)
     print("Authenticated.\n")
 
-    components, template_configs, workflows = fetch_all(
-        env_url, token, args.bot_id)
+    try:
+        components, template_configs, workflows = fetch_all(
+            env_url, token, args.bot_id)
+    except APIError as e:
+        print(e.format_for_terminal())
+        sys.exit(1)
     paths = save_temp_files(components, template_configs, workflows)
     rc = run_setup(env_url, args.bot_id, args.name, args.schema,
                    args.managed, paths)

--- a/solutions/ess-maker-skills/scripts/http_errors.py
+++ b/solutions/ess-maker-skills/scripts/http_errors.py
@@ -41,18 +41,29 @@ class APIError(requests.exceptions.HTTPError):
     still catch it. Adds structured fields for display formatting.
     """
 
-    def __init__(self, response, resource_name=None, operation=None,
-                 required_role=None, message=None, tip=None):
-        self.status_code = response.status_code if response is not None else 0
+    def __init__(self, response=None, resource_name=None, operation=None,
+                 required_role=None, message=None, tip=None, status_code=None):
+        # When a response is provided (the common case), pull diagnostics
+        # from it. When it isn't (e.g. a synthetic AuthExpiredError raised
+        # by something that doesn't have a Response on hand), the caller
+        # must supply status_code so the friendly message picks the right
+        # template.
+        if response is not None:
+            self.status_code = response.status_code
+            self.url = (response.request.url if response.request else None)
+            self.request_id = response.headers.get("x-ms-request-id")
+            self._method = (
+                response.request.method if response.request else None
+            )
+        else:
+            self.status_code = status_code or 0
+            self.url = None
+            self.request_id = None
+            self._method = None
+
         self.resource_name = resource_name
         self.operation = operation or "access"
         self.required_role = required_role
-        self.url = (response.request.url if response is not None
-                    and response.request else None)
-        self.request_id = (
-            response.headers.get("x-ms-request-id")
-            if response is not None else None
-        )
 
         # Build user-facing message
         friendly = _friendly_name(resource_name)
@@ -84,15 +95,7 @@ class APIError(requests.exceptions.HTTPError):
         if self.url:
             # Truncate URL to avoid leaking full query strings
             display_url = self.url.split("?")[0]
-            method_verb = (self.operation or "GET").upper()
-            if method_verb in ("READ", "ACCESS"):
-                method_verb = "GET"
-            elif method_verb == "UPDATE":
-                method_verb = "PATCH"
-            elif method_verb == "CREATE":
-                method_verb = "POST"
-            elif method_verb == "DELETE":
-                method_verb = "DELETE"
+            method_verb = (self._method or "GET").upper()
             lines.append(
                 f"  Detail: HTTP {self.status_code} — {method_verb} {display_url}"
             )
@@ -112,7 +115,7 @@ def _build_message(status_code, friendly_resource, operation, required_role):
         )
     if status_code == 401:
         return (
-            "Your session has expired or the token is invalid."
+            "Your session has expired or the token is invalid (HTTP 401)."
         )
     if status_code == 403:
         return (

--- a/solutions/ess-maker-skills/scripts/http_errors.py
+++ b/solutions/ess-maker-skills/scripts/http_errors.py
@@ -1,0 +1,192 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Maker Kit - User-Friendly HTTP Error Handling
+
+Provides a central helper that translates raw HTTP status codes into
+actionable messages with troubleshooting tips. Used by auth.py and
+the installer scripts (discover.py, fetch_and_setup.py) to surface
+clear guidance when API calls fail.
+
+FlightCheck clients (graph_client, pp_admin_client, pva_client) have
+their own error patterns (returning _error dicts) and are NOT changed.
+"""
+
+import requests
+
+
+# Friendly display names for Dataverse entity sets.
+_ENTITY_DISPLAY_NAMES = {
+    "bots": "agents",
+    "botcomponents": "agent components",
+    "workflows": "cloud flows",
+    "msdyn_employeeselfservicetemplateconfigs": "ESS template configurations",
+    "connections": "connections",
+    "connectionreferences": "connection references",
+}
+
+
+def _friendly_name(resource_name):
+    """Map an entity set name to a user-friendly label."""
+    if not resource_name:
+        return "this resource"
+    return _ENTITY_DISPLAY_NAMES.get(resource_name, resource_name)
+
+
+class APIError(requests.exceptions.HTTPError):
+    """HTTP error with user-friendly message and troubleshooting tip.
+
+    Subclasses requests.HTTPError so existing `except HTTPError` handlers
+    still catch it. Adds structured fields for display formatting.
+    """
+
+    def __init__(self, response, resource_name=None, operation=None,
+                 required_role=None, message=None, tip=None):
+        self.status_code = response.status_code if response is not None else 0
+        self.resource_name = resource_name
+        self.operation = operation or "access"
+        self.required_role = required_role
+        self.url = (response.request.url if response is not None
+                    and response.request else None)
+        self.request_id = (
+            response.headers.get("x-ms-request-id")
+            if response is not None else None
+        )
+
+        # Build user-facing message
+        friendly = _friendly_name(resource_name)
+        self._friendly_message = message or _build_message(
+            self.status_code, friendly, self.operation, self.required_role
+        )
+        self._tip = tip or _build_tip(
+            self.status_code, friendly, self.operation, self.required_role
+        )
+
+        # Call parent with the friendly message as the exception string
+        super().__init__(str(self), response=response)
+
+    def __str__(self):
+        parts = [self._friendly_message]
+        if self._tip:
+            parts.append(f"  -> {self._tip}")
+        return "\n".join(parts)
+
+    def format_for_terminal(self):
+        """Format the error for terminal display with technical details."""
+        lines = [
+            "",
+            f"  ERROR: {self._friendly_message}",
+        ]
+        if self._tip:
+            lines.append(f"  Tip:   {self._tip}")
+        # Technical detail line (compact, for debugging)
+        if self.url:
+            # Truncate URL to avoid leaking full query strings
+            display_url = self.url.split("?")[0]
+            method_verb = (self.operation or "GET").upper()
+            if method_verb in ("READ", "ACCESS"):
+                method_verb = "GET"
+            elif method_verb == "UPDATE":
+                method_verb = "PATCH"
+            elif method_verb == "CREATE":
+                method_verb = "POST"
+            elif method_verb == "DELETE":
+                method_verb = "DELETE"
+            lines.append(
+                f"  Detail: HTTP {self.status_code} — {method_verb} {display_url}"
+            )
+        if self.request_id:
+            lines.append(f"  Request ID: {self.request_id}")
+        lines.append("")
+        return "\n".join(lines)
+
+
+def _build_message(status_code, friendly_resource, operation, required_role):
+    """Build the main error message based on status code."""
+    if status_code == 400:
+        return (
+            f"Bad request while trying to {operation} {friendly_resource}. "
+            "The API rejected the query — this may indicate a version mismatch "
+            "or unsupported filter."
+        )
+    if status_code == 401:
+        return (
+            "Your session has expired or the token is invalid."
+        )
+    if status_code == 403:
+        return (
+            f"You signed in successfully, but your account doesn't have "
+            f"permission to {operation} {friendly_resource}."
+        )
+    if status_code == 404:
+        return (
+            f"Could not find {friendly_resource}. The resource doesn't exist "
+            "or the required solution may not be deployed in this environment."
+        )
+    if status_code == 429:
+        return (
+            "Too many requests — the API is rate-limiting your account."
+        )
+    if status_code in (500, 502, 503, 504):
+        return (
+            f"The server returned an error (HTTP {status_code}) while trying "
+            f"to {operation} {friendly_resource}. This is usually temporary."
+        )
+    return (
+        f"Unexpected HTTP {status_code} while trying to {operation} "
+        f"{friendly_resource}."
+    )
+
+
+def _build_tip(status_code, friendly_resource, operation, required_role):
+    """Build the troubleshooting tip for a given status code."""
+    if status_code == 400:
+        return (
+            "Check that the environment URL is correct and the ESS solution "
+            "version matches this kit version."
+        )
+    if status_code == 401:
+        return "Run the command again — you'll be prompted to sign in."
+    if status_code == 403:
+        role = required_role or "Bot Author, Bot Contributor, or System Administrator"
+        return (
+            f"Ask your Power Platform admin to assign the {role} security role "
+            "to your account in this environment."
+        )
+    if status_code == 404:
+        return (
+            "Verify the ESS solution is installed in this environment, or "
+            "choose a different environment."
+        )
+    if status_code == 429:
+        return "Wait 1-2 minutes and try again."
+    if status_code in (500, 502, 503, 504):
+        return (
+            "Wait a few minutes and try again. If the problem persists, check "
+            "the Power Platform Service Health dashboard."
+        )
+    return "Check the status code and URL above for clues."
+
+
+def raise_api_error(response, resource_name=None, operation=None,
+                    required_role=None):
+    """Inspect a response and raise APIError if it indicates failure.
+
+    Call this AFTER any 401 check (AuthExpiredError) but INSTEAD of
+    resp.raise_for_status(). This produces user-friendly errors for
+    all non-2xx responses.
+
+    Args:
+        response: The requests.Response object.
+        resource_name: The Dataverse entity set or API resource being accessed.
+        operation: The operation being performed (read/create/update/delete).
+        required_role: Role to suggest in 403 messages (optional).
+    """
+    if response.status_code >= 400:
+        raise APIError(
+            response,
+            resource_name=resource_name,
+            operation=operation,
+            required_role=required_role,
+        )

--- a/tests/scripts/test_http_errors.py
+++ b/tests/scripts/test_http_errors.py
@@ -1,0 +1,379 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for solutions/ess-maker-skills/scripts/http_errors.py.
+
+http_errors.py is pure logic that translates a ``requests.Response`` into a
+``requests.HTTPError`` subclass (``APIError``) with a friendly message, a
+troubleshooting tip, and structured fields for terminal display. These tests
+exercise:
+
+* per-status-code messages and tips (400/401/403/404/429/5xx/unknown)
+* the entity-set-name → friendly-label mapping (and the unmapped fallback)
+* ``format_for_terminal`` output structure (ERROR / Tip / Detail / Request ID)
+* the ``response.request.method`` source for the HTTP verb in Detail
+* backward compatibility with ``except HTTPError``
+* ``raise_api_error`` no-op on 2xx and raise on 4xx/5xx
+* ``AuthExpiredError`` is catchable as ``APIError`` (PR #135 review fix)
+  and round-trips through ``format_for_terminal`` when given a response
+
+The module never makes HTTP calls itself — it inspects a response object
+passed in by auth.py — so tests build small fake response objects rather
+than relying on the ``responses`` library.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from http_errors import (
+    APIError,
+    _ENTITY_DISPLAY_NAMES,
+    _friendly_name,
+    raise_api_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake response helpers
+# ---------------------------------------------------------------------------
+#
+# APIError reads exactly four things off the response: ``status_code``,
+# ``request.url``, ``request.method``, and ``headers.get("x-ms-request-id")``.
+# A lightweight SimpleNamespace keeps tests honest — a loose MagicMock would
+# make every nested attribute truthy and silently change format_for_terminal
+# output.
+
+
+def _fake_response(
+    status_code: int,
+    *,
+    method: str = "GET",
+    url: str = "https://orgmock.crm.dynamics.com/api/data/v9.2/bots",
+    request_id: str | None = None,
+):
+    headers = {}
+    if request_id:
+        headers["x-ms-request-id"] = request_id
+    request = SimpleNamespace(method=method, url=url)
+    return SimpleNamespace(
+        status_code=status_code,
+        request=request,
+        headers=headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Friendly name mapping
+# ---------------------------------------------------------------------------
+
+
+class TestFriendlyName:
+    def test_maps_known_entity_sets(self) -> None:
+        assert _friendly_name("bots") == "agents"
+        assert _friendly_name("botcomponents") == "agent components"
+        assert _friendly_name("workflows") == "cloud flows"
+
+    def test_falls_back_to_raw_name_when_unknown(self) -> None:
+        # Unmapped entity sets stay verbatim — better to leak a Dataverse-y
+        # name than to pretend we know what it is.
+        assert _friendly_name("solutions") == "solutions"
+
+    def test_returns_generic_placeholder_when_missing(self) -> None:
+        assert _friendly_name(None) == "this resource"
+        assert _friendly_name("") == "this resource"
+
+    def test_mapping_covers_entity_sets_used_in_auth_py(self) -> None:
+        # Pin the contract: these are the entity sets auth.py passes today.
+        # Adding a new caller without extending the map is fine — the
+        # fallback shows the raw name — but removing one of these should be
+        # an intentional choice, not an accident.
+        for name in ("bots", "botcomponents", "workflows",
+                     "msdyn_employeeselfservicetemplateconfigs"):
+            assert name in _ENTITY_DISPLAY_NAMES
+
+
+# ---------------------------------------------------------------------------
+# APIError message + tip per status code
+# ---------------------------------------------------------------------------
+
+
+class TestApiErrorMessages:
+    def test_400_message_and_tip(self) -> None:
+        err = APIError(_fake_response(400), resource_name="bots",
+                       operation="read")
+        assert err.status_code == 400
+        assert "Bad request" in err._friendly_message
+        assert "agents" in err._friendly_message  # entity name translated
+        assert "version" in err._tip.lower()
+
+    def test_401_message_includes_http_401(self) -> None:
+        # test_preferred_solution.py asserts ``"401" in r.result`` where
+        # r.result is ``str(AuthExpiredError)``. Pin that "401" stays in
+        # the friendly message so the assertion keeps holding.
+        err = APIError(_fake_response(401))
+        assert "401" in err._friendly_message
+        assert "expired" in err._friendly_message.lower()
+        assert "sign in" in err._tip.lower()
+
+    def test_403_message_includes_operation_and_friendly_name(self) -> None:
+        err = APIError(
+            _fake_response(403),
+            resource_name="botcomponents",
+            operation="update",
+        )
+        assert "permission" in err._friendly_message.lower()
+        assert "update" in err._friendly_message
+        assert "agent components" in err._friendly_message
+
+    def test_403_tip_mentions_custom_required_role(self) -> None:
+        err = APIError(
+            _fake_response(403),
+            resource_name="bots",
+            operation="create",
+            required_role="Bot Author",
+        )
+        assert "Bot Author" in err._tip
+
+    def test_403_tip_defaults_when_no_role_supplied(self) -> None:
+        err = APIError(_fake_response(403), resource_name="bots",
+                       operation="read")
+        assert "System Administrator" in err._tip
+
+    def test_404_message_suggests_missing_solution(self) -> None:
+        err = APIError(
+            _fake_response(404),
+            resource_name="msdyn_employeeselfservicetemplateconfigs",
+            operation="read",
+        )
+        assert "Could not find" in err._friendly_message
+        assert "ESS template configurations" in err._friendly_message
+        assert "solution" in err._tip.lower()
+
+    def test_429_message_and_tip(self) -> None:
+        err = APIError(_fake_response(429))
+        assert "Too many requests" in err._friendly_message
+        assert "Wait" in err._tip
+
+    @pytest.mark.parametrize("code", [500, 502, 503, 504])
+    def test_5xx_messages_are_transient(self, code: int) -> None:
+        err = APIError(_fake_response(code), resource_name="bots",
+                       operation="read")
+        assert str(code) in err._friendly_message
+        assert "temporary" in err._friendly_message.lower()
+        assert "again" in err._tip.lower()
+
+    def test_unknown_status_falls_back_to_generic_message(self) -> None:
+        # 418 isn't in the mapping. The message should still be sensible:
+        # it includes the operation and the friendly name, and the tip
+        # tells the user to look at the technical detail.
+        err = APIError(_fake_response(418), resource_name="bots",
+                       operation="read")
+        assert "418" in err._friendly_message
+        assert "agents" in err._friendly_message
+        assert err._tip  # non-empty fallback
+
+    def test_caller_provided_message_and_tip_win(self) -> None:
+        err = APIError(
+            _fake_response(403),
+            resource_name="bots",
+            operation="read",
+            message="custom message",
+            tip="custom tip",
+        )
+        assert err._friendly_message == "custom message"
+        assert err._tip == "custom tip"
+
+
+# ---------------------------------------------------------------------------
+# format_for_terminal
+# ---------------------------------------------------------------------------
+
+
+class TestFormatForTerminal:
+    def test_includes_error_tip_detail_and_request_id_lines(self) -> None:
+        err = APIError(
+            _fake_response(
+                403,
+                method="PATCH",
+                url="https://orgmock.crm.dynamics.com/api/data/v9.2/bots(123)",
+                request_id="req-abc-123",
+            ),
+            resource_name="bots",
+            operation="update",
+        )
+        out = err.format_for_terminal()
+        assert "ERROR:" in out
+        assert "Tip:" in out
+        assert "Detail: HTTP 403" in out
+        assert "PATCH" in out                  # method from response.request
+        assert "Request ID: req-abc-123" in out
+
+    def test_detail_uses_request_method_not_operation(self) -> None:
+        # The whole point of PR #135 review comment #3 — don't reverse-
+        # engineer the verb from the operation string. ``operation="read"``
+        # combined with ``method="POST"`` (e.g. an OData $batch read) must
+        # display POST in the Detail line.
+        err = APIError(
+            _fake_response(429, method="POST"),
+            resource_name="bots",
+            operation="read",
+        )
+        assert "POST" in err.format_for_terminal()
+
+    def test_method_is_uppercased(self) -> None:
+        err = APIError(
+            _fake_response(500, method="get"),
+            resource_name="bots",
+            operation="read",
+        )
+        assert "HTTP 500 — GET" in err.format_for_terminal()
+
+    def test_detail_strips_url_query_string(self) -> None:
+        # Query strings can hold $filter values that include user-typed
+        # text. Strip them from terminal output so we don't echo sensitive
+        # input back into the terminal scrollback.
+        err = APIError(
+            _fake_response(
+                404,
+                url=("https://orgmock.crm.dynamics.com/api/data/v9.2/bots"
+                     "?$filter=name eq 'secret'&$select=name"),
+            ),
+            resource_name="bots",
+            operation="read",
+        )
+        out = err.format_for_terminal()
+        assert "bots" in out
+        assert "secret" not in out
+        assert "$filter" not in out
+
+    def test_omits_detail_line_when_no_response(self) -> None:
+        # AuthExpiredError() with no response shouldn't render a
+        # ``Detail: HTTP 401 — GET None`` line.
+        err = APIError(response=None, status_code=401)
+        out = err.format_for_terminal()
+        assert "ERROR:" in out
+        assert "Detail:" not in out
+        assert "Request ID:" not in out
+
+    def test_omits_request_id_line_when_header_missing(self) -> None:
+        err = APIError(_fake_response(500))
+        assert "Request ID" not in err.format_for_terminal()
+
+
+# ---------------------------------------------------------------------------
+# raise_api_error
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseApiError:
+    @pytest.mark.parametrize("code", [200, 201, 204, 304])
+    def test_no_raise_on_2xx_or_3xx(self, code: int) -> None:
+        # raise_api_error is gated on status_code >= 400 — anything below
+        # that is the caller's responsibility (it's a Dataverse choice
+        # whether 304 means "use cached" or "this is fine").
+        raise_api_error(
+            _fake_response(code),
+            resource_name="bots",
+            operation="read",
+        )
+
+    @pytest.mark.parametrize("code", [400, 401, 403, 404, 429, 500, 503])
+    def test_raises_apierror_on_4xx_5xx(self, code: int) -> None:
+        with pytest.raises(APIError) as excinfo:
+            raise_api_error(
+                _fake_response(code),
+                resource_name="bots",
+                operation="read",
+            )
+        assert excinfo.value.status_code == code
+
+    def test_raised_apierror_is_also_an_http_error(self) -> None:
+        # Backward compat: existing ``except requests.HTTPError`` handlers
+        # in callers we haven't migrated yet must still catch this.
+        with pytest.raises(requests.HTTPError):
+            raise_api_error(
+                _fake_response(500),
+                resource_name="bots",
+                operation="read",
+            )
+
+    def test_passes_resource_name_and_operation_through(self) -> None:
+        with pytest.raises(APIError) as excinfo:
+            raise_api_error(
+                _fake_response(403),
+                resource_name="workflows",
+                operation="delete",
+                required_role="Custom Role",
+            )
+        err = excinfo.value
+        assert err.resource_name == "workflows"
+        assert err.operation == "delete"
+        assert "cloud flows" in err._friendly_message
+        assert "Custom Role" in err._tip
+
+
+# ---------------------------------------------------------------------------
+# AuthExpiredError ↔ APIError subclassing (PR #135 review comment #1)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthExpiredErrorSubclassing:
+    """Regression tests for PR #135 review comment 1: 401s used to escape
+    the friendly handler because callers only caught APIError. Now
+    AuthExpiredError inherits from APIError, so ``except APIError`` in
+    discover.py / fetch_and_setup.py picks up 401s too while
+    ``except AuthExpiredError`` in push.py / FlightCheck still works.
+    """
+
+    def test_is_catchable_as_apierror(self) -> None:
+        # The fix that closes the reviewer's loop.
+        from auth import AuthExpiredError
+        with pytest.raises(APIError):
+            raise AuthExpiredError()
+
+    def test_is_catchable_as_authexpirederror(self) -> None:
+        # push.py and FlightCheck do ``except AuthExpiredError`` for re-
+        # auth-and-retry. That contract must still hold.
+        from auth import AuthExpiredError
+        with pytest.raises(AuthExpiredError):
+            raise AuthExpiredError()
+
+    def test_default_message_includes_http_401(self) -> None:
+        # test_preferred_solution.py:369 asserts ``"401" in r.result``.
+        from auth import AuthExpiredError
+        err = AuthExpiredError()
+        assert "401" in str(err)
+        assert err.status_code == 401
+
+    def test_legacy_string_message_argument_is_preserved(self) -> None:
+        # FlightCheck test_licensing.py constructs
+        # ``AuthExpiredError("401")`` directly. That positional-message
+        # signature must keep working — the supplied text must appear in
+        # the str output (APIError still appends its tip line, which is
+        # fine since neither existing test asserts an exact string).
+        from auth import AuthExpiredError
+        err = AuthExpiredError("custom 401 message")
+        assert "custom 401 message" in str(err)
+        assert err.status_code == 401
+
+    def test_round_trips_response_diagnostics_through_format(self) -> None:
+        # When auth.py raises ``AuthExpiredError(response=resp)`` (the
+        # common path now), format_for_terminal should include the HTTP
+        # method and URL just like other APIErrors do.
+        from auth import AuthExpiredError
+        resp = _fake_response(
+            401,
+            method="PATCH",
+            url="https://orgmock.crm.dynamics.com/api/data/v9.2/bots(123)",
+            request_id="req-xyz-789",
+        )
+        err = AuthExpiredError(response=resp)
+        out = err.format_for_terminal()
+        assert "HTTP 401" in out
+        assert "PATCH" in out
+        assert "bots(123)" in out
+        assert "Request ID: req-xyz-789" in out


### PR DESCRIPTION
## Summary

ADO tasks https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7469877 and https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7469904

Adds a centralized HTTP error handler that translates raw status codes into actionable messages with troubleshooting tips. This significantly improves the experience when users hit permission or connectivity issues during install/setup.

## Problem

When API calls fail (e.g., user lacks Dataverse read permission), the scripts showed raw tracebacks like:
`
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://org.crm.dynamics.com/api/data/v9.2/bots?=...
`

Non-technical users don't know what a 403 means or how to fix it.

## Solution

New `scripts/http_errors.py` module with:
- `APIError` class (subclasses `requests.HTTPError` for backward compat)
- `raise_api_error(response, resource_name, operation, required_role)` helper
- Friendly entity name mapping (`bots` → "agents", `workflows` → "cloud flows")
- Operation-aware messages (read/create/update/delete)
- Compact technical detail line for debugging

### Example output (403 on bots query):
`
  ERROR: You signed in successfully, but your account doesn't have permission to read agents.
  Tip:   Ask your Power Platform admin to assign the Bot Author, Bot Contributor, or System Administrator security role to your account in this environment.
  Detail: HTTP 403 — GET https://org.crm.dynamics.com/api/data/v9.2/bots
`

### Status codes covered:
| Code | Message theme |
|------|--------------|
| 400 | Version mismatch / bad query |
| 401 | Session expired, re-sign-in |
| 403 | Permission denied + role suggestion |
| 404 | Resource/solution not deployed |
| 429 | Rate limiting + wait guidance |
| 5xx | Transient server error + retry advice |

## Files changed
- **New:** `scripts/http_errors.py` — central error handler
- `scripts/auth.py` — replace `raise_for_status()` with `raise_api_error()`
- `scripts/discover.py` — catch `APIError`, show friendly output
- `scripts/fetch_and_setup.py` — catch `APIError` in refresh + normal modes

## Design decisions
- FlightCheck clients (graph_client, pp_admin_client) NOT changed — they already handle errors via `_error` dicts
- `sync_docs.py` / `sync_samples.py` NOT changed — internal tooling, not user-facing during install
- 401 still uses existing `AuthExpiredError` (callers depend on it for re-auth)
- `APIError` subclasses `HTTPError` so existing `except HTTPError` handlers still work

## Testing
Verified via unit mock: all status codes produce correct messages, 2xx doesn't raise, `except HTTPError` still catches `APIError`.