### PR TITLE
Describe what each passed FlightCheck validated

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
+++ b/solutions/ess-maker-skills/scripts/flightcheck/AGENTS.md
@@ -335,7 +335,12 @@ and do the per-tier verification.
      — so identical fixes across multiple resources collapse to a
      single de-duplicated line instead of repeating verbatim per
      resource. Resource names live in `result`.
-   - `PASSED` results have no `remediation`. There is nothing to fix.
+   - `PASSED` results carry no fix, but DO set `remediation` to a
+     short "Validated: …" note describing the exact success criterion
+     the check confirmed (which API/field/value made it pass). This
+     lets an operator read the passing row and understand what was
+     actually verified. The report blanks the Role column for
+     Passed/Skipped rows, but the "Validated: …" remediation IS shown.
    - This is the general form of the rule MANUAL spelled out in
      principle 2 — apply it everywhere.
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/authentication.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/authentication.py
@@ -33,6 +33,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Microsoft Entra ID configured",
                 result=f"Tenant: {org['displayName']} ({org.get('id', 'N/A')})",
+                remediation="Validated: the tenant exposes a Microsoft Entra ID organization record via Microsoft Graph (GET /organization returned an org with a displayName and id).",
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
         else:
@@ -70,6 +71,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                     f"{len(enabled)} enabled, "
                     f"{len(report_only)} report-only"
                 ),
+                remediation="Validated: Conditional Access policies are readable via Microsoft Graph (GET /identity/conditionalAccess/policies) and at least one policy exists in the tenant.",
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
         else:
@@ -99,6 +101,7 @@ def run_authentication_checks(runner) -> list[CheckResult]:
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="User identity synchronization",
                 result=f"Verified: {len(users)} sample users found in Entra ID",
+                remediation="Validated: a sample of users resolves in Entra ID via Microsoft Graph (GET /users returned at least one user), confirming identities are present/synchronized.",
                 doc_link=f"{DOC_BASE}/prerequisites#identity-authentication-and-single-sign-on-sso",
             ))
         else:
@@ -494,6 +497,7 @@ def _check_workday_app_user_assignment(graph) -> list[CheckResult]:
             priority=Priority.CRITICAL.value, status=Status.PASSED.value,
             description=description,
             result=_format_sp_state(passed_items),
+            remediation="Validated: the service principal(s) listed above are present in Entra ID and report the expected OBO/OAuth and user/group assignment configuration.",
             doc_link=doc_link,
         ))
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/connections.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/connections.py
@@ -134,7 +134,7 @@ def check_connector_connections(
                 status=Status.PASSED.value if connected else Status.FAILED.value,
                 description=f"{category} connections",
                 result=f"{len(conns)} total — {len(connected)} connected, {len(errored)} errored",
-                remediation="Re-authenticate errored connections in Power Platform." if errored else "",
+                remediation="Re-authenticate errored connections in Power Platform." if errored else f"Validated: {len(connected)} of {len(conns)} {category} connection(s) report 'Connected' state via the Power Platform connections API (GET /providers/Microsoft.PowerApps/scopes/admin/environments/{{env_id}}/connections).",
                 doc_link=doc_link,
             ))
 
@@ -150,7 +150,7 @@ def check_connector_connections(
                     status=Status.PASSED.value if status == "Connected" else Status.FAILED.value,
                     description=f"Connection: {name}",
                     result=f"Status: {status}",
-                    remediation=f"Re-authenticate '{name}' in Power Platform." if status != "Connected" else "",
+                    remediation=f"Re-authenticate '{name}' in Power Platform." if status != "Connected" else f"Validated: connection '{name}' reports 'Connected' status via the Power Platform connections API.",
                 ))
         else:
             results.append(CheckResult(

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -240,6 +240,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
             priority=Priority.CRITICAL.value, status=Status.PASSED.value,
             description="Power Platform environment exists",
             result=f"Environment: {display_name}",
+            remediation="Validated: a Power Platform environment with the configured environment ID exists and is readable via the BAP Admin API (GET /providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/{env_id}).",
             doc_link=f"{DOC_BASE}/prepare#set-up-your-power-platform-environment",
         ))
 
