### PR TITLE
FlightCheck: add tests for ported checks + surface PP 401/403 (DLP fix)

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/environment.py
@@ -293,7 +293,20 @@ def run_environment_checks(runner) -> list[CheckResult]:
     # ---- ENV-008: DLP policies ----
     try:
         policies = pp.get_dlp_policies_for_env(env_id)
-        if policies:
+        if isinstance(policies, dict) and "_error" in policies:
+            # The apiPolicies admin endpoint returned 401/403 — we could
+            # NOT read DLP state. Report this honestly as a SKIP rather
+            # than claiming "no DLP policies" (which would falsely imply
+            # the environment is unrestricted).
+            results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
+                checkpoint_id="ENV-008", category="Environment",
+                priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+                description="DLP policies configured",
+                result="DLP policy check skipped — the apiPolicies admin endpoint returned a permissions error.",
+                remediation="Re-run FlightCheck signed in with the Power Platform Administrator role so DLP policies can be read.",
+                doc_link=f"{DOC_BASE}/prepare#allow-the-external-systems-connector",
+            ))
+        elif policies:
             results.append(CheckResult(roles=[Role.POWER_PLATFORM_ADMIN.value],
                 checkpoint_id="ENV-008", category="Environment",
                 priority=Priority.HIGH.value, status=Status.PASSED.value,

--- a/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
@@ -173,15 +173,23 @@ class PPAdminClient:
         resp.raise_for_status()
         return resp.json()
 
-    def _get_all(self, base: str, path: str, params: dict | None = None, *, use_flow_token: bool = False) -> list:
-        """Paginate through results."""
+    def _get_all(self, base: str, path: str, params: dict | None = None, *, use_flow_token: bool = False) -> list | dict:
+        """Paginate through results.
+
+        On 401/403 returns a structured ``{"_error": ...}`` dict (matching
+        ``_get``) so callers surface the permission failure instead of
+        mistaking a swallowed auth error for an empty collection. Every
+        consumer of the list-returning methods (get_connections,
+        get_flows, get_environments, get_dlp_policies) already guards
+        with ``isinstance(result, dict) and "_error" in result``.
+        """
         items: list = []
         url = f"{base}{path}"
         h = self.flow_headers if use_flow_token else self.headers
         while url:
             resp = _SESSION.get(url, headers=h, params=params, timeout=60)
             if resp.status_code in (401, 403):
-                return items
+                return {"_error": "insufficient_permissions", "_status": resp.status_code}
             resp.raise_for_status()
             data = resp.json()
             items.extend(data.get("value", []))
@@ -287,9 +295,15 @@ class PPAdminClient:
             params={"api-version": "2021-04-01"},
         )
 
-    def get_dlp_policies_for_env(self, env_id: str) -> list:
+    def get_dlp_policies_for_env(self, env_id: str) -> list | dict:
         """List DLP policies applied to a specific environment."""
         all_policies = self.get_dlp_policies()
+        # Surface a permission failure rather than treating it as "no
+        # DLP policies" — the caller (ENV-008) renders this as a SKIP
+        # ("requires Power Platform Administrator") instead of a false
+        # "environment is unrestricted" verdict.
+        if isinstance(all_policies, dict) and "_error" in all_policies:
+            return all_policies
         # Filter to policies that include this environment
         relevant = []
         for p in all_policies:

--- a/tests/flightcheck/checks/test_authentication_prereqs.py
+++ b/tests/flightcheck/checks/test_authentication_prereqs.py
@@ -1,0 +1,109 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for the tenant-prerequisite authentication checks that
+lacked coverage: AUTH-001 (Entra ID configured), AUTH-002 (Conditional
+Access policies), AUTH-004 (user identity synchronization).
+
+The Workday-app sub-checks (AUTH-005/006) are covered by
+``test_authentication.py`` / ``test_authentication_saml.py``; here a fake
+Graph client returns no service principals so those sub-checks no-op
+while AUTH-001/002/004 are exercised. Data shapes come from the
+validatable ``graph`` mock builders.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+from tests.conftest import require_validated_mock
+from tests.mocks import graph as gr
+
+require_validated_mock(gr)
+
+
+class _FakeGraph:
+    """Returns canned (validatable-builder-shaped) responses for the
+    Graph methods the authentication checks call. Service-principal
+    methods return empty so AUTH-005/006 short-circuit."""
+
+    def __init__(self, *, org=None, policies=None, users=None):
+        self._org = org
+        self._policies = policies if policies is not None else []
+        self._users = users if users is not None else []
+
+    def get_organization(self):
+        return self._org
+
+    def get_conditional_access_policies(self):
+        return self._policies
+
+    def get_users_sample(self, top: int = 10):
+        return self._users
+
+    def get_service_principals(self, *a, **kw):
+        return []
+
+    def get_application_templates(self, *a, **kw):
+        return []
+
+    def get_app_role_assignments(self, *a, **kw):
+        return []
+
+    def get_claims_mapping_policies(self, *a, **kw):
+        return []
+
+    def get(self, *a, **kw):
+        return {}
+
+
+def _run(graph):
+    from flightcheck.checks.authentication import run_authentication_checks
+    return run_authentication_checks(SimpleNamespace(graph=graph))
+
+
+def _by_id(results, cid):
+    matches = [r for r in results if r.checkpoint_id == cid]
+    assert len(matches) == 1, [r.checkpoint_id for r in results]
+    return matches[0]
+
+
+def test_auth_001_002_004_pass():
+    graph = _FakeGraph(
+        org=gr.organization(display_name="Contoso"),
+        policies=[gr.conditional_access_policy(state="enabled")],
+        users=[gr.user(), gr.user(user_id="u2")],
+    )
+    results = _run(graph)
+
+    auth001 = _by_id(results, "AUTH-001")
+    assert auth001.status == "Passed"
+    assert "Contoso" in auth001.result
+
+    auth002 = _by_id(results, "AUTH-002")
+    assert auth002.status == "Passed"
+    assert "1 enabled" in auth002.result
+
+    auth004 = _by_id(results, "AUTH-004")
+    assert auth004.status == "Passed"
+    assert "2 sample users" in auth004.result
+
+
+def test_auth_001_fails_without_org():
+    auth001 = _by_id(_run(_FakeGraph(org=None)), "AUTH-001")
+    assert auth001.status == "Failed"
+    assert "Unable to retrieve organization info" in auth001.result
+    assert "Entra ID is properly configured" in auth001.remediation
+
+
+def test_auth_002_warns_without_policies():
+    auth002 = _by_id(_run(_FakeGraph(org=gr.organization(), policies=[])), "AUTH-002")
+    assert auth002.status == "Warning"
+    assert "No Conditional Access policies" in auth002.result
+
+
+def test_auth_004_fails_without_users():
+    auth004 = _by_id(_run(_FakeGraph(org=gr.organization(), users=[])), "AUTH-004")
+    assert auth004.status == "Failed"
+    assert "No users found in Entra ID" in auth004.result

--- a/tests/flightcheck/checks/test_connections_helpers.py
+++ b/tests/flightcheck/checks/test_connections_helpers.py
@@ -343,19 +343,15 @@ class TestCheckConnectorConnectionsHandlesApiErrors:
         assert "simulated transport blowup" in r.result
 
     @responses.activate
-    def test_http_403_silently_degrades_to_not_configured(
+    def test_http_403_reported_as_permissions_warning(
         self, runner: _MinimalRunner
     ) -> None:
-        """A real 401/403 on ``/connections`` is swallowed by
-        ``PPAdminClient._get_all`` into an empty list (see
-        pp_admin_client.py:183-184). The helper has no way to tell
-        "missing admin role" from "no matching connections" and emits
-        ``NotConfigured``.
-
-        This is a known silent-failure mode — the same trap AUTH-006
-        and ENV-009 added explicit probe queries to work around. Pin
-        the current behavior so a future fix (probe + WARNING split)
-        flips this assertion intentionally rather than silently.
+        """A real 401/403 on ``/connections`` is surfaced by
+        ``PPAdminClient._get_all`` as a ``{"_error": ...}`` dict, and the
+        helper renders it as a WARNING that names the missing Power
+        Platform Administrator role — distinct from "no matching
+        connections" (NotConfigured). (Fix for "bug 2": ``_get_all`` no
+        longer swallows 401/403 into an empty list.)
         """
         from flightcheck.checks.connections import check_connector_connections
         responses.add(**pp.list_connections(env_id=runner.env_id, connections=[], status=403))
@@ -368,10 +364,9 @@ class TestCheckConnectorConnectionsHandlesApiErrors:
             not_found_remediation="Run /connect workday to configure.",
         )
         r = _result_by_id(results, "X-CONN-001")
-        # TODO: when get_connections is augmented with a probe (like
-        # AUTH-006 / ENV-009), flip this to status == "Warning" with
-        # a permissions remediation.
-        assert r.status == "NotConfigured"
+        assert r.status == "Warning"
+        assert "Unable to list connections" in r.result
+        assert "Power Platform Admin" in r.remediation
 
 
 class TestCheckConnectorConnectionsBucketing:

--- a/tests/flightcheck/checks/test_env_008_dlp_remediation.py
+++ b/tests/flightcheck/checks/test_env_008_dlp_remediation.py
@@ -230,3 +230,24 @@ def test_env_008_permission_error_remediation_names_role_and_links(monkeypatch):
     assert _NAV_PATH in rem, rem
     for broken in ("/policies", "/dlp", "/datapolicies"):
         assert _ADMIN_URL + broken.lstrip("/") not in rem, rem
+
+
+def test_env_008_skips_when_apipolicies_returns_permission_error(monkeypatch):
+    """When the apiPolicies admin endpoint returns 401/403, the client
+    surfaces a structured ``{"_error": ...}`` dict. ENV-008 must report
+    this as a SKIP ("requires Power Platform Administrator") rather than
+    a false "No DLP policies found" — the kit must not claim the
+    environment is unrestricted when it could not actually read DLP."""
+    from flightcheck.checks import environment as env_mod
+
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+    runner = _make_runner(_FakePPAdmin(
+        dlp_policies={"_error": "insufficient_permissions", "_status": 403},
+    ))
+    results = env_mod.run_environment_checks(runner)
+    env008 = _get_env_008(results)
+
+    assert env008.status == "Skipped"
+    assert "permissions error" in env008.result
+    assert "No DLP policies found" not in env008.result  # no false "all clear"
+    assert "Power Platform Administrator" in env008.remediation

--- a/tests/flightcheck/checks/test_environment_basics.py
+++ b/tests/flightcheck/checks/test_environment_basics.py
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for the basic Power Platform environment checks that
+lacked assertions: ENV-001 (environment exists), ENV-002 (Dataverse
+provisioned), ENV-003 (environment type).
+
+ENV-004 / ENV-008 / ENV-009 are covered by their own test files; here
+``query_all`` (ENV-004) is stubbed to [] and the BAP environment record
+is supplied via a minimal fake PP Admin client mirroring
+``test_env_008_dlp_remediation.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    repo_root = Path(__file__).resolve().parents[3]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+class _FakePPAdmin:
+    def __init__(self, *, env_props=None, env_error=None):
+        self._env_props = env_props if env_props is not None else {
+            "displayName": "Test Env",
+            "linkedEnvironmentMetadata": {"resourceProvisioningState": "Succeeded"},
+            "databaseType": "CommonDataService",
+            "environmentSku": "Production",
+        }
+        self._env_error = env_error
+
+    def get_environment(self, _env_id):
+        if self._env_error is not None:
+            return {"_error": self._env_error}
+        return {"properties": self._env_props}
+
+    def get_dlp_policies_for_env(self, _env_id):
+        return []
+
+    def get_connections(self, _env_id):
+        return []
+
+
+def _runner(pp_admin):
+    return SimpleNamespace(
+        pp_admin=pp_admin, env_id="env-guid",
+        env_url="https://example.crm.dynamics.com", dv_token="t",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_query_all(monkeypatch):
+    """Neutralize ENV-004's Dataverse call so these tests stay offline."""
+    from flightcheck.checks import environment as env_mod
+    monkeypatch.setattr(env_mod, "query_all", lambda *a, **kw: [])
+
+
+def _by_id(results, cid):
+    matches = [r for r in results if r.checkpoint_id == cid]
+    assert len(matches) == 1, [r.checkpoint_id for r in results]
+    return matches[0]
+
+
+def _run(pp_admin):
+    from flightcheck.checks.environment import run_environment_checks
+    return run_environment_checks(_runner(pp_admin))
+
+
+def test_env_001_002_003_pass():
+    results = _run(_FakePPAdmin())
+
+    env001 = _by_id(results, "ENV-001")
+    assert env001.status == "Passed"
+    assert "Test Env" in env001.result
+
+    env002 = _by_id(results, "ENV-002")
+    assert env002.status == "Passed"
+    assert "Succeeded" in env002.result
+
+    env003 = _by_id(results, "ENV-003")
+    assert env003.status == "Passed"
+    assert "Production" in env003.result
+
+
+def test_env_002_fails_when_no_dataverse():
+    results = _run(_FakePPAdmin(env_props={"displayName": "No DB Env"}))
+    env002 = _by_id(results, "ENV-002")
+    assert env002.status == "Failed"
+    assert "Enable Dataverse database" in env002.remediation
+
+
+def test_env_001_warns_on_api_error():
+    results = _run(_FakePPAdmin(env_error="403 Forbidden"))
+    env001 = _by_id(results, "ENV-001")
+    assert env001.status == "Warning"
+    assert "Unable to query environment" in env001.result
+    assert "Power Platform Administrator role" in env001.remediation

--- a/tests/flightcheck/checks/test_external_systems.py
+++ b/tests/flightcheck/checks/test_external_systems.py
@@ -1,0 +1,115 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Integration tests for external-system discovery (EXT-001, WD-001,
+SN-001, SAP-001) in ``flightcheck.checks.external_systems``.
+
+Pattern mirrors ``test_servicenow_connections.py``: mock the Power
+Automate admin flow-listing endpoint with ``responses`` via the
+validated ``pp_admin`` builders, instantiate a real ``PPAdminClient``
+with a pre-populated token, run ``run_external_systems_checks``, and
+assert on the resulting CheckResults.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import responses
+
+from tests.conftest import require_validated_mock
+from tests.mocks import pp_admin as pp
+
+require_validated_mock(pp)
+
+
+@dataclass
+class _MinimalRunner:
+    pp_admin: Any
+    env_id: str
+
+
+@pytest.fixture
+def pp_client(fake_token: str):
+    from flightcheck.pp_admin_client import PPAdminClient
+    client = PPAdminClient(tenant_id="00000000-0000-0000-0000-000000001111")
+    client._token = fake_token
+    client._flow_token = fake_token  # flow listing uses a separate token
+    return client
+
+
+@pytest.fixture
+def runner(pp_client) -> _MinimalRunner:
+    return _MinimalRunner(pp_admin=pp_client, env_id=pp.MOCK_ENV_ID)
+
+
+def _by_id(results, cid):
+    matches = [r for r in results if r.checkpoint_id == cid]
+    assert len(matches) == 1, [r.checkpoint_id for r in results]
+    return matches[0]
+
+
+@responses.activate
+def test_all_three_solutions_detected(runner):
+    from flightcheck.checks.external_systems import run_external_systems_checks
+    responses.add(**pp.list_flows(env_id=runner.env_id, flows=[
+        pp.flow(display_name="Workday Get Worker", env_id=runner.env_id),
+        pp.flow(display_name="ServiceNow HRSD Case Lookup", env_id=runner.env_id),
+        pp.flow(display_name="SAP SuccessFactors Time Off", env_id=runner.env_id),
+    ]))
+
+    results = run_external_systems_checks(runner)
+
+    wd = _by_id(results, "WD-001")
+    assert wd.status == "Passed"
+    assert "1 Workday flow(s)" in wd.result
+
+    sn = _by_id(results, "SN-001")
+    assert sn.status == "Passed"
+    assert "1 ServiceNow flow(s)" in sn.result
+    assert "1 HRSD" in sn.result  # categorization surfaced
+
+    sap = _by_id(results, "SAP-001")
+    assert sap.status == "Passed"
+    assert "1 SAP flow(s)" in sap.result
+
+
+@responses.activate
+def test_none_detected_reports_not_configured(runner):
+    from flightcheck.checks.external_systems import run_external_systems_checks
+    responses.add(**pp.list_flows(env_id=runner.env_id, flows=[
+        pp.flow(display_name="Some Unrelated Flow", env_id=runner.env_id),
+    ]))
+
+    results = run_external_systems_checks(runner)
+
+    for cid, system in (("WD-001", "Workday"), ("SN-001", "ServiceNow"),
+                        ("SAP-001", "SAP SuccessFactors")):
+        r = _by_id(results, cid)
+        assert r.status == "NotConfigured"
+        assert "No" in r.result
+        assert "extension pack" in r.remediation
+
+
+@responses.activate
+def test_ext001_warns_when_flow_listing_fails(runner):
+    from flightcheck.checks.external_systems import run_external_systems_checks
+
+    class _RaisingPP:
+        def get_flows(self, env_id):
+            raise RuntimeError("flow API unavailable")
+
+    runner.pp_admin = _RaisingPP()
+    results = run_external_systems_checks(runner)
+
+    ext = _by_id(results, "EXT-001")
+    assert ext.status == "Warning"
+    assert "Unable to list flows" in ext.result
+    assert "flow API unavailable" in ext.result
+
+
+def test_skips_when_no_env_id():
+    from flightcheck.checks.external_systems import run_external_systems_checks
+    assert run_external_systems_checks(_MinimalRunner(pp_admin=None, env_id=None)) == []

--- a/tests/flightcheck/checks/test_prerequisites.py
+++ b/tests/flightcheck/checks/test_prerequisites.py
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Integration tests for the prerequisites checks (PRE-001 Copilot
+licenses, PRE-002 Copilot Studio licenses, PRE-003 Teams licenses,
+PRE-008 Global Admin role, PRE-009 Power Platform Admin role).
+
+Uses a real ``GraphClient`` with a fake token, mocking the Graph
+``/subscribedSkus``, ``/directoryRoles`` and ``/directoryRoles/{id}/
+members`` endpoints via the validatable ``graph`` mock builders.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import responses
+
+from tests.conftest import require_validated_mock
+from tests.mocks import graph as gr
+
+require_validated_mock(gr)
+
+_GA_ID = "00000000-0000-0000-0000-0000000051a1"
+_PP_ID = "00000000-0000-0000-0000-0000000051b2"
+
+
+def _graph_client():
+    from flightcheck.graph_client import GraphClient
+    client = GraphClient(gr.MOCK_TENANT_ID)
+    client._token = "REDACTED_TOKEN"  # noqa: S105 — test fixture
+    return client
+
+
+def _by_id(results, cid):
+    matches = [r for r in results if r.checkpoint_id == cid]
+    assert len(matches) == 1, [r.checkpoint_id for r in results]
+    return matches[0]
+
+
+@responses.activate
+def test_all_prerequisites_pass():
+    from flightcheck.checks.prerequisites import run_prerequisites_checks
+
+    responses.add(**gr.list_subscribed_skus(skus=[
+        gr.subscribed_sku(sku_part_number="MICROSOFT_365_COPILOT",
+                          consumed_units=5, enabled_units=10),
+        gr.subscribed_sku(sku_part_number="ENTERPRISEPACK",  # Teams-bearing (O365 E3)
+                          consumed_units=50, enabled_units=100),
+    ]))
+    responses.add(**gr.list_directory_roles(roles=[
+        gr.directory_role(role_id=_GA_ID, display_name="Global Administrator"),
+        gr.directory_role(role_id=_PP_ID, display_name="Power Platform Administrator"),
+    ]))
+    responses.add(**gr.list_role_members(role_id=_GA_ID, members=[gr.user()]))
+    responses.add(**gr.list_role_members(role_id=_PP_ID, members=[gr.user()]))
+
+    results = run_prerequisites_checks(SimpleNamespace(graph=_graph_client()))
+
+    assert _by_id(results, "PRE-001").status == "Passed"
+    assert _by_id(results, "PRE-002").status == "Passed"   # bundle covers Studio
+    pre003 = _by_id(results, "PRE-003")
+    assert pre003.status == "Passed"
+    assert "50 users licensed for Teams" in pre003.result
+    assert _by_id(results, "PRE-008").status == "Passed"
+    assert _by_id(results, "PRE-009").status == "Passed"
+
+
+@responses.activate
+def test_missing_licenses_and_roles():
+    from flightcheck.checks.prerequisites import run_prerequisites_checks
+
+    responses.add(**gr.list_subscribed_skus(skus=[]))
+    responses.add(**gr.list_directory_roles(roles=[]))
+
+    results = run_prerequisites_checks(SimpleNamespace(graph=_graph_client()))
+
+    pre001 = _by_id(results, "PRE-001")
+    assert pre001.status == "Failed"
+    assert "No M365 Copilot licenses" in pre001.result
+
+    assert _by_id(results, "PRE-002").status == "Failed"
+    assert _by_id(results, "PRE-003").status == "Warning"
+
+    pre008 = _by_id(results, "PRE-008")
+    assert pre008.status == "Failed"
+    assert "Global Administrator role not found" in pre008.result
+
+    assert _by_id(results, "PRE-009").status == "Warning"

--- a/tests/flightcheck/checks/test_servicenow_deep.py
+++ b/tests/flightcheck/checks/test_servicenow_deep.py
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for the ServiceNow checks that lacked coverage:
+``_check_flow_status`` (SN-FLOW-*), ``_check_template_configs``
+(SN-CFG-*), and ``_check_local_topics`` (SN-LOCAL-*).
+
+The connection helper (SN-CONN-*) is covered separately in
+``test_servicenow_connections.py``. Flow status and local topics are
+pure-logic (flow dicts / local files); template configs reads Dataverse
+via ``query_all``, which is stubbed here (the Dataverse contract itself
+is exercised by the connection/env tests).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.mocks import pp_admin as pp
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    repo_root = Path(__file__).resolve().parents[3]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def _by_id(results, cid):
+    matches = [r for r in results if r.checkpoint_id == cid]
+    assert len(matches) == 1, [r.checkpoint_id for r in results]
+    return matches[0]
+
+
+# --------------------------------------------------------------------------
+# _check_flow_status — SN-FLOW-000 summary + SN-FLOW-NNN per flow
+# --------------------------------------------------------------------------
+
+def test_flow_status_all_enabled():
+    from flightcheck.checks.servicenow import _check_flow_status
+    flows = [
+        pp.flow(display_name="ServiceNow HRSD Create Case", state="Started"),
+        pp.flow(display_name="ServiceNow ITSM Create Ticket", state="Started"),
+    ]
+    results = _check_flow_status(SimpleNamespace(), flows)
+
+    summary = _by_id(results, "SN-FLOW-000")
+    assert summary.status == "Passed"
+    assert "2 enabled, 0 disabled" in summary.result
+
+    first = _by_id(results, "SN-FLOW-001")
+    assert first.status == "Passed"
+    assert "Enabled" in first.result
+
+
+def test_flow_status_one_disabled_warns_and_fails_row():
+    from flightcheck.checks.servicenow import _check_flow_status
+    flows = [
+        pp.flow(display_name="ServiceNow HRSD Create Case", state="Started"),
+        pp.flow(display_name="ServiceNow ITSM Create Ticket", state="Stopped"),
+    ]
+    results = _check_flow_status(SimpleNamespace(), flows)
+
+    summary = _by_id(results, "SN-FLOW-000")
+    assert summary.status == "Warning"
+    assert "1 enabled, 1 disabled" in summary.result
+    assert "enable them in Power Automate" in summary.remediation
+
+    disabled = _by_id(results, "SN-FLOW-002")
+    assert disabled.status == "Failed"
+    assert "Enable" in disabled.remediation
+
+
+# --------------------------------------------------------------------------
+# _check_template_configs — SN-CFG-001 + per-pack SN-CFG-010 / SN-CFG-020
+# --------------------------------------------------------------------------
+
+_ALL_SCENARIOS = [
+    "ServiceNowHRSDCreateCase", "ServiceNowHRSDGetCaseDetails",
+    "ServiceNowHRSDGetCasesList",
+    "ServiceNowITSMCreateTicket", "ServiceNowITSMGetTicketDetails",
+    "ServiceNowITSMGetUserTickets", "ServiceNowITSMUpdateTicket",
+]
+
+
+def test_template_configs_all_present(monkeypatch):
+    import auth
+    monkeypatch.setattr(
+        auth, "query_all",
+        lambda *a, **kw: [{"msdyn_name": s} for s in _ALL_SCENARIOS],
+    )
+    from flightcheck.checks.servicenow import _check_template_configs
+    runner = SimpleNamespace(env_url="https://org.crm.dynamics.com", dv_token="t")
+    results = _check_template_configs(runner)
+
+    cfg = _by_id(results, "SN-CFG-001")
+    assert cfg.status == "Passed"
+    assert "7 ServiceNow template config(s)" in cfg.result
+    # Per-pack completeness rows.
+    assert _by_id(results, "SN-CFG-010").status == "Passed"
+    assert _by_id(results, "SN-CFG-020").status == "Passed"
+
+
+def test_template_configs_none_found(monkeypatch):
+    import auth
+    monkeypatch.setattr(auth, "query_all", lambda *a, **kw: [])
+    from flightcheck.checks.servicenow import _check_template_configs
+    runner = SimpleNamespace(env_url="https://org.crm.dynamics.com", dv_token="t")
+    cfg = _by_id(_check_template_configs(runner), "SN-CFG-001")
+    assert cfg.status == "NotConfigured"
+    assert "No ServiceNow template configs" in cfg.result
+    assert "extension pack" in cfg.remediation
+
+
+def test_template_configs_skipped_without_token():
+    from flightcheck.checks.servicenow import _check_template_configs
+    runner = SimpleNamespace(env_url="", dv_token="")
+    cfg = _by_id(_check_template_configs(runner), "SN-CFG-001")
+    assert cfg.status == "Skipped"
+    assert "Dataverse token not available" in cfg.result
+
+
+# --------------------------------------------------------------------------
+# _check_local_topics — SN-LOCAL-001/002/003
+# --------------------------------------------------------------------------
+
+def _make_agent(tmp_path, files: dict[str, str]):
+    agent = tmp_path / "workspace" / "agents" / "ess-hr"
+    topics = agent / "topics"
+    topics.mkdir(parents=True)
+    for name, content in files.items():
+        (topics / name).write_text(content, encoding="utf-8")
+
+
+def test_local_topics_hrsd_and_itsm_present(tmp_path, monkeypatch):
+    _make_agent(tmp_path, {
+        "servicenowhrsdcreatecase.mcs.yml": "kind: x\nServiceNow case",
+        "servicenowitsmcreateticket.mcs.yml": "kind: x\nServiceNow ticket",
+    })
+    monkeypatch.chdir(tmp_path)
+    from flightcheck.checks.servicenow import _check_local_topics
+    results = _check_local_topics(SimpleNamespace())
+
+    assert _by_id(results, "SN-LOCAL-001").status == "Passed"
+    assert _by_id(results, "SN-LOCAL-002").status == "Passed"   # HRSD
+    assert _by_id(results, "SN-LOCAL-003").status == "Passed"   # ITSM
+
+
+def test_local_topics_none_found_not_configured(tmp_path, monkeypatch):
+    _make_agent(tmp_path, {"weather.mcs.yml": "kind: x\nno integration here"})
+    monkeypatch.chdir(tmp_path)
+    from flightcheck.checks.servicenow import _check_local_topics
+    r = _by_id(_check_local_topics(SimpleNamespace()), "SN-LOCAL-001")
+    assert r.status == "NotConfigured"
+    assert "No ServiceNow topics found" in r.result

--- a/tests/flightcheck/checks/test_workday_connection_token_health.py
+++ b/tests/flightcheck/checks/test_workday_connection_token_health.py
@@ -316,27 +316,17 @@ class TestEdgeCases:
     @responses.activate
     def test_403_from_bap_returns_warning(self, runner: _MinimalRunner) -> None:
         """403 from BAP — the operator's account lacks PP Admin role.
-        Per the existing pattern in WD-CONN-001 this surfaces as a
-        WARNING, not a misleading NotConfigured. Note: WD-CONN-001
-        currently mis-reports this scenario (latent bug pinned in
-        test_workday_connections.py::test_403_from_bap_is_misreported_as_not_configured);
-        WD-CONN-101 sits behind the same client method so it shares
-        the same buggy "looks like empty list" behavior. Pin the
-        current behavior here so a fix to PPAdminClient._get_all
-        will surface this test for an update at the same time."""
+        Now that ``PPAdminClient._get_all`` surfaces 401/403 as a
+        structured error dict, WD-CONN-101 reports a WARNING naming the
+        missing role instead of a misleading NotConfigured."""
         from flightcheck.checks.workday import _check_connection_token_health
 
         responses.add(**pp.insufficient_permissions(env_id=runner.env_id))
 
         results = _check_connection_token_health(runner)
         wd_101 = _result_by_id(results, "WD-CONN-101")
-        # Current buggy behavior — same root cause as WD-CONN-001's pin.
-        # When PPAdminClient._get_all is fixed to surface 401/403 as a
-        # structured error dict (see test_workday_connections.py edge
-        # test for the recommended fix), flip this assertion to:
-        #   assert wd_101.status == "Warning"
-        #   assert "Power Platform" in wd_101.remediation
-        assert wd_101.status == "NotConfigured"
+        assert wd_101.status == "Warning"
+        assert "Power Platform Admin" in wd_101.remediation
 
     def test_skips_when_env_id_missing(self, pp_client) -> None:
         """No env_id → empty list (no result), don't crash, don't make

--- a/tests/flightcheck/checks/test_workday_connections.py
+++ b/tests/flightcheck/checks/test_workday_connections.py
@@ -227,31 +227,19 @@ class TestMixedState:
 
 class TestEdgeCases:
     @responses.activate
-    def test_403_from_bap_is_misreported_as_not_configured(
+    def test_403_from_bap_reported_as_warning(
         self, runner: _MinimalRunner
     ) -> None:
-        """Regression: latent bug. PPAdminClient._get_all returns an
-        empty list on 401/403, but PPAdminClient._get (single-item
-        getter) returns {"_error": "..."} dict. The check expects the
-        dict shape from get_connections() and only reports WARNING when
-        it sees one — but get_connections() uses _get_all, so a 403
-        silently looks identical to "no Workday connections" and the
-        operator is told to configure connections rather than told
-        their account lacks PP Admin role.
+        """A 401/403 from the BAP connections endpoint is surfaced as a
+        WARNING that names the missing Power Platform Administrator role
+        — NOT a "no connections / configure connections" NotConfigured
+        (which would mislead an operator whose account simply lacks the
+        admin role).
 
-        Severity: medium. The check still surfaces a non-PASS result so
-        the operator knows something is off, but the remediation
-        message points at the wrong action.
-
-        TODO (production fix, choose one):
-          (a) Make _get_all also return {"_error": "...", "_status": ...}
-              dict on 401/403 (mirrors _get), and update _check_connections
-              to handle that shape from get_connections.
-          (b) Make _get_all raise a typed exception on 401/403 and let
-              callers decide whether to swallow it.
-
-        See solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py:131-144.
-        Flip this test to expect WARNING when fixed.
+        This pins the fix for "bug 2": ``_get_all`` now returns a
+        ``{"_error": ...}`` dict on 401/403 (mirroring ``_get``), and
+        ``check_connector_connections`` renders it as a permissions
+        WARNING.
         """
         from flightcheck.checks.workday import _check_connections
 
@@ -259,16 +247,9 @@ class TestEdgeCases:
 
         results = _check_connections(runner)
         wd_001 = _result_by_id(results, "WD-CONN-001")
-        # Buggy behavior: 403 is indistinguishable from empty list.
-        assert wd_001.status == "NotConfigured", (
-            "PPAdminClient was fixed to surface 403 as a structured error — "
-            "flip this test to assert WARNING + 'Power Platform Admin' "
-            "in the remediation."
-        )
-        assert "No Workday connections" in wd_001.result
-        # Once fixed, this assertion should change to:
-        #   assert wd_001.status == "Warning"
-        #   assert "Power Platform Admin" in wd_001.remediation
+        assert wd_001.status == "Warning"
+        assert "Unable to list connections" in wd_001.result
+        assert "Power Platform Admin" in wd_001.remediation
 
     def test_skips_when_env_id_missing(self, pp_client) -> None:
         """No env_id (e.g. derive_environment_id failed) — check returns

--- a/tests/flightcheck/test_local_files_inventory.py
+++ b/tests/flightcheck/test_local_files_inventory.py
@@ -1,0 +1,157 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for the local-file check helpers that lacked coverage:
+``_check_topic_inventory`` (TOPIC-011), ``_check_variables`` (CONFIG-012),
+``_check_template_configs`` (LOCAL-TC-001), and the ``LOCAL-001``
+agent-discovery branch of ``run_local_file_checks``.
+
+These checks read only the local agent working copy under
+``workspace/agents/{slug}/`` — no network, no cassettes — so they are
+pure-logic tests per tests/AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(scripts_dir))
+        except ValueError:
+            pass
+
+
+def _result_by_id(results, cid):
+    return next(r for r in results if r.checkpoint_id == cid)
+
+
+# --------------------------------------------------------------------------
+# _check_topic_inventory — TOPIC-011
+# --------------------------------------------------------------------------
+
+def test_topic_inventory_passes_with_enough_topics(tmp_path):
+    from flightcheck.checks.local_files import _check_topic_inventory
+    topics = tmp_path / "topics"
+    topics.mkdir()
+    for i in range(5):
+        (topics / f"topic{i}.mcs.yml").write_text("kind: x", encoding="utf-8")
+
+    results = _check_topic_inventory(tmp_path, "Agent A")
+    r = _result_by_id(results, "TOPIC-011")
+    assert r.status == "Passed"
+    assert "5 topic(s)" in r.result
+
+
+def test_topic_inventory_warns_when_too_few(tmp_path):
+    from flightcheck.checks.local_files import _check_topic_inventory
+    topics = tmp_path / "topics"
+    topics.mkdir()
+    (topics / "only.mcs.yml").write_text("kind: x", encoding="utf-8")
+
+    results = _check_topic_inventory(tmp_path, "Agent A")
+    r = _result_by_id(results, "TOPIC-011")
+    assert r.status == "Warning"
+    assert "1 topic(s)" in r.result
+    assert "20+ topics" in r.remediation
+
+
+def test_topic_inventory_skipped_when_no_topics_dir(tmp_path):
+    from flightcheck.checks.local_files import _check_topic_inventory
+    assert _check_topic_inventory(tmp_path, "Agent A") == []
+
+
+# --------------------------------------------------------------------------
+# _check_variables — CONFIG-012
+# --------------------------------------------------------------------------
+
+def test_variables_pass_when_present(tmp_path):
+    from flightcheck.checks.local_files import _check_variables
+    vars_dir = tmp_path / "variables"
+    vars_dir.mkdir()
+    (vars_dir / "UserContext.mcs.yml").write_text("kind: v", encoding="utf-8")
+
+    r = _result_by_id(_check_variables(tmp_path, "Agent A"), "CONFIG-012")
+    assert r.status == "Passed"
+    assert "1 variable(s) found" in r.result
+
+
+def test_variables_warn_when_dir_empty(tmp_path):
+    from flightcheck.checks.local_files import _check_variables
+    (tmp_path / "variables").mkdir()
+
+    r = _result_by_id(_check_variables(tmp_path, "Agent A"), "CONFIG-012")
+    assert r.status == "Warning"
+    assert "0 variable(s) found" in r.result
+    assert "Create User Context variables" in r.remediation
+
+
+def test_variables_warn_when_dir_missing(tmp_path):
+    from flightcheck.checks.local_files import _check_variables
+    r = _result_by_id(_check_variables(tmp_path, "Agent A"), "CONFIG-012")
+    assert r.status == "Warning"
+    assert "Variables directory not found" in r.result
+    assert "/setup" in r.remediation
+
+
+# --------------------------------------------------------------------------
+# _check_template_configs — LOCAL-TC-001
+# --------------------------------------------------------------------------
+
+def test_template_configs_counts_files(tmp_path):
+    from flightcheck.checks.local_files import _check_template_configs
+    tc = tmp_path / "template-configs"
+    tc.mkdir()
+    (tc / "a.xml").write_text("<x/>", encoding="utf-8")
+    (tc / "b.xml").write_text("<x/>", encoding="utf-8")
+    (tc / "a.meta.json").write_text("{}", encoding="utf-8")
+
+    r = _result_by_id(_check_template_configs(tmp_path, "Agent A"), "LOCAL-TC-001")
+    assert r.status == "Passed"
+    assert "2 XML template(s)" in r.result
+    assert "1 metadata file(s)" in r.result
+
+
+def test_template_configs_skipped_when_no_dir(tmp_path):
+    from flightcheck.checks.local_files import _check_template_configs
+    assert _check_template_configs(tmp_path, "Agent A") == []
+
+
+# --------------------------------------------------------------------------
+# run_local_file_checks — LOCAL-001 agent-discovery branch
+# --------------------------------------------------------------------------
+
+def _runner():
+    return SimpleNamespace(env_id="env-guid", config={})
+
+
+def test_local_001_skipped_when_workspace_missing(tmp_path, monkeypatch):
+    from flightcheck.checks.local_files import run_local_file_checks
+    monkeypatch.chdir(tmp_path)  # no workspace/agents/ here
+    results = run_local_file_checks(_runner())
+    r = _result_by_id(results, "LOCAL-001")
+    assert r.status == "Skipped"
+    assert "workspace/agents/ directory not found" in r.result
+    assert "/setup" in r.remediation
+
+
+def test_local_001_skipped_when_no_agent_folders(tmp_path, monkeypatch):
+    from flightcheck.checks.local_files import run_local_file_checks
+    (tmp_path / "workspace" / "agents").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    results = run_local_file_checks(_runner())
+    r = _result_by_id(results, "LOCAL-001")
+    assert r.status == "Skipped"
+    assert "No agent folders found" in r.result

--- a/tests/flightcheck/test_pp_admin_client.py
+++ b/tests/flightcheck/test_pp_admin_client.py
@@ -42,23 +42,22 @@ def pp_client(fake_token: str):
 
 class TestPermissionHandling:
     @responses.activate
-    def test_get_connections_handles_403_gracefully_returns_empty_list(
+    def test_get_connections_returns_error_dict_on_403(
         self, pp_client
     ) -> None:
-        """Companion test: 401/403 ARE handled (return empty list).
-        This pins the existing behavior so we know it doesn't regress.
-
-        Note: returning an empty list here is itself bug 2 (the kit
-        also has a separate inconsistency between _get_all returning a
-        list and _get returning a dict on 401/403). When bug 2 is
-        fixed, both this test and the test_403_from_bap_is_misreported_*
-        test in test_workday_connections.py need updating in lockstep.
+        """401/403 on a paginated endpoint surfaces a structured
+        ``{"_error": ...}`` dict (matching ``_get``), so callers can
+        distinguish a permission failure from a genuinely empty
+        collection. (Previously ``_get_all`` swallowed 401/403 into an
+        empty list — "bug 2"; this is the fixed behavior.)
         """
         responses.add(**pp.insufficient_permissions(
             env_id=pp.MOCK_ENV_ID, endpoint="connections",
         ))
         result = pp_client.get_connections(pp.MOCK_ENV_ID)
-        assert result == []
+        assert isinstance(result, dict)
+        assert result["_error"] == "insufficient_permissions"
+        assert result["_status"] == 403
 
 
 class TestFindEnvironmentIdByDataverseUrl:

--- a/tests/mocks/graph.py
+++ b/tests/mocks/graph.py
@@ -920,3 +920,67 @@ def list_connection_operations(
         ),
         "status": 200,
     }
+
+
+# ────────────────────────────────────────────────────────────────────────
+# subscribedSku + directoryRole members (PRE-001/002/003/008/009)
+# ────────────────────────────────────────────────────────────────────────
+
+
+def subscribed_sku(
+    *,
+    sku_part_number: str = "MICROSOFT_365_COPILOT",
+    consumed_units: int = 5,
+    enabled_units: int = 10,
+    sku_id: str = "00000000-0000-0000-0000-0000000040a1",
+) -> dict[str, Any]:
+    """Build a single Graph /subscribedSkus record.
+
+    Cited consumers:
+      - flightcheck/checks/prerequisites.py (PRE-001/002/003 — license SKUs).
+      - flightcheck/graph_client.py:194-196 (get_subscribed_skus).
+
+    Source (validatable):
+      Schema: https://graph.microsoft.com/v1.0/$metadata
+              EntityType Name="subscribedSku" — fields used:
+                skuPartNumber (Edm.String)
+                consumedUnits (Edm.Int32)
+                prepaidUnits (ComplexType licenseUnitsDetail; enabled Edm.Int32)
+      Docs: https://learn.microsoft.com/graph/api/subscribedsku-list
+    """
+    return {
+        "skuId": sku_id,
+        "skuPartNumber": sku_part_number,
+        "consumedUnits": consumed_units,
+        "prepaidUnits": {"enabled": enabled_units, "suspended": 0, "warning": 0},
+    }
+
+
+def list_subscribed_skus(
+    *, skus: Iterable[Mapping[str, Any]] | None = None
+) -> dict[str, Any]:
+    """Mock GET /v1.0/subscribedSkus."""
+    return {
+        "method": "GET",
+        "url": f"{GRAPH_BASE}/subscribedSkus",
+        "json": collection(
+            skus if skus is not None else [subscribed_sku()],
+            odata_context="$metadata#subscribedSkus",
+        ),
+        "status": 200,
+    }
+
+
+def list_role_members(
+    *, role_id: str, members: Iterable[Mapping[str, Any]] | None = None
+) -> dict[str, Any]:
+    """Mock GET /v1.0/directoryRoles/{role_id}/members."""
+    return {
+        "method": "GET",
+        "url": f"{GRAPH_BASE}/directoryRoles/{role_id}/members",
+        "json": collection(
+            members if members is not None else [user()],
+            odata_context="$metadata#directoryObjects",
+        ),
+        "status": 200,
+    }


### PR DESCRIPTION
## Summary

Two related changes, surfaced while validating FlightCheck against the original PowerShell pre-flight validator on the same tenant/user:

1. **Unit tests for previously-untested checks** — audited checkpoint coverage and added tests for the check modules that were ported from PowerShell without unit tests.
2. **Fix: surface Power Platform 401/403 instead of swallowing them** — a latent bug that made Python silently report "No DLP policies found" where it actually lacked permission to read them.

## 1. Test coverage

Added tests (all following `tests/AGENTS.md` mock-tier rules):

- **prerequisites** — PRE-001/002/003 (licenses), PRE-008/009 (directory roles)
- **authentication** — AUTH-001 (Entra org), AUTH-002 (Conditional Access), AUTH-004 (user sync)
- **environment** — ENV-001 (exists), ENV-002 (Dataverse), ENV-003 (type)
- **external_systems** — EXT-001, WD-001, SN-001, SAP-001
- **servicenow deep** — SN-CFG-* (template configs), SN-FLOW-* (flow status), SN-LOCAL-* (local topics)
- **local_files** — TOPIC-011 (inventory), CONFIG-012 (variables), LOCAL-TC-001 (template configs), LOCAL-001 (agent discovery)

New validatable mock builders in `tests/mocks/graph.py`: `subscribed_sku`, `list_subscribed_skus`, `list_role_members` (cited against the Graph CSDL). No new cassette required.

## 2. DLP / 401-403 fix

`PPAdminClient._get_all` returned the (empty) accumulated list on 401/403, while `_get` returned `{"_error": ...}`. Every list-returning caller already guarded for the `{"_error"}` dict, so the swallow made that handling dead code — a permission failure looked identical to an empty collection.

- `_get_all` now returns `{"_error": "insufficient_permissions", "_status"}` on 401/403, mirroring `_get`.
- `get_dlp_policies_for_env` propagates it.
- **ENV-008** now reports **Skipped** ("requires Power Platform Administrator") instead of a false "No DLP policies found."
- **WD-CONN-001 / WD-CONN-101 / ServiceNow** connection checks now emit a **Warning naming the missing PP Admin role** on 403.
- Flipped the 3 tests that pinned the old swallow behavior (they had TODOs to do exactly this) and added an ENV-008-skips-on-403 test.

## Verification

- `ruff check solutions/ess-maker-skills/scripts` — clean
- `pytest tests` — **634 passed, 8 skipped** (8 pre-existing skips)
