### PR TITLE
flightcheck: add PRE-006 prepaid message capacity check (heritage pre…

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
@@ -638,11 +638,19 @@ def _check_prepaid_message_capacity(runner) -> CheckResult:
             return _pre006(Status.FAILED.value,
                 "No prepaid Copilot Studio message capacity has been purchased for this tenant, and Pay-as-you-go billing is not configured, so users without a Microsoft 365 Copilot license have no message capacity to consume — ESS agent invocations will fail at runtime.",
                 f"Purchase Microsoft Copilot Studio prepaid message capacity in the {_PREPAID_CATALOG}, then allocate it to this environment in {_CAPACITY_PORTAL}; alternatively, configure Pay-as-you-go billing (see PRE-005).")
-        # purchased is None and env allocation not > 0: neither signal could
-        # confirm or deny a purchase -> WARNING (surface it; never a false
-        # FAIL/PASS). Mirrors PRE-005's "could not be determined" handling.
+        # purchased is None and env allocation not > 0: the tenant-wide signal
+        # could not confirm or deny a purchase -> WARNING (surface it; never a
+        # false FAIL/PASS). Mirrors PRE-005's "could not be determined"
+        # handling. Describe the env allocation accurately: it was either
+        # unreadable (None) or read successfully as zero, which are different
+        # operator stories.
+        if env_alloc is None:
+            env_signal = "this environment's Power Platform allocation could not be read"
+        else:
+            env_signal = "this environment has no dedicated Power Platform allocation (read as 0)"
         return _pre006(Status.WARNING.value,
-            "Could not determine whether prepaid Copilot Studio message capacity has been purchased: Microsoft Graph was unavailable or directory read was denied, and this environment's Power Platform allocation could not be read.",
+            "Could not determine whether prepaid Copilot Studio message capacity has been purchased: "
+            f"Microsoft Graph was unavailable or directory read was denied, and {env_signal}.",
             f"Sign in to Microsoft Graph when prompted (or grant Directory.Read.All) and ensure Power Platform Admin access so FlightCheck can read prepaid capacity, then re-run. Review or purchase prepaid capacity in the {_PREPAID_CATALOG}.")
     except Exception as e:
         # Per-check convention (mirrors PRE-004/005): a check that raises

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py
@@ -48,6 +48,20 @@ COPILOT_STUDIO_SKUS: tuple[str, ...] = (
     "MICROSOFT_365_COPILOT",           # M365 Copilot bundle includes Studio messages
 )
 
+# Prepaid Copilot Studio message-capacity SKUs for PRE-006. Deliberately a
+# NARROWER list than COPILOT_STUDIO_SKUS: it EXCLUDES the MICROSOFT_365_COPILOT
+# bundle. Owning end-user Microsoft 365 Copilot licenses is NOT the same as
+# having *purchased prepaid message capacity* — prepaid capacity exists
+# specifically for users WITHOUT a Copilot license. Counting the bundle here
+# would make PRE-006 pass on virtually every ESS tenant (they all hold
+# MICROSOFT_365_COPILOT for PRE-001) and never catch a missing prepaid purchase.
+PREPAID_CAPACITY_SKUS: tuple[str, ...] = (
+    "COPILOT_STUDIO",                  # Copilot Studio plan (monthly message allotment)
+    "MICROSOFT_COPILOT_STUDIO",        # alternate naming convention
+    "POWER_VIRTUAL_AGENTS",            # legacy PVA / prepaid capacity SKUs
+    "CCIBOTS_PRIVPREV_VIRAL",          # original PVA preview SKU
+)
+
 # SKUs that carry Microsoft Teams entitlement, including bundles
 # whose part numbers do not literally contain "TEAMS".
 TEAMS_BEARING_SKUS: tuple[str, ...] = (
@@ -102,6 +116,29 @@ def _has_prepaid_messages(graph) -> bool | None:
     except Exception:
         return None
     return any(_sku_matches(s, COPILOT_STUDIO_SKUS) for s in skus)
+
+
+def _has_prepaid_capacity(graph) -> bool | None:
+    """Whether the tenant owns a prepaid Copilot Studio message-capacity SKU.
+
+    PRE-006-specific signal. Unlike ``_has_prepaid_messages`` (PRE-005), this
+    matches ``PREPAID_CAPACITY_SKUS``, which EXCLUDES the Microsoft 365 Copilot
+    bundle: end-user Copilot licenses are not prepaid message capacity, and
+    counting them would make PRE-006 pass on essentially every ESS tenant.
+
+    Returns:
+      - ``True``  — a prepaid Copilot Studio message-capacity SKU is present.
+      - ``False`` — Graph is reachable and no such SKU exists.
+      - ``None``  — could not determine (no Graph client, or the call failed);
+        the caller must not treat this as either present or absent.
+    """
+    if graph is None:
+        return None
+    try:
+        skus = graph.get_subscribed_skus()
+    except Exception:
+        return None
+    return any(_sku_matches(s, PREPAID_CAPACITY_SKUS) for s in skus)
 
 
 # Copilot Studio message capacity in the Power Platform Licensing
@@ -513,6 +550,111 @@ def _check_copilot_studio_capacity(runner) -> CheckResult:
             "Ensure Power Platform Admin and Dataverse/Graph access, then re-run.")
 
 
+# PRE-006 — prepaid Copilot Studio message capacity purchased. The ESS
+# prerequisites doc's "Set up prepaid messages" section is the heritage anchor;
+# the purchase itself happens in the Microsoft 365 admin center catalog.
+_PREPAID_DOC = f"{DOC_BASE}/prerequisites#set-up-prepaid-messages"
+_PREPAID_CATALOG = (
+    "[Microsoft 365 admin center > Billing > Purchase services]"
+    "(https://admin.microsoft.com/Adminportal/Home#/catalog)"
+)
+
+
+def _pre006(status: str, result: str, remediation: str = "") -> CheckResult:
+    """Build a PRE-006 row (every branch shares id / category / priority / role)."""
+    return CheckResult(
+        roles=[Role.POWER_PLATFORM_ADMIN.value],
+        checkpoint_id="PRE-006", category="Prerequisites",
+        priority=Priority.HIGH.value, status=status,
+        description="Prepaid message capacity purchased",
+        result=result, remediation=remediation, doc_link=_PREPAID_DOC,
+    )
+
+
+def _check_prepaid_message_capacity(runner) -> CheckResult:
+    """PRE-006 — prepaid Copilot Studio message capacity purchased.
+
+    Heritage check (ESS Pre-flight Validator, PRE-006): "Prepaid message
+    capacity purchased | Power Platform API | Message capacity > 0". Confirms
+    the tenant has actually *purchased* prepaid Copilot Studio message
+    capacity — the non-Pay-as-you-go billing model ESS uses for users without
+    a Microsoft 365 Copilot license.
+
+    Scope vs the sibling capacity checks (deliberately non-overlapping):
+      - PRE-005 answers "is *a* billing model configured for this environment"
+        (PayG health OR per-env capacity).
+      - PRE-004 answers "is the allocated capacity *sufficient* for the
+        shared/published user population" (one-credit-per-user floor).
+      - PRE-006 answers the narrower heritage question "has prepaid message
+        capacity been *purchased* at all (> 0)". It is the prepaid-billing
+        gate, and is skipped when Pay-as-you-go already covers billing.
+
+    Determinism / safety: idempotent and read-only (no tenant writes). Two
+    documented, read-only signals are consulted:
+      - Power Platform Licensing currency-allocation API (per-environment
+        ``MCSMessages``) via ``_env_mcs_allocation`` — the heritage
+        "Power Platform API, message capacity > 0" signal.
+      - Microsoft Graph ``subscribedSkus`` (tenant-wide prepaid Copilot Studio
+        SKU) via ``_has_prepaid_capacity`` — confirms the capacity was
+        purchased even when it is not yet allocated to this environment. Uses
+        the narrowed ``PREPAID_CAPACITY_SKUS`` (the Microsoft 365 Copilot bundle
+        does NOT count: end-user licenses are not prepaid capacity).
+
+    Outcomes (admin-focused):
+      - SKIPPED — Pay-as-you-go is configured (``runner._payg_configured`` is
+        True); prepaid capacity is not required. PRE-005 owns that path.
+      - PASS    — message capacity > 0 (env allocation > 0, or the tenant owns
+        prepaid Copilot Studio capacity).
+      - FAIL    — prepaid-only (no PayG) AND no prepaid capacity purchased
+        (capacity == 0).
+      - WARNING — could not determine the capacity state (permission denied /
+        API unavailable), or an unexpected error occurred while checking.
+        Surfaced (never a silent pass) so the operator resolves the gap and
+        re-runs. Mirrors PRE-005's "could not be determined" handling.
+    """
+    try:
+        # PayG covers billing -> prepaid capacity is optional. PRE-005 already
+        # evaluated the PayG path; don't double-report it as a prepaid gap.
+        if getattr(runner, "_payg_configured", None) is True:
+            return _pre006(Status.SKIPPED.value,
+                "Pay-as-you-go billing is configured for this environment (see PRE-005), so prepaid Copilot Studio message capacity is not required. Skipping the prepaid-capacity purchase check.")
+
+        env_alloc = _env_mcs_allocation(
+            getattr(runner, "powerplatform", None), getattr(runner, "env_id", None))
+        purchased = _has_prepaid_capacity(getattr(runner, "graph", None))
+
+        # Power Platform API confirms message capacity > 0 on this environment.
+        if env_alloc is not None and env_alloc > 0:
+            return _pre006(Status.PASSED.value,
+                f"Prepaid Copilot Studio message capacity is purchased and provisioned: {env_alloc} message credit(s) are allocated to this environment (Power Platform Licensing API).")
+        # Tenant owns prepaid capacity even if this environment's allocation is
+        # zero/unreadable. Purchase is confirmed; PRE-004 judges sufficiency.
+        if purchased is True:
+            return _pre006(Status.PASSED.value,
+                "The tenant has purchased prepaid Copilot Studio message capacity (a Copilot Studio message-bearing SKU is present). PRE-004 evaluates whether the allocation to this environment is sufficient for the shared/published user population.")
+        # Tenant has no prepaid SKU at all and PayG is not configured -> the
+        # heritage FAIL: prepaid-only with capacity == 0.
+        if purchased is False:
+            return _pre006(Status.FAILED.value,
+                "No prepaid Copilot Studio message capacity has been purchased for this tenant, and Pay-as-you-go billing is not configured, so users without a Microsoft 365 Copilot license have no message capacity to consume — ESS agent invocations will fail at runtime.",
+                f"Purchase Microsoft Copilot Studio prepaid message capacity in the {_PREPAID_CATALOG}, then allocate it to this environment in {_CAPACITY_PORTAL}; alternatively, configure Pay-as-you-go billing (see PRE-005).")
+        # purchased is None and env allocation not > 0: neither signal could
+        # confirm or deny a purchase -> WARNING (surface it; never a false
+        # FAIL/PASS). Mirrors PRE-005's "could not be determined" handling.
+        return _pre006(Status.WARNING.value,
+            "Could not determine whether prepaid Copilot Studio message capacity has been purchased: Microsoft Graph was unavailable or directory read was denied, and this environment's Power Platform allocation could not be read.",
+            f"Sign in to Microsoft Graph when prompted (or grant Directory.Read.All) and ensure Power Platform Admin access so FlightCheck can read prepaid capacity, then re-run. Review or purchase prepaid capacity in the {_PREPAID_CATALOG}.")
+    except Exception as e:
+        # Per-check convention (mirrors PRE-004/005): a check that raises
+        # degrades to its own WARNING row rather than bubbling up and turning
+        # the whole Prerequisites category into a single ERROR. Include the
+        # exception type so a genuine code bug isn't hidden behind an
+        # environmental-looking warning during triage.
+        return _pre006(Status.WARNING.value,
+            f"Unable to determine prepaid Copilot Studio message capacity: {type(e).__name__}: {e}",
+            f"Ensure Power Platform Admin and Microsoft Graph directory read access, then re-run. Review prepaid capacity in the {_PREPAID_CATALOG}.")
+
+
 def run_prerequisites_checks(runner) -> list[CheckResult]:
     """Execute all prerequisites checks using the Graph client."""
     graph = runner.graph
@@ -821,7 +963,7 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
         # check passed on the prepaid arm), so the capacity/prepaid checks can
         # read it via getattr(runner, "_payg_configured", None) and treat True
         # as "PayG covers billing" (AGENTS.md principle #11). PRE-004 (capacity)
-        # consumes it immediately below; PRE-006 (prepaid) will too.
+        # consumes it immediately below; PRE-006 (prepaid) does too.
         runner._payg_configured = payg_configured
         results.append(payg_result)
 
@@ -830,5 +972,11 @@ def run_prerequisites_checks(runner) -> list[CheckResult]:
     # cross-check). The report sorts by priority then id, so append order is
     # cosmetic — PRE-004 still renders in numeric order.
     results.append(_check_copilot_studio_capacity(runner))
+
+    # ---- PRE-006: prepaid Copilot Studio message capacity purchased ----
+    # Runs after PRE-005 so it can read runner._payg_configured (skip when PayG
+    # already covers billing). Append order is cosmetic — the report sorts by
+    # priority then checkpoint id.
+    results.append(_check_prepaid_message_capacity(runner))
 
     return results

--- a/tests/flightcheck/checks/test_prerequisites.py
+++ b/tests/flightcheck/checks/test_prerequisites.py
@@ -1003,3 +1003,217 @@ def test_pre004_reads_payg_flag_from_pre005(monkeypatch):
     assert pre004.status == "Warning"
     assert "Pay-as-you-go billing is configured" in pre004.result
 
+
+# ---------------------------------------------------------------------------
+# PRE-006 — prepaid Copilot Studio message capacity purchased
+#
+# Heritage rule (ESS Pre-flight Validator, PRE-006): "Prepaid message capacity
+# purchased | Power Platform API | Message capacity > 0". PRE-006 is the
+# prepaid-billing gate — distinct from PRE-005 (is *a* billing model
+# configured) and PRE-004 (is the allocation *sufficient* for the population).
+#
+# Outcomes: SKIPPED (PayG covers billing), PASS (capacity > 0), FAIL
+# (prepaid-only AND capacity == 0), WARNING (could not determine, or an
+# unexpected error -- mirrors PRE-004/005's "could not be determined"). There
+# is no runway/balance WARN band: the Power Platform Licensing API exposes
+# allocated capacity but not remaining balance or consumption rate, so an
+# estimated "30-day runway" is not computable and was intentionally dropped
+# (the WARN state the heritage enhancement asked for cannot be evaluated
+# without consumption telemetry). Deep link for the purchase action is the
+# Microsoft 365 admin center catalog.
+#
+# Unit tests drive _check_prepaid_message_capacity(runner) directly with the
+# shared _FakePP / _FakeGraphSharing stubs; the integration tests run the full
+# run_prerequisites_checks to prove PRE-006 reads PRE-005's _payg_configured.
+# ---------------------------------------------------------------------------
+
+_CATALOG_DEEP_LINK = "https://admin.microsoft.com/Adminportal/Home#/catalog"
+
+
+def _run_pre006(runner):
+    from flightcheck.checks.prerequisites import _check_prepaid_message_capacity
+    return _check_prepaid_message_capacity(runner)
+
+
+def _pre006_runner(*, graph, powerplatform, payg=None, env_id="env-1"):
+    runner = SimpleNamespace(graph=graph, powerplatform=powerplatform, env_id=env_id)
+    if payg is not None:
+        runner._payg_configured = payg
+    return runner
+
+
+def _purchased_graph():
+    """Graph stub whose tenant owns a Copilot Studio message-bearing SKU."""
+    return _FakeGraphSharing(skus=[
+        gr.subscribed_sku(sku_part_number=PREPAID_SKU, consumed_units=1, enabled_units=1),
+    ])
+
+
+def test_pre006_env_allocation_present_passes():
+    # Power Platform API confirms message capacity > 0 on the environment ->
+    # PASS, even without a tenant-wide SKU signal.
+    r = _run_pre006(_pre006_runner(
+        graph=_FakeGraphSharing(skus=[]), powerplatform=_FakePP(_mcs(25000)), payg=False))
+    assert r.checkpoint_id == "PRE-006"
+    assert r.status == "Passed"
+    assert "purchased and provisioned" in r.result
+    assert "25000" in r.result
+    assert r.remediation == ""
+
+
+def test_pre006_tenant_purchased_but_env_zero_passes():
+    # Env allocation is 0 but the tenant has purchased prepaid capacity ->
+    # PASS (purchase confirmed; PRE-004 judges allocation sufficiency).
+    r = _run_pre006(_pre006_runner(
+        graph=_purchased_graph(), powerplatform=_FakePP([]), payg=False))
+    assert r.status == "Passed"
+    assert "tenant has purchased" in r.result
+    assert "PRE-004" in r.result
+    assert r.remediation == ""
+
+
+def test_pre006_nothing_purchased_fails():
+    # Prepaid-only (no PayG) AND capacity == 0 -> the heritage FAIL. The
+    # admin-focused remediation deep-links the M365 admin center catalog.
+    r = _run_pre006(_pre006_runner(
+        graph=_FakeGraphSharing(skus=[]), powerplatform=_FakePP([]), payg=False))
+    assert r.status == "Failed"
+    assert "No prepaid Copilot Studio message capacity has been purchased" in r.result
+    assert _CATALOG_DEEP_LINK in r.remediation
+
+
+def test_pre006_m365_copilot_bundle_alone_is_not_prepaid_capacity():
+    # Regression guard for the false-PASS bug: owning Microsoft 365 Copilot
+    # licenses is NOT the same as purchasing prepaid Copilot Studio message
+    # capacity (which exists for users WITHOUT a Copilot license). The bundle
+    # SKU must NOT satisfy PRE-006 -- otherwise the check passes on virtually
+    # every ESS tenant and never catches a missing prepaid purchase.
+    graph = _FakeGraphSharing(skus=[
+        gr.subscribed_sku(sku_part_number="MICROSOFT_365_COPILOT",
+                          consumed_units=5, enabled_units=10),
+    ])
+    r = _run_pre006(_pre006_runner(
+        graph=graph, powerplatform=_FakePP([]), payg=False))
+    assert r.status == "Failed"
+    assert "No prepaid Copilot Studio message capacity has been purchased" in r.result
+
+
+def test_pre006_payg_configured_skips():
+    # PayG covers billing -> prepaid capacity is optional -> SKIPPED (PRE-005
+    # owns the PayG path). Short-circuits before reading any capacity signal.
+    r = _run_pre006(_pre006_runner(
+        graph=_FakeGraphSharing(skus=[]), powerplatform=_FakePP([]), payg=True))
+    assert r.status == "Skipped"
+    assert "Pay-as-you-go billing is configured" in r.result
+    assert r.remediation == ""
+
+
+def test_pre006_permission_denied_warns():
+    # Per-env allocation read denied (_error sentinel -> None) AND Graph
+    # unavailable (purchased None) -> cannot determine -> WARNING (surface it),
+    # never a false FAIL/PASS. Mirrors PRE-005's could-not-determine handling.
+    r = _run_pre006(_pre006_runner(
+        graph=None,
+        powerplatform=_FakePP({"_error": "insufficient_permissions", "_status": 403}),
+        payg=False))
+    assert r.status == "Warning"
+    assert "Could not determine" in r.result
+    assert _CATALOG_DEEP_LINK in r.remediation
+
+
+def test_pre006_graph_unavailable_with_zero_env_alloc_warns():
+    # Env read succeeded with 0 allocation, but tenant purchase can't be
+    # confirmed (Graph None) -> WARNING, not FAIL (incomplete info must not
+    # produce a false hard failure).
+    r = _run_pre006(_pre006_runner(
+        graph=None, powerplatform=_FakePP([]), payg=False))
+    assert r.status == "Warning"
+    assert "Could not determine" in r.result
+
+
+def test_pre006_unexpected_error_degrades_to_warning():
+    # An UNEXPECTED error (a code defect) degrades to PRE-006's own WARNING row
+    # -- matching PRE-004/005 -- rather than bubbling up and turning the whole
+    # Prerequisites category into a single ERROR. A non-iterable allocations
+    # payload makes _env_mcs_allocation raise past its own guard.
+    r = _run_pre006(_pre006_runner(
+        graph=_FakeGraphSharing(skus=[]), powerplatform=_FakePP(5), payg=False))
+    assert r.status == "Warning"
+    assert "Unable to determine" in r.result
+
+
+def _setup_pre006_pass():
+    return _pre006_runner(
+        graph=_FakeGraphSharing(skus=[]), powerplatform=_FakePP(_mcs(25000)), payg=False)
+
+
+def _setup_pre006_fail():
+    return _pre006_runner(
+        graph=_FakeGraphSharing(skus=[]), powerplatform=_FakePP([]), payg=False)
+
+
+def _setup_pre006_could_not_determine():
+    return _pre006_runner(graph=None, powerplatform=_FakePP([]), payg=False)
+
+
+def _setup_pre006_skipped():
+    return _pre006_runner(
+        graph=_FakeGraphSharing(skus=[]), powerplatform=_FakePP([]), payg=True)
+
+
+@pytest.mark.parametrize("setup, expected_status", [
+    (_setup_pre006_pass, "Passed"),
+    (_setup_pre006_fail, "Failed"),
+    (_setup_pre006_could_not_determine, "Warning"),
+    (_setup_pre006_skipped, "Skipped"),
+])
+def test_pre006_result_schema_and_owning_role(setup, expected_status):
+    # Shared-step schema contract: every PRE-006 row carries
+    # status / description / result / remediation, is owned by the Power
+    # Platform admin, and links docs. remediation is empty exactly on the
+    # no-action rows (Passed / Skipped) and populated on FAIL / WARNING.
+    from flightcheck.runner import Role
+
+    r = _run_pre006(setup())
+
+    assert r.checkpoint_id == "PRE-006"
+    assert r.priority == "High"
+    assert r.category == "Prerequisites"
+    assert r.status == expected_status
+    assert isinstance(r.description, str) and r.description
+    assert isinstance(r.result, str) and r.result
+    assert isinstance(r.remediation, str)
+    assert (r.remediation == "") is (expected_status in ("Passed", "Skipped"))
+    assert r.roles == [Role.POWER_PLATFORM_ADMIN.value]
+    assert r.doc_link
+
+
+@responses.activate
+def test_pre006_integration_skipped_when_payg_configured():
+    # Full run: PayG healthy -> PRE-005 sets _payg_configured True ->
+    # PRE-006 skips (no double-reporting of the billing gap).
+    from flightcheck.checks.prerequisites import run_prerequisites_checks
+
+    runner = _setup_pre005_pass()
+    results = run_prerequisites_checks(runner)
+
+    assert runner._payg_configured is True
+    assert _by_id(results, "PRE-005").status == "Passed"
+    assert _by_id(results, "PRE-006").status == "Skipped"
+
+
+@responses.activate
+def test_pre006_integration_fails_when_no_billing_or_prepaid():
+    # Full run: no billing policy, no prepaid SKU, zero env allocation ->
+    # PRE-005 FAILs and PRE-006 FAILs (prepaid-only AND capacity == 0).
+    from flightcheck.checks.prerequisites import run_prerequisites_checks
+
+    runner = _setup_pre005_fail()
+    results = run_prerequisites_checks(runner)
+
+    assert runner._payg_configured is False
+    pre006 = _by_id(results, "PRE-006")
+    assert pre006.status == "Failed"
+    assert "No prepaid Copilot Studio message capacity has been purchased" in pre006.result
+    assert _CATALOG_DEEP_LINK in pre006.remediation
+


### PR DESCRIPTION
## Description

Adds **`PRE-006` — prepaid Copilot Studio message capacity check**, a FlightCheck
prerequisites validation ported from the ESS Preflight Validator heritage matrix.
It verifies that prepaid Copilot Studio message capacity has actually been
*purchased* (heritage rule: capacity > 0).

Outcomes are mapped to the runner's existing 7-status taxonomy (AGENTS.md design
principle #2), mirroring how `PRE-004`/`PRE-005` handle "could-not-determine":

- **PASSED** — environment has message credits allocated (> 0), OR the tenant holds prepaid capacity.
- **FAILED** — prepaid-only and purchased capacity is 0 (the heritage failure case).
- **SKIPPED** — `runner._payg_configured` is True; Pay-As-You-Go covers billing, so prepaid purchase is not required (`PRE-005` owns that path).
- **WARNING** — capacity could not be determined (permission denied / Graph unavailable) or a catch-all read error. Conservative: never raises, never false-passes.

**Why it's needed:** `PRE-005` confirms *a* billing model is configured; `PRE-004`
confirms allocation is *sufficient* for the shared population. Neither answers the
narrower heritage question — has prepaid capacity been *purchased at all*? When a
tenant relies on prepaid (no PayG) and capacity is zero, agent runs fail.
`PRE-006` closes that gap without overlapping the other two checks.

**Key design decision:** the tenant prepaid signal uses a new `PREPAID_CAPACITY_SKUS`
list that **excludes the Microsoft 365 Copilot bundle**. Reusing `PRE-002`'s
`COPILOT_STUDIO_SKUS` (which substring-matches `MICROSOFT_365_COPILOT`) would
return True on nearly every ESS tenant, making `FAILED` unreachable and producing
a false `PASS`. End-user Copilot licenses are not purchased prepaid message capacity.

**Known limitation (consistent with `PRE-005`):** no remaining-balance / consumption
API exists for Copilot Studio message capacity, so a "30-day runway" WARN band is
not computable. `PRE-006` validates *purchased > 0* only. Read-only and idempotent
(GET-only); admin remediation deep-links the M365 admin center catalog.

## Related issue
<!-- Replace with the tracking issue if one exists, e.g. `Fixes #123`. -->
Refs #

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / cleanup

## Testing
- `ruff check solutions/ess-maker-skills/scripts` — clean.
- `pytest tests/flightcheck` — **541 passed**.
- `PRE-006` unit coverage (`tests/flightcheck/checks/test_prerequisites.py`, 57 passed):
  env-allocation PASS, tenant-capacity PASS, prepaid-only zero FAIL,
  could-not-determine WARNING, catch-all WARNING, the
  `test_pre006_m365_copilot_bundle_alone_is_not_prepaid_capacity` regression,
  the 4-field schema / owning-role contract (remediation empty iff PASS/SKIP),
  and integration with `PRE-005` PASS (→ SKIP) / FAIL (→ FAIL).

## Checklist
- [x] My code follows the existing style
- [x] I have added/updated tests where applicable
- [ ] I have updated documentation as needed

## Static validation (samples/ only)
N/A — this PR does not touch anything under `samples/` (changes are limited to
`solutions/ess-maker-skills/scripts/flightcheck/checks/prerequisites.py` and
`tests/flightcheck/checks/test_prerequisites.py`).