### PR TITLE
Add per-check Role (next-step owner) to FlightCheck

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
+++ b/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
@@ -238,6 +238,12 @@ When a single constructor's status is conditional (e.g.
 `roles`: the report shows it only when the row actually lands on an
 actionable status.
 
+For uniformity (and because a regression test enforces it — see
+`tests/flightcheck/test_check_roles.py`), set `roles` on **every**
+`CheckResult` constructor, including pure-SKIPPED branches, even though
+the renderer blanks the Role cell on Passed/Skipped rows. Use the role
+that would own the fix if the check were actionable.
+
 The seven roles (`Role.<NAME>.value`):
 
 | Role | Owns checks whose fix happens in… |

--- a/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
+++ b/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
@@ -185,7 +185,7 @@ check function:
   guard before use (e.g. `if not runner.graph: return skipped`).
 - Returns `list[CheckResult]`.
 - Each result has `checkpoint_id`, `category`, `priority`, `status`,
-  `description`, `result`, optional `remediation` and `doc_link`.
+  `description`, `result`, `roles`, optional `remediation` and `doc_link`.
 - Maps cleanly to good-state / bad-state / partial-state branches.
 
 Runner attributes available to checks (set up by `cli.py`):
@@ -203,7 +203,7 @@ Runner attributes available to checks (set up by `cli.py`):
 Minimal example:
 
 ```python
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Status, Priority, Role
 
 def run_my_checks(runner) -> list[CheckResult]:
     results = []
@@ -216,9 +216,45 @@ def run_my_checks(runner) -> list[CheckResult]:
         description="Thing is set up correctly",
         result="Found N things",
         remediation="",  # only needed for non-pass statuses
+        roles=[Role.ESS_MAKER.value],  # who owns the fix if this can fail
     ))
     return results
 ```
+
+### Assigning `roles` (the next-step owner)
+
+`roles` is a `list[str]` of `Role` enum values naming **every admin
+persona who must take the next action** to FIX a failing/errored check
+OR PERFORM the manual validation of a MANUAL / NOT_CONFIGURED result.
+It surfaces as a "Role" column in the HTML report and `results.json`,
+and on the terminal action/manual rows.
+
+**Set `roles` on any check that can produce a Failed, Error, Warning,
+Manual, or NotConfigured result.** A row that only ever Passes or is
+Skipped has no next step, so it needs no role — the report blanks the
+Role cell for Passed/Skipped rows regardless of what the field holds.
+When a single constructor's status is conditional (e.g.
+`Status.PASSED.value if connected else Status.FAILED.value`), still set
+`roles`: the report shows it only when the row actually lands on an
+actionable status.
+
+The seven roles (`Role.<NAME>.value`):
+
+| Role | Owns checks whose fix happens in… |
+|------|-----------------------------------|
+| `Role.ENTRA_ADMIN` | Entra ID: app registrations, enterprise apps, SAML, conditional access, directory-role assignment |
+| `Role.M365_ADMIN` | Microsoft 365 admin center: license/SKU assignment, Office Cloud Policies, Graph connectors, Integrated-apps approval |
+| `Role.POWER_PLATFORM_ADMIN` | Power Platform: environments, DLP, connections, solution import, cloud-flow state, Dataverse env vars |
+| `Role.WORKDAY_ADMIN` | The Workday tenant: ISU accounts, security groups, domain permissions, RaaS, auth policies |
+| `Role.SERVICENOW_ADMIN` | The ServiceNow instance: service accounts, roles, ACLs |
+| `Role.SAP_ADMIN` | The SAP SuccessFactors tenant |
+| `Role.ESS_MAKER` | Local agent files the maker authors: topics, variables, template configs, evaluations, publishing/QA gates |
+
+A check may need more than one role (e.g. a Workday SAML signing cert
+lives on the Entra app but is compared in the Workday tenant ->
+`[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value]`). Pick the role(s)
+from WHO performs the fix described in `remediation`, not from the
+category alone.
 
 ### 4. Write the test BEFORE you ship
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/authentication.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/authentication.py
@@ -9,7 +9,7 @@ Checks Entra ID configuration, SSO, Conditional Access, user sync.
 
 import json
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 from ._saml_utils import (
     WORKDAY_SAML_SP_FILTER,
     WORKDAY_SSO_TUTORIAL_DOC,
@@ -28,7 +28,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
     try:
         org = graph.get_organization()
         if org and "displayName" in org:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="AUTH-001", category="Authentication",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Microsoft Entra ID configured",
@@ -36,7 +36,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="AUTH-001", category="Authentication",
                 priority=Priority.CRITICAL.value, status=Status.FAILED.value,
                 description="Microsoft Entra ID configured",
@@ -45,7 +45,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id="AUTH-001", category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Microsoft Entra ID",
@@ -61,7 +61,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 p for p in policies
                 if p.get("state") == "enabledForReportingButNotEnforced"
             ]
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="AUTH-002", category="Authentication",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="Conditional Access policies",
@@ -73,7 +73,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="AUTH-002", category="Authentication",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description="Conditional Access policies",
@@ -82,7 +82,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id="AUTH-002", category="Authentication",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Conditional Access policies",
@@ -94,7 +94,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
     try:
         users = graph.get_users_sample(top=10)
         if users:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="AUTH-004", category="Authentication",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="User identity synchronization",
@@ -102,7 +102,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="AUTH-004", category="Authentication",
                 priority=Priority.HIGH.value, status=Status.FAILED.value,
                 description="User identity synchronization",
@@ -111,7 +111,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id="AUTH-004", category="Authentication",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="User identity sync",
@@ -232,7 +232,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
     doc_link = f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso"
 
     if not graph:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.SKIPPED.value,
             description=description,
@@ -242,7 +242,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
     try:
         template_ids = _resolve_workday_template_ids(graph)
     except Exception as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description=description,
@@ -258,7 +258,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
         )]
 
     if not template_ids:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description=description,
@@ -286,7 +286,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
         filter_clause = f"({template_clause})"
         sps = graph.get_service_principals(filter_expr=filter_clause)
     except Exception as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description=description,
@@ -299,7 +299,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
         )]
 
     if not sps:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.SKIPPED.value,
             description=description,
@@ -469,7 +469,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
     # If you change either the renderer keying or the buckets here,
     # update both ends together.
     if failed_items:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.FAILED.value,
             description=description,
@@ -479,7 +479,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
         ))
 
     if warning_items:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description=description,
@@ -489,7 +489,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
         ))
 
     if passed_items:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category="Authentication",
             priority=Priority.CRITICAL.value, status=Status.PASSED.value,
             description=description,
@@ -561,7 +561,7 @@ def _run_saml_nameid_check(runner) -> list[CheckResult]:
 
     graph = getattr(runner, "graph", None)
     if graph is None:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -585,7 +585,7 @@ def _run_saml_nameid_check(runner) -> list[CheckResult]:
             raise_on_permission_error=True,
         )
     except PermissionError as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -603,7 +603,7 @@ def _run_saml_nameid_check(runner) -> list[CheckResult]:
             doc_link=doc_link,
         )]
     except Exception as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -616,7 +616,7 @@ def _run_saml_nameid_check(runner) -> list[CheckResult]:
         )]
 
     if not workday_sps:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description=description,
@@ -650,7 +650,7 @@ def _run_saml_nameid_check(runner) -> list[CheckResult]:
         f"/servicePrincipals/{first_sp_id}/claimsMappingPolicies"
     )
     if cmp_probe.get("_status") in (401, 403):
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -733,7 +733,7 @@ def _run_saml_nameid_check(runner) -> list[CheckResult]:
             + " (likely missing Policy.Read.All consent)."
         )
 
