### PR TITLE
Add Workday setup skills plan (decomposed skills + atomic flightcheck + evals)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 !solutions/
 !samples/
 !tests/
+!plans/
 !tools/
 !docs/
 !README.md

--- a/plans/workday-setup/README.md
+++ b/plans/workday-setup/README.md
@@ -19,7 +19,7 @@ focused **sub-plans** beside it in this folder, each reviewable and shippable on
 | [`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md) | Add `--checkpoint <ID>` single-checkpoint invocation to flightcheck, via a **checkpoint registry + prerequisite hydration**. **Integration-agnostic.** | — |
 | [`shared-building-blocks`](./shared-building-blocks.md) | Parameterized Entra-app helper (de-dups connector authorization across Workday + ServiceNow), role-gate (programmatic + attestation), connection-field helper, config schema, checklist updater. | — |
 
-### The 6 atomic skills (build in order 1→6)
+### The 6 atomic skills (numbered in dependency order — the **Depends on** column is authoritative)
 
 | Sub-plan | Role | Depends on |
 | --- | --- | --- |
@@ -64,7 +64,7 @@ focused **sub-plans** beside it in this folder, each reviewable and shippable on
 | --- | --- | --- |
 | Deploy env + Dataverse + Copilot Studio capacity | Power Platform Admin | **1. provision-power-platform-environment** |
 | Deploy base ESS agent (AppSource) | Environment Maker | **2. install-ess** |
-| SSO gallery app (SAML, cert) — **fully Graph-automated** | App / Cloud App Admin | **3. provision-workday-entra-app** (prereq) |
+| SSO gallery app (SAML, cert) — **Graph-first + portal fallback** | App / Cloud App Admin | **3. provision-workday-entra-app** (prereq) |
 | Workday connector in Entra (scope, authorize `4e4707ca`, Graph, consent, enterprise-app assignment) | App / Cloud App Admin (consent-capable) | **3. provision-workday-entra-app** (core) |
 | Configure Workday tenant (X.509, security, auth policies, API client) | Workday Administrator | **4. configure-workday-tenant** |
 | Install extension pack + connections + flows | Environment Maker | **5. install-workday-extension-pack** |
@@ -80,14 +80,19 @@ focused **sub-plans** beside it in this folder, each reviewable and shippable on
 5. **command-wiring** (retire monolith once the skills exist)
 6. **evals** (after extension-pack + create-topic skills exist)
 
-## Review hardening (applied — multi-model rubber-duck)
+## Review hardening (applied — multi-model rubber-duck, rounds 1–2)
 
-Folded in after critique by Claude Opus 4.8, GPT-5.5, and GPT-5.3-Codex:
+Folded in after critique by Claude Opus 4.8, GPT-5.5, and GPT-5.3-Codex (round 1) and a
+round-2 re-review (Opus 4.8 + GPT-5.5) that pressure-tested the Graph-automation claim against
+the repo source of truth:
 
 - **Flightcheck needs a checkpoint registry + prerequisite hydration**, not naive per-check
   isolation — checks share state within category functions, and `cli.py` must stop requiring
   Dataverse for Entra-only checkpoints. *(highest-priority change)*
-- **skill-5 uses new simplified-only checkpoints** (`WD-PKG/CONN/CONN-AUTH/REST/FLOW/NET-*`);
+- **skill-5 reuses existing simplified-aware checkpoints** `WD-PKG-001` + `WD-CONN-012` +
+  `WD-FLOW-*` (`checks/workday.py`'s `_check_flow_status` already emits one `WD-FLOW-{n}` per cloud flow —
+  don't re-mint) and mints only `WD-CONN-AUTH-001`, `DV-CONN-001`, `WD-REST-001`, `WD-REST-002`,
+  `WD-NET-001`;
   **never reuse legacy `WD-ENV-*`/`WD-WF-*`** (ISU/RaaS, skipped on simplified).
 - **Admin consent is not GA-only** — any consent-capable role (App Admin / Cloud App Admin /
   Priv Role Admin / GA); attempt programmatically, escalate to manual if blocked.
@@ -101,12 +106,64 @@ Folded in after critique by Claude Opus 4.8, GPT-5.5, and GPT-5.3-Codex:
   network-unreachable vs config-invalid distinctly.
 - **`MANUAL` ≠ done** — manual/attestation rows need explicit acknowledgement; the orchestrator
   won't advance on a flightcheck pass alone.
-- **skill-3 is fully Graph-automated end-to-end** (gallery app + SAML + cert + connector +
-  Graph perms + admin consent + enterprise-app assignment) — no Entra portal step; the only
-  escalation is admin consent when the caller lacks a consent-capable role.
+- **skill-3 is Graph-first with a mandatory per-step portal fallback.** This *extends* the
+  existing mixed pattern in `connect/workday/step2.md` (which uses `az rest` Graph calls and
+  already falls back to the portal for the not-authorized / portal-only cases) to a fallback on
+  **every** step. \~9 of 11 Entra sub-steps are Graph-GA (instantiate, SAML mode,
+  identifier/reply/sign-on/logout URLs, cert add **and activate** via
+  `preferredTokenSigningKeyThumbprint`, scope, pre-authorize `4e4707ca`, Graph perms, admin
+  consent, enterprise-app assignment). **Two are not one-liners and are explicit gates:** the
+  **"Sign SAML response and assertion" signing option is portal-only** (no Graph property), and
+  **NameID requires a `claimsMappingPolicy` create+assign** (GA but finicky, no repo precedent).
+- **Reuse existing simplified-aware checkpoints; don't re-mint.** `WD-PKG-001`, `WD-CONN-012`,
+  `WD-CONN-102`, `WD-CONN-010` already exist and are simplified-aware — skills 3/4/5 reuse them
+  and mint new IDs only for genuinely-uncovered outputs (see [`master-checklist`](./master-checklist.md)).
+- **`92b66` is the Dataverse connector, not a Workday ref** — simplified fingerprints a single
+  `ff0df` Workday ref; verify `92b66` under a separate non-`WD` checkpoint.
+- **skill-4 captures REST and SOAP base URLs from different sources** — REST from "View API
+  Client", SOAP derived from the Workday **web host** pattern (per `step1.md`, user-prompt
+  fallback) — and runs a single-tenant SAML IdP pre-gate (a second Entra tenant silently breaks
+  the first federation).
+- **`WD-NET-001` defaults to a MANUAL/InfoSec attestation** (allowlist evidence) because a local
+  CLI probe only proves the dev machine — not the managed-connector outbound IPs — can reach
+  Workday; an in-environment connector probe is an optional later enhancement, never a local
+  probe presented as a gate.
+- \*\*The flightcheck registry resolves prerequisites transitively, validates an acyclic DAG, and
+  has a **setup-scoped** drift test\*\* (it asserts the registry covers every *setup-owned* emitted
+  checkpoint ID; other integrations' checkpoints stay out of scope, validated via `--scope`).
 - **Added:** enterprise-app user/group assignment gate (skill-3), live-agent rollback before
   the redirect push (skill-5), attestation-based gating for Workday/InfoSec roles, and evals
   derived from the installed topic inventory (not a hand list).
+
+## Implementation conventions (read before executing any sub-plan)
+
+- **Base directory:** every repo-relative path in these plans (e.g. `scripts/flightcheck/cli.py`,
+  `src/skills/setup/workday/…`, `src/reference/ess-docs/…`) is relative to
+  **`solutions/ess-maker-skills/`** unless it explicitly says "repo root". The `plans/` folder
+  and `.gitignore` are the only repo-root paths referenced.
+- **Skills are markdown playbooks**, not application code — each new skill is authored under
+  `src/skills/setup/workday/` (the canonical home introduced by command-wiring) and invoked by
+  the orchestrator (see
+  [`command-wiring`](./command-wiring.md)); the only Python touched is `scripts/flightcheck/`
+  and the shared helpers in [`shared-building-blocks`](./shared-building-blocks.md).
+- **Definition of done for a sub-plan** = its own *Acceptance criteria* section is fully met and
+  every checkpoint it owns is registered in [`master-checklist`](./master-checklist.md) and runs
+  in isolation via `--checkpoint <ID>`.
+
+## Resolved judgment calls (no open questions)
+
+These were the four items flagged during review; all are now decided in-plan:
+
+1. **skill-4 task ordering** — register API client **before** scoping auth policies. \*Confirmed
+   correct by both models\* (the policy must reference the OAuth client identity).
+2. **User-context redirect push under simplified (skill-5)** — **keep it**, but first confirm
+   it's still required (V2 REST `/workers/me`) and **skip if already present**; always create a
+   rollback checkpoint before mutating the live agent.
+3. **Workday Admin / InfoSec role gating** — **attestation + captured evidence** (no queryable
+   directory), never a silent pass.
+4. **Evals data-correctness** — OOTB integration tests are **shape checks by default**; true
+   data-correctness requires a **sanitized golden test user** the operator supplies (see
+   [`evals`](./evals.md)). Absent that fixture, the eval stays shape-only — not a blocker.
 
 ## Out of scope
 
@@ -115,4 +172,4 @@ Folded in after critique by Claude Opus 4.8, GPT-5.5, and GPT-5.3-Codex:
 
 ## Housekeeping
 
-- Pending uncommitted change: `.gitignore` (`!plans/` allowlist) + the `plans/` folder — commit alongside this work.
+- The `plans/` folder is tracked via a repo-root `.gitignore` `!plans/` allowlist (committed).

--- a/plans/workday-setup/README.md
+++ b/plans/workday-setup/README.md
@@ -1,0 +1,118 @@
+# Workday Setup — Primary Plan
+
+Automate configuration of **Workday for the ESS Agent** by re-decomposing the
+`/connect workday` monolith into atomic, role-scoped skills for the **simplified** Workday
+integration, grounded in the official docs (authoritative):
+
+- [Workday simplified setup](https://learn.microsoft.com/en-us/microsoft-365/copilot/employee-self-service/workday-simplified-setup)
+- [Configure Workday for SSO with Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/saas-apps/workday-tutorial)
+
+This is the **primary plan** (the folder's `README`). The detailed work is broken into
+focused **sub-plans** beside it in this folder, each reviewable and shippable on its own cadence.
+
+## Sub-plans
+
+### Foundation (no Workday dependency)
+
+| Sub-plan | Scope | Depends on |
+| --- | --- | --- |
+| [`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md) | Add `--checkpoint <ID>` single-checkpoint invocation to flightcheck, via a **checkpoint registry + prerequisite hydration**. **Integration-agnostic.** | — |
+| [`shared-building-blocks`](./shared-building-blocks.md) | Parameterized Entra-app helper (de-dups connector authorization across Workday + ServiceNow), role-gate (programmatic + attestation), connection-field helper, config schema, checklist updater. | — |
+
+### The 6 atomic skills (build in order 1→6)
+
+| Sub-plan | Role | Depends on |
+| --- | --- | --- |
+| [`skill-1-provision-power-platform-environment`](./skill-1-provision-power-platform-environment.md) | Power Platform Admin | foundation |
+| [`skill-2-install-ess`](./skill-2-install-ess.md) | Environment Maker | skill-1 |
+| [`skill-3-provision-workday-entra-app`](./skill-3-provision-workday-entra-app.md) | App / Cloud App Admin (consent-capable role) | foundation |
+| [`skill-4-configure-workday-tenant`](./skill-4-configure-workday-tenant.md) | Workday Administrator | skill-3 |
+| [`skill-5-install-workday-extension-pack`](./skill-5-install-workday-extension-pack.md) | Environment Maker | skill-2, skill-4 (+ firewall gate) |
+| [`skill-6-create-new-topic`](./skill-6-create-new-topic.md) | Environment Maker + Workday SME | skill-5 |
+
+> **Cross-skill data & manual gates:** skill-4 captures the **SOAP + REST base URLs** and the
+> **OAuth client identity** that skill-5 consumes. skill-5's *functional* verification is gated
+> on **firewall allowlisting (REST + SOAP)** — without it, connection auth fails for network
+> reasons indistinguishable from a config error, so skill-5 must report "unreachable" vs
+> "misconfigured" distinctly.
+
+### Orchestration & verification
+
+| Sub-plan | Scope | Depends on |
+| --- | --- | --- |
+| [`master-checklist`](./master-checklist.md) | One trackable checklist spanning all 6 skills + manual rows; defines the new Workday flightcheck checkpoints + role-gating. | foundation |
+| [`command-wiring`](./command-wiring.md) | Retire the `connect/workday` monolith; route `/connect workday` to the new orchestrator. | skills 1–6 |
+| [`evals`](./evals.md) | Per-skill eval sets (OOTB baseline + auto-gen per new topic). | skill-5, skill-6 |
+
+## Confirmed decisions (apply across all sub-plans)
+
+| # | Decision | Choice |
+| --- | --- | --- |
+| 1 | Relationship to existing `connect/workday` | **Full re-decomposition** — 6 skills replace the monolith |
+| 2 | Install-path scope | **Simplified only** — drop legacy |
+| 3 | Net-new skills | **Build all fully**, incl. provision-env + install-ess |
+| 4 | Entra app design | **Per official docs** — SSO gallery app first, then connector config; no generic `c26b24aa` reuse |
+| 5 | Workday-tenant tasks | **New 6th skill `configure-workday-tenant`** (Workday Admin) |
+| 6 | Evals coverage | **Per-skill** — OOTB baseline + auto-gen per new topic |
+| 7 | Atomic flightcheck | **Single-checkpoint invocation** (`--checkpoint <ID>`); keep existing scopes |
+| 8 | Checklist structure | **One master checklist**, each row linked to a flightcheck checkpoint |
+| 9 | Plan location | **`plans/workday-setup/` only** — this `README` (primary) + the sub-plans beside it; session `plan.md` is a pointer |
+
+## Official simplified-setup sequence → skill mapping
+
+| Official step | Role | Skill |
+| --- | --- | --- |
+| Deploy env + Dataverse + Copilot Studio capacity | Power Platform Admin | **1. provision-power-platform-environment** |
+| Deploy base ESS agent (AppSource) | Environment Maker | **2. install-ess** |
+| SSO gallery app (SAML, cert) — **fully Graph-automated** | App / Cloud App Admin | **3. provision-workday-entra-app** (prereq) |
+| Workday connector in Entra (scope, authorize `4e4707ca`, Graph, consent, enterprise-app assignment) | App / Cloud App Admin (consent-capable) | **3. provision-workday-entra-app** (core) |
+| Configure Workday tenant (X.509, security, auth policies, API client) | Workday Administrator | **4. configure-workday-tenant** |
+| Install extension pack + connections + flows | Environment Maker | **5. install-workday-extension-pack** |
+| Customizations / new scenarios | Environment Maker + Workday SME | **6. create-new-topic** |
+| Firewall/network allowlisting (**REST + SOAP**) | InfoSec/IT | *Manual row in master checklist; gates skill-5 functional check* |
+
+## Recommended delivery order
+
+1. **flightcheck-single-checkpoint** (unblocks atomic verification for every skill)
+2. **shared-building-blocks** (foundation; parameterizes the connector for Workday + ServiceNow)
+3. **master-checklist** (the spine the skills update + the new Workday checkpoints)
+4. **skills 1→6** (in dependency order)
+5. **command-wiring** (retire monolith once the skills exist)
+6. **evals** (after extension-pack + create-topic skills exist)
+
+## Review hardening (applied — multi-model rubber-duck)
+
+Folded in after critique by Claude Opus 4.8, GPT-5.5, and GPT-5.3-Codex:
+
+- **Flightcheck needs a checkpoint registry + prerequisite hydration**, not naive per-check
+  isolation — checks share state within category functions, and `cli.py` must stop requiring
+  Dataverse for Entra-only checkpoints. *(highest-priority change)*
+- **skill-5 uses new simplified-only checkpoints** (`WD-PKG/CONN/CONN-AUTH/REST/FLOW/NET-*`);
+  **never reuse legacy `WD-ENV-*`/`WD-WF-*`** (ISU/RaaS, skipped on simplified).
+- **Admin consent is not GA-only** — any consent-capable role (App Admin / Cloud App Admin /
+  Priv Role Admin / GA); attempt programmatically, escalate to manual if blocked.
+- **The connector refactor is parameterization/de-dup, not a ServiceNow bug fix** —
+  `c26b24aa` is the *correct* ServiceNow connector; only a misleading comment is wrong.
+- **MCP stays out of verification** because standing up a Workday MCP connection needs the
+  *same* setup as the ESS connection (circular), regardless of credentials.
+- **skill-4 registers the API client before scoping auth policies**; it captures **both** SOAP
+  and REST base URLs for skill-5.
+- **Firewall (REST + SOAP) gates skill-5's functional check**; skill-5 reports
+  network-unreachable vs config-invalid distinctly.
+- **`MANUAL` ≠ done** — manual/attestation rows need explicit acknowledgement; the orchestrator
+  won't advance on a flightcheck pass alone.
+- **skill-3 is fully Graph-automated end-to-end** (gallery app + SAML + cert + connector +
+  Graph perms + admin consent + enterprise-app assignment) — no Entra portal step; the only
+  escalation is admin consent when the caller lacks a consent-capable role.
+- **Added:** enterprise-app user/group assignment gate (skill-3), live-agent rollback before
+  the redirect push (skill-5), attestation-based gating for Workday/InfoSec roles, and evals
+  derived from the installed topic inventory (not a hand list).
+
+## Out of scope
+
+- Legacy ISU / security-group / RaaS path in the new skills (existing legacy installs keep working via the old reference docs).
+- New flightcheck *scopes* (single-checkpoint invocation only).
+
+## Housekeeping
+
+- Pending uncommitted change: `.gitignore` (`!plans/` allowlist) + the `plans/` folder — commit alongside this work.