@@ -256,6 +257,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Dataverse database provisioned",
                 result=f"State: {db_state or 'Available'}, Type: {db_type or 'N/A'}",
+                remediation="Validated: the environment's BAP record reports a provisioned Dataverse database (linkedEnvironmentMetadata is present with a non-error state).",
                 doc_link=f"{DOC_BASE}/prepare#set-up-your-power-platform-environment",
             ))
         else:
@@ -275,6 +277,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Environment type",
             result=f"Type: {env_type}",
+            remediation=f"Validated: the environment's BAP record exposes an environment type ('{env_type}') readable via the BAP Admin API.",
             doc_link=f"{DOC_BASE}/prepare#set-up-your-power-platform-environment",
         ))
 
@@ -299,6 +302,7 @@ def run_environment_checks(runner) -> list[CheckResult]:
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="DLP policies configured",
                 result=f"{len(policies)} policy/policies apply to this environment",
+                remediation="Validated: at least one DLP (data loss prevention) policy from the BAP apiPolicies endpoint applies to this environment.",
                 doc_link=f"{DOC_BASE}/prepare#allow-the-external-systems-connector",
             ))
         else:
@@ -954,6 +958,7 @@ def _check_preferred_solution(runner) -> list[CheckResult]:
                         f"is one of {len(solutions)} eligible unmanaged "
                         f"solution(s) in this environment ({eligible_summary})."
                     ),
+                    remediation="Validated: the current maker has a preferred unmanaged solution selected (Dataverse usersettings preferredsolutionid) and it resolves to one of the eligible unmanaged solutions in this environment.",
                     doc_link=_PREFSOL_DOC_LINK,
                 )]
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/external_systems.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/external_systems.py
@@ -84,6 +84,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Workday solution installed",
             result=f"Found {len(wd_flows)} Workday flow(s)",
+            remediation=f"Validated: {len(wd_flows)} Workday cloud flow(s) are present in the environment, indicating the Workday solution/extension pack is installed.",
             doc_link=f"{DOC_BASE}/workday",
         ))
     else:
@@ -115,6 +116,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="ServiceNow solution installed",
             result=detail,
+            remediation="Validated: ServiceNow cloud flow(s) are present in the environment, indicating the ServiceNow (HRSD/ITSM) solution is installed.",
             doc_link=f"{DOC_BASE}/servicenow",
         ))
     else:
@@ -136,6 +138,7 @@ def run_external_systems_checks(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="SAP SuccessFactors solution installed",
             result=f"Found {len(sap_flows)} SAP flow(s)",
+            remediation=f"Validated: {len(sap_flows)} SAP SuccessFactors cloud flow(s) are present in the environment, indicating the SAP SuccessFactors solution is installed.",
             doc_link=f"{DOC_BASE}/sap-successfactors",
         ))
     else:

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/graph_connector_kb.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/graph_connector_kb.py
@@ -344,6 +344,12 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
                     f"Connection '{connection_id}' is ready and the most recent "
                     "crawl operation completed successfully."
                 ),
+                remediation=(
+                    f"Validated: Graph connector '{connection_id}' reports state "
+                    "'ready' and its most recent crawl operation completed "
+                    "successfully (per the connection + crawl status from "
+                    "Microsoft Graph external connectors)."
+                ),
             ))
         elif op_status == "failed":
             failed.append(display)
@@ -500,7 +506,7 @@ def run_graph_connector_kb_checks(runner) -> list[CheckResult]:
     else:
         summary_status = Status.PASSED.value
         result_text = f"{total} Graph Connector knowledge source(s) ready"
-        summary_remediation = ""
+        summary_remediation = f"Validated: all {total} Graph connector knowledge source(s) are in the ready state with their most recent crawl completed successfully."
 
     results.insert(0, CheckResult(
         checkpoint_id="EXT-002",

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/licensing.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/licensing.py
@@ -193,6 +193,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Agent flow licensing",
             result="No agent topics invoke a Power Automate flow (no InvokeFlowAction references found).",
+            remediation="Validated: no agent topic contains an InvokeFlowAction, so the agent invokes no Power Automate flow and no premium-connector flow licensing applies.",
             doc_link=PA_LICENSING_FAQ,
         )]
 