-    return [CheckResult(
+    return [CheckResult(roles=[Role.ENTRA_ADMIN.value],
         checkpoint_id=cp_id, category=category,
         priority=Priority.HIGH.value, status=Status.MANUAL.value,
         description=description,

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/cloud_policy.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/cloud_policy.py
@@ -62,7 +62,7 @@ add an OCPS client, and replace the MANUAL bodies with effective-per-group
 PASS/FAIL/WARN logic.
 """
 
-from ..runner import CheckResult, Priority, Status
+from ..runner import CheckResult, Priority, Role, Status
 
 # Checkpoint identifiers.
 POL_FB_FEEDBACK = "POL-FB-001"
@@ -208,6 +208,7 @@ def check_feedback_enabled(runner) -> CheckResult:
             notice=MAKER_NOTICE,
         ),
         doc_link=DOC_LINK,
+        roles=[Role.M365_ADMIN.value],
     )
 
 
@@ -251,6 +252,7 @@ def check_feedback_attachments(runner) -> CheckResult:
             still_stuck=still_stuck,
         ),
         doc_link=DOC_LINK,
+        roles=[Role.M365_ADMIN.value],
     )
 
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/connections.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/connections.py
@@ -12,7 +12,7 @@ environment.py, and any future connector-specific check modules.
 
 from __future__ import annotations
 
-from ..runner import CheckResult, Priority, Status
+from ..runner import CheckResult, Priority, Role, Status
 
 
 def get_connection_status(conn: dict) -> str:
@@ -104,6 +104,7 @@ def check_connector_connections(
             status=Status.SKIPPED.value,
             description=f"{category} connections",
             result="Power Platform Admin API not available — skipping connection checks",
+            roles=[Role.POWER_PLATFORM_ADMIN.value],
         ))
         return results
 
@@ -118,6 +119,7 @@ def check_connector_connections(
                 description=f"{category} connections",
                 result=f"Unable to list connections: {all_conns['_error']}",
                 remediation="Requires Power Platform Admin role.",
+                roles=[Role.POWER_PLATFORM_ADMIN.value],
             ))
             return results
 
@@ -136,6 +138,7 @@ def check_connector_connections(
                 result=f"{len(conns)} total — {len(connected)} connected, {len(errored)} errored",
                 remediation="Re-authenticate errored connections in Power Platform." if errored else "",
                 doc_link=doc_link,
+                roles=[Role.POWER_PLATFORM_ADMIN.value],
             ))
 
             for i, c in enumerate(conns):
@@ -151,6 +154,7 @@ def check_connector_connections(
                     description=f"Connection: {name}",
                     result=f"Status: {status}",
                     remediation=f"Re-authenticate '{name}' in Power Platform." if status != "Connected" else "",
+                    roles=[Role.POWER_PLATFORM_ADMIN.value],
                 ))
         else:
             results.append(CheckResult(
@@ -162,6 +166,7 @@ def check_connector_connections(
                 result=f"No {category} connections found",
                 remediation=not_found_remediation,
                 doc_link=doc_link,
+                roles=[Role.POWER_PLATFORM_ADMIN.value],
             ))
     except Exception as e:
         results.append(CheckResult(
@@ -171,6 +176,7 @@ def check_connector_connections(
             status=Status.WARNING.value,
             description=f"{category} connections",
             result=f"Unable to check: {e}",
+            roles=[Role.POWER_PLATFORM_ADMIN.value],
         ))
 
     return results

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -9,7 +9,7 @@ Checks Power Platform environment, Dataverse, DLP policies, and related config.
 
 import uuid
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 from ._maker_urls import (
     maker_connections_url,
     maker_solution_url,
@@ -210,7 +210,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
     results: list[CheckResult] = []
 
     if not env_id:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-001", category="Environment",
             priority=Priority.CRITICAL.value, status=Status.FAILED.value,
             description="Power Platform environment exists",
@@ -223,7 +223,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
     try:
         env = pp.get_environment(env_id)
         if "_error" in env:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-001", category="Environment",
                 priority=Priority.CRITICAL.value, status=Status.WARNING.value,
                 description="Power Platform environment exists",
@@ -235,7 +235,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
 
         props = env.get("properties", {})
         display_name = props.get("displayName", env_id)
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-001", category="Environment",
             priority=Priority.CRITICAL.value, status=Status.PASSED.value,
             description="Power Platform environment exists",
@@ -251,7 +251,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
         # Also check databaseType
         db_type = props.get("databaseType", "")
         if db_state.lower() == "succeeded" or db_type:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-002", category="Environment",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Dataverse database provisioned",
@@ -259,7 +259,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prepare#set-up-your-power-platform-environment",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-002", category="Environment",
                 priority=Priority.CRITICAL.value, status=Status.FAILED.value,
                 description="Dataverse database provisioned",
@@ -270,7 +270,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
 
         # ---- ENV-003: Environment type ----
         env_type = props.get("environmentSku", "")
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-003", category="Environment",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Environment type",
@@ -279,7 +279,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
         ))
 
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-001", category="Environment",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Power Platform environment",
@@ -294,7 +294,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
     try:
         policies = pp.get_dlp_policies_for_env(env_id)
         if policies:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-008", category="Environment",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="DLP policies configured",
@@ -313,7 +313,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
             # groups cannot be combined in a single flow/agent action,
             # so "allowlisting" really means group-coexistence, not
             # just "unblock".
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-008", category="Environment",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description="DLP policies configured",
@@ -330,7 +330,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prepare#allow-the-external-systems-connector",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-008", category="Environment",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="DLP policies",
@@ -392,7 +392,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
     dv_token = getattr(runner, "dv_token", None)
 
     if not pp or not env_id:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-004", category="Environment",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Connections & connection references",
@@ -402,7 +402,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         return results
 
     if not env_url or not dv_token:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-004", category="Environment",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Connections & connection references",
@@ -415,7 +415,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
     try:
         all_conns = pp.get_connections(env_id)
         if isinstance(all_conns, dict) and "_error" in all_conns:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-004", category="Environment",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description="Connections & connection references",
@@ -424,7 +424,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
             ))
             return results
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-004", category="Environment",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Connections & connection references",
@@ -447,7 +447,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
             "connectorid,connectionid,connectionreferencedisplayname,statuscode",
         )
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-004", category="Environment",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Connections & connection references",
@@ -589,7 +589,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         if overall_status == Status.FAILED.value
         else f"{DOC_BASE}/prepare#set-up-your-power-platform-environment"
     )
-    results.append(CheckResult(
+    results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
         checkpoint_id="ENV-004", category="Environment",
         priority=Priority.HIGH.value, status=overall_status,
         description="Connections & connection references",
@@ -605,7 +605,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         )
         dead_conn_id = ref.get("connectionid", "?")
         sol_url, sol_label = _solution_link_parts(ref, solution_info, solutions_url)
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id=f"ENV-004-OR-{i + 1:03d}", category="Environment",
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description=f"Orphan reference: {ref_name}",
@@ -624,7 +624,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
             "connectionreferencelogicalname", "Unknown"
         )
         sol_url, sol_label = _solution_link_parts(ref, solution_info, solutions_url)
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id=f"ENV-004-UR-{i + 1:03d}", category="Environment",
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description=f"Unbound reference: {ref_name}",
@@ -651,7 +651,7 @@ def _check_connections_and_refs(runner) -> list[CheckResult]:
         api_id = props.get("apiId", "")
         connector_label = api_id.split("/")[-1] if api_id else "unknown"
         conn_status = get_connection_status(conn)
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id=f"ENV-004-UC-{i + 1:03d}", category="Environment",
             priority=Priority.MEDIUM.value, status=Status.WARNING.value,
             description=f"Unbound connection: {conn_name}",
@@ -810,7 +810,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
     token = getattr(runner, "dv_token", None)
 
     if not env_url or not token:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-009", category="Environment",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=_PREFSOL_DESCRIPTION,
@@ -827,7 +827,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
             _ELIGIBLE_SOLUTION_FILTER,
         )
         if not solutions:
-            return [CheckResult(
+            return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-009", category="Environment",
                 priority=Priority.HIGH.value, status=Status.FAILED.value,
                 description=_PREFSOL_DESCRIPTION,
@@ -901,7 +901,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
                         publisher_prefix = publisher.get(
                             "customizationprefix"
                         ) or "<unknown>"
-                        return [CheckResult(
+                        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                             checkpoint_id="ENV-009", category="Environment",
                             priority=Priority.HIGH.value,
                             status=Status.WARNING.value,
@@ -944,7 +944,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
                 else:
                     publisher_suffix = ""
 
-                return [CheckResult(
+                return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                     checkpoint_id="ENV-009", category="Environment",
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=_PREFSOL_DESCRIPTION,
@@ -961,7 +961,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
         # solution outside the eligible set (e.g. a managed solution or
         # Default). Both collapse into the same hardening warning - the action
         # is identical.
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-009", category="Environment",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=_PREFSOL_DESCRIPTION,
@@ -984,7 +984,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
         )]
 
     except AuthExpiredError as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-009", category="Environment",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=_PREFSOL_DESCRIPTION,
@@ -999,7 +999,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
         # distinguishable from a 5xx (transient) at a glance (PR #128 review).
         status_code = getattr(getattr(e, "response", None), "status_code", None)
         status_hint = f" [HTTP {status_code}]" if status_code is not None else ""
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="ENV-009", category="Environment",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=_PREFSOL_DESCRIPTION,

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/external_systems.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/external_systems.py
@@ -8,7 +8,7 @@ Discovers installed integration solutions by scanning flows for name patterns.
 Solution-scoped: uses agent name to filter relevant flows.
 """
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 
@@ -55,7 +55,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
     try:
         all_flows = pp.get_flows(env_id)
         if isinstance(all_flows, dict) and "_error" in all_flows:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="EXT-001", category="External Systems",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description="Flow inventory",
@@ -64,7 +64,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             ))
             return results
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="EXT-001", category="External Systems",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Flow inventory",
@@ -79,7 +79,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
     wd_flows = _match_flows(all_flows, WORKDAY_PATTERNS)
     runner._workday_flows = wd_flows
     if wd_flows:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-001", category="External Systems",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Workday solution installed",
@@ -87,7 +87,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             doc_link=f"{DOC_BASE}/workday",
         ))
     else:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-001", category="External Systems",
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description="Workday solution installed",
@@ -110,7 +110,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             detail += f", {len(other)} other"
         if hrsd or itsm or other:
             detail += ")"
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SN-001", category="External Systems",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="ServiceNow solution installed",
@@ -118,7 +118,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             doc_link=f"{DOC_BASE}/servicenow",
         ))
     else:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SN-001", category="External Systems",
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description="ServiceNow solution installed",
@@ -131,7 +131,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
     sap_flows = _match_flows(all_flows, SAP_PATTERNS)
     runner._sap_flows = sap_flows
     if sap_flows:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SAP-001", category="External Systems",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="SAP SuccessFactors solution installed",
@@ -139,7 +139,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             doc_link=f"{DOC_BASE}/sap-successfactors",
         ))
     else:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SAP-001", category="External Systems",
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description="SAP SuccessFactors solution installed",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/graph_connector_kb.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/graph_connector_kb.py
@@ -70,7 +70,7 @@ verified against the public CSDL at
 
 from __future__ import annotations
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 
 DOC_BASE = "https://learn.microsoft.com/graph/api"
 
@@ -135,7 +135,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
     # client. Surface as WARNING (not skipped) — the customer DID opt
     # into the at-risk path, so silence would defeat the point.
     if not graph:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="EXT-002",
             category="Graph Connector KB",
             priority=Priority.HIGH.value,
@@ -158,7 +158,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
     try:
         connections = graph.get_external_connections()
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="EXT-002",
             category="Graph Connector KB",
             priority=Priority.HIGH.value,
@@ -208,7 +208,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
 
         if not ref:
             failed.append(display)
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id=cid,
                 category="Graph Connector KB",
                 priority=Priority.HIGH.value,
@@ -239,7 +239,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
                 fetched = graph.get_external_connection(ref)
             except Exception as e:
                 failed.append(display)
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                     checkpoint_id=cid,
                     category="Graph Connector KB",
                     priority=Priority.HIGH.value,
