### PR TITLE
FlightCheck: auto-open HTML report in browser after run

### DIFF
--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -761,7 +761,12 @@ if ($FlightCheckOnly) {
         Write-Warn2 "  cd $workspace"
         Write-Warn2 '  python scripts/flightcheck/cli.py --scope full'
     }
-    exit 0
+    # ``return`` (not ``exit 0``) so the script ends without terminating the
+    # PowerShell host. When this installer is invoked via
+    # ``iex (irm .../bootstrap-flightcheck.ps1)`` from an interactive shell,
+    # ``exit`` closes the user's terminal window; ``return`` just stops the
+    # script and lets ``$LASTEXITCODE`` from cli.py propagate to callers.
+    return
 }
 
 # ---------------------------------------------------------------------------

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -761,11 +761,12 @@ if ($FlightCheckOnly) {
         Write-Warn2 "  cd $workspace"
         Write-Warn2 '  python scripts/flightcheck/cli.py --scope full'
     }
-    # ``return`` (not ``exit 0``) so the script ends without terminating the
-    # PowerShell host. When this installer is invoked via
-    # ``iex (irm .../bootstrap-flightcheck.ps1)`` from an interactive shell,
-    # ``exit`` closes the user's terminal window; ``return`` just stops the
-    # script and lets ``$LASTEXITCODE`` from cli.py propagate to callers.
+    # ``return`` (not ``exit 0``) so the script ends without terminating
+    # the PowerShell host. When this installer is invoked via
+    # ``iex (irm .../bootstrap-flightcheck.ps1)`` from an interactive
+    # shell, ``exit`` closes the user's terminal window; ``return`` just
+    # stops the script and leaves ``$LASTEXITCODE`` from ``cli.py``
+    # available to the calling session.
     return
 }
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -38,8 +38,9 @@ The same Codespace environment can be used to run FlightCheck without the full m
 1. Open the `solutions/ess-maker-skills` folder (File → Open Folder → `/workspaces/Employee-Self-Service-Agent-Developer-Kit/solutions/ess-maker-skills`)
 2. Open a terminal and run:
    ```bash
-   python scripts/flightcheck/cli.py --scope full
+   python scripts/flightcheck/cli.py --scope full --no-open
    ```