@@ -290,6 +291,7 @@ def _check_traditional_flow_licensing(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Agent flow licensing",
             result="; ".join(detail_bits) + ".",
+            remediation="Validated: every agent-invoked Power Automate flow uses only standard-tier connectors (no premium or custom connector detected), so no per-user premium license is required for these flows.",
             doc_link=PA_LICENSING_FAQ,
         )]
 
@@ -591,6 +593,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Shared-user flow licensing",
             result="The agent is not yet shared with any user; no licenses to verify.",
+            remediation="Validated: the agent is not shared with any user, so there are no shared-with principals whose premium-connector flow licensing needs checking.",
             doc_link=PA_LICENSING_FAQ,
         )]
 
@@ -670,6 +673,7 @@ def _check_shared_user_licensing(runner) -> list[CheckResult]:
         priority=Priority.HIGH.value, status=Status.PASSED.value,
         description="Shared-user flow licensing",
         result=base + ". All shared-with users hold a qualifying license.",
+        remediation="Validated: every user the agent is shared with holds a qualifying Power Automate / Power Platform license for the premium-connector flow(s) the agent invokes.",
         doc_link=PA_LICENSING_FAQ,
     )]
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/local_files.py
@@ -198,6 +198,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description=f"{label}: Agent instructions",
                 result=f"Instructions present ({word_count} words)",
+                remediation=f"Validated: the agent identity file contains a non-empty instructions field ({word_count} words, above the minimum threshold).",
                 doc_link=f"{DOC_BASE}/customize",
             ))
         else:
@@ -234,6 +235,7 @@ def _check_agent_identity(agent_path: Path, label: str, runner=None, agent_name:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description=f"{label}: Starter prompts",
             result=f"{count} starter prompt(s) found",
+            remediation=f"Validated: {count} conversation starter prompt(s) are defined in the local agent identity file.",
             doc_link=f"{DOC_BASE}/customize#customize-starter-prompts",
         ))
     elif count > 0:
@@ -304,6 +306,7 @@ def _check_required_topics(agent_path: Path, label: str, runner=None, agent_name
                 priority=req["priority"], status=Status.PASSED.value,
                 description=f"{label}: {req['name']}",
                 result="Topic found",
+                remediation=f"Validated: the required topic '{req['name']}' is present in the agent's local topics/ folder.",
                 doc_link=f"{DOC_BASE}/customize#customize-topics",
             ))
         else:
@@ -335,7 +338,7 @@ def _check_topic_inventory(agent_path: Path, label: str) -> list[CheckResult]:
         status=Status.PASSED.value if count >= 5 else Status.WARNING.value,
         description=f"{label}: Topic inventory",
         result=f"{count} topic(s) in agent",
-        remediation="ESS agents typically have 20+ topics." if count < 5 else "",
+        remediation="ESS agents typically have 20+ topics." if count < 5 else f"Validated: the agent has {count} local topic file(s), at least the minimum of 5 expected.",
     ))
 
     return results
@@ -363,7 +366,7 @@ def _check_variables(agent_path: Path, label: str) -> list[CheckResult]:
         status=Status.PASSED.value if var_files else Status.WARNING.value,
         description=f"{label}: User Context variables",
         result=f"{len(var_files)} variable(s) found",
-        remediation="Create User Context variables for employee data." if not var_files else "",
+        remediation="Create User Context variables for employee data." if not var_files else f"Validated: {len(var_files)} local variable definition file(s) (User Context variables) are present in the agent's variables/ folder.",
         doc_link=f"{DOC_BASE}/customize",
     ))
 
@@ -657,6 +660,7 @@ def _check_topic_descriptions(agent_path: Path, label: str, runner=None, agent_n
             priority=Priority.MEDIUM.value, status=Status.PASSED.value,
             description=f"{label}: Topic description quality",
             result=f"All {checked} AI-routed topic(s) have descriptions >= {_MIN_DESCRIPTION_WORDS} words with no placeholders",
+            remediation=f"Validated: every AI-routed topic ({checked} checked) has a modelDescription of at least {_MIN_DESCRIPTION_WORDS} words with no placeholder text.",
             doc_link=f"{DOC_BASE}/customize#customize-topics",
         ))
 