@@ -250,7 +250,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
                 continue
             if isinstance(fetched, dict) and fetched.get("_status") == 404:
                 failed.append(display)
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                     checkpoint_id=cid,
                     category="Graph Connector KB",
                     priority=Priority.HIGH.value,
@@ -271,7 +271,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
                 continue
             if isinstance(fetched, dict) and fetched.get("_status") in (401, 403):
                 warned.append(display)
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                     checkpoint_id=cid,
                     category="Graph Connector KB",
                     priority=Priority.HIGH.value,
@@ -297,7 +297,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
 
         if state in _NON_READY_STATES:
             failed.append(display)
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id=cid,
                 category="Graph Connector KB",
                 priority=Priority.HIGH.value,
@@ -314,7 +314,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
         if state and state != "ready":
             # Unknown state — WARNING so we learn about new states.
             warned.append(display)
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id=cid,
                 category="Graph Connector KB",
                 priority=Priority.HIGH.value,
@@ -334,7 +334,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
         op_status = _latest_operation_status(graph, connection_id)
         if op_status == "completed":
             passed.append(display)
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id=cid,
                 category="Graph Connector KB",
                 priority=Priority.HIGH.value,
@@ -359,7 +359,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
                 op_failed_remediation = _delete_and_recreate_remediation(
                     connection_id, connection_name
                 )
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id=cid,
                 category="Graph Connector KB",
                 priority=Priority.HIGH.value,
@@ -377,7 +377,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
             ))
         elif op_status == "inprogress":
             warned.append(display)
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id=cid,
                 category="Graph Connector KB",
                 priority=Priority.HIGH.value,
@@ -414,7 +414,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
 
             if is_gallery:
                 warned.append(display)
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                     checkpoint_id=cid,
                     category="Graph Connector KB",
                     priority=Priority.HIGH.value,
@@ -434,7 +434,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
                 ))
             elif ingested > 0:
                 warned.append(display)
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                     checkpoint_id=cid,
                     category="Graph Connector KB",
                     priority=Priority.HIGH.value,
@@ -460,7 +460,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
                 ))
             else:
                 failed.append(display)
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                     checkpoint_id=cid,
                     category="Graph Connector KB",
                     priority=Priority.HIGH.value,
@@ -502,7 +502,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
         result_text = f"{total} Graph Connector knowledge source(s) ready"
         summary_remediation = ""
 
