### PR TITLE
WD-CONN-013: Agent connection OBO parameter-sharing check

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -652,10 +652,10 @@ def run_workday_checks(runner) -> list[CheckResult]:
     results.extend(_check_connections(runner))
     results.extend(_check_connection_token_health(runner))
 
-    # WD-CONN-013 — Workday connection OBO parameter sharing. Verifies the
-    # agent's Workday connections have "Allow permission to share parameters"
+    # WD-CONN-013 — Agent connection OBO parameter sharing. Verifies every
+    # connection the agent uses has "Allow permission to share parameters"
     # enabled (read from the connectionreference config columns) so end users
-    # invoke Workday without a first-use connection prompt.
+    # invoke the backing services without a first-use connection prompt.
     results.extend(_check_workday_connection_obo_sharing(runner))
 
     # --- Flow Status ---
@@ -1364,16 +1364,16 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
 # Which references count as "the agent's connections":
 #   Copilot Studio creates the agent's own connection references with a logical
 #   name of the form ``{schema}.{guid}.{connectorName}`` — e.g.
-#   ``msdyn_copilotforemployeeselfservicehr.<guid>.shared_workdaysoap`` — i.e.
-#   ending in ``.shared_workdaysoap`` (the connector as the final dotted
-#   segment). Those are the rows the toggle writes to. The solution-template
-#   references shipped by the install (``new_sharedworkdaysoap_ff0df``,
-#   ``msdyn_sharedcommondataserviceforapps_92b66``) are bound but are NOT the
-#   agent's Connection-Settings connections; their underscore-only logical names
-#   don't end in ``.shared_workdaysoap``, so they're excluded. (We match on this
-#   structural suffix rather than the agent schema name from config: the
-#   reference prefix is the *product* bot schema, which does not necessarily
-#   equal the published agent's ``config.agent.schemaName``.)
+#   ``msdyn_copilotforemployeeselfservicehr.<guid>.shared_workdaysoap`` — i.e. a
+#   GUID delimited by dots (the connector is the final segment). Those are the
+#   rows the toggle writes to, for EVERY connector the agent uses (Workday SOAP,
+#   Dataverse, etc.). The solution-template references shipped by the install
+#   (``new_sharedworkdaysoap_ff0df``, ``msdyn_sharedcommondataserviceforapps_92b66``)
+#   are bound but are NOT the agent's Connection-Settings connections; their
+#   underscore-only logical names carry no ``.{guid}.`` segment, so they're
+#   excluded. (We match on this structural format rather than the agent schema
+#   name from config: the reference prefix is the *product* bot schema, which
+#   does not necessarily equal the published agent's ``config.agent.schemaName``.)
 #
 # Data source: the same documented-tier Dataverse ``connectionreferences`` query
 # WD-PKG-001 already makes, with two extra columns
@@ -1381,9 +1381,11 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
 # endpoint, no cassette.
 
 
-# Suffix on the agent's own Workday connection-reference logical names — the
-# connector appears as the final dotted segment (``{schema}.{guid}.{connector}``).
-_AGENT_WORKDAY_REF_SUFFIX = ".shared_workdaysoap"
+# An agent's own connection reference logical name embeds a GUID between dots:
+# ``{schema}.{guid}.{connector}``. Solution-template refs (``new_x_y``) don't.
+_AGENT_CONNECTION_REF_RE = re.compile(
+    r"\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.", re.I
+)
 
 
 def _connection_label(ref: dict) -> str:
@@ -1395,18 +1397,17 @@ def _connection_label(ref: dict) -> str:
 
 
 def _check_workday_connection_obo_sharing(runner) -> list[CheckResult]:
-    """WD-CONN-013 — every Workday connection the agent uses has OBO parameter
-    sharing enabled, so end users invoke Workday without a first-use connection
-    prompt.
+    """WD-CONN-013 — every connection the agent uses has OBO parameter sharing
+    ("Allow permission to share parameters") enabled, so end users invoke the
+    backing services without a first-use connection prompt.
 