@@ -679,6 +683,7 @@ def _check_template_configs(agent_path: Path, label: str) -> list[CheckResult]:
         priority=Priority.MEDIUM.value, status=Status.PASSED.value,
         description=f"{label}: Template configurations",
         result=f"{len(xml_files)} XML template(s), {len(meta_files)} metadata file(s)",
+        remediation=f"Validated: the agent's local template-config folder contains {len(xml_files)} XML template(s) and {len(meta_files)} metadata file(s).",
     ))
 
     return results
@@ -812,6 +817,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description=f"{label}: '{name}' ({source_type})",
                 result=f"Status: {crawl_status} \u2014 indexed and ready",
+                remediation=f"Validated: knowledge source '{name}' ({source_type}) reports an indexed/ready crawl status ('{crawl_status}').",
             ))
         elif crawl_status in _NOT_READY_STATUSES:
             all_ready = False
@@ -865,6 +871,7 @@ def _check_knowledge_sources_via_gateway(pva, bot_id: str, knowledge_files: list
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description=f"{label}: All knowledge sources indexed",
             result=f"{len(sources)} knowledge source(s) fully indexed and ready",
+            remediation=f"Validated: all {len(sources)} knowledge source(s) report a fully indexed/ready crawl status.",
         ))
 
     return results

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
@@ -80,6 +80,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Microsoft 365 Copilot licenses",
                 result=f"Found {consumed} consumed / {enabled} enabled",
+                remediation="Validated: at least one Microsoft 365 Copilot license seat is consumed in the tenant, read via Microsoft Graph (GET /subscribedSkus, consumedUnits > 0).",
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
         else:
@@ -112,6 +113,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Copilot Studio licenses",
                 result=f"Found: {names}",
+                remediation="Validated: at least one Copilot Studio license SKU is present in the tenant, read via Microsoft Graph (GET /subscribedSkus).",
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
         else:
@@ -143,6 +145,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Microsoft Teams licenses",
                 result=f"{consumed} users licensed for Teams",
+                remediation="Validated: at least one Microsoft Teams license is consumed in the tenant, read via Microsoft Graph (GET /subscribedSkus, consumedUnits > 0).",
                 doc_link=f"{DOC_BASE}/prerequisites#licensing",
             ))
         else:
@@ -176,6 +179,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Global Admin role assigned",
                 result=f"Assigned to {len(members)} user(s)",
+                remediation="Validated: the Global Administrator directory role has at least one active member, read via Microsoft Graph (GET /directoryRoles + members).",
                 doc_link=f"{DOC_BASE}/prerequisites#required-roles",
             ))
         else:
@@ -209,6 +213,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
                 priority=Priority.CRITICAL.value, status=Status.PASSED.value,
                 description="Power Platform Admin role assigned",
                 result=f"Assigned to {len(members)} user(s)",
+                remediation="Validated: the Power Platform Administrator directory role has at least one active member, read via Microsoft Graph (GET /directoryRoles + members).",
                 doc_link=f"{DOC_BASE}/prerequisites#required-roles",
             ))
         else:

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/servicenow.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/servicenow.py
@@ -124,7 +124,7 @@ def _check_flow_status(runner, sn_flows: list) -> list[CheckResult]:
             status=Status.PASSED.value if is_on else Status.FAILED.value,
             description=f"Flow [{pack_label}]: {name}",
             result=f"State: {'Enabled' if is_on else 'Disabled'}",
-            remediation=f"Enable '{name}' in Power Automate." if not is_on else "",
+            remediation=f"Enable '{name}' in Power Automate." if not is_on else f"Validated: ServiceNow flow '{name}' is in an enabled/started state in Power Automate.",
             doc_link=f"{DOC_BASE}/servicenow",
         ))
 
@@ -141,7 +141,7 @@ def _check_flow_status(runner, sn_flows: list) -> list[CheckResult]:
             status=Status.PASSED.value if disabled == 0 else Status.WARNING.value,
             description="ServiceNow flow status summary",
             result=f"{len(sn_flows)} flows ({breakdown}) — {enabled} enabled, {disabled} disabled",