-    results.insert(0, CheckResult(
+    results.insert(0, CheckResult(roles=[Role.M365_ADMIN.value],
         checkpoint_id="EXT-002",
         category="Graph Connector KB",
         priority=Priority.HIGH.value,
@@ -519,7 +519,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
     # NOT_CONFIGURED with concrete pointers so the operator knows what
     # to verify in the portal — silence here would let the most cited
     # silent-failure mode for Graph Connector KBs ship unchecked.
-    results.append(CheckResult(
+    results.append(CheckResult(roles=[Role.M365_ADMIN.value],
         checkpoint_id="EXT-002-ACL",
         category="Graph Connector KB",
         priority=Priority.HIGH.value,

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/licensing.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/licensing.py
@@ -84,7 +84,7 @@ from auth import (
     retrieve_shared_principals_and_access,
 )
 
-from ..runner import CheckResult, Priority, Status
+from ..runner import CheckResult, Priority, Role, Status
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 PA_LICENSING_FAQ = (
@@ -188,7 +188,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
     all_flow_ids = {fid for ids in refs_by_agent.values() for fid in ids}
 
     if not all_flow_ids:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="LIC-FLOW-001", category="Licensing",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Agent flow licensing",
@@ -197,7 +197,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
         )]
 
     if not pp or not env_id:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="LIC-FLOW-001", category="Licensing",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Agent flow licensing",
@@ -247,7 +247,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
         # resolved — we can't assert anything, so SKIP (mirrors the
         # no-pp_admin branch) rather than falsely PASS.
         if auth_blocked and standard_count == 0:
-            return [CheckResult(
+            return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="LIC-FLOW-001", category="Licensing",
                 priority=Priority.HIGH.value, status=Status.SKIPPED.value,
                 description="Agent flow licensing",
@@ -270,7 +270,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
         # premium-connector flow may be hidden among the unreadable ones, so
         # this can't be a clean PASS.
         if auth_blocked:
-            return [CheckResult(
+            return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="LIC-FLOW-001", category="Licensing",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description="Agent flow licensing",
@@ -285,7 +285,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
                 ),
                 doc_link=PA_LICENSING_FAQ,
             )]
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="LIC-FLOW-001", category="Licensing",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Agent flow licensing",
@@ -324,7 +324,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
         "[Power Automate](https://make.powerautomate.com/). LIC-FLOW-002 verifies the "
         "shared-with users' licenses."
     )
-    return [CheckResult(
+    return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
         checkpoint_id="LIC-FLOW-001", category="Licensing",
         priority=Priority.HIGH.value, status=Status.WARNING.value,
         description="Agent flow licensing",
@@ -511,7 +511,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
     bot_ids = _bot_ids(runner)
 
     if not graph or not env_url or not dv_token:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="LIC-FLOW-002", category="Licensing",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Shared-user flow licensing",
@@ -527,7 +527,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
             doc_link=PA_LICENSING_FAQ,
         )]
     if not bot_ids:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="LIC-FLOW-002", category="Licensing",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Shared-user flow licensing",
@@ -572,7 +572,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
         # Nobody resolvable. If enumeration itself failed, that's a SKIP;
         # otherwise the agent simply isn't shared with any user yet.
         if enumerate_failed or undetermined:
-            return [CheckResult(
+            return [CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id="LIC-FLOW-002", category="Licensing",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description="Shared-user flow licensing",
@@ -586,7 +586,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
                 ),
                 doc_link=PA_LICENSING_FAQ,
             )]
-        return [CheckResult(
+        return [CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="LIC-FLOW-002", category="Licensing",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Shared-user flow licensing",
@@ -628,7 +628,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
     # avoids a mass false-FAIL when the kit's token simply can't read
     # licenseDetails (which would make every user look unlicensed).
     if missing and licensed:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="LIC-FLOW-002", category="Licensing",
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description="Shared-user flow licensing",
@@ -640,7 +640,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
     if missing and not licensed:
         # Everyone looks unlicensed — more likely a permission gap than a
         # tenant with zero premium licenses. Don't FAIL; flag to verify.
-        return [CheckResult(
+        return [CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="LIC-FLOW-002", category="Licensing",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Shared-user flow licensing",
@@ -653,7 +653,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
             doc_link=PA_LICENSING_FAQ,
         )]
     if undetermined:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="LIC-FLOW-002", category="Licensing",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Shared-user flow licensing",
@@ -665,7 +665,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
             ),
             doc_link=PA_LICENSING_FAQ,
         )]
-    return [CheckResult(
+    return [CheckResult(roles=[Role.M365_ADMIN.value],
         checkpoint_id="LIC-FLOW-002", category="Licensing",
         priority=Priority.HIGH.value, status=Status.PASSED.value,
         description="Shared-user flow licensing",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import yaml
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 STUDIO_BASE = "https://copilotstudio.microsoft.com"
@@ -83,7 +83,7 @@ def run_local_file_checks(runner) -> list[CheckResult]:
     # Discover all agent folders under workspace/agents/
     agents_root = Path("workspace/agents")
     if not agents_root.exists():
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="LOCAL-001", category="Local Files",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Agent files available",
@@ -95,7 +95,7 @@ def run_local_file_checks(runner) -> list[CheckResult]:
     agent_folders = [d for d in agents_root.iterdir() if d.is_dir() and not d.name.startswith(".")]
 
     if not agent_folders:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="LOCAL-001", category="Local Files",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Agent files available",
@@ -150,7 +150,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
     studio_link = _studio_link_md(runner, agent_name, "the agent in Copilot Studio")
 
     if not agent_file.exists():
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-007", category=f"Configuration ({label})",
             priority=Priority.CRITICAL.value, status=Status.FAILED.value,
             description=f"{label}: Agent identity file",
@@ -178,7 +178,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
         parsed = None
 
     if parsed is None:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-007", category=f"Configuration ({label})",
             priority=Priority.CRITICAL.value, status=Status.FAILED.value,
             description=f"{label}: Agent instructions",
@@ -193,7 +193,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
     if instruction_text:
         word_count = len(instruction_text.split())
         if word_count >= 50:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="CONFIG-007", category=f"Configuration ({label})",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description=f"{label}: Agent instructions",
@@ -201,7 +201,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
                 doc_link=f"{DOC_BASE}/customize",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="CONFIG-007", category=f"Configuration ({label})",
                 priority=Priority.CRITICAL.value, status=Status.WARNING.value,
                 description=f"{label}: Agent instructions",
@@ -210,7 +210,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
                 doc_link=f"{DOC_BASE}/customize",
             ))
     else:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-007", category=f"Configuration ({label})",
             priority=Priority.CRITICAL.value, status=Status.FAILED.value,
             description=f"{label}: Agent instructions",
@@ -229,7 +229,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
         starters = []
     count = sum(1 for item in starters if isinstance(item, dict) and item.get("text"))
     if count >= 3:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-005", category=f"Configuration ({label})",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description=f"{label}: Starter prompts",
@@ -237,7 +237,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
             doc_link=f"{DOC_BASE}/customize#customize-starter-prompts",
         ))
     elif count > 0:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-005", category=f"Configuration ({label})",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=f"{label}: Starter prompts",
@@ -246,7 +246,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
             doc_link=f"{DOC_BASE}/customize#customize-starter-prompts",
         ))
     else:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-005", category=f"Configuration ({label})",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=f"{label}: Starter prompts",
@@ -266,7 +266,7 @@ def _check_required_topics(agent_path: Path, label: str, runner=None, agent_name
 
     if not topics_dir.exists():
         for req in REQUIRED_TOPICS:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id=req["id"], category=f"Topics ({label})",
                 priority=req["priority"], status=Status.SKIPPED.value,
                 description=f"{label}: {req['name']}",
@@ -299,7 +299,7 @@ def _check_required_topics(agent_path: Path, label: str, runner=None, agent_name
         found = any(re.search(pattern, stem) for stem in normalized_stems)
 
         if found:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id=req["id"], category=f"Topics ({label})",
                 priority=req["priority"], status=Status.PASSED.value,
                 description=f"{label}: {req['name']}",
@@ -307,7 +307,7 @@ def _check_required_topics(agent_path: Path, label: str, runner=None, agent_name
                 doc_link=f"{DOC_BASE}/customize#customize-topics",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id=req["id"], category=f"Topics ({label})",
                 priority=req["priority"], status=Status.WARNING.value,
                 description=f"{label}: {req['name']}",
@@ -329,7 +329,7 @@ def _check_topic_inventory(agent_path: Path, label: str) -> list[CheckResult]:
 
     count = len(list(topics_dir.glob("*.mcs.yml")))
 
-    results.append(CheckResult(
+    results.append(CheckResult(roles=[Role.ESS_MAKER.value],
         checkpoint_id="TOPIC-011", category=f"Topics ({label})",
         priority=Priority.MEDIUM.value,
         status=Status.PASSED.value if count >= 5 else Status.WARNING.value,
@@ -347,7 +347,7 @@ def _check_variables(agent_path: Path, label: str) -> list[CheckResult]:
     vars_dir = agent_path / "variables"
 
     if not vars_dir.exists():
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-012", category=f"Configuration ({label})",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description=f"{label}: User Context variables",
@@ -357,7 +357,7 @@ def _check_variables(agent_path: Path, label: str) -> list[CheckResult]:
         return results
 
     var_files = list(vars_dir.glob("*.mcs.yml"))
-    results.append(CheckResult(
+    results.append(CheckResult(roles=[Role.ESS_MAKER.value],
         checkpoint_id="CONFIG-012", category=f"Configuration ({label})",
         priority=Priority.CRITICAL.value,
         status=Status.PASSED.value if var_files else Status.WARNING.value,
@@ -494,7 +494,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
     topics_dir = agent_path / "topics"
 
     if not topics_dir.exists():
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-014", category=f"Topics ({label})",
             priority=Priority.MEDIUM.value, status=Status.SKIPPED.value,
             description=f"{label}: Topic description quality",
@@ -601,7 +601,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
         names = ", ".join(unparseable[:10])
         overflow = f" (+{len(unparseable) - 10} more)" if len(unparseable) > 10 else ""
         studio_link_for_unparseable = _studio_link_md(runner, agent_name, "the agent in Copilot Studio")
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-014", category=f"Topics ({label})",
             priority=Priority.LOW.value, status=Status.SKIPPED.value,
             description=f"{label}: Topic description quality (unparseable files skipped)",
@@ -618,7 +618,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
         ))
 
     if not checked:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-014", category=f"Topics ({label})",
             priority=Priority.MEDIUM.value, status=Status.SKIPPED.value,
             description=f"{label}: Topic description quality",
@@ -631,7 +631,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
         topic_list = "; ".join(has_placeholder[:5])
         if len(has_placeholder) > 5:
             topic_list += "..."
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-014", category=f"Topics ({label})",
             priority=Priority.MEDIUM.value, status=Status.FAILED.value,
             description=f"{label}: Topic descriptions contain placeholders",
@@ -642,7 +642,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
 
     # Report too-short descriptions
     if too_short:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-014", category=f"Topics ({label})",
             priority=Priority.MEDIUM.value, status=Status.WARNING.value,
             description=f"{label}: Topic descriptions too short",
@@ -652,7 +652,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
         ))
 
     if not has_placeholder and not too_short:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-014", category=f"Topics ({label})",
             priority=Priority.MEDIUM.value, status=Status.PASSED.value,
             description=f"{label}: Topic description quality",
@@ -674,7 +674,7 @@ def _check_template_configs(agent_path: Path, label: str) -> list[CheckResult]:
     xml_files = list(tc_dir.glob("*.xml"))
     meta_files = list(tc_dir.glob("*.meta.json"))
 
-    results.append(CheckResult(
+    results.append(CheckResult(roles=[Role.ESS_MAKER.value],
         checkpoint_id="LOCAL-TC-001", category=f"Template Configs ({label})",
         priority=Priority.MEDIUM.value, status=Status.PASSED.value,
         description=f"{label}: Template configurations",
@@ -703,7 +703,7 @@ def _check_knowledge_sources(agent_path: Path, label: str, runner=None, agent_na
     knowledge_dir = agent_path / "knowledge"
 
     if not knowledge_dir.exists():
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=f"{label}: Knowledge source readiness",
@@ -713,7 +713,7 @@ def _check_knowledge_sources(agent_path: Path, label: str, runner=None, agent_na
 
     knowledge_files = list(knowledge_dir.glob("*.mcs.yml"))
     if not knowledge_files:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=f"{label}: Knowledge source readiness",
@@ -728,7 +728,7 @@ def _check_knowledge_sources(agent_path: Path, label: str, runner=None, agent_na
         bot_id = runner.config.get("agent", {}).get("botId")
 
     if not pva or not pva.is_configured or not bot_id:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=f"{label}: Knowledge source readiness",
@@ -755,7 +755,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
     try:
         sources = pva.get_knowledge_sources(bot_id)
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=f"{label}: Knowledge source crawl status",
@@ -768,7 +768,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
     # This catches the case where a local source was never published (false PASSED
     # in the previous implementation when local>0 and remote=0 only).
     if len(knowledge_files) > len(sources):
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=f"{label}: Local/remote knowledge source count mismatch",
@@ -807,7 +807,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
         source_type = _format_source_type(source_kind)
 
         if crawl_status in _READY_STATUSES:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description=f"{label}: '{name}' ({source_type})",
@@ -815,7 +815,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
             ))
         elif crawl_status in _NOT_READY_STATUSES:
             all_ready = False
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
                 priority=Priority.HIGH.value, status=Status.FAILED.value,
                 description=f"{label}: '{name}' ({source_type})",
@@ -830,7 +830,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
             # Unknown status string, but the API DID return a status field.
             # WARNING with the raw value so we learn the new status over time.
             all_ready = False
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description=f"{label}: '{name}' ({source_type})",
@@ -845,7 +845,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
             # No `status` returned at all — we only have lifecycle `state`.
             # That is NOT proof of indexing; surface as WARNING, not PASSED.
             all_ready = False
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
                 priority=Priority.HIGH.value, status=Status.WARNING.value,
                 description=f"{label}: '{name}' ({source_type})",
@@ -860,7 +860,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
             ))
 
     if all_ready and sources and len(knowledge_files) <= len(sources):
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="CONFIG-013", category=f"Knowledge Sources ({label})",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description=f"{label}: All knowledge sources indexed",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
@@ -8,7 +8,7 @@ Checks Microsoft 365 Copilot licenses, Copilot Studio licenses, Teams
 licenses, role assignments, and capacity.
 """
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 
@@ -75,7 +75,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
             s.get("prepaidUnits", {}).get("enabled", 0) for s in copilot_skus
         )
         if copilot_skus and consumed > 0:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id="PRE-001", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Microsoft 365 Copilot licenses",
@@ -83,7 +83,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id="PRE-001", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.FAILED.value,
                 description="Microsoft 365 Copilot licenses",
@@ -92,7 +92,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="PRE-001", category="Prerequisites",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Microsoft 365 Copilot licenses",
@@ -107,7 +107,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
         cs_skus = [s for s in skus if _sku_matches(s, COPILOT_STUDIO_SKUS)]
         if cs_skus:
             names = ", ".join(s.get("skuPartNumber", "") for s in cs_skus)
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id="PRE-002", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Copilot Studio licenses",
@@ -115,7 +115,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id="PRE-002", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.FAILED.value,
                 description="Copilot Studio licenses",
@@ -124,7 +124,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="PRE-002", category="Prerequisites",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Copilot Studio licenses",
@@ -138,7 +138,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
         teams_skus = [s for s in skus if _sku_matches(s, TEAMS_BEARING_SKUS)]
         consumed = sum(s.get("consumedUnits", 0) for s in teams_skus)
         if teams_skus and consumed > 0:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id="PRE-003", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Microsoft Teams licenses",
@@ -146,7 +146,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.M365_ADMIN.value],
                 checkpoint_id="PRE-003", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.WARNING.value,
                 description="Microsoft Teams licenses",
@@ -155,7 +155,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.M365_ADMIN.value],
             checkpoint_id="PRE-003", category="Prerequisites",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Microsoft Teams licenses",
@@ -171,7 +171,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
         )
         if ga_role:
             members = graph.get_role_members(ga_role["id"])
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="PRE-008", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Global Admin role assigned",
@@ -179,7 +179,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#required-roles",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="PRE-008", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.FAILED.value,
                 description="Global Admin role assigned",
@@ -188,7 +188,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#required-roles",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id="PRE-008", category="Prerequisites",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Global Admin role assigned",
@@ -204,7 +204,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
         )
         if pp_role:
             members = graph.get_role_members(pp_role["id"])
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="PRE-009", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Power Platform Admin role assigned",
@@ -212,7 +212,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#required-roles",
             ))
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
                 checkpoint_id="PRE-009", category="Prerequisites",
                 priority=Priority.CRITICAL.value, status=Status.WARNING.value,
                 description="Power Platform Admin role assigned",
@@ -221,7 +221,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 doc_link=f"{DOC_BASE}/prerequisites#required-roles",
             ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value],
             checkpoint_id="PRE-009", category="Prerequisites",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Power Platform Admin role assigned",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/publishing.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/publishing.py
@@ -19,7 +19,7 @@ Bucketing: MANUAL routes to the "Needs manual verification" section
 of the FlightCheck report. These checks never fail readiness.
 """
 
-from ..runner import CheckResult, Status
+from ..runner import CheckResult, Role, Status
 
 DOC_BASE = "https://learn.microsoft.com/en-us/copilot/microsoft-365/employee-self-service"
 STUDIO_BASE = "https://copilotstudio.microsoft.com"
@@ -100,6 +100,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "QA-001",
             "p": "Critical",
+            "roles": [Role.ESS_MAKER.value],
             "desc": "Build a library of ≥50 evaluation prompts (golden queries)",
             "result": (
                 "The kit can't inspect Copilot Studio evaluation test sets — "
@@ -119,6 +120,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "QA-002",
             "p": "Critical",
+            "roles": [Role.ESS_MAKER.value],
             "desc": "Run the evaluation test set against the agent",
             "result": (
                 "The kit can't read evaluation runs — "
@@ -138,6 +140,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "QA-012",
             "p": "Critical",
+            "roles": [Role.ESS_MAKER.value],
             "desc": "Review evaluation scores against an accuracy target",
             "result": (
                 "The kit can't measure response accuracy — "
@@ -158,6 +161,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "PUB-001",
             "p": "Critical",
+            "roles": [Role.ESS_MAKER.value],
             "desc": "Export your customization solution as a managed solution",
             "result": (
                 "The kit can't inspect maker-portal solution exports — "
@@ -176,6 +180,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "PUB-002",
             "p": "Critical",
+            "roles": [Role.ESS_MAKER.value, Role.POWER_PLATFORM_ADMIN.value],
             "desc": "Import the managed solution into a test environment",
             "result": (
                 "The kit only sees the configured environment — "
@@ -194,6 +199,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "PUB-003",
             "p": "Critical",
+            "roles": [Role.ESS_MAKER.value],
             "desc": "Complete UAT and capture business sign-off",
             "result": (
                 "The kit can't track sign-off — "
@@ -212,6 +218,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "PUB-006",
             "p": "Critical",
+            "roles": [Role.ESS_MAKER.value, Role.M365_ADMIN.value],
             "desc": "Obtain Microsoft 365 admin approval for the agent",
             "result": (
                 "The kit can't read the Microsoft 365 admin center — "
@@ -232,6 +239,7 @@ def _build_checks(runner) -> list[dict]:
         {
             "id": "PUB-011",
             "p": "Medium",
+            "roles": [Role.M365_ADMIN.value],
             "desc": "Allow up to 48 hours for rollout to Microsoft 365 Copilot",
             "result": (
                 "Informational — after admin approval, Teams/Microsoft 365 Copilot "
@@ -268,6 +276,7 @@ def run_publishing_checks(runner) -> list[CheckResult]:
             result=c["result"],
             remediation=c["remediation"],
             doc_link=c["doc_link"],
+            roles=c["roles"],
         )
         for c in _build_checks(runner)
     ]

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/servicenow.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/servicenow.py
@@ -12,7 +12,7 @@ import os
 import sys
 from pathlib import Path
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 from .connections import check_connector_connections
 from .external_systems import _categorize_servicenow_flows
 
@@ -118,7 +118,7 @@ def _check_flow_status(runner, sn_flows: list) -> list[CheckResult]:
         elif f in itsm:
             pack_label = "ITSM"
 
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id=cid, category="ServiceNow",
             priority=Priority.HIGH.value,
             status=Status.PASSED.value if is_on else Status.FAILED.value,
@@ -135,7 +135,7 @@ def _check_flow_status(runner, sn_flows: list) -> list[CheckResult]:
         other_detail = f"{len(other)} other" if other else ""
         breakdown = ", ".join(filter(None, [hrsd_detail, itsm_detail, other_detail]))
 
-        results.insert(0, CheckResult(
+        results.insert(0, CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SN-FLOW-000", category="ServiceNow",
             priority=Priority.HIGH.value,
             status=Status.PASSED.value if disabled == 0 else Status.WARNING.value,
@@ -154,7 +154,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
     dv_token = runner.dv_token
 
     if not env_url or not dv_token:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SN-CFG-001", category="ServiceNow",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ServiceNow template configurations",
@@ -175,7 +175,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
         )
 
         if configs:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="SN-CFG-001", category="ServiceNow",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="ServiceNow template configurations",
@@ -188,7 +188,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
             _validate_expected_configs(results, config_names, "hrsd", "SN-CFG-01")
             _validate_expected_configs(results, config_names, "itsm", "SN-CFG-02")
         else:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="SN-CFG-001", category="ServiceNow",
                 priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
                 description="ServiceNow template configurations",
@@ -201,7 +201,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
             ))
 
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SN-CFG-001", category="ServiceNow",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ServiceNow template configurations",
@@ -235,6 +235,7 @@ def _validate_expected_configs(
             priority=Priority.MEDIUM.value, status=Status.PASSED.value,
             description=f"ServiceNow {pack_label} template configs",
             result=f"All {len(expected)} expected {pack_label} configs present",
+            roles=[Role.ESS_MAKER.value, Role.POWER_PLATFORM_ADMIN.value],
         ))
     elif found:
         results.append(CheckResult(
@@ -243,6 +244,7 @@ def _validate_expected_configs(
             description=f"ServiceNow {pack_label} template configs",
             result=f"{len(found)}/{len(expected)} configs found — missing: {', '.join(missing)}",
             remediation=f"Reinstall the ServiceNow {pack_label} extension pack or create missing configs manually.",
+            roles=[Role.ESS_MAKER.value, Role.POWER_PLATFORM_ADMIN.value],
         ))
     # If none found, the pack likely isn't installed — don't flag as error
 
@@ -291,7 +293,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
             continue
 
     if sn_topic_count > 0:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="SN-LOCAL-001", category="ServiceNow",
             priority=Priority.MEDIUM.value, status=Status.PASSED.value,
             description=f"{label}: ServiceNow topics present",
@@ -303,7 +305,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
         itsm_found = _count_matching_topics(topic_files, "itsm")
 
         if hrsd_found:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="SN-LOCAL-002", category="ServiceNow",
                 priority=Priority.MEDIUM.value, status=Status.PASSED.value,
                 description=f"{label}: ServiceNow HRSD topics",
@@ -311,7 +313,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
             ))
 
         if itsm_found:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="SN-LOCAL-003", category="ServiceNow",
                 priority=Priority.MEDIUM.value, status=Status.PASSED.value,
                 description=f"{label}: ServiceNow ITSM topics",
@@ -319,7 +321,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
             ))
 
         if not hrsd_found and not itsm_found:
-            results.append(CheckResult(
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="SN-LOCAL-002", category="ServiceNow",
                 priority=Priority.MEDIUM.value, status=Status.WARNING.value,
                 description=f"{label}: ServiceNow HRSD/ITSM topics",
@@ -327,7 +329,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
                 remediation="Verify the ServiceNow extension pack installed correctly.",
             ))
     else:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id="SN-LOCAL-001", category="ServiceNow",
             priority=Priority.MEDIUM.value, status=Status.NOT_CONFIGURED.value,
             description=f"{label}: ServiceNow topics",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/servicenow.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/servicenow.py
@@ -154,7 +154,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
     dv_token = runner.dv_token
 
     if not env_url or not dv_token:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value, Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SN-CFG-001", category="ServiceNow",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ServiceNow template configurations",
@@ -175,7 +175,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
         )
 
         if configs:
-            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value, Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="SN-CFG-001", category="ServiceNow",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="ServiceNow template configurations",
@@ -188,7 +188,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
             _validate_expected_configs(results, config_names, "hrsd", "SN-CFG-01")
             _validate_expected_configs(results, config_names, "itsm", "SN-CFG-02")
         else:
-            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+            results.append(CheckResult(roles=[Role.ESS_MAKER.value, Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="SN-CFG-001", category="ServiceNow",
                 priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
                 description="ServiceNow template configurations",
@@ -201,7 +201,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
             ))
 
     except Exception as e:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.ESS_MAKER.value, Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="SN-CFG-001", category="ServiceNow",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ServiceNow template configurations",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -1274,7 +1274,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     dv_token = runner.dv_token
 
     if not env_url or not dv_token:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1315,7 +1315,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
                 isu_value = v.get("value", "") or None
                 break
     except Exception as e:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1326,7 +1326,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     if not isu_value:
         # WD-ENV-001 already covers the missing-value remediation; skip
         # here to avoid double-reporting the same root cause.
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1339,7 +1339,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     # the most decisive failure mode and must be reported even when
     # Graph auth has failed.
     if "@" not in isu_value:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1364,7 +1364,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     # SKIP so the operator knows the deeper check wasn't performed.
     graph = getattr(runner, "graph", None)
     if not graph:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1381,7 +1381,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     try:
         org = graph.get_organization()
     except Exception as e:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1391,7 +1391,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
         return results
 
     if not isinstance(org, dict) or not org:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1411,7 +1411,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
 
     domain = isu_value.rsplit("@", 1)[1].lower()
     if not verified:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1425,7 +1425,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
         return results
 
     if domain in verified:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1433,7 +1433,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
             doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
         ))
     else:
-        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -37,7 +37,7 @@ from xml.sax.saxutils import escape as xml_escape
 from defusedxml import ElementTree as ET
 from defusedxml.common import DefusedXmlException
 
-from ..runner import CheckResult, Status, Priority
+from ..runner import CheckResult, Priority, Role, Status
 from ._maker_urls import maker_connections_url
 from ._saml_utils import (
     WORKDAY_SAML_SP_FILTER,
@@ -504,7 +504,7 @@ def _check_entra_workday_federation_alignment(runner) -> list[CheckResult]:
 
     graph = getattr(runner, "graph", None)
     if graph is None:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -528,7 +528,7 @@ def _check_entra_workday_federation_alignment(runner) -> list[CheckResult]:
             raise_on_permission_error=True,
         )
     except PermissionError as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -548,7 +548,7 @@ def _check_entra_workday_federation_alignment(runner) -> list[CheckResult]:
             doc_link=doc_link,
         )]
     except Exception as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -575,7 +575,7 @@ def _check_entra_workday_federation_alignment(runner) -> list[CheckResult]:
         # from this tenant would silently break that foreign tenant's
         # federation. Keep the manual verification advice on the
         # remediation path for the pre-install/foreign-tenant scenario.
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description=description,
@@ -649,7 +649,7 @@ def _check_entra_workday_federation_alignment(runner) -> list[CheckResult]:
         + "\n".join(app_entries)
     )
 
-    return [CheckResult(
+    return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
         checkpoint_id=cp_id, category=category,
         priority=Priority.HIGH.value, status=Status.MANUAL.value,
         description=description,
@@ -762,7 +762,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
 
     if not env_url or not dv_token:
         runner._workday_package_flavor = "skipped"
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-PKG-001", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Workday install flavor (simplified vs full / legacy)",
@@ -782,7 +782,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
         )
     except Exception as e:
         runner._workday_package_flavor = "skipped"
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-PKG-001", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Workday install flavor (simplified vs full / legacy)",
@@ -812,7 +812,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
     # 1. No Workday integration at all.
     if not workday_refs:
         runner._workday_package_flavor = "none"
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-PKG-001", category="Workday",
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description="Workday install flavor (simplified vs full / legacy)",
@@ -839,7 +839,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
                 " No Workday flows are deployed yet in this environment "
                 "— the package is present but downstream flows have not run."
             )
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-PKG-001", category="Workday",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Workday install flavor (simplified vs full / legacy)",
@@ -863,7 +863,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
                 " No Workday flows are deployed yet in this environment "
                 "— the package is present but downstream flows have not run."
             )
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-PKG-001", category="Workday",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Workday install flavor (simplified vs full / legacy)",
@@ -882,7 +882,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
         missing = LEGACY_REF_SUFFIXES - known_suffixes
         observed_roles = ", ".join(sorted(_REF_SUFFIX_ROLES[s] for s in known_suffixes))
         missing_roles = ", ".join(sorted(_REF_SUFFIX_ROLES[s] for s in missing))
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-PKG-001", category="Workday",
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description="Workday install flavor (simplified vs full / legacy)",
@@ -916,7 +916,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
             "rows with unexpected logical-name format: "
             + ", ".join(sorted(unknown_format_names))
         )
-    results.append(CheckResult(
+    results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
         checkpoint_id="WD-PKG-001", category="Workday",
         priority=Priority.HIGH.value, status=Status.WARNING.value,
         description="Workday install flavor (simplified vs full / legacy)",
@@ -964,7 +964,7 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
         # Workday refs (NOT_CONFIGURED), or found an unrecognized
         # shape (WARNING). In any of those cases this check can't add
         # signal beyond what WD-PKG-001 already reported.
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-012", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Workday package connection-reference binding completeness",
@@ -1020,7 +1020,7 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
     )
 
     if not problems:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-012", category="Workday",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Workday package connection-reference binding completeness",
@@ -1032,7 +1032,7 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
             doc_link=doc_link,
         )]
 
-    return [CheckResult(
+    return [CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
         checkpoint_id="WD-CONN-012", category="Workday",
         priority=Priority.HIGH.value, status=Status.FAILED.value,
         description="Workday package connection-reference binding completeness",
@@ -1095,7 +1095,7 @@ def _simplified_install_skip(
     (WD-PKG-001's verdict); `remediation` carries the actionable
     contingency for an operator who intended the OTHER install flavor.
     """
-    return CheckResult(
+    return CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
         checkpoint_id=checkpoint_id,
         category=category,
         priority=priority,
@@ -1147,7 +1147,7 @@ def _check_env_vars(runner) -> list[CheckResult]:
     dv_token = runner.dv_token
 
     if not env_url or not dv_token:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-001", category="Workday",
             priority=Priority.CRITICAL.value, status=Status.SKIPPED.value,
             description="Workday environment variables",
@@ -1191,7 +1191,7 @@ def _check_env_vars(runner) -> list[CheckResult]:
                     break
 
             if actual_value:
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                     checkpoint_id=meta["id"], category="Workday",
                     priority=Priority.CRITICAL.value if meta["critical"] else Priority.HIGH.value,
                     status=Status.PASSED.value,
@@ -1200,7 +1200,7 @@ def _check_env_vars(runner) -> list[CheckResult]:
                     doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
                 ))
             elif meta["critical"]:
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                     checkpoint_id=meta["id"], category="Workday",
                     priority=Priority.CRITICAL.value, status=Status.FAILED.value,
                     description=meta["description"],
@@ -1209,7 +1209,7 @@ def _check_env_vars(runner) -> list[CheckResult]:
                     doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
                 ))
             else:
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                     checkpoint_id=meta["id"], category="Workday",
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=meta["description"],
@@ -1217,7 +1217,7 @@ def _check_env_vars(runner) -> list[CheckResult]:
                     doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
                 ))
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-001", category="Workday",
             priority=Priority.CRITICAL.value, status=Status.WARNING.value,
             description="Workday environment variables",
@@ -1274,7 +1274,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     dv_token = runner.dv_token
 
     if not env_url or not dv_token:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1315,7 +1315,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
                 isu_value = v.get("value", "") or None
                 break
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1326,7 +1326,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     if not isu_value:
         # WD-ENV-001 already covers the missing-value remediation; skip
         # here to avoid double-reporting the same root cause.
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1339,7 +1339,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     # the most decisive failure mode and must be reported even when
     # Graph auth has failed.
     if "@" not in isu_value:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1364,7 +1364,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     # SKIP so the operator knows the deeper check wasn't performed.
     graph = getattr(runner, "graph", None)
     if not graph:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1381,7 +1381,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
     try:
         org = graph.get_organization()
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1391,7 +1391,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
         return results
 
     if not isinstance(org, dict) or not org:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1411,7 +1411,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
 
     domain = isu_value.rsplit("@", 1)[1].lower()
     if not verified:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1425,7 +1425,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
         return results
 
     if domain in verified:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1433,7 +1433,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
             doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
         ))
     else:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-ENV-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="ISU username vs Entra UPN format alignment",
@@ -1690,7 +1690,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
     try:
         all_conns = pp.get_connections(env_id)
     except Exception as e:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Workday connection token health",
@@ -1699,7 +1699,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
         return results
 
     if isinstance(all_conns, dict) and "_error" in all_conns:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Workday connection token health",
@@ -1711,7 +1711,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
     wd_conns = filter_connections_by_connector(all_conns, "workday")
 
     if not wd_conns:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description="Workday connection token health",
@@ -1735,7 +1735,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
         })
 
     if not unhealthy:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Workday connection token health",
@@ -1767,7 +1767,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
     if failed_entries:
         details = [_format_unhealthy_detail(e) for e in failed_entries]
         remediations = [_format_unhealthy_remediation(e, env_id) for e in failed_entries]
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description="Workday connection token health",
@@ -1783,7 +1783,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
     if warning_entries:
         details = [_format_unhealthy_detail(e) for e in warning_entries]
         remediations = [_format_unhealthy_remediation(e, env_id) for e in warning_entries]
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id="WD-CONN-101", category="Workday",
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description="Workday connection token health",
@@ -2220,7 +2220,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
 
     graph = getattr(runner, "graph", None)
     if graph is None:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -2242,7 +2242,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
             raise_on_permission_error=True,
         )
     except PermissionError as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -2261,7 +2261,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
             doc_link=doc_link,
         )]
     except Exception as e:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -2275,7 +2275,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
         )]
 
     if not workday_sps:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description=description,
@@ -2438,7 +2438,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
 
     if failed_entries:
         bodies = "\n".join(e["summary"] for e in failed_entries)
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description=description,
@@ -2487,7 +2487,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
         bodies = "\n".join(e["summary"] for e in warning_entries)
         # Hardening framing per AGENTS.md principle 9 — these aren't
         # functional blockers today, only operational risk.
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -2539,7 +2539,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
                 "have a healthy active signing certificate in Entra"
             )
         )
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.MANUAL.value,
             description=description,
@@ -2673,7 +2673,7 @@ def _check_flow_status(runner, wd_flows: list) -> list[CheckResult]:
         else:
             disabled += 1
 
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
             checkpoint_id=cid, category="Workday",
             priority=Priority.HIGH.value,
             status=Status.PASSED.value if is_on else Status.FAILED.value,
@@ -2726,7 +2726,7 @@ def _check_workflows(runner) -> list[CheckResult]:
     wd_base_url, wd_tenant, test_employee = _resolve_workday_metadata(runner)
 
     if not wd_base_url or not wd_tenant:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-WF-000", category="Workday Workflows",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Workday SOAP workflow tests",
@@ -2737,7 +2737,7 @@ def _check_workflows(runner) -> list[CheckResult]:
         return results
 
     if not test_employee:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-WF-000", category="Workday Workflows",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Workday SOAP workflow tests",
@@ -2755,7 +2755,7 @@ def _check_workflows(runner) -> list[CheckResult]:
     try:
         import httpx  # noqa: F401  (used inside _soap_call)
     except ImportError:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-WF-000", category="Workday Workflows",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Workday SOAP workflow tests",
@@ -2770,7 +2770,7 @@ def _check_workflows(runner) -> list[CheckResult]:
     # local variable. ---
     wd_username, wd_password = _resolve_workday_credentials(runner, wd_tenant)
     if not wd_username or not wd_password:
-        results.append(CheckResult(
+        results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id="WD-WF-000", category="Workday Workflows",
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description="Workday SOAP workflow tests",
@@ -2799,13 +2799,13 @@ def _check_workflows(runner) -> list[CheckResult]:
                 wf["service"], body,
             )
             if result["success"] or "permission" not in result.get("error", "").lower():
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
                     checkpoint_id=cid, category="Workday Workflows",
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=desc, result="API accessible",
                 ))
             else:
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
                     checkpoint_id=cid, category="Workday Workflows",
                     priority=Priority.HIGH.value, status=Status.FAILED.value,
                     description=desc, result="Permission denied",
@@ -2830,13 +2830,13 @@ def _check_workflows(runner) -> list[CheckResult]:
                 root = ET.fromstring(result["response"])
                 found = root.findall(wf["xpath"])
                 if found:
-                    results.append(CheckResult(
+                    results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
                         checkpoint_id=cid, category="Workday Workflows",
                         priority=Priority.HIGH.value, status=Status.PASSED.value,
                         description=desc, result="Data retrieved",
                     ))
                 else:
-                    results.append(CheckResult(
+                    results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
                         checkpoint_id=cid, category="Workday Workflows",
                         priority=Priority.HIGH.value, status=Status.PASSED.value,
                         description=desc,
@@ -2849,7 +2849,7 @@ def _check_workflows(runner) -> list[CheckResult]:
                 # DTDForbidden, NotSupportedError). Both should fall through
                 # to the structured "unparseable XML" result instead of
                 # surfacing as an unhandled traceback to the user.
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
                     checkpoint_id=cid, category="Workday Workflows",
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=desc, result="API responded (unparseable XML)",
@@ -2857,14 +2857,14 @@ def _check_workflows(runner) -> list[CheckResult]:
         else:
             error = result.get("error", "Unknown")
             if any(k in error.lower() for k in ("permission", "unauthorized", "not authorized")):
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
                     checkpoint_id=cid, category="Workday Workflows",
                     priority=Priority.HIGH.value, status=Status.FAILED.value,
                     description=desc, result="Permission denied",
                     remediation="Ask Workday Admin to grant required security domain.",
                 ))
             else:
-                results.append(CheckResult(
+                results.append(CheckResult(roles=[Role.WORKDAY_ADMIN.value],
                     checkpoint_id=cid, category="Workday Workflows",
                     priority=Priority.HIGH.value, status=Status.FAILED.value,
                     description=desc, result=f"Error: {error[:100]}",
@@ -2899,7 +2899,7 @@ def _append_wd_wf_cat_link_trailer(runner, results: list[CheckResult]) -> None:
     unknown = _get_unknown_workday_scenarios(runner)
     if not unknown:
         return
-    results.append(CheckResult(
+    results.append(CheckResult(roles=[Role.ESS_MAKER.value],
         checkpoint_id="WD-WF-CAT-LINK", category="Workday Workflows",
         priority=Priority.MEDIUM.value, status=Status.MANUAL.value,
         description="Custom Workday scenarios outside the SOAP-test catalog",
@@ -3257,7 +3257,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
 
     flavor = getattr(runner, "_workday_package_flavor", None)
     if flavor == "simplified":
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.MANUAL.value,
             description=description,
@@ -3283,7 +3283,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
     # at all rather than emitting a spurious MANUAL/FAIL.
     wd_base_url, wd_tenant, test_employee = _resolve_workday_metadata(runner)
     if not wd_base_url or not wd_tenant:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -3301,7 +3301,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
         )]
 
     if not test_employee:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.MANUAL.value,
             description=description,
@@ -3323,7 +3323,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
     try:
         import httpx  # noqa: F401
     except ImportError:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -3338,7 +3338,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
     # must not interpolate any local variable into a print/log.
     wd_username, wd_password = _resolve_workday_credentials(runner, wd_tenant)
     if not wd_username or not wd_password:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.MANUAL.value,
             description=description,
@@ -3359,7 +3359,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
     verdict = _classify_personal_data_write_response(soap_result)
 
     if verdict == "denied":
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.FAILED.value,
             description=description,
@@ -3401,7 +3401,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
         )]
 
     if verdict == "auth":
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -3423,7 +3423,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
         )]
 
     if verdict == "pass":
-        return [CheckResult(
+        return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description=description,
@@ -3448,7 +3448,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
     # would no longer match the email regex applied after the slice).
     raw_err = soap_result.get("error") or "(no error text)"
     err = _redact_faultstring_pii(raw_err)[:200]
-    return [CheckResult(
+    return [CheckResult(roles=[Role.WORKDAY_ADMIN.value],
         checkpoint_id=cp_id, category=category,
         priority=Priority.HIGH.value, status=Status.WARNING.value,
         description=description,
@@ -3915,7 +3915,7 @@ def _check_custom_workflow_inventory(runner) -> list[CheckResult]:
 
     workspace_root = Path("workspace/agents")
     if not workspace_root.exists():
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -3935,7 +3935,7 @@ def _check_custom_workflow_inventory(runner) -> list[CheckResult]:
 
     if not discovered:
         runner._workday_unknown_scenarios = []
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -3962,7 +3962,7 @@ def _check_custom_workflow_inventory(runner) -> list[CheckResult]:
         # Suppress the trailer too — without the catalog we cannot
         # legitimately list "unknowns."
         runner._workday_unknown_scenarios = []
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.SKIPPED.value,
             description=description,
@@ -3987,7 +3987,7 @@ def _check_custom_workflow_inventory(runner) -> list[CheckResult]:
         # query_error: <msg> — surface verbatim per principle #3.
         err_msg = status_code.removeprefix("query_error: ") or "unknown error"
         runner._workday_unknown_scenarios = []
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.WARNING.value,
             description=description,
@@ -4018,7 +4018,7 @@ def _check_custom_workflow_inventory(runner) -> list[CheckResult]:
     runner._workday_unknown_scenarios = unknown
 
     if not unknown:
-        return [CheckResult(
+        return [CheckResult(roles=[Role.ESS_MAKER.value],
             checkpoint_id=cp_id, category=category,
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description=description,
@@ -4033,7 +4033,7 @@ def _check_custom_workflow_inventory(runner) -> list[CheckResult]:
         )]
 
     body = _format_unknown_scenarios(unknown)
-    return [CheckResult(
+    return [CheckResult(roles=[Role.ESS_MAKER.value],
         checkpoint_id=cp_id, category=category,
         priority=Priority.HIGH.value, status=Status.MANUAL.value,
         description=description,

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -386,7 +386,8 @@ def _print_prioritized_summary(result):
         print("  " + "-" * 62)
         for r in action:
             tag = _status_tag(r.status)
-            print(f"  {tag} {r.checkpoint_id} [{r.priority}]: {r.result}")
+            role_text = f" | {', '.join(r.roles)}" if r.roles else ""
+            print(f"  {tag} {r.checkpoint_id} [{r.priority}{role_text}]: {r.result}")
             if r.remediation:
                 # Indent multi-line remediation under the arrow so
                 # multi-step fixes stay visually grouped with their
@@ -405,7 +406,8 @@ def _print_prioritized_summary(result):
         print("  " + "-" * 62)
         for r in manual:
             tag = _status_tag(r.status)
-            print(f"  {tag} {r.checkpoint_id} [{r.priority}]: "
+            role_text = f" | {', '.join(r.roles)}" if r.roles else ""
+            print(f"  {tag} {r.checkpoint_id} [{r.priority}{role_text}]: "
                   f"{r.description}")
         print("  (Open report.html for the full result + verification "
               "steps.)")

--- a/solutions/ess-maker-skills/scripts/flightcheck/runner.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/runner.py
@@ -40,6 +40,27 @@ class Priority(str, Enum):
     LOW = "Low"
 
 
+class Role(str, Enum):
+    """Persona who owns the next step on a check.
+
+    A check's ``roles`` list names every admin persona whose action is
+    required to FIX a failing/errored result or to PERFORM the manual
+    validation of a MANUAL/NOT_CONFIGURED result. A check may need more
+    than one role (e.g. a Workday SAML cert lives on an Entra app but is
+    compared in the Workday tenant — Entra Admin + Workday Admin).
+
+    The value is the human-readable label rendered in the report.
+    """
+
+    ENTRA_ADMIN = "Entra Admin"
+    M365_ADMIN = "Microsoft 365 Admin"
+    POWER_PLATFORM_ADMIN = "Power Platform Admin"
+    WORKDAY_ADMIN = "Workday Admin"
+    SERVICENOW_ADMIN = "ServiceNow Admin"
+    SAP_ADMIN = "SAP Admin"
+    ESS_MAKER = "ESS Maker / Agent Developer"
+
+
 @dataclass
 class CheckResult:
     checkpoint_id: str
@@ -50,6 +71,11 @@ class CheckResult:
     result: str            # Finding detail
     remediation: str = ""  # How to fix
     doc_link: str = ""     # Microsoft Learn URL
+    # roles — the persona(s) who own the next step (fix or manual
+    # validation). Every production check sets this; defaults to empty
+    # so the runner's ERROR fallback and unit-test constructions still
+    # build. Values are Role enum strings.
+    roles: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -114,6 +140,7 @@ class FlightCheckRunner:
                     description=f"{category} validation",
                     result=f"Check failed with error: {e}",
                     remediation="Review permissions and retry. See terminal output for details.",
+                    roles=[Role.ESS_MAKER.value],
                 ))
                 traceback.print_exc()
 
@@ -621,12 +648,19 @@ def _render_rows(results: list[CheckResult]) -> str:
         if res.doc_link:
             remediation += f' <a href="{res.doc_link}" target="_blank">[docs]</a>'
 
+        # The Role column names who owns the next step (fix / manual
+        # validation). It only applies to actionable rows — a Passed or
+        # Skipped check has no next step, so its Role cell is blank.
+        actionable = res.status not in (Status.PASSED.value, Status.SKIPPED.value)
+        roles_text = _html_escape(", ".join(res.roles)) if (actionable and res.roles) else "—"
+
         rows.append(
             f'                <tr class="{priority_class}">\n'
             f"                    <td>{res.checkpoint_id}</td>\n"
             f"                    <td>{res.category}</td>\n"
             f"                    <td>{res.priority}</td>\n"
             f'                    <td class="{status_class}">{res.status}</td>\n'
+            f"                    <td>{roles_text}</td>\n"
             f'                    <td class="cell-text">{_html_escape(res.result)}</td>\n'
             f'                    <td class="cell-text">{remediation}</td>\n'
             f"                </tr>"
@@ -663,6 +697,7 @@ def _render_section(
             '                    <th>Category</th>\n'
             '                    <th>Priority</th>\n'
             '                    <th>Status</th>\n'
+            '                    <th>Role</th>\n'
             '                    <th>Result</th>\n'
             '                    <th>Remediation</th>\n'
             '                </tr>\n'

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/validation-matrix.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/validation-matrix.md
@@ -18,6 +18,30 @@ and extended with local file validation checks unique to the Copilot Kit.
 | Medium | Important but can be addressed post-deployment |
 | Low | Nice-to-have; optional configuration |
 
+## Roles (next-step owner)
+
+Every actionable result (Failed, Error, Warning, Manual, or
+NotConfigured) is tagged with one or more **roles** — the admin
+persona(s) who must take the next action to fix it or perform the
+manual validation. The role(s) appear as a "Role" column in the HTML
+report and `results.json`, and on the terminal action/manual rows.
+Passed and Skipped rows have no next step, so no role is shown.
+
+| Role | Acts in… |
+|------|----------|
+| Entra Admin | Entra ID: app registrations, SAML, conditional access, directory-role assignment |
+| Microsoft 365 Admin | M365 admin center: license assignment, Office Cloud Policies, Graph connectors, Integrated-apps approval |
+| Power Platform Admin | Power Platform: environments, DLP, connections, solution import, cloud-flow state, Dataverse env vars |
+| Workday Admin | The Workday tenant: ISU accounts, security groups, domain permissions, RaaS, auth policies |
+| ServiceNow Admin | The ServiceNow instance: service accounts, roles, ACLs |
+| SAP Admin | The SAP SuccessFactors tenant |
+| ESS Maker / Agent Developer | Local agent files: topics, variables, template configs, evaluations, publishing/QA gates |
+
+A check can carry more than one role when the fix spans systems (e.g.
+WD-CONN-102's SAML cert lives on the Entra app but is compared in
+Workday → Entra Admin + Workday Admin).
+
+
 ---
 
 ## 1. Prerequisites (PRE-xxx)

--- a/tests/flightcheck/test_check_roles.py
+++ b/tests/flightcheck/test_check_roles.py
@@ -1,0 +1,157 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the per-check `roles` field (next-step owner).
+
+Pure-logic tests — no network, no cassettes. They pin:
+  * The `Role` enum membership.
+  * `CheckResult.roles` defaults to an empty list.
+  * The HTML report renders a "Role" column (header + cell).
+  * `save_results` persists `roles` into results.json.
+  * The terminal summary surfaces the role(s) on action/manual rows.
+  * A representative production check module (publishing) sets roles on
+    every result it emits.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    scripts_dir = (
+        Path(__file__).resolve().parents[1]
+        / "solutions" / "ess-maker-skills" / "scripts"
+    )
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def _result(checkpoint_id, status, roles, priority="High"):
+    from flightcheck.runner import CheckResult
+    return CheckResult(
+        checkpoint_id=checkpoint_id,
+        category="Test",
+        priority=priority,
+        status=status,
+        description=f"desc {checkpoint_id}",
+        result=f"result {checkpoint_id}",
+        remediation="fix it" if status != "Passed" else "",
+        roles=roles,
+    )
+
+
+def test_role_enum_has_expected_members():
+    from flightcheck.runner import Role
+    assert {r.value for r in Role} == {
+        "Entra Admin",
+        "Microsoft 365 Admin",
+        "Power Platform Admin",
+        "Workday Admin",
+        "ServiceNow Admin",
+        "SAP Admin",
+        "ESS Maker / Agent Developer",
+    }
+
+
+def test_checkresult_roles_defaults_to_empty_list():
+    from flightcheck.runner import CheckResult
+    r = CheckResult(
+        checkpoint_id="X-001", category="Test", priority="High",
+        status="Passed", description="d", result="r",
+    )
+    assert r.roles == []
+
+
+def test_html_rows_render_role_column():
+    from flightcheck.runner import Role, _render_rows
+    rows = _render_rows([
+        _result("X-001", "Failed",
+                [Role.ENTRA_ADMIN.value, Role.WORKDAY_ADMIN.value]),
+    ])
+    assert "Entra Admin, Workday Admin" in rows
+
+
+def test_html_rows_render_dash_when_no_roles():
+    from flightcheck.runner import _render_rows
+    rows = _render_rows([_result("X-002", "Passed", [])])
+    assert "—" in rows
+
+
+def test_html_rows_blank_role_for_passed_even_if_populated():
+    """Passed/Skipped rows have no next step — Role cell is blank even
+    if the constructor populated roles (e.g. a conditional-status check
+    that happened to pass)."""
+    from flightcheck.runner import Role, _render_rows
+    passed = _render_rows([_result("X-005", "Passed", [Role.WORKDAY_ADMIN.value])])
+    assert "Workday Admin" not in passed
+    skipped = _render_rows([_result("X-006", "Skipped", [Role.WORKDAY_ADMIN.value])])
+    assert "Workday Admin" not in skipped
+
+
+def test_html_rows_show_role_for_actionable_statuses():
+    from flightcheck.runner import Role, _render_rows
+    for status in ("Failed", "Warning", "Manual", "NotConfigured", "Error"):
+        rows = _render_rows([_result("X-007", status, [Role.ENTRA_ADMIN.value])])
+        assert "Entra Admin" in rows, f"role missing for {status}"
+
+
+def test_html_section_header_includes_role_column():
+    from flightcheck.runner import _render_section
+    section = _render_section(
+        section_id="s", title="t", subtitle="sub", empty_text="none",
+        rows_html="<tr></tr>", count=1, open_by_default=True,
+    )
+    assert "<th>Role</th>" in section
+    # Role column sits between Status and Result.
+    assert section.index("<th>Status</th>") < section.index("<th>Role</th>")
+    assert section.index("<th>Role</th>") < section.index("<th>Result</th>")
+
+
+def test_results_json_persists_roles(tmp_path):
+    from flightcheck.runner import RunResult, Role, save_results
+    rr = RunResult(scope="full", started="2026-01-01T00-00-00")
+    rr.results = [_result("X-003", "Failed", [Role.POWER_PLATFORM_ADMIN.value])]
+    rr.total = 1
+    rr.failed = 1
+    save_results(rr, output_dir=str(tmp_path))
+    data = json.loads((tmp_path / "results.json").read_text(encoding="utf-8"))
+    assert data["results"][0]["roles"] == ["Power Platform Admin"]
+
+
+def test_terminal_summary_shows_roles_on_action_rows(capsys):
+    from flightcheck.runner import RunResult, Role
+    from flightcheck.cli import _print_prioritized_summary
+    rr = RunResult(scope="full", started="2026-01-01T00-00-00", overall="NOT_READY")
+    rr.results = [_result("X-004", "Failed", [Role.WORKDAY_ADMIN.value])]
+    rr.total = 1
+    rr.failed = 1
+    _print_prioritized_summary(rr)
+    out = capsys.readouterr().out
+    assert "Workday Admin" in out
+    assert "X-004" in out
+
+
+def test_publishing_checks_all_carry_roles():
+    """Every result from a real check module must declare at least one role."""
+    from flightcheck.checks.publishing import run_publishing_checks
+
+    class _Runner:
+        env_id = None
+        config = {}
+
+    results = run_publishing_checks(_Runner())
+    assert results
+    for r in results:
+        assert r.roles, f"{r.checkpoint_id} has no roles"

--- a/tests/flightcheck/test_check_roles.py
+++ b/tests/flightcheck/test_check_roles.py
@@ -155,3 +155,32 @@ def test_publishing_checks_all_carry_roles():
     assert results
     for r in results:
         assert r.roles, f"{r.checkpoint_id} has no roles"
+
+
+def test_all_check_modules_carry_roles_on_every_constructor():
+    """AST-scan checks/*.py — every CheckResult(...) call must pass roles=.
+
+    Structural enforcement of the repo-wide convention: a future check
+    added without roles= fails here, not just in publishing.py.
+    """
+    import ast
+
+    checks_dir = (
+        Path(__file__).resolve().parents[1]
+        / "solutions" / "ess-maker-skills" / "scripts"
+        / "flightcheck" / "checks"
+    )
+    missing = []
+    for f in sorted(checks_dir.glob("*.py")):
+        if f.name == "__init__.py":
+            continue
+        tree = ast.parse(f.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "CheckResult"
+                and not any(k.arg == "roles" for k in node.keywords)
+            ):
+                missing.append(f"{f.name}:{node.lineno}")
+    assert not missing, f"CheckResult() missing roles=: {missing}"


### PR DESCRIPTION
## Summary

Adds a **Role** to every actionable FlightCheck result — the admin persona(s) who must take the next action to fix a failure or perform the manual validation — and surfaces it as a new column in the report output.

## What changed

- **`runner.py`**: new `Role` enum (Entra Admin, Microsoft 365 Admin, Power Platform Admin, Workday Admin, ServiceNow Admin, SAP Admin, ESS Maker / Agent Developer) and a `roles: list[str]` field on `CheckResult`.
- **Per-check assignment**: `roles` set on all 229 `CheckResult` constructors across the check modules, chosen by **who performs the remediation**. Multi-role where the fix spans systems (e.g. `WD-CONN-010` / `WD-CONN-102` → Entra + Workday Admin; ServiceNow template configs → ESS Maker + Power Platform Admin).
- **Output surfaces**:
  - HTML report — new **Role** column, blanked (`—`) on Passed/Skipped rows (no next step).
  - Terminal — role shown on the ACTION REQUIRED and NEEDS MANUAL VERIFICATION rows.
  - `results.json` — `roles` included automatically.
- **Docs**: "Assigning roles" section added to `flightcheck/AGENTS.md` (incl. updated minimal example) and a Roles legend added to `validation-matrix.md`.
- **Tests**: new `tests/flightcheck/test_check_roles.py` covering the enum, the field default, status-gated rendering, JSON persistence, and terminal output.

## Design note

Roles are only meaningful for actionable results (Failed / Error / Warning / Manual / NotConfigured). Passed and Skipped rows have no next step, so the Role column is blanked for them at render time.

## Verification

- `ruff check solutions/ess-maker-skills/scripts` — clean
- `pytest tests` — **602 passed, 8 skipped** (8 pre-existing skips)
