### PR TITLE
Add FlightCheck Cloud Policy feedback checks (POL-FB-001/002)

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/cloud_policy.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/cloud_policy.py
@@ -98,8 +98,8 @@ DOC_LINK = (
 # Maker-facing data-sharing notice — VERBATIM. Surfaced whenever feedback is
 # (or should be) enabled so the maker can lift it directly into their privacy
 # documentation. Acceptance criteria require this exact wording; do not
-# paraphrase. The same constant is mirrored verbatim in the FlightCheck
-# reference docs (remediation-guide.md / validation-matrix.md).
+# paraphrase. The same constant is reproduced verbatim in the FlightCheck
+# remediation guide (remediation-guide.md); validation-matrix.md references it.
 # --------------------------------------------------------------------------
 MAKER_NOTICE = (
     "End-user feedback collected from Copilot responses in this deployment "
@@ -123,11 +123,10 @@ def render_directive(
     These checkpoints ask the operator to confirm a setting, not to diagnose a
     symptom they're already seeing — so the directive leads with "How to
     verify" (the actionable steps), not a "probable cause." The remaining
-    role-aware sections (Shared Steps #7433818 / #7433819 / #7433820) follow:
-    Scope + confidence (IT-admin scope, since Cloud Policy is admin-controlled)
-    and Still stuck. When ``notice`` is supplied, the verbatim data-sharing
-    notice is appended as a final section so it travels with the directive
-    output, not just the console.
+    role-aware sections follow: Scope + confidence (IT-admin scope, since
+    Cloud Policy is admin-controlled) and Still stuck. When ``notice`` is
+    supplied, the verbatim data-sharing notice is appended as a final section
+    so it travels with the directive output, not just the console.
 
     The WHY of acting lives in the ``CheckResult.result`` field (the impact +
     silent-failure mode), per the result-vs-remediation contract.

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/cloud_policy.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/cloud_policy.py
@@ -1,0 +1,269 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS FlightCheck — Cloud Policies / Telemetry & Feedback (POL-FB-xxx)
+
+Validates the two Microsoft 365 Cloud Policies (Office Cloud Policy Service,
+managed in the Microsoft 365 Apps admin center → Policy Management) that gate
+end-user Copilot feedback for the ESS deployment:
+
+  POL-FB-001  "Allow users to send feedback to Microsoft about Microsoft 365
+              apps"            — must be Enabled for the ESS deployment group.
+  POL-FB-002  "Allow users to include screenshots and attachments when they
+              submit feedback to Microsoft"
+                               — should be Enabled for high-fidelity capture.
+
+When feedback is enabled, end users see the thumbs up/down control on Copilot
+responses; that signal is the primary closed-loop source for the FlightCheck
+Trend Miner, IcM correlation, and product-quality improvement. When the
+"Allow feedback" policy is Disabled / Not Configured for the deployment group,
+the control silently disappears — no error, no failed request, no log entry —
+so a maker can be unaware their tenant opted out of the quality signal.
+
+Why these are MANUAL (Status.MANUAL), not automated PASS/FAIL
+-------------------------------------------------------------
+The Office Cloud Policy Service (OCPS) has NO supported programmatic way for
+FlightCheck to read EFFECTIVE per-security-group feedback policy state:
+
+  * There is no GA / publicly-documented Microsoft Graph endpoint for OCPS
+    policy assignments (verified 2026-06 against MS Learn; the Cloud Policy
+    overview documents a UI + Entra-role-based service only, with no API).
+  * The admin center's private backend (``config.office.com/policyadmin/...``)
+    sits behind Azure Application Gateway and rejects a service-acquired
+    bearer (HTTP 403) without the browser's session cookies + Origin — there
+    is no documented service-principal / app-permission auth path.
+
+Per FlightCheck's design rule "no misleading results," a check that can only
+authenticate during a manual cassette capture but SKIP/ERROR on every real
+customer run is worse than no check. So these checkpoints follow the same
+``Status.MANUAL`` pattern as the publishing checklist (``checks/publishing.py``):
+the kit surfaces WHY the policy is worth verifying, HOW to verify it (portal
+steps + deep link), and the verbatim data-sharing notice, then the operator
+confirms the state in the Microsoft 365 Apps admin center. MANUAL items route
+to the "Needs manual verification" section of the report and never fail
+readiness.
+
+Output framing for a MANUAL verification checkpoint
+---------------------------------------------------
+Because the operator isn't looking at a symptom — they're being asked to
+confirm a setting — the rows do NOT lead with a "probable cause." Instead:
+
+  * ``result`` = WHY this is worth verifying (the impact + the silent failure
+    mode), so the operator understands the stakes before acting.
+  * ``remediation`` = HOW to verify it: the role-aware deployment directive
+    rendered as "How to verify" steps + "Scope + confidence" + "Still stuck?"
+    (+ the verbatim data-sharing notice on POL-FB-001).
+
+If Microsoft ships a GA programmatic OCPS policy API (e.g. the preview Graph
+Tenant Configuration Management API reaching GA), these can be promoted to
+automated checks — register the API in ``tests/fixtures/cassettes/INDEX.md``,
+add an OCPS client, and replace the MANUAL bodies with effective-per-group
+PASS/FAIL/WARN logic.
+"""
+
+from ..runner import CheckResult, Priority, Status
+
+# Checkpoint identifiers.
+POL_FB_FEEDBACK = "POL-FB-001"
+POL_FB_ATTACHMENTS = "POL-FB-002"
+
+# Report category for these checkpoints.
+CATEGORY = "Cloud Policies / Telemetry & Feedback"
+
+# Verbatim Cloud Policy display names (as shown in the Microsoft 365 Apps
+# admin center). Output names the policy by this exact string so the operator
+# can find it without ambiguity.
+POLICY_NAME_FEEDBACK = (
+    "Allow users to send feedback to Microsoft about Microsoft 365 apps"
+)
+POLICY_NAME_ATTACHMENTS = (
+    "Allow users to include screenshots and attachments when they submit "
+    "feedback to Microsoft"
+)
+
+# Microsoft 365 Apps admin center (Office Cloud Policy Service) portal root.
+# The navigation path (Policy Management → the configuration assigned to the
+# ESS deployment group) is spelled out in remediation text rather than a
+# fabricated deep URL.
+M365_APPS_ADMIN_URL = "https://config.office.com/"
+
+# Verified Microsoft Learn reference for the Cloud Policy service.
+DOC_LINK = (
+    "https://learn.microsoft.com/en-us/microsoft-365-apps/admin-center/"
+    "overview-cloud-policy"
+)
+
+# --------------------------------------------------------------------------
+# Maker-facing data-sharing notice — VERBATIM. Surfaced whenever feedback is
+# (or should be) enabled so the maker can lift it directly into their privacy
+# documentation. Acceptance criteria require this exact wording; do not
+# paraphrase. The same constant is mirrored verbatim in the FlightCheck
+# reference docs (remediation-guide.md / validation-matrix.md).
+# --------------------------------------------------------------------------
+MAKER_NOTICE = (
+    "End-user feedback collected from Copilot responses in this deployment "
+    "\u2014 including any verbatim text, screenshots, and attachments the "
+    "end user chooses to include \u2014 will be shared with Microsoft for "
+    "product-quality and support improvement purposes. Confirm that your "
+    "organization's privacy notice and end-user training cover this data "
+    "flow before launch."
+)
+
+
+def render_directive(
+    *,
+    how_to_verify: str,
+    scope_confidence: str,
+    still_stuck: str,
+    notice: str | None = None,
+) -> str:
+    """Render the role-aware deployment-directive block for a MANUAL check.
+
+    These checkpoints ask the operator to confirm a setting, not to diagnose a
+    symptom they're already seeing — so the directive leads with "How to
+    verify" (the actionable steps), not a "probable cause." The remaining
+    role-aware sections (Shared Steps #7433818 / #7433819 / #7433820) follow:
+    Scope + confidence (IT-admin scope, since Cloud Policy is admin-controlled)
+    and Still stuck. When ``notice`` is supplied, the verbatim data-sharing
+    notice is appended as a final section so it travels with the directive
+    output, not just the console.
+
+    The WHY of acting lives in the ``CheckResult.result`` field (the impact +
+    silent-failure mode), per the result-vs-remediation contract.
+
+    Args:
+        how_to_verify: The concrete verification steps + deep link / nav path.
+        scope_confidence: Who owns the check + that this is a manual confirm.
+        still_stuck: The fallback if the setting looks right but feedback
+            still doesn't behave as expected.
+        notice: Optional verbatim notice to append (pass ``MAKER_NOTICE``).
+
+    Returns:
+        A markdown block with one bolded label per section.
+    """
+    sections = [
+        f"**How to verify** \u2014 {how_to_verify}",
+        f"**Scope + confidence** \u2014 {scope_confidence}",
+        f"**Still stuck?** \u2014 {still_stuck}",
+    ]
+    if notice:
+        sections.append(f"**Data-sharing notice** \u2014 {notice}")
+    return "\n\n".join(sections)
+
+
+# Shared scope/confidence line — identical for both checkpoints (Cloud Policy
+# is admin-controlled and the kit can't read OCPS state programmatically).
+_SCOPE_CONFIDENCE = (
+    "IT admin scope \u2014 Cloud Policy is admin-controlled (Office Apps "
+    "Administrator). FlightCheck cannot read Office Cloud Policy Service "
+    "state programmatically, so this is a manual confirmation rather than an "
+    "automated verdict."
+)
+
+
+def check_feedback_enabled(runner) -> CheckResult:
+    """POL-FB-001 — "Allow feedback" Cloud Policy enabled for the group."""
+    # result = WHY this is worth verifying (impact + silent failure mode).
+    why = (
+        "Thumbs up / down feedback on Copilot responses is the primary "
+        "closed-loop quality signal for this deployment \u2014 it feeds the "
+        "FlightCheck Trend Miner, IcM correlation, and product-quality "
+        "improvements. End users only see the feedback control when "
+        f'"{POLICY_NAME_FEEDBACK}" is Enabled for the security group that owns '
+        "the deployment. If that cloud policy is Disabled or Not Configured "
+        "the control disappears with no error, no failed request, and no log "
+        "entry \u2014 so the tenant can opt out of the signal without anyone "
+        "noticing. Worth confirming before launch."
+    )
+    how_to_verify = (
+        f"In the [Microsoft 365 Apps admin center]({M365_APPS_ADMIN_URL}) "
+        "\u2192 Policy Management, open the policy configuration assigned to "
+        "the security group that owns the ESS Agent deployment, search its "
+        'settings for "feedback", and confirm '
+        f'"{POLICY_NAME_FEEDBACK}" is set to Enabled. If no policy '
+        "configuration targets that group, create one (or assign an existing "
+        "one) with this policy Enabled."
+    )
+    still_stuck = (
+        "If the setting already looks correct but users still don't see the "
+        "feedback control, confirm the policy configuration is assigned to "
+        "the right security group and isn't overridden by a higher-priority "
+        f"configuration. See {DOC_LINK} for how Cloud Policy resolves "
+        "effective settings per group."
+    )
+    return CheckResult(
+        checkpoint_id=POL_FB_FEEDBACK,
+        category=CATEGORY,
+        priority=Priority.HIGH.value,
+        status=Status.MANUAL.value,
+        description=(
+            f'Cloud Policy "{POLICY_NAME_FEEDBACK}" Enabled for the ESS '
+            "deployment group"
+        ),
+        result=why,
+        remediation=render_directive(
+            how_to_verify=how_to_verify,
+            scope_confidence=_SCOPE_CONFIDENCE,
+            still_stuck=still_stuck,
+            notice=MAKER_NOTICE,
+        ),
+        doc_link=DOC_LINK,
+    )
+
+
+def check_feedback_attachments(runner) -> CheckResult:
+    """POL-FB-002 — "Allow attachments" Cloud Policy enabled for the group."""
+    why = (
+        "Screenshots and attachments give the feedback signal its diagnostic "
+        f'fidelity. "{POLICY_NAME_ATTACHMENTS}" controls whether end users '
+        "can include them. If it is Disabled while feedback itself is Enabled, "
+        "feedback still flows but arrives without the diagnostic context "
+        "attachments provide \u2014 a lower-fidelity Trend Miner signal. This "
+        "is a fidelity consideration, not a feedback blocker. Worth confirming "
+        "before launch."
+    )
+    how_to_verify = (
+        f"In the [Microsoft 365 Apps admin center]({M365_APPS_ADMIN_URL}) "
+        "\u2192 Policy Management, open the policy configuration assigned to "
+        "the ESS deployment group and confirm "
+        f'"{POLICY_NAME_ATTACHMENTS}" is set to Enabled (on the same '
+        "configuration where you enabled the feedback policy)."
+    )
+    still_stuck = (
+        "Confirm the attachments policy is set on the same configuration that "
+        f"targets the deployment group. See {DOC_LINK}. The data-sharing "
+        "notice on POL-FB-001 already covers the screenshots/attachments this "
+        "policy enables."
+    )
+    return CheckResult(
+        checkpoint_id=POL_FB_ATTACHMENTS,
+        category=CATEGORY,
+        priority=Priority.HIGH.value,
+        status=Status.MANUAL.value,
+        description=(
+            f'Cloud Policy "{POLICY_NAME_ATTACHMENTS}" Enabled for the ESS '
+            "deployment group"
+        ),
+        result=why,
+        remediation=render_directive(
+            how_to_verify=how_to_verify,
+            scope_confidence=_SCOPE_CONFIDENCE,
+            still_stuck=still_stuck,
+        ),
+        doc_link=DOC_LINK,
+    )
+
+
+def run_cloud_policy_checks(runner) -> list[CheckResult]:
+    """Run the Cloud Policies / Telemetry & Feedback checks (POL-FB-xxx).
+
+    Both checkpoints are ``Status.MANUAL`` (see module docstring): ``result``
+    explains WHY the policy is worth verifying, ``remediation`` explains HOW to
+    verify it (portal steps) and carries the verbatim data-sharing notice.
+    They never fail readiness.
+    """
+    return [
+        check_feedback_enabled(runner),
+        check_feedback_attachments(runner),
+    ]

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -19,6 +19,7 @@ Scopes:
     servicenow      — ServiceNow deep validation
     local           — Local agent file validation
     publishing      — Publishing/QA checklist
+    cloudpolicy     — Cloud Policy feedback checks (POL-FB-*)
 """
 
 import argparse
@@ -53,6 +54,7 @@ from flightcheck.checks.servicenow import run_servicenow_checks
 from flightcheck.checks.local_files import run_local_file_checks
 from flightcheck.checks.publishing import run_publishing_checks
 from flightcheck.checks.licensing import run_licensing_checks
+from flightcheck.checks.cloud_policy import run_cloud_policy_checks
 
 
 SCOPE_MAP = {
@@ -75,6 +77,7 @@ SCOPE_MAP = {
     "local": [("Local Files", run_local_file_checks)],
     "publishing": [("Publishing", run_publishing_checks)],
     "licensing": [("Licensing", run_licensing_checks)],
+    "cloudpolicy": [("Cloud Policies", run_cloud_policy_checks)],
 }
 
 FULL_SCOPE = [
@@ -88,6 +91,7 @@ FULL_SCOPE = [
     ("Local Files", run_local_file_checks),
     ("Licensing", run_licensing_checks),
     ("Publishing", run_publishing_checks),
+    ("Cloud Policies", run_cloud_policy_checks),
 ]
 
 

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/remediation-guide.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/remediation-guide.md
@@ -164,3 +164,61 @@ verdict.
 
 Refer to the [deployment checklist](https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service/deploy-overview-alm)
 for detailed guidance on each item.
+
+## Cloud Policies / Telemetry & Feedback
+
+End-user feedback (thumbs up / thumbs down, optional verbatim, optional
+screenshots/attachments) on Copilot responses is gated by two Microsoft 365
+Cloud Policies in the **Microsoft 365 Apps admin center → Policy Management**.
+When the "Allow feedback" policy is Disabled / Not Configured for the ESS
+deployment group, end users simply see no feedback control — there is no error,
+no failed request, no log entry — and the FlightCheck Trend Miner loses its
+primary customer-signal source.
+
+These two checkpoints are **manual** (`Status.Manual`): the Office Cloud Policy
+Service exposes no supported API for reading effective per-group policy state,
+so FlightCheck explains *why* each policy matters and *how* to confirm it in the
+portal, then you verify it. They don't fail readiness.
+
+### POL-FB-001: confirm "Allow feedback" is Enabled for the deployment group
+
+- **Why verify** — Thumbs up / down feedback is the primary closed-loop quality
+  signal (it feeds the Trend Miner, IcM correlation, and product-quality work).
+  The control only appears when **"Allow users to send feedback to Microsoft
+  about Microsoft 365 apps"** is Enabled for the deployment group; if it's
+  Disabled / Not Configured the control disappears silently, so the tenant can
+  opt out of the signal unnoticed.
+- **How to verify** — Open the [Microsoft 365 Apps admin center](https://config.office.com/)
+  → Policy Management → the policy configuration assigned to the security group
+  that owns the ESS deployment → search its settings for "feedback" → confirm
+  **"Allow users to send feedback to Microsoft about Microsoft 365 apps"** is
+  set to **Enabled**. If no configuration targets that group, create or assign
+  one with this policy Enabled.
+- **Scope + confidence** — IT admin scope (Cloud Policy is admin-controlled).
+  This is a manual confirmation — FlightCheck can't read OCPS state directly.
+- **Still stuck?** — If the setting looks right but users still don't see the
+  control, confirm the configuration is assigned to the correct group and isn't
+  overridden by a higher-priority configuration.
+
+### POL-FB-002: confirm "Allow attachments" is Enabled (fidelity)
+
+- **Why verify** — Screenshots and attachments give the feedback signal its
+  diagnostic fidelity. If **"Allow users to include screenshots and attachments
+  when they submit feedback to Microsoft"** is Disabled while feedback is
+  Enabled, feedback still flows but without diagnostic context — a lower-fidelity
+  Trend Miner signal. This is a fidelity consideration, not a feedback blocker.
+- **How to verify** — In the same policy configuration (where you enabled the
+  feedback policy), confirm **"Allow users to include screenshots and
+  attachments when they submit feedback to Microsoft"** is set to **Enabled**.
+
+### Data-sharing notice (emitted verbatim)
+
+Whenever feedback is (or should be) enabled, FlightCheck emits the following
+notice. It is reproduced here **verbatim** so you can lift it directly into
+your organization's privacy documentation and end-user training:
+
+> End-user feedback collected from Copilot responses in this deployment —
+> including any verbatim text, screenshots, and attachments the end user
+> chooses to include — will be shared with Microsoft for product-quality and
+> support improvement purposes. Confirm that your organization's privacy
+> notice and end-user training cover this data flow before launch.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/validation-matrix.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/validation-matrix.md
@@ -128,6 +128,28 @@ standalone FlightCheck tool did not have.
 | SN-LOCAL-002 | HRSD topics present | Medium | Scan `topics/` | [servicenow](https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service/servicenow) |
 | SN-LOCAL-003 | ITSM topics present | Medium | Scan `topics/` | [servicenow](https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service/servicenow) |
 
+## 6.5. Cloud Policies / Telemetry & Feedback (POL-FB-xxx)
+
+These checkpoints validate the two Microsoft 365 Cloud Policies (Office Cloud
+Policy Service, managed in the Microsoft 365 Apps admin center → Policy
+Management → Cloud policies) that gate end-user Copilot feedback — the primary
+closed-loop signal for product quality, IcM correlation, and the FlightCheck
+Trend Miner. Cloud Policy is admin-controlled, so these are IT-admin scope.
+
+| ID | Check | Priority | Method | Doc Link |
+|----|-------|----------|--------|----------|
+| POL-FB-001 | Cloud Policy "Allow users to send feedback to Microsoft about Microsoft 365 apps" Enabled for the ESS deployment group | High | Manual (no supported OCPS API) | [overview-cloud-policy](https://learn.microsoft.com/en-us/microsoft-365-apps/admin-center/overview-cloud-policy) |
+| POL-FB-002 | Cloud Policy "Allow users to include screenshots and attachments when they submit feedback to Microsoft" Enabled for the ESS deployment group | High | Manual (no supported OCPS API) | [overview-cloud-policy](https://learn.microsoft.com/en-us/microsoft-365-apps/admin-center/overview-cloud-policy) |
+
+**Why manual:** The Office Cloud Policy Service has no GA / publicly-documented
+API for reading effective per-security-group feedback policy state, and its
+admin-center backend rejects a service-acquired token. So these checkpoints are
+`Manual` (they don't fail readiness): FlightCheck names the exact policies, deep
+-links to the Microsoft 365 Apps admin center, emits the role-aware deployment
+directive, and emits the **verbatim maker-facing data-sharing notice** (see the
+[remediation guide](./remediation-guide.md#cloud-policies--telemetry--feedback)).
+The operator confirms the effective per-group state in the portal.
+
 ## 7. Publishing & QA (Manual Checklist)
 
 | ID | Check | Priority | Method |

--- a/tests/flightcheck/checks/test_cloud_policy.py
+++ b/tests/flightcheck/checks/test_cloud_policy.py
@@ -1,0 +1,184 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the Cloud Policies / feedback checks (POL-FB-001 / POL-FB-002).
+
+These checkpoints are ``Status.MANUAL``: the Office Cloud Policy Service has
+no supported programmatic API for reading effective per-security-group
+feedback policy state (no GA Graph endpoint; the admin-center backend rejects
+a service-acquired bearer at the WAF). So FlightCheck surfaces the policies to
+verify, the portal deep link, the role-aware deployment directive, and the
+verbatim data-sharing notice, then defers the comparison to the operator —
+mirroring the publishing checklist.
+
+There is no external API call here, so these are pure-logic tests (no
+cassette). The notice wording is mandated verbatim by the acceptance criteria
+so customers can lift it into their privacy documentation; the exact substring
+assertions are intentional and must not be loosened.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    """Make `flightcheck.*` importable from the kit's scripts dir."""
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def _results_by_id() -> dict:
+    from flightcheck.checks.cloud_policy import run_cloud_policy_checks
+
+    runner = SimpleNamespace(config={})
+    return {r.checkpoint_id: r for r in run_cloud_policy_checks(runner)}
+
+
+# --------------------------------------------------------------------------
+# Constants / pure helpers
+# --------------------------------------------------------------------------
+
+
+def test_checkpoint_and_category_constants():
+    from flightcheck.checks import cloud_policy as cp
+
+    assert cp.POL_FB_FEEDBACK == "POL-FB-001"
+    assert cp.POL_FB_ATTACHMENTS == "POL-FB-002"
+    assert cp.CATEGORY == "Cloud Policies / Telemetry & Feedback"
+
+
+def test_policy_display_names_are_verbatim():
+    from flightcheck.checks import cloud_policy as cp
+
+    assert cp.POLICY_NAME_FEEDBACK == (
+        "Allow users to send feedback to Microsoft about Microsoft 365 apps"
+    )
+    assert cp.POLICY_NAME_ATTACHMENTS == (
+        "Allow users to include screenshots and attachments when they submit "
+        "feedback to Microsoft"
+    )
+
+
+def test_maker_notice_is_verbatim():
+    from flightcheck.checks import cloud_policy as cp
+
+    assert cp.MAKER_NOTICE == (
+        "End-user feedback collected from Copilot responses in this "
+        "deployment \u2014 including any verbatim text, screenshots, and "
+        "attachments the end user chooses to include \u2014 will be shared "
+        "with Microsoft for product-quality and support improvement "
+        "purposes. Confirm that your organization's privacy notice and "
+        "end-user training cover this data flow before launch."
+    )
+    assert "will be shared with Microsoft" in cp.MAKER_NOTICE
+    assert "product-quality and support improvement purposes" in cp.MAKER_NOTICE
+    assert "privacy notice" in cp.MAKER_NOTICE
+
+
+def test_render_directive_has_three_sections_in_order():
+    from flightcheck.checks import cloud_policy as cp
+
+    out = cp.render_directive(
+        how_to_verify="open the admin center and confirm the setting.",
+        scope_confidence="IT admin scope.",
+        still_stuck="contact your tenant admin.",
+    )
+    # Leads with How to verify (not a 'probable cause' for an unseen symptom).
+    assert out.startswith("**How to verify**")
+    assert (
+        out.index("How to verify")
+        < out.index("Scope + confidence")
+        < out.index("Still stuck?")
+    )
+    assert "Probable cause" not in out
+    assert "Data-sharing notice" not in out
+
+
+def test_render_directive_appends_notice_when_supplied():
+    from flightcheck.checks import cloud_policy as cp
+
+    out = cp.render_directive(
+        how_to_verify="v",
+        scope_confidence="s",
+        still_stuck="ss",
+        notice=cp.MAKER_NOTICE,
+    )
+    assert "**Data-sharing notice** \u2014 End-user feedback collected" in out
+    assert out.rstrip().endswith("cover this data flow before launch.")
+
+
+# --------------------------------------------------------------------------
+# Check behavior — both checkpoints are MANUAL, HIGH, in the right category
+# --------------------------------------------------------------------------
+
+
+def test_emits_both_checkpoints():
+    by_id = _results_by_id()
+    assert set(by_id) == {"POL-FB-001", "POL-FB-002"}
+
+
+def test_both_are_manual_high_and_correctly_categorized():
+    for r in _results_by_id().values():
+        assert r.status == "Manual"  # never fails readiness
+        assert r.priority == "High"
+        assert r.category == "Cloud Policies / Telemetry & Feedback"
+
+
+def test_feedback_checkpoint_explains_why_and_how_with_notice():
+    r = _results_by_id()["POL-FB-001"]
+    # result = WHY it's worth verifying (impact + silent failure), no fix prose.
+    assert "primary closed-loop quality signal" in r.result
+    assert "no error" in r.result and "no log entry" in r.result
+    assert "How to verify" not in r.result  # steps live in remediation
+    # remediation = HOW to verify (leads with verification steps, not a cause).
+    assert r.remediation.startswith("**How to verify**")
+    assert "Probable cause" not in r.remediation
+    assert "**Scope + confidence**" in r.remediation
+    assert "**Still stuck?**" in r.remediation
+    # names the exact policy display name...
+    assert (
+        "Allow users to send feedback to Microsoft about Microsoft 365 apps"
+        in r.remediation
+    )
+    # ...IT-admin scope framing...
+    assert "IT admin scope" in r.remediation
+    # ...the portal deep link...
+    assert "config.office.com" in r.remediation
+    # ...and the verbatim data-sharing notice.
+    assert "will be shared with Microsoft for product-quality" in r.remediation
+    assert "privacy notice and end-user training" in r.remediation
+    # Verified doc link, not fabricated.
+    assert r.doc_link == (
+        "https://learn.microsoft.com/en-us/microsoft-365-apps/admin-center/"
+        "overview-cloud-policy"
+    )
+
+
+def test_attachments_checkpoint_explains_fidelity_why_and_how():
+    r = _results_by_id()["POL-FB-002"]
+    # result = WHY (fidelity rationale), framed as not a blocker.
+    assert "diagnostic fidelity" in r.result
+    assert "lower-fidelity" in r.result
+    assert "not a feedback blocker" in r.result
+    # remediation = HOW to verify.
+    assert r.remediation.startswith("**How to verify**")
+    assert (
+        "Allow users to include screenshots and attachments when they submit "
+        "feedback to Microsoft"
+        in r.remediation
+    )
+    assert "config.office.com" in r.remediation

--- a/tests/flightcheck/checks/test_cloud_policy.py
+++ b/tests/flightcheck/checks/test_cloud_policy.py
@@ -182,3 +182,13 @@ def test_attachments_checkpoint_explains_fidelity_why_and_how():
         in r.remediation
     )
     assert "config.office.com" in r.remediation
+
+
+def test_attachments_does_not_duplicate_data_sharing_notice():
+    # The verbatim MAKER_NOTICE belongs to POL-FB-001 only (POL-FB-002's
+    # "Still stuck?" points back to it). Pin the absence so a future edit that
+    # passes notice= to POL-FB-002's render_directive can't silently duplicate
+    # the compliance string across two rows.
+    r = _results_by_id()["POL-FB-002"]
+    assert "Data-sharing notice" not in r.remediation
+    assert "will be shared with Microsoft" not in r.remediation


### PR DESCRIPTION
## What

Adds FlightCheck checkpoints **POL-FB-001** and **POL-FB-002** (category *Cloud Policies / Telemetry & Feedback*, priority HIGH) for the two Microsoft 365 Cloud Policies that gate end-user Copilot feedback for the ESS deployment:

- **POL-FB-001** — "Allow users to send feedback to Microsoft about Microsoft 365 apps"
- **POL-FB-002** — "Allow users to include screenshots and attachments when they submit feedback to Microsoft"

Feedback is the primary closed-loop quality signal (Trend Miner / IcM / product-quality). If the feedback policy is off for the deployment group, the thumbs control silently disappears — no error, no log entry — so it must be verified before launch.

## Why these are `Status.MANUAL` (not automated PASS/FAIL)

The original ask was an automated, effective-per-security-group check. I researched and verified that this is **not feasible**:

- No GA / publicly-documented Microsoft Graph endpoint exists for the Office Cloud Policy Service (OCPS) — the Cloud Policy overview documents a UI + Entra-role-based service only.
- The admin-center private backend (`config.office.com/policyadmin/...`) sits behind Azure App Gateway and **returns 403 to a service-acquired bearer** (confirmed live) — no documented service-principal/app-permission auth path.

Per FlightCheck's "no misleading results" rule, a check that authenticates only during a manual cassette capture but SKIP/ERRORs on every real run is worse than none. So these follow the existing `publishing.py` MANUAL pattern.

## Output framing

Because the operator is confirming a setting (not diagnosing a symptom):
- **`result`** explains *why* to verify (impact + silent-failure mode).
- **`remediation`** leads with **How to verify** (portal steps) + Scope+confidence + Still stuck?, and **POL-FB-001 emits the verbatim maker-facing data-sharing notice** for privacy documentation.

## Changes

- `scripts/flightcheck/checks/cloud_policy.py` — new module (POL-FB-001/002)
- `scripts/flightcheck/cli.py` — new `cloudpolicy` scope + full-scope wiring
- `tests/flightcheck/checks/test_cloud_policy.py` — 9 pure-logic tests
- `src/reference/ess-docs/flightcheck/{validation-matrix,remediation-guide}.md` — catalog rows + verbatim notice

## Acceptance-criteria notes

Satisfied: both checkpoints, category, HIGH priority; verbatim data-sharing notice in report + directive; named policies + portal deep link; role-aware directive; documented with verbatim notice in the reference.

Adapted: the per-group automated PASS/FAIL/WARN derivation is **not possible** (no reachable API), so it's delivered as MANUAL portal-verification guidance. The module documents how to promote to automated checks if the preview Graph Tenant Configuration Management API reaches GA.

## Testing

- 9 new tests; full flightcheck suite **304 passed**
- `ruff` clean
- `--scope cloudpolicy` renders both rows as Manual/High (overall READY)