### PR TITLE
fix(flightcheck-skill): stop opening the report twice

### DIFF
--- a/solutions/ess-maker-skills/src/skills/flightcheck/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/flightcheck/SKILL.md
@@ -73,12 +73,12 @@ python scripts/flightcheck/cli.py --scope {SCOPE}
 
 Wait for the script to finish.
 
-Then open the HTML report in the user's default browser. Use Python to
-handle paths with spaces correctly:
-
-```
-python -c "import webbrowser, os; webbrowser.open('file:///' + os.path.abspath('workspace/flightcheck/report.html').replace(os.sep, '/'))"
-```
+`cli.py` automatically opens the HTML report (`workspace/flightcheck/report.html`)
+in the user's default browser when it finishes. **Do not open it yourself** — a
+second `webbrowser.open` / `Start-Process` would launch a duplicate tab pointing
+at the same file. If the report does not appear (Codespaces, headless box, or
+the user passed `--no-open`), tell them to open it manually from the file
+explorer rather than spawning another tab from this skill.
 
 ---
 
@@ -209,11 +209,9 @@ After all auto-fixes complete, re-run flightcheck:
 python scripts/flightcheck/cli.py --scope {SCOPE}
 ```
 
-Open the updated report:
-
-```
-Start-Process "workspace/flightcheck/report.html"
-```
+`cli.py` reopens the updated report in the browser automatically — **do not run
+`Start-Process` or `webbrowser.open` yourself**, or the user will end up with
+two tabs of the same report.
 
 Then present the new results using the same format (3a → 3b → 3c).
 


### PR DESCRIPTION
## What this fixes

When running `/flightcheck` from Copilot Chat, **two browser tabs** would open at the end, both pointing at the same `workspace/flightcheck/report.html`. A teammate flagged this as "the flight check installer opens 2 tabs" — the installer itself is fine; the duplicate is in the chat skill.

## Root cause

`SKILL.md` (the `/flightcheck` chat skill) tells the assistant to run `cli.py` AND THEN explicitly open the report with `webbrowser.open` / `Start-Process`. The second step is redundant: `cli.py` already calls `open_report_in_browser(args.output)` at the end of `main()` ([`scripts/flightcheck/cli.py:320`](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/blob/main/solutions/ess-maker-skills/scripts/flightcheck/cli.py#L320)), which fires `webbrowser.open()` on the same file.

Two affected sites in `SKILL.md`:
- **Step 2** (post-cli.py-run): `python -c "import webbrowser, os; webbrowser.open(...)"`
- **Step 4** (re-run after auto-fix): `Start-Process "workspace/flightcheck/report.html"`

## How this regressed

Git blame is clean — the bug is a timing collision between two individually-correct changes:

| When | Commit | What |
|---|---|---|
| 2026-05-07 | [`0ea94f59`](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/commit/0ea94f59) (PR #7) | SKILL.md added with explicit browser-open. At the time, `cli.py` did NOT auto-open the report, so the skill had to. |
| 2026-06-09 | [`40519300`](https://github.com/microsoft/Employee-Self-Service-Agent-Developer-Kit/commit/40519300) | Added `open_report_in_browser` to `cli.py` so direct CLI users (FlightCheck-only installer, anyone invoking `cli.py` outside chat) get the report popped open too. The SKILL.md duplicate path was missed. |

## Fix

Remove the explicit `webbrowser.open` / `Start-Process` lines from both step 2 and the post-auto-fix re-run. Replace with a brief explainer + an explicit **"do not open it yourself"** warning so Copilot doesn't re-introduce the second open out of helpful instinct.

`cli.py` is already cross-platform-safe for paths with spaces / OneDrive / non-ASCII (uses `Path.as_uri()`), so removing the skill-side handler loses nothing in coverage.

If the report ever fails to appear (Codespaces, headless boxes, or someone passing `--no-open`), the skill now instructs the user to open it manually from the file explorer rather than spawning another tab from chat.

## Scope of impact

- **`/flightcheck` in Copilot Chat**: was double-opening every run → now opens once. ✅
- **FlightCheck-only installer** (`Install-EssAdk.ps1 -FlightCheckOnly`, `install-ess-adk.sh`, `bootstrap-flightcheck.ps1`): unaffected by this bug — invokes `cli.py` once and gets one tab. ✅
- **Direct `python scripts/flightcheck/cli.py --scope full`**: unaffected, gets one tab from `cli.py`. ✅
- **`--no-open`**: unaffected, still suppresses the tab (used by Codespaces). ✅

## Diff

One file, +9 / -11:
- `solutions/ess-maker-skills/src/skills/flightcheck/SKILL.md`