-    Scopes to the agent's own Workday SOAP connection references (logical name
-    ending in ``.shared_workdaysoap`` — the Copilot Studio
-    ``{schema}.{guid}.{connector}`` format) and requires
+    Scopes to the agent's own connection references (logical name of the form
+    ``{schema}.{guid}.{connector}``, any connector) and requires
     ``connectionparametersetconfig`` to be populated on each. See the module
     comment for why this column / scoping is correct.
     """
     cp_id = "WD-CONN-013"
-    desc = "Workday connection OBO parameter sharing"
+    desc = "Agent connection OBO parameter sharing"
     doc_link = f"{DOC_BASE}/workday#step-3-connection-references"
     roles = [Role.POWER_PLATFORM_ADMIN.value]
 
@@ -1437,26 +1438,27 @@ def _check_workday_connection_obo_sharing(runner) -> list[CheckResult]:
             remediation="Confirm the FlightCheck identity has Dataverse read access on connectionreferences.",
         )]
 
-    agent_wd = [
+    agent_refs = [
         r for r in refs
         if r.get("connectionid")
-        and (r.get("connectionreferencelogicalname") or "")
-        .lower().endswith(_AGENT_WORKDAY_REF_SUFFIX)
+        and _AGENT_CONNECTION_REF_RE.search(
+            r.get("connectionreferencelogicalname") or ""
+        )
     ]
 
-    if not agent_wd:
+    if not agent_refs:
         return [CheckResult(roles=roles, checkpoint_id=cp_id, category="Workday",
             priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
             description=desc,
             result=(
-                "No Workday connections found for this agent — nothing to evaluate "
-                "for OBO parameter sharing."
+                "No agent connection references found — nothing to evaluate for "
+                "OBO parameter sharing."
             ),
             doc_link=doc_link,
         )]
 
     unshared = [
-        r for r in agent_wd
+        r for r in agent_refs
         if not (r.get("connectionparametersetconfig") or r.get("connectionparametersconfig"))
     ]
 
@@ -1465,9 +1467,9 @@ def _check_workday_connection_obo_sharing(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.PASSED.value,
             description=desc,
             result=(
-                f"All {len(agent_wd)} Workday connection(s) the agent uses have OBO "
-                "parameter sharing enabled — end users invoke Workday without a "
-                "first-use connection prompt."
+                f"All {len(agent_refs)} connection(s) the agent uses have OBO "
+                "parameter sharing enabled — end users invoke the backing "
+                "services without a first-use connection prompt."
             ),
             doc_link=doc_link,
         )]
@@ -1478,10 +1480,10 @@ def _check_workday_connection_obo_sharing(runner) -> list[CheckResult]:
         priority=Priority.HIGH.value, status=Status.FAILED.value,
         description=desc,
         result=(
-            f"{len(unshared)} of {len(agent_wd)} Workday connection(s) the agent "
-            f"uses do NOT have OBO parameter sharing enabled: {names}. End users "
-            "will be prompted to establish their own connection the first time the "
-            "agent uses Workday."
+            f"{len(unshared)} of {len(agent_refs)} connection(s) the agent uses "
+            f"do NOT have OBO parameter sharing enabled: {names}. End users will "
+            "be prompted to establish their own connection the first time the "
+            "agent uses the backing service."
         ),
         remediation=(
             f"In Copilot Studio, open {studio} → Settings → Connection Settings → "

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -652,6 +652,12 @@ def run_workday_checks(runner) -> list[CheckResult]:
     results.extend(_check_connections(runner))
     results.extend(_check_connection_token_health(runner))
 
+    # WD-CONN-013 — Workday connection OBO parameter sharing. Verifies the
+    # agent's Workday connections have "Allow permission to share parameters"
+    # enabled (read from the connectionreference config columns) so end users
+    # invoke Workday without a first-use connection prompt.
+    results.extend(_check_workday_connection_obo_sharing(runner))
+
     # --- Flow Status ---
     results.extend(_check_flow_status(runner, wd_flows))
 
@@ -1335,6 +1341,155 @@ def _check_package_connection_completeness(runner) -> list[CheckResult]:
         doc_link=doc_link,
     )]
 
+
+# ─────────────────────────────────────────────────────────────────────────
+# WD-CONN-013 — Workday connection OBO parameter sharing
+# ─────────────────────────────────────────────────────────────────────────
+#
+# Microsoft Learn → Copilot Studio → Create and manage connections →
+# "Share connection parameters for On-Behalf-Of (OBO) authentication": the agent
+# maker turns on "Allow permission to share parameters" on each Workday
+# connection (Agent → Settings → Connection Settings → the connection → See
+# details → Connection parameters) so end users invoke Workday without being
+# prompted to establish their own connection at first use.
+#
+# Where the setting is stored (confirmed empirically by toggling it live):
+#   The flag is persisted on the AGENT's own connection reference rows in the
+#   Dataverse ``connectionreference`` table — column
+#   ``connectionparametersetconfig`` (Memo / JSON): populated = shared, null =
+#   not shared. (``promptingbehavior`` is unrelated — it is the solution-import
+#   "Prompt on import / Skip" choice. The connection ``/permissions`` role
+#   assignments are a different, unrelated sharing surface.)
+#
+# Which references count as "the agent's connections":
+#   Copilot Studio creates the agent's own connection references with a logical
+#   name of the form ``{schema}.{guid}.{connectorName}`` — e.g.
+#   ``msdyn_copilotforemployeeselfservicehr.<guid>.shared_workdaysoap`` — i.e.
+#   ending in ``.shared_workdaysoap`` (the connector as the final dotted
+#   segment). Those are the rows the toggle writes to. The solution-template
+#   references shipped by the install (``new_sharedworkdaysoap_ff0df``,
+#   ``msdyn_sharedcommondataserviceforapps_92b66``) are bound but are NOT the
+#   agent's Connection-Settings connections; their underscore-only logical names
+#   don't end in ``.shared_workdaysoap``, so they're excluded. (We match on this
+#   structural suffix rather than the agent schema name from config: the
+#   reference prefix is the *product* bot schema, which does not necessarily
+#   equal the published agent's ``config.agent.schemaName``.)
+#
+# Data source: the same documented-tier Dataverse ``connectionreferences`` query
+# WD-PKG-001 already makes, with two extra columns
+# (``connectionparametersetconfig`` / ``connectionparametersconfig``). No new
+# endpoint, no cassette.
+
+
+# Suffix on the agent's own Workday connection-reference logical names — the
+# connector appears as the final dotted segment (``{schema}.{guid}.{connector}``).
+_AGENT_WORKDAY_REF_SUFFIX = ".shared_workdaysoap"
+
+
+def _connection_label(ref: dict) -> str:
+    return (
+        ref.get("connectionreferencedisplayname")
+        or ref.get("connectionreferencelogicalname")
+        or "(unnamed connection)"
+    )
+
+
+def _check_workday_connection_obo_sharing(runner) -> list[CheckResult]:
+    """WD-CONN-013 — every Workday connection the agent uses has OBO parameter
+    sharing enabled, so end users invoke Workday without a first-use connection
+    prompt.
+
+    Scopes to the agent's own Workday SOAP connection references (logical name
+    ending in ``.shared_workdaysoap`` — the Copilot Studio
+    ``{schema}.{guid}.{connector}`` format) and requires
+    ``connectionparametersetconfig`` to be populated on each. See the module
+    comment for why this column / scoping is correct.
+    """
+    cp_id = "WD-CONN-013"
+    desc = "Workday connection OBO parameter sharing"
+    doc_link = f"{DOC_BASE}/workday#step-3-connection-references"
+    roles = [Role.POWER_PLATFORM_ADMIN.value]
+
+    env_url = getattr(runner, "env_url", None)
+    dv_token = getattr(runner, "dv_token", None)
+    if not env_url or not dv_token:
+        return [CheckResult(roles=roles, checkpoint_id=cp_id, category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description=desc,
+            result="Dataverse token not available — cannot read connection-reference sharing config.",
+        )]
+
+    try:
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+        from auth import query_all
+
+        refs = query_all(
+            env_url, dv_token, "connectionreferences",
+            "connectionreferencelogicalname,connectionreferencedisplayname,"
+            "connectorid,connectionid,connectionparametersetconfig,"
+            "connectionparametersconfig",
+        )
+    except Exception as e:
+        return [CheckResult(roles=roles, checkpoint_id=cp_id, category="Workday",
+            priority=Priority.HIGH.value, status=Status.SKIPPED.value,
+            description=desc,
+            result=f"Unable to read Dataverse connection references: {e}.",
+            remediation="Confirm the FlightCheck identity has Dataverse read access on connectionreferences.",
+        )]
+
+    agent_wd = [
+        r for r in refs
+        if r.get("connectionid")
+        and (r.get("connectionreferencelogicalname") or "")
+        .lower().endswith(_AGENT_WORKDAY_REF_SUFFIX)
+    ]
+
+    if not agent_wd:
+        return [CheckResult(roles=roles, checkpoint_id=cp_id, category="Workday",
+            priority=Priority.HIGH.value, status=Status.NOT_CONFIGURED.value,
+            description=desc,
+            result=(
+                "No Workday connections found for this agent — nothing to evaluate "
+                "for OBO parameter sharing."
+            ),
+            doc_link=doc_link,
+        )]
+
+    unshared = [
+        r for r in agent_wd
+        if not (r.get("connectionparametersetconfig") or r.get("connectionparametersconfig"))
+    ]
+
+    if not unshared:
+        return [CheckResult(roles=roles, checkpoint_id=cp_id, category="Workday",
+            priority=Priority.HIGH.value, status=Status.PASSED.value,
+            description=desc,
+            result=(
+                f"All {len(agent_wd)} Workday connection(s) the agent uses have OBO "
+                "parameter sharing enabled — end users invoke Workday without a "
+                "first-use connection prompt."
+            ),
+            doc_link=doc_link,
+        )]
+
+    names = ", ".join(sorted(_connection_label(r) for r in unshared))
+    studio = _wd_studio_link(runner)
+    return [CheckResult(roles=roles, checkpoint_id=cp_id, category="Workday",
+        priority=Priority.HIGH.value, status=Status.FAILED.value,
+        description=desc,
+        result=(
+            f"{len(unshared)} of {len(agent_wd)} Workday connection(s) the agent "
+            f"uses do NOT have OBO parameter sharing enabled: {names}. End users "
+            "will be prompted to establish their own connection the first time the "
+            "agent uses Workday."
+        ),
+        remediation=(
+            f"In Copilot Studio, open {studio} → Settings → Connection Settings → "
+            "the connection → See details → Connection parameters → turn on "
+            "'Allow permission to share parameters' and select the parameters."
+        ),
+        doc_link=doc_link,
+    )]
 
 # ─────────────────────────────────────────────────────────────────────────
 # Install-flavor gating helper (see AGENTS.md design principle #11)

--- a/tests/flightcheck/checks/test_workday_connection_obo_sharing.py
+++ b/tests/flightcheck/checks/test_workday_connection_obo_sharing.py
@@ -23,18 +23,24 @@ from typing import Any
 import pytest
 
 SCHEMA = "msdyn_copilotforemployeeselfservicehr"
-_WD_CONNECTOR = "/providers/Microsoft.PowerApps/apis/shared_workdaysoap"
 _SHARED_CFG = '{"name":"oauth","values":{}}'
 
+# Real GUID-format middle segments — the agent connection-ref detector requires
+# a ``.{guid}.`` segment.
+G1 = "9f1b2c3d-4e5f-6789-abcd-1234567890ab"
+G2 = "aab52569-483a-f111-8e38-0022480875be"
+G3 = "11111111-2222-3333-4444-555555555555"
 
-def _agent_ref(guid: str, *, shared: bool = True, display: str = "ESS HR Workday",
+
+def _agent_ref(guid: str, *, connector: str = "shared_workdaysoap",
+               shared: bool = True, display: str = "ESS HR Workday",
                via_params_config: bool = False):
     setcfg = None if (via_params_config or not shared) else _SHARED_CFG
     paramscfg = _SHARED_CFG if (via_params_config and shared) else None
     return {
-        "connectionreferencelogicalname": f"{SCHEMA}.{guid}.shared_workdaysoap",
+        "connectionreferencelogicalname": f"{SCHEMA}.{guid}.{connector}",
         "connectionreferencedisplayname": display,
-        "connectorid": _WD_CONNECTOR,
+        "connectorid": f"/providers/Microsoft.PowerApps/apis/{connector}",
         "connectionid": f"conn-{guid}",
         "connectionparametersetconfig": setcfg,
         "connectionparametersconfig": paramscfg,
@@ -42,11 +48,11 @@ def _agent_ref(guid: str, *, shared: bool = True, display: str = "ESS HR Workday
 
 
 def _solution_ref(name: str = "new_sharedworkdaysoap_ff0df"):
-    # A bound Workday SOAP ref that is NOT the agent's (no schema prefix), unshared.
+    # A bound ref that is NOT the agent's (no ``.{guid}.`` segment), unshared.
     return {
         "connectionreferencelogicalname": name,
         "connectionreferencedisplayname": "OAuthUser",
-        "connectorid": _WD_CONNECTOR,
+        "connectorid": "/providers/Microsoft.PowerApps/apis/shared_workdaysoap",
         "connectionid": "conn-ff0df",
         "connectionparametersetconfig": None,
         "connectionparametersconfig": None,
@@ -75,37 +81,50 @@ def _run(runner) -> Any:
     return results[0]
 
 
-# ── PASS / FAIL on the agent's Workday connections ─────────────────────────
+# ── PASS / FAIL on the agent's connections ─────────────────────────────────
 
 def test_all_agent_connections_shared_passes(monkeypatch):
     _stub(monkeypatch, [
-        _agent_ref("g1", shared=True, display="ESS HR Workday"),
-        _agent_ref("g2", shared=True, display="ESS HR Workday Get User Context V2"),
+        _agent_ref(G1, shared=True, display="ESS HR Workday"),
+        _agent_ref(G2, shared=True, display="ESS HR Workday Get User Context V2"),
         _solution_ref(),  # excluded
     ])
     r = _run(_runner())
     assert r.status == "Passed"
-    assert "All 2 Workday connection(s)" in r.result
+    assert "All 2 connection(s) the agent uses" in r.result
 
 
 def test_one_unshared_connection_fails(monkeypatch):
     _stub(monkeypatch, [
-        _agent_ref("g1", shared=True, display="ESS HR Workday"),
-        _agent_ref("g2", shared=False, display="ESS HR Workday Get User Context V2"),
+        _agent_ref(G1, shared=True, display="ESS HR Workday"),
+        _agent_ref(G2, shared=False, display="ESS HR Workday Get User Context V2"),
     ])
     r = _run(_runner())
     assert r.status == "Failed"
     assert "1 of 2" in r.result
     assert "ESS HR Workday Get User Context V2" in r.result
-    # The shared one is not listed as a problem.
     assert "Allow permission to share parameters" in r.remediation
 
 
-def test_solution_refs_are_excluded(monkeypatch):
-    # Only one agent connection (shared) + an unshared solution ref. The solution
-    # ref must NOT drag the verdict to FAIL.
+def test_covers_every_connector_the_agent_references(monkeypatch):
+    # Not just Workday SOAP — a non-Workday agent connection that is unshared
+    # must also fail the check.
     _stub(monkeypatch, [
-        _agent_ref("g1", shared=True),
+        _agent_ref(G1, connector="shared_workdaysoap", shared=True),
+        _agent_ref(G3, connector="shared_commondataserviceforapps",
+                   shared=False, display="Microsoft Dataverse"),
+    ])
+    r = _run(_runner())
+    assert r.status == "Failed"
+    assert "1 of 2" in r.result
+    assert "Microsoft Dataverse" in r.result
+
+
+def test_solution_refs_are_excluded(monkeypatch):
+    # One agent connection (shared) + unshared solution refs (no .{guid}. segment).
+    # The solution refs must NOT drag the verdict to FAIL.
+    _stub(monkeypatch, [
+        _agent_ref(G1, shared=True),
         _solution_ref(),
         {"connectionreferencelogicalname": "msdyn_sharedcommondataserviceforapps_92b66",
          "connectorid": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",
@@ -114,23 +133,23 @@ def test_solution_refs_are_excluded(monkeypatch):
     ])
     r = _run(_runner())
     assert r.status == "Passed"
-    assert "All 1 Workday connection(s)" in r.result
+    assert "All 1 connection(s) the agent uses" in r.result
 
 
 def test_sharing_via_parameters_config_column_also_counts(monkeypatch):
-    _stub(monkeypatch, [_agent_ref("g1", shared=True, via_params_config=True)])
+    _stub(monkeypatch, [_agent_ref(G1, shared=True, via_params_config=True)])
     r = _run(_runner())
     assert r.status == "Passed"
 
 
 # ── NOT_CONFIGURED / SKIPPED branches ──────────────────────────────────────
 
-def test_no_agent_workday_refs_is_not_configured(monkeypatch):
-    # Only solution refs (no schema-prefixed agent refs).
+def test_no_agent_refs_is_not_configured(monkeypatch):
+    # Only solution refs (no .{guid}. agent-connection segment).
     _stub(monkeypatch, [_solution_ref()])
     r = _run(_runner())
     assert r.status == "NotConfigured"
-    assert "No Workday connections found for this agent" in r.result
+    assert "No agent connection references found" in r.result
 
 
 def test_no_dataverse_token_is_skipped():

--- a/tests/flightcheck/checks/test_workday_connection_obo_sharing.py
+++ b/tests/flightcheck/checks/test_workday_connection_obo_sharing.py
@@ -1,15 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Tests for WD-CONN-013 (Workday connection OBO parameter sharing).
+"""Tests for WD-CONN-013 (Agent connection OBO parameter sharing).
 
