### PR TITLE
Fix /setup environment selection (render Markdown table instead of scraping terminal)

### DIFF
--- a/solutions/ess-maker-skills/scripts/discover.py
+++ b/solutions/ess-maker-skills/scripts/discover.py
@@ -87,6 +87,7 @@ def main():
         from list_environments import (
             get_dataverse_environments,
             print_environment_table,
+            write_environment_markdown,
         )
 
         dv_environments, excluded = get_dataverse_environments()
@@ -101,6 +102,13 @@ def main():
             sys.exit(1)
 
         print_environment_table(dv_environments)
+
+        # Also write a complete Markdown table the onboarding flow can show
+        # the user verbatim, so selection never depends on scraping the
+        # (possibly truncated) terminal output.
+        if args.select is None:
+            md_path = write_environment_markdown(dv_environments)
+            print(f"ENV_TABLE_MARKDOWN:{md_path}")
 
         if args.select is not None:
             idx = args.select

--- a/solutions/ess-maker-skills/scripts/list_environments.py
+++ b/solutions/ess-maker-skills/scripts/list_environments.py
@@ -116,6 +116,30 @@ def print_environment_table(environments):
     print()
 
 
+def write_environment_markdown(environments, path="workspace/onboarding/environments.md"):
+    """Write a clean, numbered Markdown table of environments to a file.
+
+    The onboarding flow reads this file to show the user a complete,
+    untruncated table — rather than scraping the terminal scrollback, which
+    Copilot Chat may truncate. Returns the path written.
+    """
+    lines = [
+        "| # | Environment Name | Type | Region | URL |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for i, e in enumerate(environments, 1):
+        name = (e.get("displayName") or "").replace("|", "\\|")
+        env_type = (e.get("type") or "").replace("|", "\\|")
+        region = (e.get("region") or "").replace("|", "\\|")
+        url = e.get("instanceUrl") or "(no Dataverse linked)"
+        lines.append(f"| {i} | {name} | {env_type} | {region} | {url} |")
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+    return path
+
+
 def main():
     """Standalone entry point for listing environments."""
     import argparse

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1.md
@@ -47,35 +47,34 @@ A browser window will open for sign-in. Wait for the script to finish.
 
 **Check the terminal output:**
 
-- **Script printed a table of environments → go to step 1.1a.**
+- **Script printed `ENV_TABLE_MARKDOWN:<path>` → go to step 1.1a.**
 - **Script failed with an auth/permission error → go to step 1.1c.**
 
 ---
 
-## 1.1a — Ask the user to pick an environment
+## 1.1a — Show the table and ask the user to pick
 
-Build options from the script's environment table. Each row becomes an
-option with the environment name as the label and the URL + type as
-the description.
+Read the Markdown file at the path printed after `ENV_TABLE_MARKDOWN:`
+(it is `workspace/onboarding/environments.md`). It contains a complete,
+numbered table of environments. Do NOT rebuild it from the terminal
+output — read it from the file so no rows are lost.
 
-Use the `vscode_askQuestions` tool:
+Show the user this Message, with `{TABLE}` replaced by the **entire**
+contents of that Markdown file rendered as-is:
 
-```json
-[
-  {
-    "header": "Select environment",
-    "question": "Which environment is your ESS agent deployed in?",
-    "options": [
-      { "label": "{env 1 name}", "description": "{URL} [{type}]" },
-      { "label": "{env 2 name}", "description": "{URL} [{type}]" }
-    ],
-    "allowFreeformInput": false
-  }
-]
-```
+**Message:**
 
-Map the selected environment name back to its row number from the script
-output.
+Here are the Power Platform environments in your tenant:
+
+{TABLE}
+
+Reply with the **number** of the environment your ESS agent is deployed
+in (for example, `2`).
+
+**End message.**
+
+Wait for the user to reply with a number. Save it as NUMBER and go to
+step 1.1b.
 
 ---
 
@@ -91,6 +90,9 @@ Find the line starting with `SELECTED_ENV_JSON:` in the output. Parse the
 JSON after the colon to get the `instanceUrl` field. Save it as ENV_URL.
 **Strip any trailing slash** from ENV_URL before using it (e.g.,
 `https://org.crm.dynamics.com/` becomes `https://org.crm.dynamics.com`).
+
+If the command instead prints an `ERROR: Invalid selection` line, show the
+table again (step 1.1a) and ask for a valid number.
 
 Go to step 1.2.
 

--- a/tests/scripts/test_discover.py
+++ b/tests/scripts/test_discover.py
@@ -223,6 +223,57 @@ class TestPrintEnvironmentTable:
         assert "(no Dataverse linked)" in output
 
 
+class TestWriteEnvironmentMarkdown:
+    """Tests for list_environments.write_environment_markdown()."""
+
+    def test_writes_numbered_markdown_table(self, tmp_path):
+        import list_environments
+
+        envs = [
+            {"displayName": "Env A", "type": "Production", "region": "US",
+             "instanceUrl": "https://a.crm.dynamics.com"},
+            {"displayName": "Env B", "type": "Sandbox", "region": "EU",
+             "instanceUrl": "https://b.crm.dynamics.com"},
+        ]
+        path = tmp_path / "sub" / "environments.md"
+
+        returned = list_environments.write_environment_markdown(envs, str(path))
+
+        assert returned == str(path)
+        content = path.read_text(encoding="utf-8")
+        lines = content.strip().splitlines()
+        # Header + separator + one row per environment.
+        assert lines[0].startswith("| # | Environment Name")
+        assert lines[1].startswith("| --- |")
+        assert lines[2].startswith("| 1 | Env A |")
+        assert lines[3].startswith("| 2 | Env B |")
+        assert "https://a.crm.dynamics.com" in content
+        assert "https://b.crm.dynamics.com" in content
+
+    def test_empty_url_shows_placeholder(self, tmp_path):
+        import list_environments
+
+        envs = [{"displayName": "Empty", "type": "Dev", "region": "",
+                 "instanceUrl": ""}]
+        path = tmp_path / "environments.md"
+
+        list_environments.write_environment_markdown(envs, str(path))
+
+        assert "(no Dataverse linked)" in path.read_text(encoding="utf-8")
+
+    def test_escapes_pipe_in_display_name(self, tmp_path):
+        import list_environments
+
+        envs = [{"displayName": "A | B", "type": "Prod", "region": "US",
+                 "instanceUrl": "https://x.crm.dynamics.com"}]
+        path = tmp_path / "environments.md"
+
+        list_environments.write_environment_markdown(envs, str(path))
+        content = path.read_text(encoding="utf-8")
+        # The literal pipe in the name must be escaped so the table isn't broken.
+        assert "A \\| B" in content
+
+
 class TestDiscoverListEnvironmentsMode:
     """Tests for discover.py --list-environments integration with list_environments."""
 


### PR DESCRIPTION
## Problem

Running `/setup` and choosing "Yes, list my environments" frequently shows **no environment table** (or a truncated one), and Copilot Chat often doesn't know how to proceed.

**Root cause:** `step1.md` ran `discover.py --list-environments` (which prints a plain-text ASCII table to the terminal) and then asked the model to *read that terminal output, parse every row, and rebuild each environment into a `vscode_askQuestions` picker*. Copilot Chat truncates terminal scrollback and never surfaces the ASCII table to the user, so the reconstruction lost rows or failed entirely.

## Fix

Stop relying on the model scraping the terminal. `discover.py --list-environments` now also writes a complete, numbered **Markdown** table to `workspace/onboarding/environments.md` and prints an `ENV_TABLE_MARKDOWN:<path>` marker. `step1.md` reads that file, shows the full table to the user verbatim, asks them to type the row number, then runs `--select N`.

Benefits: no terminal scraping, no picker reconstruction, the user always sees the full table, and it scales to any number of environments.

## Changes

- **`list_environments.py`**: new `write_environment_markdown()` (pipe-escaped names, `(no Dataverse linked)` placeholder).
- **`discover.py`**: write the Markdown file and emit the `ENV_TABLE_MARKDOWN:` marker on the list (non-select) path.
- **`src/skills/onboarding/step1.md`**: §1.1/§1.1a/§1.1b now render the table from the file and use number-entry selection with an invalid-number retry.
- **`tests/scripts/test_discover.py`**: cover the Markdown writer (numbering, placeholder, pipe escaping).

## Validation

- New + existing `tests/scripts/test_discover.py` pass (16).
- Pre-existing failures in `test_installer_maker_profile.py` are unrelated (they also fail on `main`).