-            remediation=f"{disabled} flow(s) disabled — enable them in Power Automate." if disabled else "",
+            remediation=f"{disabled} flow(s) disabled — enable them in Power Automate." if disabled else f"Validated: all {len(sn_flows)} ServiceNow cloud flow(s) are in an enabled/started state in Power Automate.",
         ))
 
     return results
@@ -180,6 +180,7 @@ def _check_template_configs(runner) -> list[CheckResult]:
                 priority=Priority.HIGH.value, status=Status.PASSED.value,
                 description="ServiceNow template configurations",
                 result=f"Found {len(configs)} ServiceNow template config(s) in Dataverse",
+                remediation="Validated: at least one ServiceNow template configuration record exists in Dataverse (msdyn_employeeselfservicetemplateconfigs filtered to ServiceNow scenarios).",
                 doc_link=f"{DOC_BASE}/servicenow",
             ))
 
@@ -235,6 +236,7 @@ def _validate_expected_configs(
             priority=Priority.MEDIUM.value, status=Status.PASSED.value,
             description=f"ServiceNow {pack_label} template configs",
             result=f"All {len(expected)} expected {pack_label} configs present",
+            remediation=f"Validated: all {len(expected)} expected {pack_label} ServiceNow template config scenario(s) are present in Dataverse.",
         ))
     elif found:
         results.append(CheckResult(
@@ -296,6 +298,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
             priority=Priority.MEDIUM.value, status=Status.PASSED.value,
             description=f"{label}: ServiceNow topics present",
             result=f"Found {sn_topic_count} topic(s) referencing ServiceNow",
+            remediation=f"Validated: {sn_topic_count} local topic file(s) under the agent's topics/ folder reference ServiceNow.",
         ))
 
         # Check for HRSD topics
@@ -308,6 +311,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
                 priority=Priority.MEDIUM.value, status=Status.PASSED.value,
                 description=f"{label}: ServiceNow HRSD topics",
                 result=f"Found {hrsd_found} HRSD topic(s)",
+                remediation=f"Validated: {hrsd_found} local topic file(s) match the expected ServiceNow HRSD naming pattern.",
             ))
 
         if itsm_found:
@@ -316,6 +320,7 @@ def _check_agent_sn_topics(agent_path: Path, label: str) -> list[CheckResult]:
                 priority=Priority.MEDIUM.value, status=Status.PASSED.value,
                 description=f"{label}: ServiceNow ITSM topics",
                 result=f"Found {itsm_found} ITSM topic(s)",
+                remediation=f"Validated: {itsm_found} local topic file(s) match the expected ServiceNow ITSM naming pattern.",
             ))
 
         if not hrsd_found and not itsm_found:

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -850,6 +850,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
                 "ISU connection references (Generic User, Context Generic "
                 "User) are missing." + flow_note
             ),
+            remediation="Validated: exactly one Workday connection reference (the OAuthUser/OBO ref, logical-name suffix ff0df) is present in Dataverse — the deterministic fingerprint of the simplified install.",
             doc_link=doc_simplified,
         ))
         return results
@@ -871,6 +872,7 @@ def _check_package_flavor(runner, *, wd_flows: list) -> list[CheckResult]:
                 "Detected full / legacy SOAP+custom install shape "
                 "(3 Workday connection references: OAuthUser/OBO + 2 ISU)." + flow_note
             ),
+            remediation="Validated: all three Workday connection references (OAuthUser/OBO ff0df + the two ISU refs 0786a / d6081) are present in Dataverse — the deterministic fingerprint of the full / legacy install.",
             doc_link=doc_legacy,
         ))
         return results
@@ -1029,6 +1031,7 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
                 f"for the {flavor} install are bound to active connections "
                 f"({', '.join(sorted(bound_roles))})."
             ),
+            remediation=f"Validated: every Workday connection reference expected for the {flavor} install ({', '.join(sorted(bound_roles))}) is bound to an active connection (connectionid set and statuscode active).",
             doc_link=doc_link,
         )]
 