--- a/plans/workday-setup/command-wiring.md
+++ b/plans/workday-setup/command-wiring.md
@@ -4,15 +4,31 @@ Route `/connect workday` to the new atomic skills once they exist. Part of
 [Workday Setup](./README.md).
 **Depends on:** skills 1–6.
 
+## Current routing surface (what exists today)
+
+- **`src/skills/connect/step1.md` is the actual `/connect workday` dispatcher.** It branches on
+  checklist state and routes to `connect/workday/{step1,step2,step3}.md`, and on first run copies
+  the template **`src/skills/connect/workday/tasks.md`** → working copy
+  **`my/connect/workday/tasks.md`** (state files live under `my/connect/workday/`).
+- `src/skills/connect/SKILL.md` holds the **dual-path** (simplified vs legacy ISU/RaaS)
+  principles.
+
 ## Changes
 
-- **Retire** `src/skills/connect/workday/{step1,step2,step3}.md` and the dual-path
-  principles in `connect/SKILL.md` (simplified-only).
-- Add a new **orchestrator** that sequences the 6 skills using the
-  [master checklist](./master-checklist.md) as a **resume-aware spine** (skip steps already
-  verified; resume where the user left off). It **must not advance past a `MANUAL`/attestation
-  row on a flightcheck pass alone** — those require explicit user acknowledgement first.
-- Route `/connect workday` to the orchestrator.
+- **Introduce the `setup` orchestrator** at **`src/skills/setup/SKILL.md`** + **`src/skills/setup/
+  workday/`**, sequencing the 6 skills using the [master checklist](./master-checklist.md) as a
+  **resume-aware spine** (skip steps already verified; resume where the user left off). It **must
+  not advance past a `MANUAL`/attestation row on a flightcheck pass alone** — those require
+  explicit user acknowledgement first. Its checklist template is
+  **`src/skills/setup/workday/tasks.md`** rendered to **`my/setup/workday/tasks.md`** (mirrors the
+  existing `my/connect/workday/` convention).
+- **Re-point the dispatcher:** change the Workday branch of **`src/skills/connect/step1.md`** to
+  invoke the `setup` orchestrator instead of `connect/workday/step1-3`.
+- **Retire** `src/skills/connect/workday/{step1,step2,step3}.md` and the dual-path principles in
+  `connect/SKILL.md` (simplified-only). Migrate any still-needed derivations (e.g. the SOAP
+  host-pattern mapping in `step1.md`) into the relevant skill before deleting.
+- Keep **`/connect workday`** as the user-facing entry point (routes through the re-pointed
+  dispatcher to the orchestrator).
 
 ## Validity fix (called out for challenge)
 
@@ -22,10 +38,12 @@ Route `/connect workday` to the new atomic skills once they exist. Part of
 
 ## Acceptance criteria
 
-- `/connect workday` drives the new orchestrator end-to-end.
-- The old `step1/step2/step3` monolith is removed; no references remain in `connect/SKILL.md`.
-- Re-running the command resumes from the first unverified checklist step rather than
-  restarting from scratch.
+- `/connect workday` drives the new `setup` orchestrator end-to-end (via the re-pointed
+  `connect/step1.md` dispatcher).
+- The old `connect/workday/step1/step2/step3` monolith is removed; no references remain in
+  `connect/step1.md` or `connect/SKILL.md`; needed derivations were migrated first.
+- Re-running the command resumes from the first unverified checklist step (`my/setup/workday/
+  tasks.md`) rather than restarting from scratch.
 
 ## Out of scope
 

--- a/plans/workday-setup/command-wiring.md
+++ b/plans/workday-setup/command-wiring.md
@@ -1,0 +1,32 @@
+# Plan: Command wiring (retire the monolith)
+
+Route `/connect workday` to the new atomic skills once they exist. Part of
+[Workday Setup](./README.md).
+**Depends on:** skills 1–6.
+
+## Changes
+
+- **Retire** `src/skills/connect/workday/{step1,step2,step3}.md` and the dual-path
+  principles in `connect/SKILL.md` (simplified-only).
+- Add a new **orchestrator** that sequences the 6 skills using the
+  [master checklist](./master-checklist.md) as a **resume-aware spine** (skip steps already
+  verified; resume where the user left off). It **must not advance past a `MANUAL`/attestation
+  row on a flightcheck pass alone** — those require explicit user acknowledgement first.
+- Route `/connect workday` to the orchestrator.
+
+## Validity fix (called out for challenge)
+
+- `connect/workday/step2.md` conflates SSO-app creation, Workday-tenant admin tasks, and
+  connector config into one block — the opposite of atomic. Retiring it removes the
+  conflation; the concerns now live in skills 3, 4, and 5 respectively.
+
+## Acceptance criteria
+
+- `/connect workday` drives the new orchestrator end-to-end.
+- The old `step1/step2/step3` monolith is removed; no references remain in `connect/SKILL.md`.
+- Re-running the command resumes from the first unverified checklist step rather than
+  restarting from scratch.
+
+## Out of scope
+
+- Legacy ISU/RaaS path (existing legacy installs keep working via the old reference docs).