-The check verifies that every Workday connection the *agent* uses has
+The check verifies that every connection the *agent* uses has
 "Allow permission to share parameters" enabled. That setting is persisted on the
 agent's own ``connectionreference`` rows (logical name
 ``{agentSchemaName}.{guid}.{connector}``) in column ``connectionparametersetconfig``
 (populated = shared, null = not shared) — confirmed empirically by toggling it
 live. Solution-template refs (``new_sharedworkdaysoap_ff0df`` etc.) are bound but
-are NOT the agent's connections, so they're excluded by the schema-name prefix.
+are NOT the agent's connections, so they're excluded because their underscore-only
+logical names carry no ``.{guid}.`` segment (the agent-connection structural format).
 
 The Dataverse ``connectionreferences`` query is documented tier — stubbed here
 via ``auth.query_all`` (no cassette).

--- a/tests/flightcheck/checks/test_workday_connection_obo_sharing.py
+++ b/tests/flightcheck/checks/test_workday_connection_obo_sharing.py
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for WD-CONN-013 (Workday connection OBO parameter sharing).
+
+The check verifies that every Workday connection the *agent* uses has
+"Allow permission to share parameters" enabled. That setting is persisted on the
+agent's own ``connectionreference`` rows (logical name
+``{agentSchemaName}.{guid}.{connector}``) in column ``connectionparametersetconfig``
+(populated = shared, null = not shared) — confirmed empirically by toggling it
+live. Solution-template refs (``new_sharedworkdaysoap_ff0df`` etc.) are bound but
+are NOT the agent's connections, so they're excluded by the schema-name prefix.
+
+The Dataverse ``connectionreferences`` query is documented tier — stubbed here
+via ``auth.query_all`` (no cassette).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+SCHEMA = "msdyn_copilotforemployeeselfservicehr"
+_WD_CONNECTOR = "/providers/Microsoft.PowerApps/apis/shared_workdaysoap"
+_SHARED_CFG = '{"name":"oauth","values":{}}'
+
+
+def _agent_ref(guid: str, *, shared: bool = True, display: str = "ESS HR Workday",
+               via_params_config: bool = False):
+    setcfg = None if (via_params_config or not shared) else _SHARED_CFG
+    paramscfg = _SHARED_CFG if (via_params_config and shared) else None
+    return {
+        "connectionreferencelogicalname": f"{SCHEMA}.{guid}.shared_workdaysoap",
+        "connectionreferencedisplayname": display,
+        "connectorid": _WD_CONNECTOR,
+        "connectionid": f"conn-{guid}",
+        "connectionparametersetconfig": setcfg,
+        "connectionparametersconfig": paramscfg,
+    }
+
+
+def _solution_ref(name: str = "new_sharedworkdaysoap_ff0df"):
+    # A bound Workday SOAP ref that is NOT the agent's (no schema prefix), unshared.
+    return {
+        "connectionreferencelogicalname": name,
+        "connectionreferencedisplayname": "OAuthUser",
+        "connectorid": _WD_CONNECTOR,
+        "connectionid": "conn-ff0df",
+        "connectionparametersetconfig": None,
+        "connectionparametersconfig": None,
+    }
+
+
+def _runner(*, config: Any = None, dv_token: str | None = "t",
+            env_url: str | None = "https://org.crm.dynamics.com"):
+    return SimpleNamespace(
+        env_url=env_url, dv_token=dv_token,
+        config=config if config is not None else {"agents": [{"schemaName": SCHEMA}]},
+    )
+
+
+def _stub(monkeypatch, refs):
+    import auth
+    monkeypatch.setattr(auth, "query_all", lambda *a, **k: list(refs))
+
+
+def _run(runner) -> Any:
+    from flightcheck.checks.workday import _check_workday_connection_obo_sharing
+
+    results = _check_workday_connection_obo_sharing(runner)
+    assert len(results) == 1
+    assert results[0].checkpoint_id == "WD-CONN-013"
+    return results[0]
+
+
+# ── PASS / FAIL on the agent's Workday connections ─────────────────────────
+
+def test_all_agent_connections_shared_passes(monkeypatch):
+    _stub(monkeypatch, [
+        _agent_ref("g1", shared=True, display="ESS HR Workday"),
+        _agent_ref("g2", shared=True, display="ESS HR Workday Get User Context V2"),
+        _solution_ref(),  # excluded
+    ])
+    r = _run(_runner())
+    assert r.status == "Passed"
+    assert "All 2 Workday connection(s)" in r.result
+
+
+def test_one_unshared_connection_fails(monkeypatch):
+    _stub(monkeypatch, [
+        _agent_ref("g1", shared=True, display="ESS HR Workday"),
+        _agent_ref("g2", shared=False, display="ESS HR Workday Get User Context V2"),
+    ])
+    r = _run(_runner())
+    assert r.status == "Failed"
+    assert "1 of 2" in r.result
+    assert "ESS HR Workday Get User Context V2" in r.result
+    # The shared one is not listed as a problem.
+    assert "Allow permission to share parameters" in r.remediation
+
+
+def test_solution_refs_are_excluded(monkeypatch):
+    # Only one agent connection (shared) + an unshared solution ref. The solution
+    # ref must NOT drag the verdict to FAIL.
+    _stub(monkeypatch, [
+        _agent_ref("g1", shared=True),
+        _solution_ref(),
+        {"connectionreferencelogicalname": "msdyn_sharedcommondataserviceforapps_92b66",
+         "connectorid": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",
+         "connectionid": "conn-dv", "connectionparametersetconfig": None,
+         "connectionparametersconfig": None},
+    ])
+    r = _run(_runner())
+    assert r.status == "Passed"
+    assert "All 1 Workday connection(s)" in r.result
+
+
+def test_sharing_via_parameters_config_column_also_counts(monkeypatch):
+    _stub(monkeypatch, [_agent_ref("g1", shared=True, via_params_config=True)])
+    r = _run(_runner())
+    assert r.status == "Passed"
+
+
+# ── NOT_CONFIGURED / SKIPPED branches ──────────────────────────────────────
+
+def test_no_agent_workday_refs_is_not_configured(monkeypatch):
+    # Only solution refs (no schema-prefixed agent refs).
+    _stub(monkeypatch, [_solution_ref()])
+    r = _run(_runner())
+    assert r.status == "NotConfigured"
+    assert "No Workday connections found for this agent" in r.result
+
+
+def test_no_dataverse_token_is_skipped():
+    from flightcheck.checks.workday import _check_workday_connection_obo_sharing
+    r = _check_workday_connection_obo_sharing(_runner(dv_token=None))[0]
+    assert r.status == "Skipped"
+    assert "Dataverse token not available" in r.result
+
+
+def test_query_error_is_skipped(monkeypatch):
+    import auth
+
+    def _boom(*a, **k):
+        raise RuntimeError("403 Forbidden")
+
+    monkeypatch.setattr(auth, "query_all", _boom)
+    r = _run(_runner())
+    assert r.status == "Skipped"
+    assert "Unable to read Dataverse connection references" in r.result
+
+
+# ── wiring ─────────────────────────────────────────────────────────────────
+
+class TestWiring:
+    @pytest.fixture
+    def _auto_stub_other_workday_checks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from flightcheck.checks import workday as wd_mod
+
+        keep = {"_check_workday_connection_obo_sharing"}
+        for name in dir(wd_mod):
+            if not name.startswith("_check_") or name in keep:
+                continue
+            if not callable(getattr(wd_mod, name)):
+                continue
+            monkeypatch.setattr(wd_mod, name, lambda *_a, **_k: [])
+
+    def test_run_workday_checks_invokes_obo_sharing(
+        self, monkeypatch: pytest.MonkeyPatch, _auto_stub_other_workday_checks: None,
+    ) -> None:
+        from flightcheck.checks.workday import run_workday_checks
+
+        # dv_token=None → the check returns SKIPPED without any query.
+        runner = SimpleNamespace(
+            _workday_flows=[{"id": "fake-flow"}],
+            env_url="https://org.crm.dynamics.com", dv_token=None,
+            config={"agents": [{"schemaName": SCHEMA}]},
+        )
+        results = run_workday_checks(runner)
+        rows = [r for r in results if r.checkpoint_id == "WD-CONN-013"]
+        assert len(rows) == 1, "WD-CONN-013 must be emitted by run_workday_checks"