@@ -1197,6 +1200,7 @@ def _check_env_vars(runner) -> list[CheckResult]:
                     status=Status.PASSED.value,
                     description=meta["description"],
                     result=f"Set to: {actual_value}",
+                    remediation=f"Validated: the Workday Dataverse environment variable '{meta['id']}' has an explicit current value ('{actual_value}').",
                     doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
                 ))
             elif meta["critical"]:
@@ -1214,6 +1218,7 @@ def _check_env_vars(runner) -> list[CheckResult]:
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=meta["description"],
                     result=f"Using default: {meta['default']}",
+                    remediation=f"Validated: the Workday Dataverse environment variable '{meta['id']}' is unset and resolves to its documented default value ('{meta['default']}').",
                     doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
                 ))
     except Exception as e:
@@ -1430,6 +1435,7 @@ def _check_isu_username_format(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="ISU username vs Entra UPN format alignment",
             result=f"ISU username '{isu_value}' matches verified tenant domain '{domain}'",
+            remediation=f"Validated: the ISU username env var value ('{isu_value}') uses the verified tenant domain ('{domain}'), matching the expected Entra UPN format.",
             doc_link=f"{DOC_BASE}/workday#step-4-environment-variables",
         ))
     else:
@@ -1740,6 +1746,7 @@ def _check_connection_token_health(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description="Workday connection token health",
             result=f"All {len(wd_conns)} Workday connection(s) report healthy auth state",
+            remediation=f"Validated: all {len(wd_conns)} Workday connection(s) report a healthy auth state (Connected with no token/credential error) via the Power Platform connections API.",
             doc_link=f"{DOC_BASE}/workday#step-3-connection-references",
         ))
         return results
@@ -2679,7 +2686,7 @@ def _check_flow_status(runner, wd_flows: list) -> list[CheckResult]:
             status=Status.PASSED.value if is_on else Status.FAILED.value,
             description=f"Flow: {name}",
             result=f"State: {'Enabled' if is_on else 'Disabled'}",
-            remediation=f"Enable '{name}' in Power Automate." if not is_on else "",
+            remediation=f"Enable '{name}' in Power Automate." if not is_on else f"Validated: Workday flow '{name}' is in an enabled/started state in Power Automate.",
             doc_link=f"{DOC_BASE}/workday#topics",
         ))
 
@@ -2803,6 +2810,7 @@ def _check_workflows(runner) -> list[CheckResult]:
                     checkpoint_id=cid, category="Workday Workflows",
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=desc, result="API accessible",
+                    remediation="Validated: this Workday SOAP workflow returned a successful response from the live Workday tenant — the ISU is authenticated and the operation is reachable.",
                 ))
             else:
                 results.append(CheckResult(
@@ -2834,6 +2842,7 @@ def _check_workflows(runner) -> list[CheckResult]:
                         checkpoint_id=cid, category="Workday Workflows",
                         priority=Priority.HIGH.value, status=Status.PASSED.value,
                         description=desc, result="Data retrieved",
+                        remediation="Validated: this Workday SOAP workflow executed against the live tenant and returned worker data — the ISU holds the required domain access.",
                     ))
                 else:
                     results.append(CheckResult(
@@ -2841,6 +2850,7 @@ def _check_workflows(runner) -> list[CheckResult]:
                         priority=Priority.HIGH.value, status=Status.PASSED.value,
                         description=desc,
                         result="API accessible (no data for this employee)",
+                        remediation="Validated: this Workday SOAP workflow executed successfully against the live tenant (reachable and authorized); it simply returned no data for the test employee.",
                     ))
             except (ET.ParseError, DefusedXmlException):
                 # ET.ParseError = malformed XML.
@@ -2853,6 +2863,7 @@ def _check_workflows(runner) -> list[CheckResult]:
                     checkpoint_id=cid, category="Workday Workflows",
                     priority=Priority.HIGH.value, status=Status.PASSED.value,
                     description=desc, result="API responded (unparseable XML)",
+                    remediation="Validated: this Workday SOAP endpoint responded over the live connection — the call was reachable and authorized, though the response body was not parseable XML.",
                 ))
         else:
             error = result.get("error", "Unknown")
