### PR TITLE
Installer: auto-launch /setup in Copilot Chat via 'code chat'

### DIFF
--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -16,7 +16,8 @@
          (GitHub.copilot, GitHub.copilot-chat, ms-python.python).
       5. Clones the Employee-Self-Service-Agent-Developer-Kit repo to a known
          location (default: $env:USERPROFILE\source\Employee-Self-Service-Agent-Developer-Kit).
-      6. Opens the ess-maker-skills workspace in VS Code.
+      6. Opens the ess-maker-skills workspace in VS Code and automatically
+         requests `/setup` in Copilot Chat (requires VS Code 1.102+).
 
     The script is idempotent: re-run to repair a partial install.
 
@@ -946,17 +947,39 @@ if ($FlightCheckOnly) {
 # 7. Launch
 # ---------------------------------------------------------------------------
 if (-not $SkipLaunch) {
-    Write-Step 'Opening workspace in VS Code'
+    Write-Step 'Opening workspace in VS Code and requesting /setup in Copilot Chat'
     $code = Get-Command code -ErrorAction SilentlyContinue
     if ($code) {
-        Start-Process -FilePath $code.Source -ArgumentList @($workspace) | Out-Null
-        Write-Ok "Launched VS Code at $workspace"
+        # `code chat <prompt>` (VS Code 1.102+, June 2025) opens the chat panel
+        # in the workspace at the current working directory and submits the
+        # prompt. We Push-Location $workspace so it targets the kit folder.
+        # Note: exit 0 means "VS Code accepted the chat request," NOT that
+        # /setup actually ran. The user may still need to grant workspace trust
+        # and sign in to GitHub/Copilot before /setup executes.
+        Push-Location $workspace
+        try {
+            $chatOutput = Invoke-Native { & $code.Source chat '/setup' }
+            $chatExit = $LASTEXITCODE
+            foreach ($line in $chatOutput) { if ($line) { Write-Host "      $line" } }
+            if ($chatExit -ne 0) {
+                Write-Warn2 "'code chat' failed or is unsupported (exit $chatExit). Falling back to opening the workspace only."
+                Write-Warn2 "If you have an older VS Code (pre-1.102 / June 2025), update VS Code and re-run, or run /setup manually in Copilot Chat."
+                Start-Process -FilePath $code.Source -ArgumentList @($workspace) | Out-Null
+                Write-Ok "Launched VS Code at $workspace"
+                Write-Host "Next: in VS Code, open Copilot Chat and run /setup to connect Dataverse." -ForegroundColor Green
+            } else {
+                Write-Ok "Requested /setup in Copilot Chat at $workspace"
+                Write-Host "If VS Code prompts you to trust the workspace or sign in to GitHub/Copilot, accept those prompts and /setup will run." -ForegroundColor Yellow
+                Write-Host "If /setup does not start after trust/sign-in, open Copilot Chat manually and run /setup." -ForegroundColor Yellow
+            }
+        } finally { Pop-Location }
     } else {
         Write-Warn2 "code CLI not on PATH. Open this folder manually: $workspace"
+        Write-Host "Next: in VS Code, open Copilot Chat and run /setup to connect Dataverse." -ForegroundColor Green
     }
 } else {
     Write-Warn2 'Skipping launch per -SkipLaunch'
+    Write-Host "Next: in VS Code, open Copilot Chat and run /setup to connect Dataverse." -ForegroundColor Green
 }
 
 Write-Host "`nDone. Workspace: $workspace" -ForegroundColor Green
-Write-Host "Next: in VS Code, open Copilot Chat and run /setup to connect Dataverse." -ForegroundColor Green

--- a/setup/README.md
+++ b/setup/README.md
@@ -14,7 +14,7 @@ iex (irm https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-mac.sh)"
 ```
 
-Once complete, VS Code opens at `solutions/ess-maker-skills/`. Run `/setup` in Copilot Chat to connect your Dataverse environment.
+Once complete, VS Code opens at `solutions/ess-maker-skills/` and `/setup` is automatically requested in Copilot Chat. You'll be prompted to trust the workspace and sign in to GitHub/Copilot — accept these prompts and `/setup` will run and connect your Dataverse environment.
 
 > **GitHub Copilot subscription is required** for the in-editor maker experience. This script installs the toolchain and extension scaffolding; it does not grant the Copilot entitlement.
 

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -4,7 +4,8 @@
 #
 # Installs the full ESS Maker Kit toolchain on macOS:
 #   Homebrew, Python 3.12, Git, GitHub CLI, VS Code, Copilot extensions,
-#   pip dependencies, clones the repo, and launches VS Code.
+#   pip dependencies, clones the repo, launches VS Code, and auto-requests
+#   /setup in Copilot Chat (requires VS Code 1.102+).
 #
 # Usage (full maker kit):
 #   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/main/setup/bootstrap-mac.sh)"
@@ -442,20 +443,34 @@ with open(sys.argv[6], 'w', encoding='utf-8') as f:
 fi
 
 # ---------------------------------------------------------------------------
-# 8. Launch VS Code
+# 8. Launch VS Code and request /setup in Copilot Chat
 # ---------------------------------------------------------------------------
-step "Launching VS Code"
+step "Launching VS Code and requesting /setup in Copilot Chat"
 
 WORKSPACE_PATH="$REPO_PATH/solutions/ess-maker-skills"
 
 if [[ -n "$CODE_CMD" ]]; then
-    "$CODE_CMD" "$WORKSPACE_PATH"
-    ok "VS Code opened at $WORKSPACE_PATH"
+    # `code chat <prompt>` (VS Code 1.102+, June 2025) opens the chat panel in
+    # the workspace at the current working directory and submits the prompt.
+    # We cd into $WORKSPACE_PATH so it targets the kit folder.
+    # NOTE: exit 0 means "VS Code accepted the chat request," NOT that /setup
+    # actually ran. The user may still need to grant workspace trust and sign
+    # in to GitHub/Copilot before /setup executes.
+    if (cd "$WORKSPACE_PATH" && "$CODE_CMD" chat "/setup"); then
+        ok "Requested /setup in Copilot Chat at $WORKSPACE_PATH"
+        warn "If VS Code prompts you to trust the workspace or sign in to GitHub/Copilot, accept those prompts and /setup will run."
+        warn "If /setup does not start after trust/sign-in, open Copilot Chat manually and run /setup."
+    else
+        warn "'code chat' failed or is unsupported. Falling back to opening the workspace only."
+        warn "If you have an older VS Code (pre-1.102 / June 2025), update VS Code and re-run, or run /setup manually in Copilot Chat."
+        "$CODE_CMD" "$WORKSPACE_PATH" || warn "Could not launch VS Code. Open manually: $WORKSPACE_PATH"
+        echo "Next: in VS Code, open Copilot Chat and run /setup to connect your Dataverse environment."
+    fi
 else
     warn "Could not launch VS Code. Open manually: $WORKSPACE_PATH"
+    echo "Next: in VS Code, open Copilot Chat and run /setup to connect your Dataverse environment."
 fi
 
 echo ""
 echo -e "${GREEN}=== ESS Maker Kit ready! ===${NC}"
-echo "Open Copilot Chat in VS Code and run /setup to connect your Dataverse environment."
 echo ""

--- a/solutions/ess-maker-skills/.vscode/settings.json
+++ b/solutions/ess-maker-skills/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "git.openRepositoryInParentFolders": "never",
+  "workbench.startupEditor": "none",
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml",
     "editor.tabSize": 2

--- a/tests/scripts/test_installer_launch.py
+++ b/tests/scripts/test_installer_launch.py
@@ -1,0 +1,333 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Regression tests for the one-shot installer's auto-/setup launch behavior.
+
+PR #144 changed the final step of `setup/Install-EssAdk.ps1` (Windows) and
+`setup/install-ess-adk.sh` (macOS) from "open VS Code at the workspace" to
+"open VS Code at the workspace AND submit `/setup` in Copilot Chat" using the
+`code chat <prompt>` CLI subcommand shipped in VS Code 1.102 (June 2025).
+
+The behavioral guarantees we want to protect against accidental regression are:
+
+  1. The launcher invokes `code chat /setup` (not just `code <workspace>`).
+  2. The invocation runs from inside the kit workspace directory, because
+     `code chat` opens the chat panel in *whatever workspace VS Code resolves
+     from cwd* — if we don't cd into the workspace first the chat opens in
+     the wrong (or no) workspace and `/setup` either fails or runs against
+     the wrong folder.
+  3. There is a fallback path: when `code chat` exits non-zero (e.g. an
+     older VS Code that predates the subcommand), we still open the
+     workspace and print manual `/setup` instructions so the install does
+     not silently leave the user with no VS Code window.
+  4. The workspace's `.vscode/settings.json` suppresses the startup editor
+     so the Welcome tab does not sit in front of the chat prompt on
+     subsequent opens (`workbench.startupEditor: "none"`).
+
+These tests are static-text assertions: they read the installer scripts as
+text and assert the key patterns are present. They deliberately do not spawn
+the installers or stub `code` on PATH (the installers run network installs of
+Homebrew / Python / git / VS Code / pip deps — out of scope for unit tests,
+and the auto-launch step was already validated by hand on a freshly
+reinstalled VS Code per the PR conversation). The goal here is to catch a
+later refactor that removes or breaks any of (1)-(4) above.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PS1_PATH = REPO_ROOT / "setup" / "Install-EssAdk.ps1"
+BASH_PATH = REPO_ROOT / "setup" / "install-ess-adk.sh"
+README_PATH = REPO_ROOT / "setup" / "README.md"
+WORKSPACE_SETTINGS_PATH = (
+    REPO_ROOT / "solutions" / "ess-maker-skills" / ".vscode" / "settings.json"
+)
+
+
+@pytest.fixture(scope="module")
+def ps1_text() -> str:
+    return PS1_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def ps1_launch_section(ps1_text: str) -> str:
+    """The PowerShell installer's '# 7. Launch' section as a single string.
+
+    Slicing to just this section keeps the assertions tight: a coincidental
+    'code chat' string elsewhere in the file (e.g. a banner or comment in an
+    unrelated section) cannot satisfy these tests.
+    """
+    match = re.search(
+        r"# 7\. Launch\s*\r?\n.*?(?=\r?\n# -+\r?\n# \d+\.|\r?\nWrite-Host\s+\"`nDone\.)",
+        ps1_text,
+        flags=re.DOTALL,
+    )
+    assert match, "could not locate '# 7. Launch' section in Install-EssAdk.ps1"
+    return match.group(0)
+
+
+@pytest.fixture(scope="module")
+def bash_text() -> str:
+    return BASH_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def bash_launch_section(bash_text: str) -> str:
+    """The Bash installer's '# 8. Launch ...' section as a single string."""
+    match = re.search(
+        r"# 8\. Launch VS Code.*?(?=\r?\necho \"\"\r?\necho -e \"\$\{GREEN\}=== ESS Maker Kit ready)",
+        bash_text,
+        flags=re.DOTALL,
+    )
+    assert match, "could not locate '# 8. Launch VS Code' section in install-ess-adk.sh"
+    return match.group(0)
+
+
+# ---------------------------------------------------------------------------
+# PowerShell installer (Install-EssAdk.ps1)
+# ---------------------------------------------------------------------------
+
+
+class TestPowerShellInstallerAutoLaunch:
+    def test_launch_section_invokes_code_chat_with_setup_prompt(
+        self, ps1_launch_section: str
+    ) -> None:
+        """Guarantee (1): the launcher calls `code chat /setup`.
+
+        Matches `& $code.Source chat '/setup'` (or `"/setup"`), allowing the
+        wrapper to be `Invoke-Native` or any other call style. Without this
+        invocation we'd be back to just opening VS Code without firing /setup.
+        """
+        assert re.search(
+            r"\$code\.Source\s+chat\s+['\"]/setup['\"]",
+            ps1_launch_section,
+        ), (
+            "PowerShell installer no longer invokes `code chat /setup` in the "
+            "launch section — PR #144's auto-/setup behavior is broken."
+        )
+
+    def test_launch_section_pushes_into_workspace_before_chat(
+        self, ps1_launch_section: str
+    ) -> None:
+        """Guarantee (2): the chat call runs from inside $workspace.
+
+        `code chat` resolves the workspace from cwd, so the chat invocation
+        must be preceded by `Push-Location $workspace` (and balanced by a
+        `Pop-Location`). If somebody refactors to `& $code chat /setup`
+        without the cd, the chat panel will open in whatever directory the
+        installer was launched from — typically the user's home dir or a
+        bootstrap temp dir — and /setup either fails or runs against the
+        wrong workspace.
+        """
+        push_match = re.search(
+            r"^\s*Push-Location\s+\$workspace", ps1_launch_section, flags=re.MULTILINE
+        )
+        chat_match = re.search(
+            r"\$code\.Source\s+chat\s+['\"]/setup['\"]", ps1_launch_section
+        )
+        pop_match = re.search(r"^\s*\}?\s*finally\s*\{\s*Pop-Location", ps1_launch_section, flags=re.MULTILINE) or re.search(r"^\s*Pop-Location", ps1_launch_section, flags=re.MULTILINE)
+        assert push_match and chat_match and pop_match, (
+            "launch section must Push-Location into $workspace, then call "
+            "`code chat /setup`, then Pop-Location (none may be inside a comment)"
+        )
+        assert push_match.start() < chat_match.start() < pop_match.start(), (
+            "Push-Location $workspace must precede the chat invocation, and "
+            "Pop-Location must follow it"
+        )
+
+    def test_launch_section_falls_back_when_code_chat_fails(
+        self, ps1_launch_section: str
+    ) -> None:
+        """Guarantee (3): non-zero exit from `code chat` triggers a fallback.
+
+        The fallback must (a) still open VS Code at the workspace with
+        `Start-Process` and (b) tell the user to run /setup manually. Without
+        this branch, an older VS Code that doesn't understand the `chat`
+        subcommand would leave the user with no window and no instructions.
+        """
+        assert re.search(r"\$LASTEXITCODE", ps1_launch_section) or re.search(
+            r"\$chatExit", ps1_launch_section
+        ), "launch section must capture and check the exit code of `code chat`"
+        assert re.search(
+            r"Start-Process\s+-FilePath\s+\$code\.Source\s+-ArgumentList\s+@\(\$workspace\)",
+            ps1_launch_section,
+        ), (
+            "fallback branch must open VS Code at the workspace via "
+            "Start-Process when `code chat` fails"
+        )
+        assert re.search(
+            r"run\s+/setup\s+manually|open Copilot Chat.*run /setup",
+            ps1_launch_section,
+            flags=re.IGNORECASE,
+        ), (
+            "fallback branch must instruct the user how to run /setup "
+            "manually (older-VS-Code escape hatch)"
+        )
+
+    def test_skiplaunch_flag_still_short_circuits_the_launch_block(
+        self, ps1_launch_section: str
+    ) -> None:
+        """The -SkipLaunch flag must continue to bypass auto-/setup.
+
+        CI / unattended re-installs rely on -SkipLaunch to avoid opening
+        VS Code at all; if PR #144's launch rewrite accidentally removed the
+        gate, every CI run would try to spawn VS Code.
+        """
+        assert re.search(
+            r"if\s*\(\s*-not\s+\$SkipLaunch\s*\)", ps1_launch_section
+        ), "launch block must still be gated on -not $SkipLaunch"
+
+    def test_help_synopsis_documents_auto_setup_behavior(self, ps1_text: str) -> None:
+        """The script's comment-based help should mention the auto-/setup.
+
+        The synopsis is what users see when they run `Get-Help Install-EssAdk.ps1`.
+        If the implementation auto-launches /setup but the help still claims
+        it only opens the workspace, users won't know to expect the chat
+        panel.
+        """
+        assert re.search(
+            r"requests\s+`?/setup`?\s+in\s+Copilot\s+Chat",
+            ps1_text,
+            flags=re.IGNORECASE,
+        ), "Install-EssAdk.ps1 help comment should mention auto-/setup"
+
+
+# ---------------------------------------------------------------------------
+# Bash installer (install-ess-adk.sh)
+# ---------------------------------------------------------------------------
+
+
+class TestBashInstallerAutoLaunch:
+    def test_launch_section_invokes_code_chat_with_setup_prompt(
+        self, bash_launch_section: str
+    ) -> None:
+        """Guarantee (1) for macOS: the launcher calls `code chat /setup`."""
+        assert re.search(
+            r'"\$CODE_CMD"\s+chat\s+"/setup"', bash_launch_section
+        ), (
+            "Bash installer no longer invokes `$CODE_CMD chat /setup` in "
+            "the launch section — PR #144's auto-/setup behavior is broken."
+        )
+
+    def test_launch_section_cds_into_workspace_before_chat(
+        self, bash_launch_section: str
+    ) -> None:
+        """Guarantee (2) for macOS: the chat call runs from $WORKSPACE_PATH.
+
+        Bash uses a subshell + `&&` chain so the cd does not leak into the
+        rest of the installer's environment; the pattern must be
+        `(cd "$WORKSPACE_PATH" && "$CODE_CMD" chat "/setup")` (with optional
+        `if (...)` wrapper for set -e compatibility).
+        """
+        assert re.search(
+            r'\(\s*cd\s+"\$WORKSPACE_PATH"\s*&&\s*"\$CODE_CMD"\s+chat\s+"/setup"\s*\)',
+            bash_launch_section,
+        ), (
+            "Bash installer must wrap the chat invocation in a subshell "
+            "`(cd \"$WORKSPACE_PATH\" && \"$CODE_CMD\" chat \"/setup\")` so "
+            "the chat opens in the kit workspace"
+        )
+
+    def test_launch_section_falls_back_when_code_chat_fails(
+        self, bash_launch_section: str
+    ) -> None:
+        """Guarantee (3) for macOS: failure of `code chat` triggers a fallback.
+
+        Because the script runs under `set -euo pipefail`, the chat call must
+        be wrapped in an `if ...; then ...; else ...; fi` so a non-zero exit
+        from `code chat` does not abort the whole installer. The fallback
+        must still open VS Code at $WORKSPACE_PATH and surface manual
+        /setup instructions.
+        """
+        assert re.search(
+            r"if\s*\(\s*cd\s+\"\$WORKSPACE_PATH\"\s*&&\s*\"\$CODE_CMD\"\s+chat",
+            bash_launch_section,
+        ), (
+            "chat invocation must be inside an `if (...)` so set -e doesn't "
+            "abort the installer when `code chat` returns non-zero"
+        )
+        assert re.search(r"else\b", bash_launch_section), (
+            "launch section must include an `else` branch for the chat-failed "
+            "case"
+        )
+        assert re.search(
+            r'"\$CODE_CMD"\s+"\$WORKSPACE_PATH"', bash_launch_section
+        ), (
+            "fallback branch must still open VS Code at $WORKSPACE_PATH "
+            "(`\"$CODE_CMD\" \"$WORKSPACE_PATH\"`)"
+        )
+        assert re.search(
+            r"run\s+/setup",
+            bash_launch_section,
+            flags=re.IGNORECASE,
+        ), "fallback branch must instruct the user how to run /setup manually"
+
+    def test_header_comment_documents_auto_setup_behavior(self, bash_text: str) -> None:
+        """The script header should advertise the auto-/setup behavior."""
+        assert re.search(
+            r"/setup\s+in\s+Copilot\s+Chat", bash_text, flags=re.IGNORECASE
+        ), "install-ess-adk.sh header comment should mention auto-/setup"
+
+
+# ---------------------------------------------------------------------------
+# Workspace settings (suppress Welcome tab)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceSettingsSuppressWelcomeTab:
+    def test_settings_json_is_valid_json(self) -> None:
+        """settings.json must remain parseable — a broken JSON file would
+        cause VS Code to ignore *all* workspace settings, not just the new
+        one we added.
+        """
+        try:
+            json.loads(WORKSPACE_SETTINGS_PATH.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover — descriptive failure
+            pytest.fail(f"{WORKSPACE_SETTINGS_PATH} is not valid JSON: {exc}")
+
+    def test_startup_editor_is_none(self) -> None:
+        """Guarantee (4): the workspace suppresses the Welcome tab.
+
+        Without this setting, every `code chat /setup` run that reuses an
+        existing window would show the Welcome tab on top of the chat panel
+        on subsequent opens, hiding the /setup prompt.
+
+        Note: this setting does NOT suppress the application-level first-run
+        Welcome on a brand-new VS Code install (that's gated by global
+        state, not workspace settings). It does suppress the tab on every
+        subsequent open of the kit workspace, which is the common case.
+        """
+        settings = json.loads(WORKSPACE_SETTINGS_PATH.read_text(encoding="utf-8"))
+        assert settings.get("workbench.startupEditor") == "none", (
+            'workspace settings.json must set "workbench.startupEditor": '
+            '"none" so the Welcome tab does not sit on top of the /setup '
+            "chat prompt"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Documentation (setup/README.md)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupReadmeDocumentsAutoLaunch:
+    def test_readme_mentions_auto_setup(self) -> None:
+        """setup/README.md should tell users to expect /setup to auto-run.
+
+        Otherwise users will be confused when the chat panel pops up
+        unprompted, or will manually re-run /setup and end up with two
+        in-flight requests.
+        """
+        text = README_PATH.read_text(encoding="utf-8")
+        assert re.search(
+            r"automatically\s+(?:run|launch|request|open).*?/setup|/setup.*?(?:automatically|auto-?(?:run|launch))",
+            text,
+            flags=re.IGNORECASE | re.DOTALL,
+        ), "setup/README.md should mention that /setup runs automatically"


### PR DESCRIPTION
## Summary

Auto-launches `/setup` in Copilot Chat at the end of the one-shot installer instead of leaving the user with "Next: in VS Code, open Copilot Chat and run /setup."

## Approach

Uses the **`code chat <prompt>`** CLI subcommand built into VS Code 1.102+ (June 2025), which opens the chat panel in the workspace at the current working directory and submits the prompt (calls `chatWidget.acceptInput()` internally — not just pre-fill). Discovered via reading `src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts` and `src/vs/platform/environment/node/argv.ts`.

`code chat` does a workspace-trust gate first; the user is prompted to trust the workspace, then `/setup` runs in chat.

## Changes

### `setup/Install-EssAdk.ps1` (Windows)
- Section 7 ("Launch") now does `Push-Location $workspace; & code chat ''/setup''; Pop-Location` (wrapped in `Invoke-Native` to match the rest of the script''s pattern), instead of `Start-Process code <workspace>`.
- Default window-targeting behavior (not `--new-window`) so re-runs reuse an existing window at the same workspace.
- **Falls back** to the old "open workspace only" behavior on any non-zero exit (e.g. pre-1.102 VS Code where `code chat` doesn''t exist).
- **Messaging is honest:** success message says `Requested /setup in Copilot Chat` (not "ran"), because exit 0 only means "VS Code accepted the chat request" — the user may still need to grant trust + sign in before `/setup` actually executes. Yellow follow-up lines tell them what to expect and how to manually run `/setup` if it doesn''t auto-fire.

### `setup/install-ess-adk.sh` (macOS)
- Mirrors the Windows behavior.
- Wraps the `code chat` call in `if (cd && code chat); then` so `set -euo pipefail` doesn''t abort the script on a non-zero exit — the fallback branch handles it cleanly.

### `solutions/ess-maker-skills/.vscode/settings.json`
- Adds `"workbench.startupEditor": "none"` so the Welcome editor doesn''t compete with the Copilot Chat panel on subsequent workspace opens.
- **Caveat:** This does NOT suppress VS Code''s one-time first-run experience (telemetry/walkthrough). On a brand-new VS Code install the user still sees that gate once, closes it, and `/setup` then runs. It''s an application-level gate that ignores workspace settings.

### `setup/README.md` + script doc-comments
- Updated to reflect the new auto-`/setup` flow.

## Validation (live)

Tested on Windows 11, uninstalled VS Code, wiped all leftover user data (`%APPDATA%\Code`, `~\.vscode`, `~\.vscode-shared`), reinstalled via winget (got 1.124.0, well past 1.102), then ran:

```powershell
Push-Location <kit-workspace>
& code chat "/setup"
```

Observed:
- ✅ `code chat --help` confirms the subcommand exists with documented options.
- ✅ Exit code `0`.
- ✅ VS Code launched with workspace title `ess-maker-skills`.
- ✅ **GitHub Copilot sign-in pop-up appeared** — this is the proof that the chat handler ran end-to-end (Copilot Chat needed auth to handle `/setup`).
- ✅ On subsequent opens (with `workbench.startupEditor: "none"` applied), no Welcome tab in the editor.
- ⚠️ On the very first launch of a brand-new VS Code install, the one-time first-run walkthrough still appeared (closing it once allowed `/setup` to proceed).

PS parse-check and `bash -n` both clean.

## Trade-offs considered (and rejected)

- **`--new-window`**: would create a duplicate window when the user already has the workspace open (e.g., re-running the installer). Default behavior — reuse a window at the same workspace, else open a new one — is friendlier.
- **`code chat --help` feature-probe before invocation**: adds a round-trip; the failure path already handles unsupported VS Code versions cleanly.
- **`.vscode/tasks.json` with `runOn: folderOpen`**: tasks can only run shell commands, not VS Code internal commands like `workbench.action.chat.open`.
- **Markdown welcome file with `command:workbench.action.chat.open?...` link**: requires a click; not actually more automatic.
- **Pre-granting workspace trust via repo settings**: defeats VS Code''s security model and isn''t honored from a workspace-level config anyway.