--- a/plans/workday-setup/evals.md
+++ b/plans/workday-setup/evals.md
@@ -1,0 +1,45 @@
+# Plan: Workday evals (per-skill)
+
+Set up evaluation test sets for the Workday functionality being enabled. Part of
+[Workday Setup](./README.md).
+**Depends on:** [`skill-5-install-workday-extension-pack`](./skill-5-install-workday-extension-pack.md)
+and [`skill-6-create-new-topic`](./skill-6-create-new-topic.md) (topics/extension pack must exist).
+
+## Approach (per-skill)
+
+- **OOTB baseline eval set** for the Workday topics shipped by the extension pack.
+- **`create-new-topic` auto-generates a matching eval set** for each new topic it creates,
+  so coverage grows with customization.
+- Reuse the existing `evaluations/create` pipeline (checkpoint → write `.mcs.yml` → scan →
+  dry run → push → verify) and the starter patterns in
+  `src/examples/ess-samples/ESSEvaluationSamples/StarterTestSets/`.
+
+## OOTB Workday coverage (derived, not hand-listed)
+
+**Enumerate the baseline from the installed solution's actual topics / template configs**
+(the official OOTB template set), not a hardcoded list — so coverage tracks the pack as it
+evolves and never drifts. (Note: *Request Time Off* is the **custom** example built in
+[`skill-6`](./skill-6-create-new-topic.md), not an OOTB topic — don't bake it into the baseline.)
+
+- Generate **Topic Triggering** tests (trigger phrases + paraphrases + negative cases) for
+  each discovered OOTB topic — reliable trigger/shape smoke tests.
+- **Integration Data** tests need **tenant-specific expected values**, so they can't be fully
+  auto-generated from topics alone. Treat OOTB integration tests as **shape** checks by
+  default; for **data-correctness**, require a sanitized test user / golden fixture with known
+  expected field values (don't assert on generic placeholders like "Employee ID").
+
+## `create-new-topic` integration
+
+- When `create-new-topic` finishes, generate a topic-triggering (and, if it calls Workday,
+  integration-data) eval set for the new topic, grouped under the appropriate area.
+
+## Acceptance criteria
+
+- A baseline Workday eval set exists and pushes cleanly for the OOTB topics, **derived from
+  the installed solution's topic inventory** (not a hardcoded list).
+- Creating a new Workday topic yields a matching eval set without a separate manual step.
+- Data-correctness tests assert against a sanitized golden fixture, not generic placeholders.
+
+## Out of scope
+
+- Non-Workday eval categories beyond what the existing pipeline already produces.

--- a/plans/workday-setup/evals.md
+++ b/plans/workday-setup/evals.md
@@ -10,9 +10,15 @@ and [`skill-6-create-new-topic`](./skill-6-create-new-topic.md) (topics/extensio
 - **OOTB baseline eval set** for the Workday topics shipped by the extension pack.
 - **`create-new-topic` auto-generates a matching eval set** for each new topic it creates,
   so coverage grows with customization.
-- Reuse the existing `evaluations/create` pipeline (checkpoint → write `.mcs.yml` → scan →
-  dry run → push → verify) and the starter patterns in
+- Reuse the existing **`src/skills/evaluations/create`** pipeline (checkpoint → write `.mcs.yml`
+  → scan → dry run → push → verify) and the starter patterns in
   `src/examples/ess-samples/ESSEvaluationSamples/StarterTestSets/`.
+- **Output location:** generated test sets are written as `.mcs.yml` files under
+  **`my/agents/{slug}/evaluations/`** (the working-copy path the create/update/delete skills
+  already use), following the existing naming convention **`{set-name}-{short-slug}.mcs.yml`**.
+- **Topic-inventory discovery** uses the same onboarding/discover logic skill-2 relies on
+  (`src/skills/onboarding` + `scripts/discover.py`) to enumerate the installed solution's topics
+  — never a hardcoded list.
 
 ## OOTB Workday coverage (derived, not hand-listed)
 

--- a/plans/workday-setup/flightcheck-single-checkpoint.md
+++ b/plans/workday-setup/flightcheck-single-checkpoint.md
@@ -1,0 +1,82 @@
+# Plan: Flightcheck single-checkpoint invocation
+
+**Standalone, integration-agnostic.** No Workday dependency — this benefits every
+integration and can ship on its own. Part of the [Workday Setup](./README.md)
+initiative because every setup skill relies on it for atomic verification.
+
+## Problem
+
+Flightcheck today runs only by **broad scope** (`full`, `workday`, `authentication`,
+`environment`, …) via `scripts/flightcheck/cli.py`. The kit needs to "validate atomic
+pieces of the setup" — verify exactly one checkpoint at a time, right after the step that
+produces it.
+
+Two real constraints make naive isolation infeasible (verified in the code):
+- **Checks are registered per *category function*, not per checkpoint.** A single function in
+  `runner.py` emits many `CheckResult`s, and several share state across checkpoints
+  (e.g. `WD-PKG-001` caches `_workday_package_flavor` / `_workday_connection_refs` consumed by
+  later Workday checks; `external_systems.py` sets `_workday_flows`). You cannot "run only the
+  check that produces `WD-CONN-012`" without first running its in-category prerequisites.
+- **`cli.py` requires `.local/config.json` + a Dataverse endpoint before any check runs.** An
+  Entra-only or Workday-manual checkpoint would fail at startup even though it needs no
+  Dataverse.
+
+## Goal
+
+Let any single checkpoint be executed and reported on its own, so each setup skill can
+verify just its own atomic outcome.
+
+## Changes
+
+### New: checkpoint registry *(the load-bearing piece)*
+- Introduce a **static registry** mapping each **checkpoint ID → owning category function →
+  required clients (`graph` / `dataverse` / `pp_admin` / `pva` / none) → required config →
+  prerequisite checkpoint IDs**.
+- It is the single source of truth for `--list-checkpoints` (read statically, no broad run)
+  and for resolving exactly what a single `--checkpoint` needs to initialize and hydrate.
+
+### `scripts/flightcheck/cli.py`
+- Add `--checkpoint <ID>` — run exactly one checkpoint by ID and report only its result.
+- Add `--list-checkpoints` — print all known checkpoint IDs (+ category, priority, roles)
+  from the registry so skills/users can discover valid IDs (no broad run required).
+- **Initialize only the clients/config the target checkpoint declares.** An Entra-only
+  checkpoint must run with **no Dataverse endpoint configured** — relax the global
+  `.local/config.json` / `dataverseEndpoint` precondition to a **per-checkpoint** requirement
+  driven by the registry.
+- `--checkpoint` is mutually exclusive with `--scope`; unknown/invalid ID → clear error
+  listing valid IDs.
+- Keep all existing scopes and behavior unchanged (additive only).
+
+### `scripts/flightcheck/runner.py`
+- Resolve the target via the registry, **run its prerequisite checkpoints first to hydrate
+  shared state** (the bootstrap chain), then the owning function, then **filter the emitted
+  results down to the target ID**. (Granular per-check execution is *not* required —
+  hydrate-then-filter is the contract.)
+- Preserve the existing `CheckResult` shape and `MANUAL` status semantics (a manual checkpoint
+  reports what it can and does **not** fail readiness). A `MANUAL` result is **not** row
+  completion — acknowledgement is handled by the checklist (see
+  [`master-checklist.md`](./master-checklist.md)).
+- Ensure single-checkpoint mode returns the same structured result/remediation/doc-link as
+  full-scope mode.
+
+### `src/reference/ess-docs/flightcheck/validation-matrix.md`
+- Document the new `--checkpoint` / `--list-checkpoints` usage.
+- (Workday-specific checkpoint IDs are added by [`master-checklist.md`](./master-checklist.md)
+  and the per-skill plans, not here.)
+
+## Acceptance criteria
+
+- `flightcheck --list-checkpoints` lists every checkpoint ID from the registry (no broad run).
+- `flightcheck --checkpoint <ID>` hydrates declared prerequisites, runs only the target, and
+  prints a single structured result — **without** requiring clients the checkpoint doesn't
+  need (e.g. an Entra-only ID runs with no Dataverse endpoint configured).
+- Unknown ID → clear error naming valid IDs; non-zero exit.
+- Existing `--scope` runs are unchanged in behavior.
+- A `MANUAL` checkpoint run in isolation reports `MANUAL` and exits success (doesn't fail readiness).
+
+## Out of scope
+
+- New scopes or new Workday checkpoints (those live in other plans).
+- Any change to how checkpoints are *defined* beyond the registry + single-ID selection.
+- Refactoring every check into an independently-registered unit (the registry's
+  hydrate-then-filter model deliberately avoids that larger rewrite).

--- a/plans/workday-setup/flightcheck-single-checkpoint.md
+++ b/plans/workday-setup/flightcheck-single-checkpoint.md
@@ -12,8 +12,9 @@ pieces of the setup" — verify exactly one checkpoint at a time, right after th
 produces it.
 
 Two real constraints make naive isolation infeasible (verified in the code):
-- **Checks are registered per *category function*, not per checkpoint.** A single function in
-  `runner.py` emits many `CheckResult`s, and several share state across checkpoints
+- **Checks are registered per *category function*, not per checkpoint.** A single category
+  function (defined in `checks/*.py` — e.g. `checks/workday.py`'s `run_workday_checks`, and
+  registered into the runner by `cli.py`) emits many `CheckResult`s, and several share state across checkpoints
   (e.g. `WD-PKG-001` caches `_workday_package_flavor` / `_workday_connection_refs` consumed by
   later Workday checks; `external_systems.py` sets `_workday_flows`). You cannot "run only the
   check that produces `WD-CONN-012`" without first running its in-category prerequisites.
@@ -29,16 +30,51 @@ verify just its own atomic outcome.
 ## Changes
 
 ### New: checkpoint registry *(the load-bearing piece)*
-- Introduce a **static registry** mapping each **checkpoint ID → owning category function →
-  required clients (`graph` / `dataverse` / `pp_admin` / `pva` / none) → required config →
-  prerequisite checkpoint IDs**.
+- Introduce a **static registry** — new module **`scripts/flightcheck/registry.py`** — mapping
+  each **checkpoint ID → owning category function → required clients (`graph` / `dataverse` /
+  `pp_admin` / `pva` / none) → required config → prerequisite checkpoint IDs**.
 - It is the single source of truth for `--list-checkpoints` (read statically, no broad run)
   and for resolving exactly what a single `--checkpoint` needs to initialize and hydrate.
+- **Scope: the ESS + Workday *setup* checkpoints, not the entire flightcheck surface.** The
+  registry owns exactly the checkpoint IDs the setup skills emit or reuse (the
+  [`master-checklist`](./master-checklist.md) registry/mint table) plus the dynamic families those
+  setup-relevant category functions emit on a simplified full run. Other integrations — ServiceNow
+  `SN-*`, graph-connector `EXT-*`, `SAP-*`, and the pre-existing `ENV-003`/`ENV-004` (+
+  `ENV-004-OR/UR/UC` detail) environment rows — remain validated by the existing `--scope` runs and
+  are **out of registry scope**; this feature exists to validate atomic pieces of the *setup*.
+- **Support family/prefix entries for dynamically-numbered IDs.** Some checkpoints are emitted
+  with data-driven numeric suffixes. Within setup scope the dynamic families are: `WD-FLOW-{n}`
+  (`checks/workday.py`'s `_check_flow_status`, one per discovered flow); `WD-CONN-{n}` (the generic
+  connection enumerator `check_connector_connections(checkpoint_prefix="WD-CONN", …)` in
+  `checks/connections.py` emits `WD-CONN-001` summary + `WD-CONN-{i+2:03d}` per discovered Workday
+  connection); `WD-WF-{n}` (per workflow — emitted but skipped on the simplified flavor, registered
+  for completeness); the legacy `WD-ENV-*` (banned for simplified, registered so the family
+  resolves); and the per-topic `TOPIC-TRIGGER-{n}` / `TOPIC-INTEGRATION-{n}` (skill-6). The registry
+  **cannot enumerate these exact IDs ahead of time**, so it registers each as a **family/prefix**
+  (e.g. `WD-FLOW-*`, `WD-CONN-*`) keyed to the owning function + clients/config/prereqs. Resolution
+  rules: `--checkpoint WD-FLOW-*` runs the whole family; an exact dynamic ID
+  (`--checkpoint WD-FLOW-002`) resolves to its family entry by **longest-prefix match**, runs the
+  family, then filters to that one emitted ID. **Exact entries resolve first**, so the reused fixed
+  IDs `WD-CONN-010` / `WD-CONN-012` / `WD-CONN-102` and the new `WD-CONN-AUTH-001` stay exact-match
+  entries while `WD-CONN-*` absorbs the dynamic per-connection (and any other pre-existing
+  `WD-CONN-NNN`) detail rows — the two coexist cleanly. (A pre-existing source quirk: the
+  zero-padded enumerator could emit `WD-CONN-010`/`WD-CONN-012` if a tenant ever had ≥9/≥11 Workday
+  connections, colliding with the fixed literals — exact-first still resolves correctly, the
+  simplified path fingerprints a single `ff0df` reference so `n` stays tiny in practice, and fixing
+  the enumerator's numbering is out of scope for this plan.)
+- **Resolve prerequisites transitively.** A target's required clients/config is the **union of
+  its own declared needs and those of every prerequisite in its transitive closure** — a
+  checkpoint that declares no Dataverse can still have a Dataverse-backed prerequisite, so naive
+  one-level resolution would under-initialize and crash. Walk the full prereq chain.
+- **Validate the graph at load.** On startup (and in a unit test) assert the prereq graph is
+  **acyclic** (a cycle = a bootstrap deadlock) and that **every referenced prerequisite ID (or
+  family)** exists in the registry. Fail fast with a precise message if not.
 
 ### `scripts/flightcheck/cli.py`
 - Add `--checkpoint <ID>` — run exactly one checkpoint by ID and report only its result.
-- Add `--list-checkpoints` — print all known checkpoint IDs (+ category, priority, roles)
-  from the registry so skills/users can discover valid IDs (no broad run required).
+- Add `--list-checkpoints` — print all **registered setup** checkpoint IDs **and families** (+ category,
+  priority, roles) from the registry so skills/users can discover valid IDs (no broad run
+  required). Dynamic families print as `WD-FLOW-*` (not fabricated concrete numbers).
 - **Initialize only the clients/config the target checkpoint declares.** An Entra-only
   checkpoint must run with **no Dataverse endpoint configured** — relax the global
   `.local/config.json` / `dataverseEndpoint` precondition to a **per-checkpoint** requirement
@@ -50,8 +86,10 @@ verify just its own atomic outcome.
 ### `scripts/flightcheck/runner.py`
 - Resolve the target via the registry, **run its prerequisite checkpoints first to hydrate
   shared state** (the bootstrap chain), then the owning function, then **filter the emitted
-  results down to the target ID**. (Granular per-check execution is *not* required —
-  hydrate-then-filter is the contract.)
+  results down to the target**. For an exact ID, filter to that ID; for a **family** target
+  (`WD-FLOW-*`) keep all emitted IDs in the family; for an exact dynamic ID (`WD-FLOW-002`) keep
+  just that one. (Granular per-check execution is *not* required — hydrate-then-filter is the
+  contract.)
 - Preserve the existing `CheckResult` shape and `MANUAL` status semantics (a manual checkpoint
   reports what it can and does **not** fail readiness). A `MANUAL` result is **not** row
   completion — acknowledgement is handled by the checklist (see
@@ -66,10 +104,38 @@ verify just its own atomic outcome.
 
 ## Acceptance criteria
 
-- `flightcheck --list-checkpoints` lists every checkpoint ID from the registry (no broad run).
+- `flightcheck --list-checkpoints` lists every **registered setup** checkpoint ID and family from
+  the registry (no broad run) — the ESS+Workday setup surface, not other integrations' checkpoints
+  (which remain reachable via `--scope`).
 - `flightcheck --checkpoint <ID>` hydrates declared prerequisites, runs only the target, and
   prints a single structured result — **without** requiring clients the checkpoint doesn't
   need (e.g. an Entra-only ID runs with no Dataverse endpoint configured).
+- Client/config initialization covers the **transitive closure** of the target's prerequisites,
+  not just its own first-level declarations.
+- A unit test (**`tests/flightcheck/test_registry.py`**) asserts the prereq graph is **acyclic**
+  and that every prerequisite ID **or family** resolves.
+- A **drift test** (**`tests/flightcheck/test_registry_drift.py`**) runs a full check and asserts
+  the registry covers every **setup-owned** checkpoint ID emitted — so the setup registry never
+  silently drifts from what the setup category functions emit. It is **scoped, not a global
+  `registry ⊇ all-emitted` assertion**: the registry declares an explicit **owned-prefix
+  allow-list** (`ENV-001`, `ENV-002`, `ENV-CAPACITY`, `ESS-SOLN`, `WD-PKG`, `WD-CONN`, `WD-FLOW`,
+  `WD-WF`, `WD-ENV`, `WD-ENTRA`, `WD-ASSIGN`, `WD-TENANT`, `WD-API-CLIENT`, `WD-REST`, `WD-NET`,
+  `DV-CONN`, `TOPIC-TRIGGER`, `TOPIC-INTEGRATION`). For each emitted ID: (1) **resolve via the
+  registry's own resolution** — exact entry first; **only if none**, longest-prefix match against a
+  registered family (the emitter **zero-pads**, so `WD-FLOW-001` / `WD-CONN-003` / `WD-WF-002`
+  resolve to `WD-FLOW-*` / `WD-CONN-*` / `WD-WF-*`); (2) if it resolves → **pass**; (3) if it does
+  **not** resolve **and** its prefix is in the owned allow-list → **FAIL** (an added/renamed setup
+  checkpoint nobody registered); (4) if it does not resolve and is **outside** the allow-list →
+  **ignore** (it belongs to another integration — e.g. `SN-CONN-*`, `SN-FLOW-*`, `EXT-002-*`,
+  `SAP-*`, or the pre-existing `ENV-003`/`ENV-004` + `ENV-004-OR/UR/UC` rows — validated via
+  `--scope`, not this registry). The runner's synthetic `{category[:3].upper()}-ERR` exception
+  sentinels (emitted by `scripts/flightcheck/runner.py` only on an unhandled category exception) are
+  **always ignored** — they are error markers, not checkpoints. **Never blanket-strip a trailing
+  `-\d+`** — that would fabricate bogus families and mis-bucket fixed IDs such as `WD-CONN-012`,
+  `ENV-001`, or `WD-REST-001`/`WD-REST-002` (which would also collide into a single non-existent
+  `WD-REST` family). Because owned IDs are also emitted conditionally inside large category
+  functions (e.g. before a no-Workday early-return), this test still catches an added/renamed setup
+  checkpoint that nobody registered.
 - Unknown ID → clear error naming valid IDs; non-zero exit.
 - Existing `--scope` runs are unchanged in behavior.
 - A `MANUAL` checkpoint run in isolation reports `MANUAL` and exits success (doesn't fail readiness).

--- a/plans/workday-setup/master-checklist.md
+++ b/plans/workday-setup/master-checklist.md
@@ -11,27 +11,113 @@ flightcheck checkpoints and the role-gating matrix. Part of
 One `tasks.md` spanning all 6 skills + manual prerequisites. Columns:
 **Step | Role | Skill | Automatable? | Flightcheck checkpoint | Status**.
 
+- **Concrete file:** working copy at **`my/setup/workday/tasks.md`**, rendered on first run from
+  the template **`src/skills/setup/workday/tasks.md`** (the `setup` orchestrator skill folder is
+  defined in [`command-wiring`](./command-wiring.md), following the existing
+  `my/connect/workday/tasks.md` precedent — state under `my/`, template under `src/skills/`).
+
 - Each skill updates **its own rows** via the shared checklist-updater.
 - Each row links to a checkpoint runnable in isolation (`--checkpoint <ID>`).
-- Explicit gated/manual rows for: SSO gallery app, admin consent (consent-capable role;
-  escalate if blocked), all Workday-admin tenant tasks, AppSource install, firewall
-  allowlisting **(REST + SOAP, InfoSec/IT — gates skill-5 functional check)**.
+- Explicit gated/manual rows for:
+  - **SSO gallery app — split into three rows** (it is not one atomic action):
+    (a) **automated** Graph instantiation + SAML mode + URLs + cert add/activate (Graph-first,
+    portal fallback); (b) **manual gate** — the "Sign SAML response and assertion" signing
+    option (portal-only); (c) **attestation** — Workday-side confirmation that the SP validates
+    against the uploaded cert/SP-ID (verified functionally downstream in skill-4/skill-5).
+  - **Admin consent** (consent-capable role; attempt programmatically, escalate to manual if
+    blocked).
+  - **NameID claim** — attempt programmatically via a `claimsMappingPolicy` create+assign
+    (skill-3's `WD-ENTRA-NAMEID-001`); if that route proves brittle in testing, **degrade this to a
+    MANUAL portal row** rather than reporting a false pass.
+  - All **Workday-admin tenant tasks** (attestation).
+  - **AppSource install** (manual gate + re-verify).
+  - **Firewall allowlisting** **(REST + SOAP, InfoSec/IT — gates skill-5 functional check)**.
+
+### Canonical checklist rows (render these exact rows into `my/setup/workday/tasks.md`)
+
+The implementer renders **exactly** these rows — stable `Step` IDs, fixed checkpoint IDs, no
+invention. `Gate` legend: **prog** = programmatic check; **manual** = explicit user action +
+re-verify; **attest** = attestation + captured evidence (no queryable directory).
+
+| Step | Role | Skill | Automatable? | Checkpoint(s) | Gate |
+|------|------|-------|--------------|---------------|------|
+| S1.1 — Provision Power Platform environment + Dataverse | Power Platform Administrator | skill-1 | Yes | `ENV-001`, `ENV-002` (reuse) | prog |
+| S1.2 — Copilot Studio capacity available | Power Platform Administrator | skill-1 | Partial | `ENV-CAPACITY-001` | prog, else attest |
+| S2.1 — Install ESS base agent from AppSource | Environment Maker | skill-2 | No | `ESS-SOLN-001` | manual |
+| S3.1 — Expose `user_impersonation`, pre-authorize `4e4707ca`, grant Graph perms | App/Cloud App Admin or App Owner | skill-3 | Yes | `WD-ENTRA-SCOPE-001` | prog |
+| S3.2 — Admin-consent the Graph delegated perms | Consent-capable role (App/Cloud App Admin, Priv Role Admin, GA) | skill-3 | Attempt | `WD-ENTRA-CONSENT-001` | prog; escalate to manual if blocked |
+| S3.3 — Enterprise-app user/group assignment (or confirm not required) | App/Cloud App Admin | skill-3 | Yes | `WD-ASSIGN-001` | prog |
+| S3.4 — Instantiate SSO gallery app: SAML mode, URLs, signing cert add+activate | App/Cloud App Admin | skill-3 | Yes | `WD-CONN-102` | prog instantiate (Graph); `WD-CONN-102` healthy-state = `MANUAL` (Entra cert health auto-checked; Workday thumbprint parity deferred to S4.4) |
+| S3.5 — NameID claim mapping (`claimsMappingPolicy`) | App/Cloud App Admin | skill-3 | Attempt | `WD-ENTRA-NAMEID-001` | prog; degrade to manual portal row if brittle |
+| S3.6 — "Sign SAML response and assertion" signing option | App/Cloud App Admin | skill-3 | No (portal-only) | `WD-ENTRA-SIGNOPT-001` | manual |
+| S3.7 — Confirm single-Entra-tenant federation alignment | App/Cloud App Admin | skill-3 | No | `WD-CONN-010` | attest |
+| S4.1 — Register Workday API client (functional areas + Include Workday Owned Scope = Yes) | Workday Administrator | skill-4 | No | `WD-API-CLIENT-001` | attest |
+| S4.2 — Capture connection fields (client ID, token endpoint, REST + SOAP base URLs, tenant) | Workday Administrator | skill-4 | No | `WD-TENANT-001` | attest |
+| S4.3 — Scope authentication policies to the OAuth client, allow SAML, activate | Workday Administrator | skill-4 | No | `WD-TENANT-001` | attest |
+| S4.4 — Signing-certificate thumbprint matches Entra (Workday-side `X509 Certificate` row) | Workday Administrator | skill-4 | No (Workday cert field not API-reachable) | `WD-CONN-102` | manual/attest (`WD-CONN-102` returns `MANUAL` — operator compares thumbprints) |
+| S5.1 — Install Workday extension pack (simplified) | Environment Maker | skill-5 | No | `WD-PKG-001` | manual |
+| S5.2 — Workday connection ref (`ff0df`) bound, own account | Environment Maker | skill-5 | Yes | `WD-CONN-012` | prog |
+| S5.3 — Connection auth type = Entra ID Integrated | Environment Maker | skill-5 | Yes | `WD-CONN-AUTH-001` | prog |
+| S5.4 — Dataverse connection (`92b66`) bound, own account | Environment Maker | skill-5 | Yes | `DV-CONN-001` | prog |
+| S5.5 — REST base URL present and trimmed to `/api` | Environment Maker | skill-5 | Yes | `WD-REST-001` | prog |
+| S5.6 — Cloud flows on | Environment Maker | skill-5 | Yes | `WD-FLOW-*` | prog |
+| S5.7 — User-context redirect push (skip if `/workers/me` present; rollback checkpoint first) | Environment Maker | skill-5 | Yes | `WD-REST-002` | prog w/ rollback |
+| S5.8 — Firewall allowlisting (REST + SOAP) | InfoSec/IT | skill-5 | No | `WD-NET-001` | attest |
+| S6.1 — New topic trigger phrases + definition | Environment Maker (+ Workday SME) | skill-6 | Yes | `TOPIC-TRIGGER-*` | prog |
+| S6.2 — New topic integration wiring (tenant reference IDs) | Environment Maker (+ Workday SME) | skill-6 | Yes | `TOPIC-INTEGRATION-*` | prog (+ SME for IDs) |
+
+> Rows whose checkpoint is a `*` family (S5.6, S6.1, S6.2) expand to one row **per** emitted /
+> created item at run time. A row backed by an **attest** or **manual** gate is **never**
+> auto-completed by its checkpoint — see the `MANUAL`/attestation rule below.
 
 ## New Workday flightcheck checkpoints
 
-Add to `scripts/flightcheck/runner.py` (+ the checkpoint registry from
-[`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md)) +
-`src/reference/ess-docs/flightcheck/validation-matrix.md`, aligned to the skills:
+Add the Workday checkpoints to `scripts/flightcheck/checks/workday.py` — the `run_workday_checks`
+category function, which is registered into the generic runner by `cli.py` (`runner.register`).
+Non-Workday IDs go in their own `checks/*.py` module (e.g. `ENV-CAPACITY-001`/`ESS-SOLN-001` in
+`checks/environment.py`), **never** in `runner.py` (that is the integration-agnostic engine). Also
+register each new ID in the checkpoint registry from
+[`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md) and document it in
+`src/reference/ess-docs/flightcheck/validation-matrix.md`, aligned to the skills.
 
-| Skill | Checkpoints |
-|-------|-------------|
-| skill-1 | `ENV-*` |
-| skill-2 | ESS solution-installed |
-| skill-3 | `AUTH-*` / new `WD-AUTH-*` + `WD-ASSIGN-*` (enterprise-app assignment) |
-| skill-4 | new `WD-TENANT-*` / `WD-API-CLIENT-*` |
-| skill-5 | new `WD-PKG-*`, `WD-CONN-*`, `WD-CONN-AUTH-*`, `WD-REST-*`, `WD-FLOW-*`, `WD-NET-*` |
-| skill-6 | `TOPIC-*` |
+> **Reuse before minting.** Several simplified-aware checkpoints already exist in `checks/workday.py`
+> and **must be reused**, not re-created: `WD-PKG-001` (package-flavor detector, returns
+> `simplified` on the exact `ff0df` match), `WD-CONN-012` (connection-reference binding
+> completeness, keyed on the simplified `ff0df` suffix), `WD-CONN-102` (SAML signing-certificate
+> health), `WD-CONN-010` (Entra↔Workday federation alignment). New IDs are minted **only** for
+> outputs no existing checkpoint covers.
 
+> **A trailing `*` denotes a data-driven checkpoint *family*, not a literal ID — and only the
+> genuinely count-variable checkpoints keep one.** Setup-scope families: `WD-FLOW-*`
+> (`checks/workday.py`'s `_check_flow_status`, one **zero-padded** `WD-FLOW-{n}` per discovered
+> flow); `WD-CONN-*` (the generic connection enumerator in `checks/connections.py` emits
+> `WD-CONN-001` summary + `WD-CONN-{i+2:03d}` per Workday connection — exact-first keeps reused
+> fixed `WD-CONN-010`/`-012`/`-102` and new `WD-CONN-AUTH-001` as literal entries, the family
+> absorbs the dynamic detail rows); `WD-WF-*` (per workflow — emitted but skipped on simplified,
+> registered for completeness); the legacy `WD-ENV-*` (banned for simplified — listed only so the
+> registry knows the family); and the per-topic `TOPIC-TRIGGER-*` / `TOPIC-INTEGRATION-*` (skill-6
+> emits one per created topic). **Every other *setup* checkpoint is a single fixed ID** (e.g.
+> `ENV-001`, `WD-ENTRA-SCOPE-001`, `WD-CONN-AUTH-001`) — no `*`, nothing for the implementer to
+> invent. (Other integrations emit their own dynamic families — `SN-CONN-*`, `SN-FLOW-*`,
+> `ENV-004-OR/UR/UC` detail rows, `EXT-002-*` — which are **out of setup-registry scope**; see
+> [`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md).) The
+> registry registers each family as a **prefix entry** so `--checkpoint WD-FLOW-*` runs the whole
+> family and the drift test compares families (normalizing numeric suffixes), **not** exact
+> dynamic IDs — see [`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md).
+
+| Skill | Reuse existing | New IDs to mint |
+|-------|----------------|-----------------|
+| skill-1 | `ENV-001` (environment exists), `ENV-002` (Dataverse provisioned) | `ENV-CAPACITY-001` (Copilot Studio capacity / attestation) |
+| skill-2 | — | `ESS-SOLN-001` (ESS solution `msdyn_copilotforemployeeselfservice*` installed) |
+| skill-3 | `WD-CONN-102` (cert health), `WD-CONN-010` (federation alignment) | `WD-ENTRA-SCOPE-001` (scope exposed + `4e4707ca` pre-authorized + Graph perms), `WD-ENTRA-CONSENT-001` (admin consent), `WD-ASSIGN-001` (enterprise-app assignment / not-required), `WD-ENTRA-NAMEID-001`, `WD-ENTRA-SIGNOPT-001` (the two at-risk SAML sub-steps) |
+| skill-4 | `WD-CONN-102` (cert thumbprint match) | `WD-TENANT-001`, `WD-API-CLIENT-001` (mostly `MANUAL`/attestation) |
+| skill-5 | `WD-PKG-001` (flavor=simplified), `WD-CONN-012` (`ff0df` binding), `WD-FLOW-*` (cloud flows on — `checks/workday.py`'s `_check_flow_status` already emits `WD-FLOW-{n}`) | `WD-CONN-AUTH-001` (Entra-Integrated auth), `DV-CONN-001` (Dataverse `92b66`, **non-`WD`-family**), `WD-REST-001` (`/api`-trimmed), `WD-REST-002` (user-context redirect pushed → REST resolves `/workers/me`), `WD-NET-001` (Power-Platform-runtime reachability / InfoSec attestation) |
+| skill-6 | — | `TOPIC-TRIGGER-*`, `TOPIC-INTEGRATION-*` |
+
+- **`92b66` is the Dataverse connector, not a Workday ref** — the simplified Workday family
+  fingerprints a **single** `ff0df` connection ref. Verify `92b66` under the **non-`WD`** ID
+  `DV-CONN-001` (named for the skill, but explicitly outside the `WD-CONN` Workday-ref family),
+  never as a second `WD-CONN` ref.
 - **Do NOT reuse the legacy `WD-ENV-*` / `WD-WF-*` checkpoints for the simplified path** —
   they test ISU/RaaS artifacts that simplified setup removes and are skipped on simplified
   installs (reusing them yields false failures / N/A noise). Define the new simplified-only IDs
@@ -39,6 +125,19 @@ Add to `scripts/flightcheck/runner.py` (+ the checkpoint registry from
 - Preserve `MANUAL` status for non-automatable Workday-admin steps (reports what it can, does
   not fail readiness). **A `MANUAL`/attestation checkpoint never auto-completes its checklist
   row** — the row needs an explicit user acknowledgement (+ captured artifact) to reach *done*.
+
+### Checkpoint ownership (single owner per concern)
+
+To avoid two plans claiming to "define" the same thing:
+
+- **This plan (`master-checklist`) is the single registry owner** — it declares the canonical
+  list of new checkpoint IDs (the table above) and their checklist rows.
+- **The `flightcheck-single-checkpoint` plan owns the registry *mechanism*** (the
+  ID→function→clients→config→prereqs schema and the `--checkpoint`/`--list-checkpoints` CLI).
+- **Each `skill-N` plan owns the *verification wiring* for its own IDs** — the actual
+  `CheckResult` emission inside the owning `checks/*.py` module (Workday IDs live in
+  `checks/workday.py`'s `run_workday_checks`) and the master-checklist row updates. Skills do not
+  invent IDs outside the table above without adding them here first.
 
 ## Permission / role gating (named error + stop)
 

--- a/plans/workday-setup/master-checklist.md
+++ b/plans/workday-setup/master-checklist.md
@@ -1,0 +1,63 @@
+# Plan: Master setup checklist + Workday flightcheck checkpoints
+
+The single, trackable checklist spanning all 6 skills, plus the new Workday-specific
+flightcheck checkpoints and the role-gating matrix. Part of
+[Workday Setup](./README.md).
+**Depends on:** [`shared-building-blocks`](./shared-building-blocks.md) (checklist updater),
+[`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md) (atomic verification).
+
+## Master checklist
+
+One `tasks.md` spanning all 6 skills + manual prerequisites. Columns:
+**Step | Role | Skill | Automatable? | Flightcheck checkpoint | Status**.
+
+- Each skill updates **its own rows** via the shared checklist-updater.
+- Each row links to a checkpoint runnable in isolation (`--checkpoint <ID>`).
+- Explicit gated/manual rows for: SSO gallery app, admin consent (consent-capable role;
+  escalate if blocked), all Workday-admin tenant tasks, AppSource install, firewall
+  allowlisting **(REST + SOAP, InfoSec/IT — gates skill-5 functional check)**.
+
+## New Workday flightcheck checkpoints
+
+Add to `scripts/flightcheck/runner.py` (+ the checkpoint registry from
+[`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md)) +
+`src/reference/ess-docs/flightcheck/validation-matrix.md`, aligned to the skills:
+
+| Skill | Checkpoints |
+|-------|-------------|
+| skill-1 | `ENV-*` |
+| skill-2 | ESS solution-installed |
+| skill-3 | `AUTH-*` / new `WD-AUTH-*` + `WD-ASSIGN-*` (enterprise-app assignment) |
+| skill-4 | new `WD-TENANT-*` / `WD-API-CLIENT-*` |
+| skill-5 | new `WD-PKG-*`, `WD-CONN-*`, `WD-CONN-AUTH-*`, `WD-REST-*`, `WD-FLOW-*`, `WD-NET-*` |
+| skill-6 | `TOPIC-*` |
+
+- **Do NOT reuse the legacy `WD-ENV-*` / `WD-WF-*` checkpoints for the simplified path** —
+  they test ISU/RaaS artifacts that simplified setup removes and are skipped on simplified
+  installs (reusing them yields false failures / N/A noise). Define the new simplified-only IDs
+  above instead.
+- Preserve `MANUAL` status for non-automatable Workday-admin steps (reports what it can, does
+  not fail readiness). **A `MANUAL`/attestation checkpoint never auto-completes its checklist
+  row** — the row needs an explicit user acknowledgement (+ captured artifact) to reach *done*.
+
+## Permission / role gating (named error + stop)
+
+Gating mechanism differs: Entra / Power Platform / Dataverse roles are checked
+**programmatically**; **Workday Administrator** and **InfoSec/IT** have no queryable directory
+here → **attestation + captured evidence**.
+
+| Role | Gated step | How gated |
+|------|-----------|-----------|
+| Power Platform Administrator | provision-power-platform-environment | programmatic |
+| Environment Maker | install-ess, install-workday-extension-pack, create-new-topic | programmatic |
+| App / Cloud App Admin or App Owner | SSO gallery app + connector config (entra-app) | programmatic |
+| App Admin / Cloud App Admin / Priv Role Admin / Global Admin | admin consent (attempt; escalate to manual if blocked) | programmatic |
+| Workday Administrator | configure-workday-tenant | attestation |
+| InfoSec/IT | firewall allowlisting (REST + SOAP; manual row) | attestation |
+
+## Acceptance criteria
+
+- The checklist renders every step with its role, skill, automatable flag, checkpoint, and
+  live status; skills update only their own rows.
+- Every non-manual row maps to a checkpoint that runs in isolation; manual rows are clearly
+  marked and never auto-completed.

--- a/plans/workday-setup/shared-building-blocks.md
+++ b/plans/workday-setup/shared-building-blocks.md
@@ -37,9 +37,13 @@ connector ID inline), so it has value independent of the Workday work.
   path/`/v1`/tenant suffix).
 
 ### 4. Config persistence schema
-- `.local/connect/workday/config.json` canonical shape:
+- **`my/connect/workday/config.json`** canonical shape (the working-copy path the connect skill
+  already uses — *not* `.local/...`):
   `installPath` (=`simplified`), `entraApp*`, `appIdUri`, `oauthClientId`,
   `tokenEndpoint`, `restBaseUrl`, `soapBaseUrl`, plus per-skill status fields.
+- **Do not confuse this with `.local/config.json`** — that is a *separate* file that
+  `scripts/flightcheck/cli.py` reads for `dataverseEndpoint`. The skills' setup state lives under
+  `my/`; the flightcheck Dataverse endpoint lives in `.local/config.json`. Keep them distinct.
 
 ### 5. Master-checklist updater
 - Shared routine each skill calls to update **its own rows** in the single master checklist
@@ -48,6 +52,30 @@ connector ID inline), so it has value independent of the Workday work.
 - A row backed by a `MANUAL`/attestation checkpoint is **never auto-completed** by a
   flightcheck pass; it requires an explicit user acknowledgement (+ captured artifact) to
   reach *done*. A `MANUAL` result means "needs manual confirmation," **not** "done."
+
+## Where each block lives + invocation convention
+
+These blocks are **markdown playbook fragments** (the agent reads the fragment and executes its
+steps), consistent with the existing `src/skills/connect/azure/app-registration.md`. Each fragment
+documents its **Inputs** (read from context/config) and **Outputs** (written to
+`my/connect/workday/config.json` and/or the master checklist) in a header block. A skill "invokes"
+a fragment by including a numbered step: *"Apply `<relative path>` with `<inputs>`."* There is no
+function-call runtime — the contract is the documented Inputs/Outputs.
+
+| Block | Target file | New/Edit | Invoked by |
+|-------|-------------|----------|------------|
+| 1. Entra-app helper | `src/skills/connect/azure/app-registration.md` | **Edit** (parameterize connector ID/scope/target) | skill-3 (passes `4e4707ca`); ServiceNow connect path (passes `c26b24aa`) |
+| 2. Permission-gate | `src/skills/setup/shared/permission-gate.md` | **New** | all 6 skills (each passes its required role) |
+| 3. Connection-fields | `src/skills/setup/shared/connection-fields.md` | **New** | skill-4 (capture), skill-5 (consume) |
+| 4. Config schema | schema doc `src/skills/setup/shared/config-schema.md`; data file `my/connect/workday/config.json` | **New** (doc) | all skills read/write the data file |
+| 5. Checklist-updater | `src/skills/setup/shared/checklist-updater.md` | **New** | all 6 skills (update own rows in `my/setup/workday/tasks.md`) |
+
+> The `src/skills/setup/` orchestrator folder is introduced by
+> [`command-wiring`](./command-wiring.md); these shared fragments live under it so all 6 skills
+> share one home. This is the **canonical** location — `src/skills/setup/shared/` for the
+> fragments and `src/skills/setup/workday/` for the six skill playbooks; do **not** nest them
+> under the legacy `connect/` tree. (Block 1 is the one exception: it **edits** the existing
+> `connect/azure/app-registration.md` in place rather than creating a new file.)
 
 ## Acceptance criteria
 

--- a/plans/workday-setup/shared-building-blocks.md
+++ b/plans/workday-setup/shared-building-blocks.md
@@ -1,0 +1,65 @@
+# Plan: Workday shared building blocks (refactor for reuse)
+
+Cross-cutting foundation extracted so the 6 Workday skills don't duplicate logic. Part of
+the [Workday Setup](./README.md) initiative. The Entra-app helper item also **de-duplicates
+connector authorization across Workday and ServiceNow** (today each path carries its own
+connector ID inline), so it has value independent of the Workday work.
+
+## Building blocks
+
+### 1. Parameterized Entra-app helper — *(parameterize + de-duplicate)*
+- **Gap (not a bug):** `src/skills/connect/azure/app-registration.md` hardcodes the
+  connector `c26b24aa-7874-4e06-ad55-7d06b1f79b63` — which is **correct for ServiceNow**.
+  Workday's `connect/workday/step2.md` already authorizes the **Workday** connector
+  `4e4707ca-5f53-46a6-a819-f7765446e6ff` inline, so the two paths **duplicate** connector
+  logic instead of sharing it. (The only real defect is a misleading comment in
+  `app-registration.md` implying `c26b24aa` "also" serves Workday — correct that comment.)
+- **Fix:** generalize the helper so the **connector app ID**, **scope**, and **target app
+  (new vs existing SSO gallery app)** are parameters. ServiceNow passes `c26b24aa`;
+  Workday passes `4e4707ca` — one helper, no duplication, no regression.
+- Preserve the existing **permission-failure → stop** pattern already in the helper
+  (section B.2 "Insufficient privileges").
+
+### 2. Permission-gate helper
+- A standard, reusable "**role check → specific named error → stop**" routine used by all
+  6 skills. Each caller supplies the required role; on failure the message names the exact
+  role (e.g. "This step requires the **Workday Administrator** role…") and halts.
+- **Gating mechanism differs by role:** Entra roles (Graph role query), Power Platform
+  (admin API), and Dataverse maker/system roles are checked **programmatically**. **Workday
+  Administrator** and **InfoSec/IT** have no queryable directory here → gate by **explicit
+  attestation + captured evidence** (a named-role prompt the user confirms), never a silent
+  pass. The helper records which mode (programmatic vs attested) verified each gate.
+
+### 3. Connection-field capture/validation helper
+- Centralizes capture + validation of: **App ID URI** (Entra resource URL), **Workday
+  OAuth token URL**, **Client ID**, **SOAP base URL**, and **REST base URL trimmed to
+  `/api`** (the documented silent-failure gotcha — copy as displayed, then trim trailing
+  path/`/v1`/tenant suffix).
+
+### 4. Config persistence schema
+- `.local/connect/workday/config.json` canonical shape:
+  `installPath` (=`simplified`), `entraApp*`, `appIdUri`, `oauthClientId`,
+  `tokenEndpoint`, `restBaseUrl`, `soapBaseUrl`, plus per-skill status fields.
+
+### 5. Master-checklist updater
+- Shared routine each skill calls to update **its own rows** in the single master checklist
+  (see [`master-checklist.md`](./master-checklist.md)), keyed by step ID, recording status
+  + the flightcheck checkpoint used to verify.
+- A row backed by a `MANUAL`/attestation checkpoint is **never auto-completed** by a
+  flightcheck pass; it requires an explicit user acknowledgement (+ captured artifact) to
+  reach *done*. A `MANUAL` result means "needs manual confirmation," **not** "done."
+
+## Acceptance criteria
+
+- The Entra-app helper produces a Workday-authorized app (`4e4707ca`, `user_impersonation`,
+  Graph `openid`/`profile`/`User.Read`, admin consent) **and** still produces the correct
+  ServiceNow result with `c26b24aa` — no regression.
+- All 6 skills consume the permission-gate + checklist-updater helpers (no duplicated
+  inline role checks or checklist writes).
+- Config written by any skill round-trips through the documented schema.
+
+## Out of scope
+
+- The skills themselves (see the `skill-*` plans) and the master checklist file
+  (see [`master-checklist.md`](./master-checklist.md)).
+- Flightcheck CLI changes (see [`flightcheck-single-checkpoint.md`](./flightcheck-single-checkpoint.md)).

--- a/plans/workday-setup/skill-1-provision-power-platform-environment.md
+++ b/plans/workday-setup/skill-1-provision-power-platform-environment.md
@@ -14,10 +14,16 @@ later installed into.
 
 ## Phases
 
-- **Automatable:** discover existing environments (reuse `discover.py`); verify Dataverse
-  is enabled and Copilot Studio capacity is available.
+- **Automatable:** discover existing environments via **`scripts/discover.py`** + the existing
+  **`scripts/flightcheck/pp_admin_client.py`** (`get_environments()` / `get_environment(env_id)`,
+  BAP admin API). Verify Dataverse is enabled by reading the environment's
+  `properties.linkedEnvironmentMetadata` (a Dataverse-linked environment exposes it). Check
+  Copilot Studio capacity from the environment's capacity/licensing properties where the
+  pp_admin API exposes them.
 - **Manual (gated):** environment creation + capacity allocation in the Power Platform
-  admin portal (guided, with explicit user action and a verification gate afterward).
+  admin portal (guided, with explicit user action and a verification gate afterward). If Copilot
+  Studio capacity is **not** queryable via pp_admin, this is an **attestation** row, not a silent
+  pass.
 
 ## Permission gating
 
@@ -26,7 +32,13 @@ later installed into.
 
 ## Verification
 
-- Flightcheck `ENV-*` checkpoints, run individually via `--checkpoint <ID>` right after the
+- **Reuse the two existing fixed checkpoint IDs** already emitted by
+  `checks/environment.py`'s `run_environment_checks` — **`ENV-001`** (Power Platform environment
+  exists) and **`ENV-002`** (Dataverse database provisioned). Do **not** re-mint them or redefine
+  their meaning; this skill drives both to green from `pp_admin_client`
+  `linkedEnvironmentMetadata`. Then emit **one** new fixed ID, **`ENV-CAPACITY-001`** — Copilot
+  Studio / Copilot capacity available (pp_admin capacity property, else `MANUAL` attestation),
+  added to `checks/environment.py`. Run each individually via `--checkpoint <ID>` right after the
   step. Updates its own rows in the master checklist.
 
 ## Acceptance criteria

--- a/plans/workday-setup/skill-1-provision-power-platform-environment.md
+++ b/plans/workday-setup/skill-1-provision-power-platform-environment.md
@@ -1,0 +1,36 @@
+# Plan: Skill 1 — `provision-power-platform-environment`
+
+**Role:** Power Platform Administrator · **Net-new skill** · Part of
+[Workday Setup](./README.md).
+**Depends on:** [`shared-building-blocks`](./shared-building-blocks.md),
+[`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md),
+[`master-checklist`](./master-checklist.md).
+
+## Purpose
+
+Create/configure the Power Platform environment (with Dataverse and the required Copilot
+Studio capacity) that hosts the ESS agent — the foundation the Workday extension pack is
+later installed into.
+
+## Phases
+
+- **Automatable:** discover existing environments (reuse `discover.py`); verify Dataverse
+  is enabled and Copilot Studio capacity is available.
+- **Manual (gated):** environment creation + capacity allocation in the Power Platform
+  admin portal (guided, with explicit user action and a verification gate afterward).
+
+## Permission gating
+
+- Not a **Power Platform Administrator** → emit the specific named error (via the shared
+  permission-gate helper) and **stop**.
+
+## Verification
+
+- Flightcheck `ENV-*` checkpoints, run individually via `--checkpoint <ID>` right after the
+  step. Updates its own rows in the master checklist.
+
+## Acceptance criteria
+
+- Skill confirms (programmatically) a usable environment with Dataverse + Copilot Studio
+  capacity, or stops with a precise remediation if not.
+- Manual creation step is clearly gated and re-verified, never assumed "done".

--- a/plans/workday-setup/skill-2-install-ess.md
+++ b/plans/workday-setup/skill-2-install-ess.md
@@ -12,8 +12,12 @@ can be added.
 
 ## Phases
 
-- **Automatable:** post-install verification — confirm the agent + its solution are present
-  (reuse onboarding discover/extract logic).
+- **Automatable:** post-install verification — confirm the agent + its solution are present,
+  reusing the onboarding discovery logic in **`src/skills/onboarding`** + **`scripts/discover.py`**.
+  The base ESS solution **unique name is `msdyn_copilotforemployeeselfservice`** (the IT/HR
+  packaged variants are `msdyn_copilotforemployeeselfserviceit` /
+  `msdyn_copilotforemployeeselfservicehr` — accept whichever the tenant deployed; this is also the
+  topic namespace skill-6 references).
 - **Manual (gated):** the AppSource install itself (guided; explicit user action), followed
   by a verification gate.
 
@@ -23,8 +27,9 @@ can be added.
 
 ## Verification
 
-- Flightcheck ESS solution-installed checkpoint(s), run individually. Updates its own master
-  checklist rows.
+- Concretize to an **`ESS-SOLN-001`** checkpoint — the ESS solution
+  (`msdyn_copilotforemployeeselfservice*`) is installed in the target environment — run
+  individually via `--checkpoint`. Updates its own master checklist rows.
 
 ## Acceptance criteria
 

--- a/plans/workday-setup/skill-2-install-ess.md
+++ b/plans/workday-setup/skill-2-install-ess.md
@@ -1,0 +1,33 @@
+# Plan: Skill 2 — `install-ess`
+
+**Role:** Environment Maker · **Net-new skill** · Part of
+[Workday Setup](./README.md).
+**Depends on:** [`skill-1-provision-power-platform-environment`](./skill-1-provision-power-platform-environment.md).
+
+## Purpose
+
+Install/deploy the base **Employee Self-Service agent** from AppSource into the provisioned
+environment — the prerequisite foundation that must exist before the Workday extension pack
+can be added.
+
+## Phases
+
+- **Automatable:** post-install verification — confirm the agent + its solution are present
+  (reuse onboarding discover/extract logic).
+- **Manual (gated):** the AppSource install itself (guided; explicit user action), followed
+  by a verification gate.
+
+## Permission gating
+
+- Not an **Environment Maker** → specific named error (shared helper) and **stop**.
+
+## Verification
+
+- Flightcheck ESS solution-installed checkpoint(s), run individually. Updates its own master
+  checklist rows.
+
+## Acceptance criteria
+
+- Skill confirms the base ESS agent + solution exist in the target environment, or stops
+  with precise remediation.
+- The AppSource install is gated and re-verified, never assumed.

--- a/plans/workday-setup/skill-3-provision-workday-entra-app.md
+++ b/plans/workday-setup/skill-3-provision-workday-entra-app.md
@@ -1,0 +1,69 @@
+# Plan: Skill 3 — `provision-workday-entra-app`
+
+**Role:** App / Cloud App Administrator (a **consent-capable** role — Application Administrator,
+Cloud Application Administrator, Privileged Role Administrator, or Global Administrator — is
+required to grant admin consent) · Part of [Workday Setup](./README.md).
+**Depends on:** [`shared-building-blocks`](./shared-building-blocks.md),
+[`flightcheck-single-checkpoint`](./flightcheck-single-checkpoint.md),
+[`master-checklist`](./master-checklist.md).
+
+## Purpose
+
+Configure the Microsoft Entra app registration for the Workday SSO integration so the agent
+can call Workday on behalf of the signed-in user. **Fully automatable via Microsoft Graph —
+no Entra portal clicks.** The only possible escalation is admin consent when the caller lacks
+a consent-capable role.
+
+## Phases
+
+### Entra SSO gallery app *(fully automated via Graph)*
+- Per the [Workday SSO tutorial](https://learn.microsoft.com/en-us/entra/identity/saas-apps/workday-tutorial):
+  instantiate the Workday gallery app (`applicationTemplates/{id}/instantiate`), then via Graph
+  set `preferredSingleSignOnMode = saml`, the **Identifier/Entity ID + reply/sign-on/logout
+  URLs**, the **NameID claim** (`user.mail`/UPN), "sign SAML response and assertion", and add
+  the **token-signing certificate** (`addTokenSigningCertificate`).
+- **No Entra portal step is required** — it's all Graph. (The Workday-side consumption of the
+  signing cert / SP-ID match is handled in [`skill-4`](./skill-4-configure-workday-tenant.md).)
+
+### Core — connector configuration *(fully automated via Graph; consent-capable role)*
+- Expose the `user_impersonation` API scope (`api.oauth2PermissionScopes`).
+- Pre-authorize the **Workday** connector **`4e4707ca-5f53-46a6-a819-f7765446e6ff`**
+  (`api.preAuthorizedApplications`) via the parameterized shared helper — **never** the
+  generic `c26b24aa`.
+- Add Microsoft Graph delegated permissions `openid`, `profile`, `User.Read`
+  (`requiredResourceAccess`).
+- **Grant admin consent via Graph** (create the `oauth2PermissionGrant`) — requires the caller
+  to hold a consent-capable role. If not, emit a named-role error and **escalate to manual
+  consent**; don't hard-fail silently.
+- **Assign the enterprise app** (`appRoleAssignedTo`): if `appRoleAssignmentRequired`, assign
+  the maker/test user (preferably the ESS user group), else mark explicitly not-required.
+- Capture the **App ID URI** (Entra resource URL) into config.
+
+## Permission gating
+
+- Connector config without an app-management role (Application Administrator / Cloud
+  Application Administrator / app owner) → named error + stop.
+- Admin consent without a **consent-capable** role (App Admin / Cloud App Admin / Privileged
+  Role Admin / Global Admin) → named error naming those roles + **escalate to manual consent**
+  (automated when privileged, manual fallback — consistent with the master checklist).
+
+## Validity fix (called out for challenge)
+
+- Corrects the hardcoded wrong connector in `app-registration.md` by using the
+  parameterized helper from [`shared-building-blocks`](./shared-building-blocks.md).
+
+## Verification
+
+- Flightcheck `AUTH-*` / new `WD-AUTH-*` checkpoints (scope exposed, connector authorized,
+  Graph perms present, admin consent granted) + `WD-ASSIGN-*` (enterprise-app user/group
+  assignment, or "not required"), run individually. Updates master checklist rows.
+
+## Acceptance criteria
+
+- App exposes `user_impersonation`, authorizes `4e4707ca`, has the three Graph perms, admin
+  consent is granted, and enterprise-app assignment is satisfied (or marked not-required) —
+  each independently verifiable by a single checkpoint.
+- The entire Entra app (SSO gallery app + connector + Graph perms + assignment) is created
+  **end-to-end via Graph**; the only possible escalation is admin consent when the caller
+  lacks a consent-capable role.
+- App ID URI persisted for downstream skills (4 and 5).

--- a/plans/workday-setup/skill-3-provision-workday-entra-app.md
+++ b/plans/workday-setup/skill-3-provision-workday-entra-app.md
@@ -10,22 +10,33 @@ required to grant admin consent) · Part of [Workday Setup](./README.md).
 ## Purpose
 
 Configure the Microsoft Entra app registration for the Workday SSO integration so the agent
-can call Workday on behalf of the signed-in user. **Fully automatable via Microsoft Graph —
-no Entra portal clicks.** The only possible escalation is admin consent when the caller lacks
-a consent-capable role.
+can call Workday on behalf of the signed-in user. **Graph-first** — almost every step is
+Microsoft Graph (GA), so this skill drives it programmatically — **with a mandatory per-step
+portal fallback**. This *extends* the mixed pattern already in `connect/workday/step2.md` (which
+uses `az rest` Graph calls and already falls back to the portal for the not-authorized /
+portal-only cases) so that **every** step has a fallback — because permission/tenant-policy and
+quoting failures are common. Two sub-steps are **not** cleanly Graph-settable and are explicit
+gates: the **SAML signing option** (portal-required) and the **NameID claim** (needs a
+`claimsMappingPolicy` create+assign, not a one-liner).
 
 ## Phases
 
-### Entra SSO gallery app *(fully automated via Graph)*
+### Entra SSO gallery app *(Graph-first + portal fallback)*
 - Per the [Workday SSO tutorial](https://learn.microsoft.com/en-us/entra/identity/saas-apps/workday-tutorial):
-  instantiate the Workday gallery app (`applicationTemplates/{id}/instantiate`), then via Graph
-  set `preferredSingleSignOnMode = saml`, the **Identifier/Entity ID + reply/sign-on/logout
-  URLs**, the **NameID claim** (`user.mail`/UPN), "sign SAML response and assertion", and add
-  the **token-signing certificate** (`addTokenSigningCertificate`).
-- **No Entra portal step is required** — it's all Graph. (The Workday-side consumption of the
-  signing cert / SP-ID match is handled in [`skill-4`](./skill-4-configure-workday-tenant.md).)
+  - **Graph (GA):** instantiate the Workday gallery app (`applicationTemplates/{id}/instantiate`);
+    set `preferredSingleSignOnMode = saml`; set **Identifier/Entity ID + reply/sign-on/logout
+    URLs**; add the **token-signing certificate** (`addTokenSigningCertificate`) **and activate
+    it** by setting `preferredTokenSigningKeyThumbprint` (capture thumbprint + expiry).
+  - **NameID claim (`user.mail`/UPN):** Graph-doable but only via a **`claimsMappingPolicy`
+    create + assign to the service principal** — scope this as its own verified sub-step (no
+    in-repo precedent; mark portal/manual if the policy route proves brittle in testing).
+  - **"Sign SAML response and assertion" signing option:** **portal-required** — no documented
+    Graph property (beta `samlSingleSignOnSettings` exposes only `relayState`). Explicit manual
+    gate + verify. A Workday SP that validates signatures will reject the assertion if this is
+    wrong, so it must not be silently skipped.
+- Every Graph step carries a **portal fallback** for permission/tenant-policy failures.
 
-### Core — connector configuration *(fully automated via Graph; consent-capable role)*
+### Core — connector configuration *(Graph GA; consent-capable role)*
 - Expose the `user_impersonation` API scope (`api.oauth2PermissionScopes`).
 - Pre-authorize the **Workday** connector **`4e4707ca-5f53-46a6-a819-f7765446e6ff`**
   (`api.preAuthorizedApplications`) via the parameterized shared helper — **never** the
@@ -49,21 +60,34 @@ a consent-capable role.
 
 ## Validity fix (called out for challenge)
 
-- Corrects the hardcoded wrong connector in `app-registration.md` by using the
-  parameterized helper from [`shared-building-blocks`](./shared-building-blocks.md).
+- `app-registration.md` today calls a connector-authorization step with the connector ID
+  effectively hardcoded and carries a **misleading comment** that conflates the generic
+  `c26b24aa` connector with Workday. This skill does **not** treat that as a ServiceNow bug
+  (`c26b24aa` is the *correct* ServiceNow connector). Instead it: (a) **parameterizes connector
+  selection** through the shared helper from
+  [`shared-building-blocks`](./shared-building-blocks.md) so Workday passes `4e4707ca` and
+  ServiceNow passes `c26b24aa`, and (b) **corrects the misleading comment**. Net effect: de-dup
+  + accuracy, no behavior change for the ServiceNow path.
 
 ## Verification
 
-- Flightcheck `AUTH-*` / new `WD-AUTH-*` checkpoints (scope exposed, connector authorized,
-  Graph perms present, admin consent granted) + `WD-ASSIGN-*` (enterprise-app user/group
-  assignment, or "not required"), run individually. Updates master checklist rows.
+- **Reuse existing simplified-aware checkpoints** where they already cover skill-3's outputs:
+  `WD-CONN-102` (Workday SAML **signing-certificate health**) and `WD-CONN-010` (Entra↔Workday
+  **federation alignment**) — both run Graph-only pre-deploy. Only mint genuinely-new IDs:
+  `WD-ENTRA-SCOPE-001` (scope exposed + `4e4707ca` pre-authorized + Graph perms),
+  `WD-ENTRA-CONSENT-001` (admin consent granted), `WD-ASSIGN-001` (enterprise-app assignment or
+  "not required"), `WD-ENTRA-NAMEID-001` and `WD-ENTRA-SIGNOPT-001` (the two at-risk SAML
+  sub-steps).
+  Run each individually; updates master checklist rows.
 
 ## Acceptance criteria
 
 - App exposes `user_impersonation`, authorizes `4e4707ca`, has the three Graph perms, admin
   consent is granted, and enterprise-app assignment is satisfied (or marked not-required) —
   each independently verifiable by a single checkpoint.
-- The entire Entra app (SSO gallery app + connector + Graph perms + assignment) is created
-  **end-to-end via Graph**; the only possible escalation is admin consent when the caller
-  lacks a consent-capable role.
+- SSO gallery app is **Graph-first with a portal fallback per step**; the **signing option** is
+  a portal-required gate and **NameID** is a verified `claimsMappingPolicy` create+assign — both
+  explicitly tracked, never silently skipped.
+- Token-signing cert is added **and activated** (`preferredTokenSigningKeyThumbprint`); skill-4
+  verifies Workday's uploaded cert matches that thumbprint.
 - App ID URI persisted for downstream skills (4 and 5).

--- a/plans/workday-setup/skill-4-configure-workday-tenant.md
+++ b/plans/workday-setup/skill-4-configure-workday-tenant.md
@@ -1,0 +1,58 @@
+# Plan: Skill 4 — `configure-workday-tenant` *(NEW)*
+
+**Role:** Workday Administrator · Part of [Workday Setup](./README.md).
+**Depends on:** [`skill-3-provision-workday-entra-app`](./skill-3-provision-workday-entra-app.md).
+
+## Purpose
+
+Perform the Workday-tenant-side configuration that the simplified setup requires. These
+tasks are **not automatable** (Workday UI) — the skill guides, gates on role, and records
+each task as a verified manual step. **No standalone Workday connection (e.g. the Workday
+MCP) is used to verify setup:** standing one up requires substantially the *same* Entra-app +
+tenant + connector configuration as the ESS agent's own connection, so it would be
+**circular/redundant** as an atomic verifier — independent of which credentials it uses — not
+a check of any single upstream step.
+
+## Tasks (from the official simplified-setup doc)
+
+> **Ordering note:** Register the API client **before** managing authentication policies — the
+> auth policy must be scoped to the OAuth client identity, which only exists once the API
+> client is registered.
+
+1. **Create X.509 public key** from the Entra signing certificate.
+2. **Edit Tenant Setup – Security:** set the redirection URL; enable **OAuth 2.0 Clients**
+   and **SAML**; verify SAML IdP fields. The **Service Provider ID must match the Entra
+   Identifier / Entity ID**.
+3. **Register API Client:** functional areas **Core Payroll, Organizations and Roles,
+   Staffing, Time Off and Leave** + **Include Workday Owned Scope = Yes** (required for REST
+   `/workers/me`). Capture **Client ID**, **Token Endpoint**, **REST base URL**, and the
+   **SOAP / web-services base URL** into config (skill-5 needs both base URLs).
+4. **Manage authentication policies:** scope to the **OAuth client from task 3**, allow SAML
+   as an allowed authentication type, then **Activate All Pending Authentication Policy
+   Changes**.
+
+## Permission gating
+
+- Not a **Workday Administrator** → named error (shared helper) + stop.
+
+## Verification
+
+- These are manual Workday-admin tasks → flightcheck reports them as `MANUAL` (captures the
+  observable artifacts it can, does **not** fail readiness). A `MANUAL` pass is **not**
+  completion: each row also needs an explicit user acknowledgement (+ captured artifact)
+  before it is marked done (see [`master-checklist.md`](./master-checklist.md)).
+- New flightcheck `WD-TENANT-*` / `WD-API-CLIENT-*` checkpoints, run individually, confirm
+  what is observable (e.g. config values captured, redirect/SP-ID match). The **functional**
+  proof comes downstream, when skill 5's Copilot Studio connection authenticates
+  successfully — not from any standalone Workday call here.
+- Role gating for **Workday Administrator** is by **attestation** (no queryable directory) —
+  a named-role prompt the user confirms, recorded as such.
+- Updates master checklist rows.
+
+## Acceptance criteria
+
+- Each of the 4 tasks is independently verifiable (single checkpoint) or clearly `MANUAL`.
+- API client registered **before** auth policies are scoped/activated.
+- Client ID / Token Endpoint / **REST base URL** / **SOAP base URL** persisted for skill 5.
+- The skill never marks a Workday-admin task "done" without an explicit manual
+  acknowledgement (no standalone Workday connection is used as a setup shortcut).

--- a/plans/workday-setup/skill-4-configure-workday-tenant.md
+++ b/plans/workday-setup/skill-4-configure-workday-tenant.md
@@ -19,14 +19,32 @@ a check of any single upstream step.
 > auth policy must be scoped to the OAuth client identity, which only exists once the API
 > client is registered.
 
-1. **Create X.509 public key** from the Entra signing certificate.
+> **Pre-gate (single-tenant SAML coupling — do this first):** Workday supports exactly **one**
+> active Entra-tenant SAML federation at a time; pointing a second Entra tenant at the same
+> Workday tenant silently breaks the first (see `scripts/flightcheck/checks/workday.py`, the
+> active-IdP warning). Before changing anything, **identify and record the current active SAML
+> IdP row**: issuer/tenant ID, **Service Provider ID**, and the **signing-cert thumbprint**
+> currently in use. If an unrelated IdP is already active, **stop and escalate** rather than
+> overwrite it.
+
+1. **Create X.509 public key** from the Entra signing certificate. **Verify its thumbprint
+   matches the one skill-3 activated** (`preferredTokenSigningKeyThumbprint`, reused via
+   `WD-CONN-102`) — a mismatch means the wrong cert was uploaded and SSO will fail.
 2. **Edit Tenant Setup – Security:** set the redirection URL; enable **OAuth 2.0 Clients**
    and **SAML**; verify SAML IdP fields. The **Service Provider ID must match the Entra
    Identifier / Entity ID**.
 3. **Register API Client:** functional areas **Core Payroll, Organizations and Roles,
    Staffing, Time Off and Leave** + **Include Workday Owned Scope = Yes** (required for REST
-   `/workers/me`). Capture **Client ID**, **Token Endpoint**, **REST base URL**, and the
-   **SOAP / web-services base URL** into config (skill-5 needs both base URLs).
+   `/workers/me`). Capture **Client ID**, **Token Endpoint**, and the **REST base URL** from
+   the registered client's **"View API Client"** page.
+   - **SOAP / web-services base URL comes from a *different* place** — it is derived from the
+     tenant's **Workday web host**, not the Register API Client page. (Repo precedent:
+     `connect/workday/step1.md` pattern-maps the logged-in Workday web host to the SOAP base URL
+     — e.g. `impl.workday.com` → `https://wd2-impl-services1.workday.com/ccx/service` — and
+     **prompts the user for it** when no pattern matches; `step3.md` then expects both base URLs
+     at connection time.) Reuse that derivation (host → `…-services1….workday.com/ccx/service`)
+     with a user-prompt fallback, and capture it separately. Persist **both** base URLs —
+     skill-5 needs each.
 4. **Manage authentication policies:** scope to the **OAuth client from task 3**, allow SAML
    as an allowed authentication type, then **Activate All Pending Authentication Policy
    Changes**.
@@ -41,18 +59,25 @@ a check of any single upstream step.
   observable artifacts it can, does **not** fail readiness). A `MANUAL` pass is **not**
   completion: each row also needs an explicit user acknowledgement (+ captured artifact)
   before it is marked done (see [`master-checklist.md`](./master-checklist.md)).
-- New flightcheck `WD-TENANT-*` / `WD-API-CLIENT-*` checkpoints, run individually, confirm
-  what is observable (e.g. config values captured, redirect/SP-ID match). The **functional**
-  proof comes downstream, when skill 5's Copilot Studio connection authenticates
-  successfully — not from any standalone Workday call here.
+- New flightcheck `WD-TENANT-001` / `WD-API-CLIENT-001` checkpoints, run individually, confirm
+  what is observable (e.g. config values captured, redirect/SP-ID match). **Reuse `WD-CONN-102`**
+  to assert the Workday-uploaded cert thumbprint matches the one skill-3 activated — don't mint
+  a new cert checkpoint. The **functional** proof comes downstream, when skill 5's Copilot
+  Studio connection authenticates successfully — not from any standalone Workday call here.
 - Role gating for **Workday Administrator** is by **attestation** (no queryable directory) —
   a named-role prompt the user confirms, recorded as such.
 - Updates master checklist rows.
 
 ## Acceptance criteria
 
+- The single-tenant SAML pre-gate ran first: active IdP issuer/tenant ID, SP-ID, and cert
+  thumbprint are recorded, and an unrelated active IdP halts with an escalation (never a silent
+  overwrite).
 - Each of the 4 tasks is independently verifiable (single checkpoint) or clearly `MANUAL`.
 - API client registered **before** auth policies are scoped/activated.
-- Client ID / Token Endpoint / **REST base URL** / **SOAP base URL** persisted for skill 5.
+- Client ID / Token Endpoint / **REST base URL** (from "View API Client") and **SOAP base URL**
+  (derived from the Workday web host, per `step1.md`, with a user-prompt fallback) are both
+  persisted for skill 5.
+- The X.509 cert thumbprint matches skill-3's activated `preferredTokenSigningKeyThumbprint`.
 - The skill never marks a Workday-admin task "done" without an explicit manual
   acknowledgement (no standalone Workday connection is used as a setup shortcut).

--- a/plans/workday-setup/skill-5-install-workday-extension-pack.md
+++ b/plans/workday-setup/skill-5-install-workday-extension-pack.md
@@ -1,0 +1,61 @@
+# Plan: Skill 5 — `install-workday-extension-pack`
+
+**Role:** Environment Maker · Part of [Workday Setup](./README.md).
+**Depends on:** [`skill-2-install-ess`](./skill-2-install-ess.md),
+[`skill-4-configure-workday-tenant`](./skill-4-configure-workday-tenant.md). **Functional
+verification is additionally gated on firewall allowlisting (REST + SOAP)** — see the manual
+row in [`master-checklist`](./master-checklist.md).
+
+## Purpose
+
+Install the Workday extension pack onto the deployed ESS agent in Copilot Studio
+(Settings → Customize → Workday → Install/Update), adding the Workday topics, cloud flows,
+and connection references.
+
+## Configuration
+
+- **Connection auth = Microsoft Entra ID Integrated** (recommended).
+- Fields (via the shared connection-field helper): **App ID URI**, Workday **OAuth token
+  URL** + **Client ID**, **SOAP base URL**, and **REST base URL trimmed to `/api`**
+  (documented silent-failure gotcha). **SOAP + REST base URLs and the OAuth client come from
+  skill-4's captured config** — don't re-derive them here.
+- **Two connections**, each with its own account:
+  - `OAuthUser` (`new_sharedworkdaysoap_ff0df`)
+  - Dataverse (`msviess_sharedcommondataserviceforapps_92b66`)
+- Confirm both cloud flows are **on**; non-UPN identity resolution (usually no action).
+- **Auto-push** the user-context topic redirect — but **create a checkpoint/rollback first**
+  (preserve the existing `step3.md` checkpoint-before-push pattern), since this mutates the
+  live agent. First **confirm the redirect is still required under simplified** (V2 user
+  context via REST `/workers/me`); skip the push if it isn't needed.
+
+## Phases
+
+- **Manual (gated):** the in-product Install/Update click + connection sign-in.
+- **Automatable:** post-install verification — 2 connection references, 2 flows on, topic
+  redirect present.
+
+## Permission gating
+
+- Not an **Environment Maker** → named error + stop.
+
+## Verification
+
+- **Use simplified-only checkpoints — not the legacy `WD-ENV-*` / `WD-WF-*` ISU/RaaS checks,
+  which are skipped on simplified installs.** Run individually:
+  - `WD-PKG-*` — extension pack present, package flavor = simplified.
+  - `WD-CONN-*` — exactly the two connection refs (`ff0df` + `92b66`) bound, each its own account.
+  - `WD-CONN-AUTH-*` — connection auth type = **Entra ID Integrated**.
+  - `WD-REST-*` — REST base URL present and **ends at `/api`** (guard the silent failure).
+  - `WD-FLOW-*` — both cloud flows on.
+  - `WD-NET-*` — Workday REST + SOAP endpoints reachable; on failure report **"network
+    unreachable (firewall)"** distinctly from **"config invalid"** so the firewall gate is
+    diagnosable.
+- Updates master checklist rows.
+
+## Acceptance criteria
+
+- Extension pack present (simplified flavor); both connections created (own accounts); both
+  flows on; user-context redirect pushed (with a rollback checkpoint) when required — each
+  independently verifiable by a single checkpoint.
+- REST base URL stored trimmed to `/api` (guard against the silent failure).
+- Functional auth failures distinguish network-unreachable (firewall) from config-invalid.

--- a/plans/workday-setup/skill-5-install-workday-extension-pack.md
+++ b/plans/workday-setup/skill-5-install-workday-extension-pack.md
@@ -20,8 +20,9 @@ and connection references.
   (documented silent-failure gotcha). **SOAP + REST base URLs and the OAuth client come from
   skill-4's captured config** — don't re-derive them here.
 - **Two connections**, each with its own account:
-  - `OAuthUser` (`new_sharedworkdaysoap_ff0df`)
-  - Dataverse (`msviess_sharedcommondataserviceforapps_92b66`)
+  - `OAuthUser` (`new_sharedworkdaysoap_ff0df`) — the **Workday** connection.
+  - Dataverse (`msviess_sharedcommondataserviceforapps_92b66`) — **not** a Workday ref; it's
+    the Common Data Service connector and is verified under a separate (non-`WD`) checkpoint.
 - Confirm both cloud flows are **on**; non-UPN identity resolution (usually no action).
 - **Auto-push** the user-context topic redirect — but **create a checkpoint/rollback first**
   (preserve the existing `step3.md` checkpoint-before-push pattern), since this mutates the
@@ -40,22 +41,43 @@ and connection references.
 
 ## Verification
 
-- **Use simplified-only checkpoints — not the legacy `WD-ENV-*` / `WD-WF-*` ISU/RaaS checks,
-  which are skipped on simplified installs.** Run individually:
-  - `WD-PKG-*` — extension pack present, package flavor = simplified.
-  - `WD-CONN-*` — exactly the two connection refs (`ff0df` + `92b66`) bound, each its own account.
-  - `WD-CONN-AUTH-*` — connection auth type = **Entra ID Integrated**.
-  - `WD-REST-*` — REST base URL present and **ends at `/api`** (guard the silent failure).
-  - `WD-FLOW-*` — both cloud flows on.
-  - `WD-NET-*` — Workday REST + SOAP endpoints reachable; on failure report **"network
-    unreachable (firewall)"** distinctly from **"config invalid"** so the firewall gate is
-    diagnosable.
+- **Reuse existing simplified-aware checkpoints — do NOT re-mint them.** `WD-PKG-001` already
+  detects the **simplified** flavor (exact `ff0df` match), `WD-CONN-012` already checks
+  simplified connection-reference **binding completeness**, and `WD-FLOW-*` is already emitted by
+  `checks/workday.py`'s `_check_flow_status` (one `WD-FLOW-{n}` per cloud flow, **not** flavor-gated);
+  reuse all three. Only mint the genuinely-new IDs below. Also **do not** reuse the legacy
+  `WD-ENV-*` / `WD-WF-*` ISU/RaaS checks (skipped on simplified). Run each individually:
+  - `WD-PKG-001` *(existing)* — extension pack present, package flavor = **simplified**.
+  - `WD-CONN-012` *(existing)* — the **Workday** connection ref (`ff0df`) bound, own account.
+    **Note:** the simplified Workday family fingerprints a **single** `ff0df` ref — `92b66` is
+    the **Dataverse** connector, verified separately (see below), **not** a `WD-CONN` ref.
+  - `WD-FLOW-*` *(existing — reuse `checks/workday.py`'s `_check_flow_status`)* — both cloud flows on
+    (one emitted `WD-FLOW-{n}` per flow; do **not** add a second emitter).
+  - `WD-CONN-AUTH-001` *(new)* — Workday connection auth type = **Entra ID Integrated**.
+  - `DV-CONN-001` *(new, **non-`WD`-family**)* — Dataverse connection (`92b66`) bound, own account.
+  - `WD-REST-001` *(new)* — REST base URL present and **ends at `/api`** (guard silent failure).
+  - `WD-REST-002` *(new)* — **user-context redirect pushed** so REST resolves **`/workers/me`**;
+    skip if already present; take the rollback checkpoint first. Distinct concern from
+    `WD-REST-001` (base-URL shape) — verified by its own `--checkpoint` so a failure is
+    unambiguous.
+  - `WD-NET-001` *(new)* — Workday REST + SOAP reachability **from the Power Platform connector
+    runtime**; on failure report **"network unreachable (firewall)"** distinctly from **"config
+    invalid"**.
+- **`WD-NET-001` default = MANUAL / InfoSec attestation (build this first).** A local HTTP probe
+  only proves the developer's machine can reach Workday — not that the managed-connector outbound
+  IPs (the ones InfoSec allowlists) can — so a local-only probe must **never** be presented as a
+  gate. The deterministic, junior-safe v1 is an **attestation checkpoint** tied to InfoSec
+  evidence (allowlist confirmation). **Optional enhancement (only if explicitly scoped later):** a
+  minimal connector/cloud-flow test triggered **in the target environment** that classifies the
+  connector response — treat this as a follow-up, not part of the initial skill.
 - Updates master checklist rows.
 
 ## Acceptance criteria
 
-- Extension pack present (simplified flavor); both connections created (own accounts); both
-  flows on; user-context redirect pushed (with a rollback checkpoint) when required — each
-  independently verifiable by a single checkpoint.
+- Extension pack present (simplified flavor, via existing `WD-PKG-001`); the Workday connection
+  (`ff0df`, via existing `WD-CONN-012`) and the Dataverse connection (`92b66`, separate ID) are
+  each bound with their own account; both flows on; user-context redirect pushed (with a
+  rollback checkpoint) when required — each independently verifiable by a single checkpoint.
 - REST base URL stored trimmed to `/api` (guard against the silent failure).
-- Functional auth failures distinguish network-unreachable (firewall) from config-invalid.
+- `WD-NET-001` reflects **Power-Platform-runtime** reachability (or is a MANUAL/InfoSec
+  attestation), distinguishing network-unreachable (firewall) from config-invalid.

--- a/plans/workday-setup/skill-6-create-new-topic.md
+++ b/plans/workday-setup/skill-6-create-new-topic.md
@@ -11,8 +11,8 @@ its template configuration and topic definition and wiring tenant-specific refer
 
 ## Approach
 
-- Workday-specialized refactor of the existing `topics/create` skill using the **Template
-  Config + Shared Flow** pattern (reuse, not reinvention).
+- Workday-specialized refactor of the existing **`src/skills/topics/create`** skill using the
+  **Template Config + Shared Flow** pattern (reuse, not reinvention).
 - A new scenario may need **additional API-client functional areas** → loops back to
   [`skill-4-configure-workday-tenant`](./skill-4-configure-workday-tenant.md) (Register API
   Client) when scopes are missing.
@@ -26,7 +26,12 @@ its template configuration and topic definition and wiring tenant-specific refer
 
 ## Verification
 
-- Flightcheck `TOPIC-*` checkpoints, run individually. Updates master checklist rows.
+- Emit two per-topic checkpoint families, run individually via `--checkpoint`:
+  **`TOPIC-TRIGGER-*`** — the new topic exists and its trigger phrases/recognition are wired; and
+  **`TOPIC-INTEGRATION-*`** — the topic's Workday system-action wiring resolves (e.g. `dialog:`
+  references to `msdyn_copilotforemployeeselfservice*.topic.WorkdaySystem…Execution` exist in the
+  deployed solution namespace, and tenant reference IDs are populated). Updates master checklist
+  rows.
 
 ## Acceptance criteria
 

--- a/plans/workday-setup/skill-6-create-new-topic.md
+++ b/plans/workday-setup/skill-6-create-new-topic.md
@@ -1,0 +1,35 @@
+# Plan: Skill 6 — `create-new-topic`
+
+**Role:** Environment Maker (+ Workday SME for tenant IDs/permissions) · Part of
+[Workday Setup](./README.md).
+**Depends on:** [`skill-5-install-workday-extension-pack`](./skill-5-install-workday-extension-pack.md).
+
+## Purpose
+
+Create a new custom Workday scenario (beyond the OOTB set, e.g. Request Time Off) by adding
+its template configuration and topic definition and wiring tenant-specific reference IDs.
+
+## Approach
+
+- Workday-specialized refactor of the existing `topics/create` skill using the **Template
+  Config + Shared Flow** pattern (reuse, not reinvention).
+- A new scenario may need **additional API-client functional areas** → loops back to
+  [`skill-4-configure-workday-tenant`](./skill-4-configure-workday-tenant.md) (Register API
+  Client) when scopes are missing.
+- On completion, **auto-generate a matching eval set** for the new topic (see
+  [`evals`](./evals.md)).
+
+## Permission gating
+
+- Not an **Environment Maker** → named error + stop. Tenant-ID/permission gaps surface the
+  Workday SME / `configure-workday-tenant` loop-back.
+
+## Verification
+
+- Flightcheck `TOPIC-*` checkpoints, run individually. Updates master checklist rows.
+
+## Acceptance criteria
+
+- New topic + template config created and wired with tenant reference IDs.
+- A matching eval set is generated automatically (no separate manual step).
+- Missing API scopes produce a clear loop-back to skill 4 rather than a silent failure.


### PR DESCRIPTION
## Summary

Adds **planning docs only** (no implementation code) under `plans/workday-setup/` for a refactored, reusable set of **skills** (markdown playbooks an agent executes) that automatically configure **Workday for the ESS Agent** via Microsoft's *simplified* integration path. The plan is designed to be executed by a coding agent steered by a junior engineer, and reached multi-model rubber-duck **consensus (no open questions)** before this PR.

References:
- [Workday simplified setup](https://learn.microsoft.com/en-us/microsoft-365/copilot/employee-self-service/workday-simplified-setup)
- [Workday Entra SSO tutorial](https://learn.microsoft.com/en-us/entra/identity/saas-apps/workday-tutorial)

## What's in the plan

**6 skills with an acyclic dependency chain:**
1. **provision-power-platform-environment** — PP env + Dataverse + Copilot Studio capacity *(Power Platform Admin)*
2. **install-ess** — base ESS agent from AppSource *(Environment Maker)*
3. **provision-workday-entra-app** — Entra app registration, `user_impersonation` scope, pre-authorize the Workday connector app, Graph delegated consent — **fully automated via Microsoft Graph** *(Entra Admin; admin consent = Global Administrator)*
4. **configure-workday-tenant** — tenant-side configuration / attestation *(Workday Admin — partly manual)*
5. **install-workday-extension-pack** — Workday topics, cloud flows, and connection references onto the agent *(Environment Maker)*
6. **create-new-topic** — custom Workday scenarios beyond the OOTB set *(Environment Maker + Workday SME)*

Chain: `1->2`; foundation `->3->4`; `{2,4}->5->6`.

**Cross-cutting docs:**
- **master-checklist.md** — trackable step-ID registry (S1.1...S6.2) + ID mint/reuse table.
- **flightcheck-single-checkpoint.md** — adds `--checkpoint <ID>` so each setup step can be validated **atomically** (static registry + hydrate-then-filter contract; per-checkpoint client init).
- **evals.md** — agent evals tied to the Workday functionality being enabled.
- **shared-building-blocks.md** + **command-wiring.md** — reuse layer so skills don't duplicate logic.
- **README.md** — primary index linking all sub-plans.

## Key design rules baked in
- Non-automatable steps are flagged **MANUAL** (e.g. InfoSec network attestation) and don't fail readiness.
- **Permission failures** return an explicit error naming the missing role.
- Flightcheck registry/drift is **scoped to ESS+Workday setup-owned** checkpoints only; other integrations stay validated via `--scope`.

## Process / status
- Multi-model rubber-duck campaign (gpt-5.5 + claude-opus-4.8) across rounds 2-9; **Round-9: both reviewers READY, zero MAJORs**.
- Ready-to-review with no open questions. Docs-only change — no build/test impact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