### PR DESCRIPTION
## What & why

Adds **WD-CONN-013 — Agent connection OBO parameter sharing**. It verifies that every connection the agent uses has *Allow permission to share parameters* (On-Behalf-Of) enabled, so end users invoke the backing services (Workday, etc.) without being prompted to establish their own connection at first use — the requirement in Microsoft Learn → Copilot Studio → *Share connection parameters for On-Behalf-Of (OBO) authentication* and the Workday Step 2/3 setup docs.

## How it works (no new endpoint, no cassette)

The OBO `Allow permission to share parameters` toggle is persisted on the agent's own Dataverse `connectionreference` rows in column **`connectionparametersetconfig`** (populated = shared, null = not shared) — confirmed empirically by toggling it live on a tenant and diffing the row. The check reads the **same documented-tier `connectionreferences` query WD-PKG-001 already makes**, with two extra columns (`connectionparametersetconfig` / `connectionparametersconfig`).

Two things were ruled out during investigation:
- `promptingbehavior` — unrelated (it's the solution-import *Prompt on import / Skip* choice, per the entity reference).
- The connection `/permissions` role-assignments endpoint — a different, unrelated sharing surface (and its connection objects leak Workday tenant/clientId, so it was abandoned).

### Scoping to the agent's connections

Copilot Studio names the agent's own connection references `{schema}.{guid}.{connector}` (a GUID delimited by dots). The check matches that **structural format** (any connector) and excludes the unused solution-template refs (`new_sharedworkdaysoap_ff0df`, `msdyn_sharedcommondataserviceforapps_92b66` — underscore-named, no `.{guid}.` segment). We deliberately match on the structural format rather than `config.agent.schemaName`: the reference prefix is the *product* bot schema, which does not necessarily equal the published agent's schema (an earlier schema-prefix attempt produced a false NOT_CONFIGURED).

### Verdicts

- **PASSED** — every agent connection has parameter sharing enabled.
- **FAILED** — lists the unshared connections, with the *Copilot Studio → Settings → Connection Settings → See details → Connection parameters → Allow permission to share parameters* remediation.
- **NOT_CONFIGURED** — no agent connection references found.
- **SKIPPED** — no Dataverse token / read error.

## Known limitation

`connectionparametersetconfig` being null is treated as "not shared" for every agent connector. A connector that does not support parameter sharing could therefore surface as a finding. This false-positive risk is accepted in favour of covering **every** connection the agent references (the requested scope).

## Tests

`tests/flightcheck/checks/test_workday_connection_obo_sharing.py` — 9 tests: PASS/FAIL, multi-connector coverage (a non-Workday agent connection), solution-ref exclusion, the alternate `connectionparametersconfig` column, NOT_CONFIGURED/SKIPPED, and wiring. Full `tests/flightcheck` suite: **559 passed**; ruff clean.

## Live validation

Verified end-to-end on a real simplified-install tenant: with both Workday connections' *Allow permission to share parameters* turned on, WD-CONN-013 reports **Passed**; with one off it correctly **FAILs** and names the connection.