@@ -3435,6 +3446,7 @@ def _check_personal_data_write_permission(runner) -> list[CheckResult]:
                 "Update Email / Update Phone topics have the runtime "
                 "permission they need."
             ),
+            remediation="Validated: Workday accepted a Get_Change_Work_Contact_Information_Event_Request from the configured ISU with no Personal Data permission denial, so the ISU's security group holds Modify on the Personal Data (Self) domain.",
             doc_link=doc_link,
         )]
 
@@ -4029,6 +4041,7 @@ def _check_custom_workflow_inventory(runner) -> list[CheckResult]:
                 "(msdyn_employeeselfservicetemplateconfigs where "
                 "ismanaged=true) and require no manual review."
             ),
+            remediation=f"Validated: all {len(discovered)} Workday scenario reference(s) found in customer topics resolve to managed template-config rows in Dataverse (msdyn_employeeselfservicetemplateconfigs, ismanaged=true), so none need manual review.",
             doc_link=doc_link,
         )]
 

--- a/tests/flightcheck/checks/test_connections_helpers.py
+++ b/tests/flightcheck/checks/test_connections_helpers.py
@@ -440,14 +440,15 @@ class TestCheckConnectorConnectionsBucketing:
         assert "2 total" in summary.result
         assert "2 connected" in summary.result
         assert "0 errored" in summary.result
-        assert summary.remediation == ""  # no remediation when all connected
+        assert summary.remediation.startswith("Validated:")  # describes what passed
+        assert "Connected" in summary.remediation
 
         # Per-connection rows: X-CONN-002 and X-CONN-003.
         for cid in ("X-CONN-002", "X-CONN-003"):
             r = _result_by_id(results, cid)
             assert r.status == "Passed"
             assert "Status: Connected" in r.result