+   `--no-open` skips the auto-launch of the HTML report (Codespaces can't open a local `file://` URL in your browser). Open the saved `workspace/flightcheck/report.html` manually from the file explorer instead.
 3. Follow the prompts to sign in and select your environment
 
 ## FlightCheck-Only Mode
@@ -76,7 +77,7 @@ iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent
 
 ### Running FlightCheck again (after initial setup)
 
-Once you've run the installer once, you can re-run FlightCheck directly without going through setup again:
+Once you've run the installer once, you can re-run FlightCheck directly without going through setup again. The HTML report opens in your default browser when the run finishes — pass `--no-open` to skip (useful for CI / headless / SSH sessions).
 
 **Windows:**
 ```powershell

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -25,6 +25,8 @@ import argparse
 import json
 import os
 import sys
+import webbrowser
+from pathlib import Path
 
 # Ensure scripts/ is on the path so we can import auth
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -89,6 +91,25 @@ FULL_SCOPE = [
     ("Licensing", run_licensing_checks),
     ("Publishing", run_publishing_checks),
 ]
+
+
+def open_report_in_browser(output_dir):
+    """Open the FlightCheck HTML report in the default browser.
+
+    Uses ``Path.as_uri()`` to build an RFC 8089 ``file://`` URI so paths
+    with spaces or non-ASCII characters (e.g. Windows OneDrive paths like
+    ``C:\\Users\\foo\\OneDrive - Microsoft Corporation\\...``) open
+    reliably across platforms.
+
+    Returns:
+        True if a browser tab was launched, False if the report file is
+        missing (e.g. FlightCheck aborted before save_results ran) or
+        ``webbrowser.open()`` reported it could not find a browser.
+    """
+    report_path = Path(output_dir) / "report.html"
+    if not report_path.exists():
+        return False
+    return webbrowser.open(report_path.resolve().as_uri())
 
 
 def main():
@@ -290,13 +311,9 @@ def main():
     # Save results
     save_results(result, args.output)
 
-    # Open HTML report in browser
+    # Open HTML report in browser (skip with --no-open for CI / headless runs)
     if not args.no_open:
-        import webbrowser
-        report_path = os.path.join(args.output, "report.html")
-        if os.path.exists(report_path):
-            abs_path = os.path.abspath(report_path)
-            webbrowser.open(f"file://{abs_path}")
+        open_report_in_browser(args.output)
 
     # Exit code
     sys.exit(1 if result.failed > 0 else 0)

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -110,6 +110,10 @@ def main():
         "--environment-id",
         help="Override the Power Platform environment ID (used by environment_picker.py)",
     )
+    parser.add_argument(
+        "--no-open", action="store_true",
+        help="Don't open the HTML report in a browser after running",
+    )
     args = parser.parse_args()
 
     # Load config
@@ -285,6 +289,14 @@ def main():
 
     # Save results
     save_results(result, args.output)
+
+    # Open HTML report in browser
+    if not args.no_open:
+        import webbrowser
+        report_path = os.path.join(args.output, "report.html")
+        if os.path.exists(report_path):
+            abs_path = os.path.abspath(report_path)
+            webbrowser.open(f"file://{abs_path}")
 
     # Exit code
     sys.exit(1 if result.failed > 0 else 0)

--- a/solutions/ess-maker-skills/scripts/list_environments.py
+++ b/solutions/ess-maker-skills/scripts/list_environments.py
@@ -39,7 +39,7 @@ def parse_raw_environments(raw_envs):
         linked = props.get("linkedEnvironmentMetadata", {})
         instance_url = linked.get("instanceUrl", "").rstrip("/")
         display_name = props.get("displayName", "Unknown")
-        env_type = props.get("environmentType", "Unknown")
+        env_type = props.get("environmentSku", props.get("environmentType", "Unknown"))
         state = props.get("states", {}).get("runtime", {}).get("id", "Unknown")
         env_id = env.get("name", "")
 

--- a/tests/flightcheck/test_cli.py
+++ b/tests/flightcheck/test_cli.py
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for solutions/ess-maker-skills/scripts/flightcheck/cli.py helpers.
+
+Currently covers ``open_report_in_browser``, the post-run hook that
+launches the HTML report in the default browser. The helper is a small
+pure-side-effect function (file existence check + ``webbrowser.open``);
+tests stub out ``webbrowser.open`` so no browser tab opens during the run.
+
+The motivation for testing this at all is that the first implementation
+built the ``file://`` URI with f-string concatenation, which produced
+malformed URIs on Windows for any path containing spaces (e.g.
+``C:\\Users\\foo\\OneDrive - Microsoft Corporation\\...``). The helper
+now goes through ``pathlib.Path.as_uri()`` to produce RFC 8089 compliant
+URIs. These tests pin that behavior so it doesn't regress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from flightcheck import cli
+
+
+class TestOpenReportInBrowser:
+    """Tests for cli.open_report_in_browser."""
+
+    def test_returns_false_when_report_missing(self, tmp_path: Path) -> None:
+        # FlightCheck can abort before save_results (e.g. fatal config
+        # error). The helper must no-op cleanly in that case rather
+        # than 404'ing a browser tab.
+        with patch("flightcheck.cli.webbrowser.open") as mock_open:
+            result = cli.open_report_in_browser(str(tmp_path))
+        assert result is False
+        mock_open.assert_not_called()
+
+    def test_returns_true_when_webbrowser_open_succeeds(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "report.html").write_text("<html></html>")
+        with patch(
+            "flightcheck.cli.webbrowser.open", return_value=True
+        ) as mock_open:
+            result = cli.open_report_in_browser(str(tmp_path))
+        assert result is True
+        mock_open.assert_called_once()
+
+    def test_returns_false_when_webbrowser_open_reports_failure(
+        self, tmp_path: Path
+    ) -> None:
+        # ``webbrowser.open`` returns False when it could not locate a
+        # browser (e.g. SSH session with no DISPLAY). The helper must
+        # propagate that so callers can decide what to do — and it must
+        # NOT raise, because FlightCheck's exit code reflects check
+        # results, not browser-launch success.
+        (tmp_path / "report.html").write_text("<html></html>")
+        with patch("flightcheck.cli.webbrowser.open", return_value=False):
+            result = cli.open_report_in_browser(str(tmp_path))
+        assert result is False
+
+    def test_passes_well_formed_file_uri(self, tmp_path: Path) -> None:
+        # All file URIs must start with ``file:///`` (three slashes —
+        # empty host segment) per RFC 8089. The pre-fix f-string
+        # produced ``file://C:\path...`` on Windows; ``Path.as_uri()``
+        # produces ``file:///C:/path/...``.
+        (tmp_path / "report.html").write_text("<html></html>")
+        with patch("flightcheck.cli.webbrowser.open") as mock_open:
+            cli.open_report_in_browser(str(tmp_path))
+
+        uri = mock_open.call_args[0][0]
+        assert uri.startswith("file:///")
+        assert uri.endswith("/report.html")
+        assert "\\" not in uri  # forward slashes only
+
+    def test_handles_paths_with_spaces(self, tmp_path: Path) -> None:
+        # The original bug: ``f"file://{abs_path}"`` produces an
+        # unescaped URI for paths with spaces (e.g. Windows OneDrive
+        # paths). ``Path.as_uri()`` percent-encodes them as ``%20``.
+        spaced = tmp_path / "my output dir"
+        spaced.mkdir()
+        (spaced / "report.html").write_text("<html></html>")
+
+        with patch("flightcheck.cli.webbrowser.open") as mock_open:
+            cli.open_report_in_browser(str(spaced))
+
+        uri = mock_open.call_args[0][0]
+        assert "%20" in uri
+        assert " " not in uri  # raw space would be malformed
+
+    def test_resolves_relative_output_dir(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # CLI's default ``--output`` is ``workspace/flightcheck`` (relative).
+        # The helper must resolve it to an absolute path so the resulting
+        # ``file:///`` URI points at the right place even after a later
+        # ``os.chdir``.
+        monkeypatch.chdir(tmp_path)
+        rel_out = Path("workspace/flightcheck")
+        rel_out.mkdir(parents=True)
+        (rel_out / "report.html").write_text("<html></html>")
+
+        with patch("flightcheck.cli.webbrowser.open") as mock_open:
+            cli.open_report_in_browser(str(rel_out))
+
+        uri = mock_open.call_args[0][0]
+        # tmp_path is absolute; the resolved URI must contain it (modulo
+        # platform-specific drive-letter encoding).
+        assert "workspace/flightcheck/report.html" in uri

--- a/tests/scripts/test_discover.py
+++ b/tests/scripts/test_discover.py
@@ -104,6 +104,88 @@ class TestListEnvironments:
         assert exc_info.value.code == 1
 
 
+class TestParseRawEnvironments:
+    """Tests for list_environments.parse_raw_environments().
+
+    Regression coverage for the env-type column that previously always
+    showed ``Unknown``: the real BAP Admin API returns the environment
+    type under ``environmentSku`` (e.g. Production, Sandbox, Developer),
+    not ``environmentType``. parse_raw_environments now reads
+    ``environmentSku`` first and falls back to ``environmentType`` for
+    forward-compat.
+    """
+
+    def test_reads_environment_sku(self):
+        """The current BAP shape (environmentSku set) populates env type."""
+        import list_environments
+
+        envs = [pp.environment(display_name="Prod-Like")]
+        # Confirm the test fixture matches the real API shape we depend on.
+        assert envs[0]["properties"]["environmentSku"] == "Production"
+
+        parsed = list_environments.parse_raw_environments(envs)
+        assert parsed[0]["type"] == "Production"
+
+    def test_falls_back_to_environment_type_when_sku_missing(self):
+        """Forward-compat: if the API ever drops Sku, the legacy field wins."""
+        import list_environments
+
+        envs = [{
+            "name": "env-legacy",
+            "properties": {
+                "displayName": "Legacy",
+                # No environmentSku key at all
+                "environmentType": "Sandbox",
+                "linkedEnvironmentMetadata": {
+                    "instanceUrl": "https://legacy.crm.dynamics.com/",
+                    "geo": "US",
+                },
+                "states": {"runtime": {"id": "Enabled"}},
+            },
+        }]
+
+        parsed = list_environments.parse_raw_environments(envs)
+        assert parsed[0]["type"] == "Sandbox"
+
+    def test_returns_unknown_when_both_fields_missing(self):
+        """Defensive default when the API returns neither field."""
+        import list_environments
+
+        envs = [{
+            "name": "env-bare",
+            "properties": {
+                "displayName": "Bare",
+                "linkedEnvironmentMetadata": {
+                    "instanceUrl": "https://bare.crm.dynamics.com/",
+                },
+                "states": {"runtime": {"id": "Enabled"}},
+            },
+        }]
+
+        parsed = list_environments.parse_raw_environments(envs)
+        assert parsed[0]["type"] == "Unknown"
+
+    def test_environment_sku_wins_over_environment_type(self):
+        """When both fields are present, prefer the current API field."""
+        import list_environments
+
+        envs = [{
+            "name": "env-both",
+            "properties": {
+                "displayName": "Both",
+                "environmentSku": "Developer",
+                "environmentType": "Sandbox",  # legacy / stale
+                "linkedEnvironmentMetadata": {
+                    "instanceUrl": "https://both.crm.dynamics.com/",
+                },
+                "states": {"runtime": {"id": "Enabled"}},
+            },
+        }]
+
+        parsed = list_environments.parse_raw_environments(envs)
+        assert parsed[0]["type"] == "Developer"
+
+
 class TestPrintEnvironmentTable:
     """Tests for list_environments.print_environment_table()."""
 


### PR DESCRIPTION
## Summary

ADO task https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7474680

Four small fixes for the FlightCheck-only installer experience. Each one is independently observable; bundling because they''re all in the same UX flow.

1. **Auto-open HTML report.** FlightCheck opens `report.html` in the default browser after completing checks. Gives users immediate visual access to the full report with expandable sections, color-coded results, and remediation steps. `--no-open` skips it for CI / headless use.

2. **Fix environment type column showing `Unknown`.** The BAP Admin API returns the environment type under `environmentSku` (e.g. Production, Sandbox, Developer), not `environmentType`. `list_environments.py` now reads `environmentSku` with `environmentType` fallback for forward-compat. Originally pushed to PR #134 but landed on its branch after the PR was merged — porting it here so it actually reaches `main`.

3. **Fix installer closing the PowerShell host on FlightCheck completion.** `Install-EssAdk.ps1` ended its FlightCheckOnly branch with `exit 0`, which terminates the calling PowerShell process — not just the script. When invoked through `iex (irm .../bootstrap-flightcheck.ps1)`, that closed the user''s terminal window the moment FlightCheck finished. Replaced with `return` so the script ends in its own scope.

4. **Fix malformed `file://` URI on Windows paths containing spaces.** The first cut of the auto-open feature built the URI via `f"file://{abs_path}"`, which produces a non-RFC-8089 URI (two slashes, backslashes, raw spaces) on any Windows path. It happened to work for paths without spaces, but broke for the common case of OneDrive-redirected user profiles (`C:\Users\foo\OneDrive - Microsoft Corporation\...`). Refactored into a small `open_report_in_browser()` helper that uses `pathlib.Path.as_uri()` to generate a proper `file:///C:/.../report.html` URI with `%20` for spaces, and returns `webbrowser.open()`''s actual result so callers see launch failures.

## Changes

- `solutions/ess-maker-skills/scripts/flightcheck/cli.py`: extract `open_report_in_browser()` helper; use `Path.as_uri()` for RFC-8089 URIs; top-level imports; new `--no-open` CLI flag.
- `solutions/ess-maker-skills/scripts/list_environments.py`: read env type from `environmentSku` with `environmentType` fallback.
- `setup/Install-EssAdk.ps1`: `exit 0` → `return` so interactive PowerShell sessions stay alive after FlightCheck completes.
- `setup/README.md`: document `--no-open` for Codespaces (file:// URLs can''t open in a cloud browser) and headless / CI re-runs.

## Tests

- `tests/flightcheck/test_cli.py` (new): cover `open_report_in_browser` for missing-report no-op, success/failure propagation, well-formed `file:///` URI shape, space-in-path `%20` encoding, and relative-output-dir resolution.
- `tests/scripts/test_discover.py`: add `TestParseRawEnvironments` covering `environmentSku` read, `environmentType` fallback, `Unknown` default, and sku-wins-over-type ordering — pins the regression that PR #134 missed.

## Behavior

- After FlightCheck finishes and saves `report.html`, it opens the file in the default browser. Cross-platform via Python''s `webbrowser` module (macOS, Windows, Linux). Works correctly on Windows paths with spaces.
- `--no-open` skips: `python scripts/flightcheck/cli.py --no-open`.
- Environment listing (`/setup`, FlightCheck-only installer) shows real env types (Production, Sandbox, Developer) instead of `Unknown`.
- The `iex (irm .../bootstrap-flightcheck.ps1)` one-liner no longer closes the user''s terminal — they can read the FlightCheck results table and re-run commands as needed.
