### PR TITLE
Add Copilot coding agent setup for sample-topic automation

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,29 +8,29 @@
 name: "Copilot Setup Steps"
 
 on:
-    workflow_dispatch:
-    push:
-        paths:
-            - .github/workflows/copilot-setup-steps.yml
-    pull_request:
-        paths:
-            - .github/workflows/copilot-setup-steps.yml
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
-    copilot-setup-steps:
-        runs-on: ubuntu-latest
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
 
-        permissions:
-            contents: read
+    permissions:
+      contents: read
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-            - name: Set up Python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.11"
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
-            - name: Install validation dependencies
-              run: pip install "PyYAML>=6,<7" "defusedxml>=0.7,<1.0"
+      - name: Install validation dependencies
+        run: pip install "pytest>=8,<9" "PyYAML>=6,<7" "defusedxml>=0.7,<1.0"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Environment setup for the GitHub Copilot coding agent.
+# The agent works on sample-topic issues under samples/ — it needs Python
+# and the same deps the validate-samples CI workflow uses.
+
+name: "Copilot Setup Steps"
+
+on:
+    workflow_dispatch:
+    push:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+    pull_request:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+    copilot-setup-steps:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v5
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
+
+            - name: Install validation dependencies
+              run: pip install "PyYAML>=6,<7" "defusedxml>=0.7,<1.0"


### PR DESCRIPTION
 Adds **copilot-setup-steps.yml** so the Copilot coding agent can autonomously work on **area:samples** issues.
 
 **What this does**
 
  - Sets up Python 3.11 + PyYAML + defusedxml (same deps as validate-samples.yml)
  - Enables the coding agent to follow the skill chain: triage: **create/update -> validate -> prepare PR**
 
 **What it does NOT do**
 
  - No changes to existing workflows, code, or repo behavior
  - No secrets or elevated permissions - **contents: read** only
 
 **To verify**
 After merge, go to **Actions -> Copilot Setup Steps -> Run workflow** to confirm it passes.