-            assert r.remediation == ""
+            assert r.remediation.startswith("Validated:")
 
     @responses.activate
     def test_all_errored_summary_fails_with_reauth_remediation(

--- a/tests/flightcheck/checks/test_env_008_dlp_remediation.py
+++ b/tests/flightcheck/checks/test_env_008_dlp_remediation.py
@@ -191,10 +191,9 @@ def test_env_008_no_policies_remediation_acknowledges_no_dlp_is_valid(monkeypatc
 # ---------------------------------------------------------------------------
 
 
-def test_env_008_with_policies_passes_with_no_remediation(monkeypatch):
-    """When at least one DLP policy applies, ENV-008 passes and emits
-    no remediation — covering the regression risk that we accidentally
-    push remediation text on the happy path."""
+def test_env_008_with_policies_passes_with_validated_note(monkeypatch):
+    """When at least one DLP policy applies, ENV-008 passes and its
+    remediation describes what was validated."""
     from flightcheck.checks import environment as env_mod
 
     monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
@@ -203,7 +202,8 @@ def test_env_008_with_policies_passes_with_no_remediation(monkeypatch):
     env008 = _get_env_008(results)
 
     assert env008.status == "Passed"
-    assert not (env008.remediation or "")
+    assert env008.remediation.startswith("Validated:")
+    assert "DLP" in env008.remediation
 
 
 # ---------------------------------------------------------------------------

--- a/tests/flightcheck/checks/test_licensing.py
+++ b/tests/flightcheck/checks/test_licensing.py
@@ -118,7 +118,8 @@ def test_passed_when_only_standard_connectors(tmp_path, monkeypatch):
     from flightcheck.runner import Status
     assert r.status == Status.PASSED.value
     assert runner._lic_flow_premium_present is False
-    assert not r.remediation
+    assert r.remediation.startswith("Validated:")
+    assert "standard-tier" in r.remediation
 
 
 # --------------------------------------------------------------- bad state
@@ -378,7 +379,8 @@ def test_lic002_passed_all_licensed(monkeypatch):
     r = _lic002(_runner002(graph))[0]
     from flightcheck.runner import Status
     assert r.status == Status.PASSED.value
-    assert not r.remediation
+    assert r.remediation.startswith("Validated:")
+    assert "qualifying" in r.remediation
 
 
 def test_lic002_fail_when_some_missing(monkeypatch):

--- a/tests/flightcheck/checks/test_preferred_solution.py
+++ b/tests/flightcheck/checks/test_preferred_solution.py
@@ -253,8 +253,9 @@ def test_passed_when_selected_solution_matches(runner: _MinimalRunner) -> None:
     # with the WARNING path (operator can confirm the binding at a glance).
     assert "ContosoPublisher" in r.result
     assert "contoso" in r.result
-    # Principle 8: PASSED has no remediation.
-    assert r.remediation == ""
+    # PASSED remediation describes what was validated.
+    assert r.remediation.startswith("Validated:")
+    assert "preferred" in r.remediation
 
 
 @responses.activate
@@ -468,7 +469,7 @@ def test_passed_when_publisher_fetch_fails_degrades_gracefully(
     assert "ESSCustomization" in r.result
     # No publisher annotation when the fetch failed.
     assert "publisher:" not in r.result
-    assert r.remediation == ""
+    assert r.remediation.startswith("Validated:")
 
 
 @responses.activate

--- a/tests/flightcheck/checks/test_workday_connection_token_health.py
+++ b/tests/flightcheck/checks/test_workday_connection_token_health.py
@@ -84,7 +84,8 @@ class TestGoodConfig:
         assert wd_101.priority == "High"
         assert "All 2 Workday connection(s)" in wd_101.result
         assert "healthy" in wd_101.result.lower()
-        assert wd_101.remediation == ""
+        assert wd_101.remediation.startswith("Validated:")
+        assert "healthy" in wd_101.remediation.lower()
 
 
 class TestBadConfig:

--- a/tests/flightcheck/checks/test_workday_personal_data.py
+++ b/tests/flightcheck/checks/test_workday_personal_data.py
@@ -437,14 +437,9 @@ class TestModeA_PassBranches:
         r = results[0]
         assert r.checkpoint_id == "WD-SEC-003"
         assert r.status == "Passed"
-        # AGENTS.md principle #8: PASSED branches have no remediation
-        # text. Use truthiness (not == "") so the test still holds if
-        # CheckResult ever changes the default from `str = ""` to e.g.
-        # `Optional[str] = None`. The HTML renderer already tolerates
-        # both via `res.remediation or ""` (runner.py line 620) — this
-        # test should match that tolerance rather than over-pin the
-        # current default.
-        assert not r.remediation
+        # PASSED remediation now describes what was validated.
+        assert r.remediation.startswith("Validated:")
+        assert "Personal Data" in r.remediation
         # Result must report the observed state — specifically that
         # the runtime permission is in place.
         assert "Personal Data" in r.result


### PR DESCRIPTION
## Summary

When a FlightCheck result passes, the report previously showed nothing under **Remediation**, so a green row gave no insight into *what* the check actually confirmed. This PR populates the `remediation` of every PASSED result with a concise **"Validated: …"** note stating the exact success criterion (which API / field / value made the check pass) — enough to understand what was verified.

## What changed

- Added a `Validated: …` remediation to all ~54 passed-producing `CheckResult` branches across the check modules: `authentication`, `connections`, `environment`, `external_systems`, `graph_connector_kb`, `licensing`, `local_files`, `prerequisites`, `servicenow`, `workday` — including the conditional pass/fail constructors (the pass branch now carries the Validated note, the fail branch keeps its fix text).
- Updated `flightcheck/AGENTS.md` principle 8: PASSED results now carry a `Validated: …` note rather than an empty remediation.
- Updated the existing tests that pinned the old "passed → empty remediation" convention to assert the new `Validated: …` text.

## Example

| Status | Result | Remediation |
|--------|--------|-------------|
| Passed | `Tenant: Contoso (…)` | `Validated: the tenant exposes a Microsoft Entra ID organization record via Microsoft Graph (GET /organization returned an org with a displayName and id).` |
| Passed | `All 2 Workday connection(s) report healthy auth state` | `Validated: all 2 Workday connection(s) report a healthy auth state (Connected with no token/credential error) via the Power Platform connections API.` |

## Verification

- `ruff check solutions/ess-maker-skills/scripts` — clean
- `pytest tests` — **592 passed, 8 skipped** (8 pre-existing skips)

## Notes

Independent of #148 (the Role column PR); no expected conflicts.
