### PR TITLE
spec(mtk): [Master] | super-pipeline + two-file session bundle redesign

### DIFF
--- a/.github/agents/mtk-master.md
+++ b/.github/agents/mtk-master.md
@@ -153,4 +153,8 @@ where the specs allow, and resolve the rest during your serial integration
   to hand it back to the worker to preserve the master/worker separation.
 - **Do not commit** unless the user explicitly asks. Stage and summarize; let the
   user decide.
+- **Commit/PR title convention.** MTK commit and PR titles follow
+  `type(scope): [Role] | subject`. Commits and PRs you create as the orchestrator
+  are prefixed `[Master]` (e.g. `spec(mtk): [Master] | super-pipeline redesign`);
+  worker commits are prefixed `[Worker]`. Always keep the role tag.
 - Cite specs by full repo-root-relative path plus a section number; never use the section-symbol shorthand.

--- a/.github/agents/mtk-worker.md
+++ b/.github/agents/mtk-worker.md
@@ -51,9 +51,11 @@ under
    worktree's own task branch, which follows the convention
    `users/aniladepu/features/mtk/task-XXX-<slug>` (the Master created it; do not
    rename it). Do not push, do not merge, do not switch or touch any other
-   branch — the Master handles integration. Use a clear message referencing the
-   task (e.g. `TASK-004: implement Dataverse client`) and include the trailer
-   `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+   branch — the Master handles integration. Use a clear message following the
+   MTK commit-title convention `type(scope): [Worker] | subject` — worker
+   commits are always prefixed with the `[Worker]` role tag (e.g.
+   `feat(mtk): [Worker] | TASK-004 implement Dataverse client`) — and include the
+   trailer `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
 8. **Report back.** Summarize the files you changed, how each **Acceptance
    Criteria** item is satisfied, the gate results, and your branch name. Do
    **not** mark the task DONE yourself — the Master reviews, merges, and updates

--- a/.github/instructions/ess-nextgen-toolkit.instructions.md
+++ b/.github/instructions/ess-nextgen-toolkit.instructions.md
@@ -28,6 +28,15 @@ anything appears to conflict, the canonical `AGENTS.md` wins.
 - Every implementation originates from an approved `TASK-XXX` in
   `04_EXECUTION/TASKS.md`; resolve its `Consumes`/`References` before coding.
 - One Migration Rule (`RULE-XXX`) maps to exactly one Pipeline Step.
+- The toolkit is a fluent **super-pipeline** of three stage pipelines —
+  Input → Migration → Output — over a shared, typed `MigrationContext`; the
+  Migration Orchestrator is only the composition root (build, configure,
+  execute, return). Pipelines and steps are generic:
+  `Pipeline[TInput, TOutput]`, `PipelineStep[TInput, TOutput]`.
+- Every execution produces one session bundle `output/session-<timestamp>/`
+  with exactly two files: `migration_report.md` (customer) and `session.log`
+  (ESS engineer). Steps accumulate into `MigrationContext` collectors; only the
+  Logger and Reporter service write files.
 - Respect architectural boundaries and dependency direction
   (Orchestration → Pipeline → Modules → Dataverse Client → Dataverse).
 - Determinism is required; never delete customer customizations.

--- a/dev-specs/ess-nextgen-migration-toolkit/00_META/INVARIANTS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/00_META/INVARIANTS.md
@@ -205,6 +205,18 @@ Diagnostics are emitted through the Diagnostics framework.
 
 ---
 
+## PIPE-007
+
+Pipelines and steps are strongly typed and composed as a super-pipeline.
+
+The framework is generic (`Pipeline[TInput, TOutput]`,
+`PipelineStep[TInput, TOutput]`). The toolkit executes as three stage pipelines —
+Input → Migration → Output — over a shared `MigrationContext`. The Migration
+Orchestrator is only the composition root; it builds, configures, executes, and
+returns. Pipeline behaviour never lives in the orchestrator.
+
+---
+
 # 6. Service Invariants
 
 ---
@@ -332,6 +344,17 @@ Examples
 * OAuth tokens
 * Secrets
 * Connection strings
+
+---
+
+## DIAG-004
+
+Every execution produces exactly one session bundle.
+
+Each run writes one timestamped folder `output/session-<timestamp>/` containing
+exactly two files: `migration_report.md` (customer-facing) and `session.log`
+(ESS-engineer diagnostics). Steps accumulate into the `MigrationContext`
+collectors; only the Logger and the Reporter service write files.
 
 ---
 

--- a/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/DOMAIN_MODEL.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/DOMAIN_MODEL.md
@@ -173,10 +173,19 @@ Migration Orchestrator
 - Environment
 - Agent
 - Components
+- ComponentSet (keyed view: ComponentType → Component[])
 - Candidates
+- Changes
+- Warnings
+- Errors
+- Logs
 - Reports
 - Diagnostics
 - Configuration
+
+`Changes`, `Warnings`, `Errors`, and `Logs` are the diagnostic accumulation
+collectors that Pipeline Steps append to; the Output Pipeline renders
+`migration_report.md` from them (see DIAGNOSTICS.md section 5).
 
 ---
 

--- a/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/PIPELINES.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/PIPELINES.md
@@ -1,7 +1,7 @@
 # PIPELINES.md
 
 # ESS NextGen Migration Toolkit — Pipeline Framework Specification
-**Status:** Draft v1.0
+**Status:** Draft v2.0
 **Owner:** Anil Kumar Adepu
 
 > **Purpose**
@@ -10,9 +10,57 @@
 >
 > The Pipeline Framework provides a deterministic, extensible execution engine for migration workflows.
 >
-> Business transformations are implemented as independent Pipeline Steps that are composed into executable Pipelines.
+> Business transformations are implemented as independent, strongly-typed Pipeline Steps that are composed into executable Pipelines.
 >
 > The framework itself is completely independent of ESS-specific migration logic.
+
+> **The toolkit is a super-pipeline (v2.0)**
+>
+> The product itself *is* a single deterministic, fluent super-pipeline composed
+> of three independently-extensible **stage pipelines**, each responsible for a
+> single concern:
+>
+> ```
+> Input Pipeline      (src/modules/preprocessing/)
+>       ↓
+> Migration Pipeline  (src/modules/migration/)
+>       ↓
+> Output Pipeline     (src/modules/postprocessing/)
+> ```
+>
+> The composition is expressed fluently:
+>
+> ```python
+> EssMigrationToolkit()
+>     .input(InputPipeline().use(...).use(...))
+>     .migrate(MigrationPipeline().use(...).use(...))
+>     .output(OutputPipeline().use(...).use(...))
+> ```
+>
+> **Each stage receives the output of the previous stage and operates over the
+> shared `MigrationContext`.** The Input Pipeline builds and enriches the
+> context (including the homogeneous keyed `ComponentSet` of customer-owned
+> components); the Migration Pipeline applies deterministic business
+> transformations to it; the Output Pipeline validates, persists, and reports on
+> it.
+>
+> **The Migration Orchestrator is only the composition root.** It builds the
+> super-pipeline, configures the execution mode (Discover / Preview / Migrate),
+> executes it, and returns the resulting reports and diagnostics. Orchestration
+> concerns are kept strictly separate from pipeline behaviour — the orchestrator
+> is *not* the primary abstraction; the super-pipeline is.
+>
+> **Typed framework foundation.** The reusable framework is generic —
+> `Pipeline[TInput, TOutput]` and `PipelineStep[TInput, TOutput]` — so the
+> Builder can type-thread steps and support type-changing steps where genuinely
+> needed. The three ESS stage pipelines instantiate this foundation over the
+> shared `MigrationContext` (`Pipeline[MigrationContext, MigrationContext]`),
+> which threads through the whole super-pipeline. (The generic `TInput, TOutput`
+> signature is the analogue of the C# `HeterogenousPipelineStepComputeUnitBase
+> <TInput, TOutput>`; a stage pipeline is the analogue of
+> `KeyedComputeUnitBase<...>`. C# runtime concerns — Autofac keyed registration,
+> `floorEpoch`/`currentEpoch` versioning, per-step `Equals`/`GetHashCode` — are
+> intentionally out of scope and not ported.)
 
 ---
 
@@ -81,6 +129,42 @@ Execution Mode selection belongs to Pipeline Steps, not the Pipeline Engine.
 Pipeline execution is fail-fast.
 
 A failed step terminates the pipeline unless explicitly configured otherwise.
+
+---
+
+## PIPE-008
+
+Pipelines and Pipeline Steps are strongly typed.
+
+The framework foundation is generic — `Pipeline[TInput, TOutput]` and
+`PipelineStep[TInput, TOutput]`. The Pipeline Builder type-threads adjacent
+steps so that the output type of one step is the input type of the next; an
+incompatible composition is a construction-time error, not a runtime error. The
+three ESS stage pipelines instantiate this foundation over the shared
+`MigrationContext`.
+
+---
+
+## PIPE-009
+
+A stage pipeline threads the shared `MigrationContext`.
+
+Within a stage, each step receives the `MigrationContext` produced by the prior
+step, enriches it, and passes it on. A step may Read, Enrich, or Validate the
+context; a step may never replace the context with an unrelated type nor smuggle
+state outside it. The context is the only object shared between steps.
+
+---
+
+## PIPE-010
+
+The toolkit is a super-pipeline of three stages.
+
+Migration executes as **Input → Migration → Output**, each a stage pipeline over
+the shared `MigrationContext`. The Migration Orchestrator is only the
+composition root: it builds the super-pipeline, configures the execution mode,
+executes it, and returns reports and diagnostics. A stage never reaches into
+another stage's steps.
 
 ---
 
@@ -183,35 +267,85 @@ Construct executable pipelines.
 
 - Register Pipeline Steps
 - Configure execution order
+- Type-thread adjacent steps (`step[n].output == step[n+1].input`)
 - Validate pipeline configuration
 
 ---
 
 ## Fluent API
 
+Each stage pipeline is built fluently over the shared `MigrationContext`. The
+generic Builder (`Pipeline.builder(name)` → `Pipeline[TInput, TOutput]`)
+type-threads every `.use(step)`; the ESS stages instantiate it as
+`Pipeline[MigrationContext, MigrationContext]`, so each step reads the context
+produced by the prior step and returns the enriched context.
+
 ```python
-pipeline = (
-    Pipeline.builder("Migration")
-
-        .use(DiscoverComponents())
-
-        .use(AnalyzeOwnership())
-
-        .use(LoadComponents())
-
-        .use(OverrideAgentMetadataStep())
-
-        .use(ReplaceEndConversationStep())
-
-        .use(ValidateMigration())
-
-        .use(Writeback())
-
-        .build()
+# Input Pipeline (src/modules/preprocessing/) — discovers artifacts and
+# builds the canonical MigrationContext, including the keyed ComponentSet.
+input_pipeline = (
+    InputPipeline()
+        .use(DiscoverAgent())
+        .use(LoadDependencies())
+        .use(RetrieveSolutionComponentLayers())
+        .use(ResolveCustomizationOwnership())
+        .use(LoadCanonicalComponents())      # populates context.ComponentSet
 )
+
+# Migration Pipeline (src/modules/migration/) — one Step per Migration Rule.
+migration_pipeline = (
+    MigrationPipeline()
+        .use(OverrideAgentMetadataStep())        # RULE-001
+        .use(ReplaceEndConversationStep())       # RULE-002
+        .use(HandleOnActivityTopicStep())        # RULE-003
+        .use(HandleGeneratedResponseTopicStep()) # RULE-004
+)
+
+# Output Pipeline (src/modules/postprocessing/) — validate, persist, and render
+# the two-file session bundle.
+output_pipeline = (
+    OutputPipeline()
+        .use(ValidateMigration())
+        .use(Writeback())                    # Migrate mode only
+        .use(GenerateMigrationReport())      # renders customer-facing migration_report.md
+)
+# session.log is streamed live by the framework Logger across all stages —
+# it is not a pipeline step.
 ```
 
-The builder creates immutable executable pipelines.
+### The super-pipeline
+
+The product itself is a single fluent super-pipeline that composes the three
+stages. Each stage receives the output of the previous stage over the shared
+`MigrationContext`:
+
+```python
+toolkit = (
+    EssMigrationToolkit()
+        .input(input_pipeline)
+        .migrate(migration_pipeline)
+        .output(output_pipeline)
+)
+
+result = toolkit.run(mode=ExecutionMode.PREVIEW)   # Discover | Preview | Migrate
+```
+
+The Builder creates immutable executable pipelines. The **Migration Orchestrator
+is only the composition root** — it assembles the super-pipeline above,
+configures the execution mode, executes it, and returns the reports and
+diagnostics (see section 16). Adding a future migration capability normally
+requires only a new Migration Rule, a new Pipeline Step, and its registration in
+the Migration Pipeline — the surrounding framework is unchanged.
+
+> **Note — where the C# reference maps.** A stage pipeline
+> (`Pipeline[TInput, TOutput]`) is the analogue of the C#
+> `KeyedComputeUnitBase<...>` (a whole module compute), and
+> `PipelineStep[TInput, TOutput]` is the analogue of
+> `HeterogenousPipelineStepComputeUnitBase<TInput, TOutput>` (a single typed step
+> compute). The C# runtime concerns — Autofac keyed registration,
+> `floorEpoch`/`currentEpoch` versioning, and per-step `Equals`/`GetHashCode` —
+> are intentionally **out of scope** for a batch migration tool and are not
+> ported.
 
 ---
 
@@ -348,11 +482,16 @@ Pipeline Steps communicate exclusively through MigrationContext.
 - Session
 - Environment
 - Agent
-- Components
+- Components (including the keyed `ComponentSet`)
 - Migration Candidates
-- Diagnostics
+- Diagnostic collectors — Logs, Warnings, Errors, Changes
 - Reports
 - Configuration
+
+The Diagnostic collectors (`Logs`, `Warnings`, `Errors`, `Changes`) are the
+accumulation buffers that steps append to; the Output Pipeline's terminal
+`GenerateMigrationReport()` step renders `migration_report.md` from them (see
+DIAGNOSTICS.md section 5).
 
 ---
 
@@ -535,50 +674,61 @@ Examples:
 
 ---
 
-# 16. Pipeline Categories
+# 16. Stage Pipelines and the Super-Pipeline
 
-The framework supports multiple Pipeline types.
+The toolkit is composed of three **stage pipelines**, each a `Pipeline` over the
+shared `MigrationContext`.
 
-## Discovery Pipeline
-
-Responsibilities
-
-- Discover components
-- Analyze ownership
-
----
-
-## Migration Pipeline
+## Input Pipeline (`src/modules/preprocessing/`)
 
 Responsibilities
 
-- Execute Migration Steps
+- Discover the target ESS Agent
+- Retrieve migration dependencies and Solution Component Layers
+- Resolve customer-owned customizations
+- Load canonical Domain Models and build the keyed `ComponentSet`
+- Produce the enriched `MigrationContext`
 
----
-
-## Validation Pipeline
-
-Responsibilities
-
-- Validate transformed artifacts
-
----
-
-## Persistence Pipeline
+## Migration Pipeline (`src/modules/migration/`)
 
 Responsibilities
 
-- Persist migrated artifacts
+- Execute Migration Steps (one Step per Migration Rule) — deterministic business
+  transformations only
 
----
-
-## Reporting Pipeline
+## Output Pipeline (`src/modules/postprocessing/`)
 
 Responsibilities
 
-- Generate reports
+- Validate migrated artifacts
+- Persist supported transformations to Dataverse (Migrate mode only)
+- Render the customer-facing `migration_report.md`
+- (The engineering `session.log` is streamed by the Logger, not a step)
 
-The Migration Orchestrator composes these pipelines into an execution workflow.
+## The Super-Pipeline
+
+The Migration Orchestrator (`src/service/mtk_orchestrator.py`) is the
+**composition root** only. It assembles the three stages into the fluent
+super-pipeline, configures the execution mode, executes it, and returns the
+reports and diagnostics:
+
+```python
+EssMigrationToolkit()
+    .input(input_pipeline)
+    .migrate(migration_pipeline)
+    .output(output_pipeline)
+```
+
+The final outputs of the toolkit are the two files of the session bundle:
+
+- `migration_report.md` — customer-facing (all modes; the product in
+  Discover/Preview)
+- `session.log` — ESS-engineer-facing diagnostics
+
+In Migrate mode the customer environment is additionally updated. Orchestration
+concerns stay strictly separate from pipeline behaviour — the super-pipeline is
+the primary abstraction; the orchestrator merely builds, configures, executes,
+and returns.
 
 ---
 

--- a/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/PIPELINES.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/PIPELINES.md
@@ -275,7 +275,7 @@ Construct executable pipelines.
 ## Fluent API
 
 Each stage pipeline is built fluently over the shared `MigrationContext`. The
-generic Builder (`Pipeline.builder(name)` → `Pipeline[TInput, TOutput]`)
+generic Builder (`Pipeline.builder(name, *, input_type=...)` → `Pipeline[TInput, TOutput]`)
 type-threads every `.use(step)`; the ESS stages instantiate it as
 `Pipeline[MigrationContext, MigrationContext]`, so each step reads the context
 produced by the prior step and returns the enriched context.

--- a/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/DIAGNOSTICS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/DIAGNOSTICS.md
@@ -168,13 +168,19 @@ YYYY-MM-DD_HH-MM-SS
 A Pipeline Step **never** opens, reads, or writes a diagnostics/report file
 itself. Instead:
 
-1. Throughout execution, every step reports through the framework **Logger**,
-   which streams the **`session.log`** live (all stages, all levels).
-2. Every step also **accumulates** structured outcome data into the shared
-   `MigrationContext` through the Diagnostics framework — `context.Logs`,
-   `context.Warnings`, `context.Errors`, and `context.Changes` (see
-   DOMAIN_MODEL.md → MigrationContext).
-3. A **single terminal step**, `GenerateMigrationReport()`, runs last in the
+1. When the run starts, the **Logger** installs a stdout/stderr tee (section
+   6.1), so **`session.log`** becomes a full live transcript of the CLI for the
+   whole run.
+2. Throughout execution, each step reports through the framework Logger using two
+   channels (section 6.2): the **engineer channel** (`LogDebug`/`LogInfo`/…) goes
+   to the CLI and is mirrored into `session.log`; the **customer channel**
+   (`LogCustomer`/`LogFancy`) appends structured entries to the report model
+   only.
+3. Every step also **accumulates** structured outcome data into the shared
+   `MigrationContext` — `context.Logs`, `context.Warnings`, `context.Errors`, and
+   `context.Changes` (see DOMAIN_MODEL.md → MigrationContext). This is the report
+   model the customer channel writes to.
+4. A **single terminal step**, `GenerateMigrationReport()`, runs last in the
    Output Pipeline and asks the **Reporter service** to render
    **`migration_report.md`** from those collectors.
 
@@ -186,24 +192,57 @@ into the session bundle.
 
 # 6. Logger
 
-The Logger is the only approved mechanism for runtime output.
+The Logger is the only approved mechanism for runtime output. Direct use of
+`print()` from business logic is prohibited (DIAG-005). The Logger is
+initialized once at the **application entry point** (the composition root, before
+the pipeline runs) and is the single I/O boundary for all console and log output.
 
-The Logger writes simultaneously to:
+## 6.1 Transcript capture (session.log is a full CLI replay)
 
-* Console
-* Session Log
+When the Logger initializes, it **installs a stdout/stderr tee** for the process.
+From that line onward, **every byte written to the CLI** — Logger output,
+incidental third-party library output, and tracebacks alike — is mirrored into
+`output/session-<timestamp>/session.log`. The engineer therefore receives a
+complete, replayable transcript of the run, not just hand-picked log lines.
 
-Direct use of:
+> Capture begins at the **Python application entry** (the migration run), not in
+> the shell wrapper. Environment provisioning output (`uv sync`, etc.) is **not**
+> part of the session bundle — the app owns the session folder and its log.
 
-```
-print()
-```
+## 6.2 Two channels
 
-is prohibited.
+The Logger exposes two semantically distinct channels:
+
+| Channel            | Method (illustrative) | Console (CLI) | `session.log` | `migration_report.md` |
+| ------------------ | --------------------- | :-----------: | :-----------: | :-------------------: |
+| **Engineer**       | `LogDebug` / `LogInfo` / `LogWarning` / `LogError` | ✅ (via tee) | ✅ | ✗ |
+| **Customer**       | `LogCustomer` / `LogFancy` | ✗ | ✗ | ✅ (rendered) |
+
+* **Engineer channel** — ordinary diagnostics. Prints to the CLI as usual; the
+  transcript tee (6.1) mirrors it into `session.log`. This is the developer/ESS
+  debugging stream and honors the log levels in section 7.
+* **Customer channel** — customer-facing narrative. It does **not** print to the
+  CLI or `session.log`. Instead it appends **structured entries** to an
+  intermediate **report model** (see 6.3) that the Reporter later renders into
+  the fancy `migration_report.md`. Example (Discover mode): recording each
+  unsupported component in a readable way so the customer can decide whether to
+  proceed with writeback.
+
+## 6.3 Report model (intermediate)
+
+Customer-channel calls accumulate into a structured, in-memory **report model**
+(the `MigrationContext` collectors — `Changes`, `Warnings`, `Errors`, plus
+summary counters; see DOMAIN_MODEL.md). The Reporter (section 9) renders this
+model into `migration_report.md` at the end of the run. Persisting the model as
+an intermediate `report.json` is permitted internally as a render input, but it
+is **not** a session-bundle artifact — the bundle remains exactly the two files
+in section 5.
 
 ---
 
 # 7. Log Levels
+
+The log levels below apply to the **engineer channel** (console + `session.log`).
 
 Supported log levels:
 

--- a/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/DIAGNOSTICS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/DIAGNOSTICS.md
@@ -132,35 +132,55 @@ Close Session
 
 ---
 
-# 5. Session Folder Structure
+# 5. Session Bundle (the product)
 
-Each execution creates timestamped output under the generated debug tree.
+Every execution produces exactly **one** timestamped **session bundle** — a
+single self-contained folder. After a run, the user is presented with exactly
+**two files**:
 
 ```
-debug/logs/
+output/
 
-    2026-07-18_14-32-05/
+    session-2026-07-18_14-32-05/
 
-        session.log
-
-        diagnostics_summary.txt
-
-debug/reports/
-
-    2026-07-18_14-32-05/
-
-        readiness_report.txt
-
-        preview_report.txt
-
-        migration_report.txt
+        migration_report.md     # customer-facing report (see section 9)
+        session.log             # engineering diagnostics log (see section 6)
 ```
 
-The timestamp format shall be:
+| File                 | Audience        | Purpose                                                    |
+| -------------------- | --------------- | ---------------------------------------------------------- |
+| `migration_report.md`| **Customer**    | The human-readable outcome: summary, changes, warnings.    |
+| `session.log`        | **ESS Engineer**| The full diagnostics log, shared for debugging issues.     |
+
+Especially in **Discover** and **Preview** modes, `migration_report.md` *is* the
+deliverable. `session.log` is what the customer forwards (or a support engineer
+retrieves) when something needs investigation. Two files, one folder — nothing
+scattered across the filesystem.
+
+The session folder name is `session-<timestamp>`, where the timestamp format is:
 
 ```
 YYYY-MM-DD_HH-MM-SS
 ```
+
+## 5.1 How the two files are produced (read-only steps)
+
+A Pipeline Step **never** opens, reads, or writes a diagnostics/report file
+itself. Instead:
+
+1. Throughout execution, every step reports through the framework **Logger**,
+   which streams the **`session.log`** live (all stages, all levels).
+2. Every step also **accumulates** structured outcome data into the shared
+   `MigrationContext` through the Diagnostics framework — `context.Logs`,
+   `context.Warnings`, `context.Errors`, and `context.Changes` (see
+   DOMAIN_MODEL.md → MigrationContext).
+3. A **single terminal step**, `GenerateMigrationReport()`, runs last in the
+   Output Pipeline and asks the **Reporter service** to render
+   **`migration_report.md`** from those collectors.
+
+This keeps DIAG-005 and PIPE-006 intact — business steps never touch the
+filesystem; only the Logger and the Reporter service write, and both write only
+into the session bundle.
 
 ---
 
@@ -230,18 +250,53 @@ Overrode agent metadata.
 
 # 9. Reporter
 
-The Reporter generates customer-facing artifacts.
+The Reporter renders the single customer-facing artifact —
+**`migration_report.md`** — from the `MigrationContext` collectors. It is the
+only component (besides the Logger) that writes files.
 
-Reports include:
+`migration_report.md` is one document composed of sections, so the customer has
+a single readable file rather than many:
 
-* Migration Readiness Report
-* Preview Report
-* Migration Report
-* Diagnostics Summary
+* **Summary** — one-pager (mode, duration, components, migrated, warnings, errors, writeback)
+* **Changes** — human-readable per-rule change log (section 9.1)
+* **Warnings** — manual-review items only (section 9.2)
 
-Reports are generated from the MigrationContext.
+The report is mode-aware: it presents the Readiness view in Discover, the
+Preview view in Preview, and the Migration view in Migrate (sections 10–13). The
+engineering `session.log` is produced separately by the Logger (section 6).
 
-Generated report output is written to `debug/reports/`.
+## 9.1 Changes section
+
+The heart of the report: what changed, grouped by Migration Rule.
+
+```
+## Changes
+
+### RULE-001 — Updated Agent Metadata
+Runtime Provider   CA → DA
+Template           CA → DA
+
+### RULE-002 — Replaced EndConversation
+Topic              Employee Leave
+Replacements       1
+
+### RULE-003 — Deprecated Topics
+Trigger            OnActivity
+Topic              Employee Context
+Reason             Unsupported in DA
+```
+
+## 9.2 Warnings section
+
+Manual-review items only.
+
+```
+## Warnings — Manual Review Required
+
+Topic            Employee Context
+Reason           OnActivity trigger unsupported.
+Recommendation   Move logic into OnConversationStart.
+```
 
 ---
 

--- a/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/DIAGNOSTICS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/DIAGNOSTICS.md
@@ -174,7 +174,7 @@ itself. Instead:
 2. Throughout execution, each step reports through the framework Logger using two
    channels (section 6.2): the **engineer channel** (`LogDebug`/`LogInfo`/…) goes
    to the CLI and is mirrored into `session.log`; the **customer channel**
-   (`LogCustomer`/`LogFancy`) appends structured entries to the report model
+   (`LogChange`/`LogAdvisory`) appends structured entries to the report model
    only.
 3. Every step also **accumulates** structured outcome data into the shared
    `MigrationContext` — `context.Logs`, `context.Warnings`, `context.Errors`, and
@@ -216,7 +216,7 @@ The Logger exposes two semantically distinct channels:
 | Channel            | Method (illustrative) | Console (CLI) | `session.log` | `migration_report.md` |
 | ------------------ | --------------------- | :-----------: | :-----------: | :-------------------: |
 | **Engineer**       | `LogDebug` / `LogInfo` / `LogWarning` / `LogError` | ✅ (via tee) | ✅ | ✗ |
-| **Customer**       | `LogCustomer` / `LogFancy` | ✗ | ✗ | ✅ (rendered) |
+| **Customer**       | `LogChange` / `LogAdvisory` | ✗ | ✗ | ✅ (rendered) |
 
 * **Engineer channel** — ordinary diagnostics. Prints to the CLI as usual; the
   transcript tee (6.1) mirrors it into `session.log`. This is the developer/ESS
@@ -227,6 +227,18 @@ The Logger exposes two semantically distinct channels:
   the fancy `migration_report.md`. Example (Discover mode): recording each
   unsupported component in a readable way so the customer can decide whether to
   proceed with writeback.
+
+  The customer channel has **two intent-revealing methods**, each feeding a
+  distinct report section (do not conflate them):
+
+  | Method        | Report model collector          | `migration_report.md` section        | Records… |
+  | ------------- | ------------------------------- | ------------------------------------ | -------- |
+  | `LogChange`   | `context.Changes` (`ChangeEntry`) | `## Changes`                        | **What the toolkit did** — a successful transformation, keyed by `RULE-xxx` (e.g. Runtime Provider CA → DA). |
+  | `LogAdvisory` | `context.Warnings` / `Errors` / `Logs` (`DiagnosticEntry`, routed by `severity`) | `## Warnings — Manual Review Required` / Errors | **What the customer must act on** — a manual-review advisory with `severity` + `recommendation`. |
+
+  `LogChange` is the changelog; `LogAdvisory` is the action list. Keeping them
+  separate lets the Reporter render Changes and Warnings without re-classifying a
+  single blended stream.
 
 ## 6.3 Report model (intermediate)
 

--- a/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/IMPLEMENTATION_GUIDE.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/IMPLEMENTATION_GUIDE.md
@@ -248,16 +248,13 @@ print()
 
 is prohibited.
 
-Execution logs must be written to:
+Execution logs and the customer-facing report are written to the per-execution
+session bundle:
 
 ```
-debug/logs/
-```
-
-Migration reports must be written to:
-
-```
-debug/reports/
+output/session-YYYY-MM-DD_HH-MM-SS/
+    migration_report.md
+    session.log
 ```
 
 ---

--- a/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/REPOSITORY_STRUCTURE.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/REPOSITORY_STRUCTURE.md
@@ -78,9 +78,10 @@ tools/
         service/
             mtk_orchestrator.py
 
-    debug/
-        logs/
-        reports/
+    output/
+        session-YYYY-MM-DD_HH-MM-SS/
+            migration_report.md
+            session.log
 
     tests/
 
@@ -312,17 +313,18 @@ orchestration logic and any command surface are added later.
 
 ---
 
-## debug/
+## output/
 
 Owns generated, gitignored execution output. It sits at the toolkit root as a
 sibling of `src/` (not a Python package).
 
-Contains:
+Contains one timestamped **session bundle** per execution:
 
-* `logs/`
-* `reports/`
+* `session-YYYY-MM-DD_HH-MM-SS/`
+  * `migration_report.md` — customer-facing report
+  * `session.log` — ESS-engineer diagnostics log
 
-The subfolders are retained in version control only through `.gitkeep` files.
+The folder is retained in version control only through a `.gitkeep` file.
 
 ---
 
@@ -440,19 +442,15 @@ End-to-end tests validate complete migration workflows through the Orchestrator.
 
 # 10. Logging and Reports
 
-Execution artifacts are written to:
+Each execution produces one timestamped session bundle under:
 
 ```text
-debug/logs/
+output/session-YYYY-MM-DD_HH-MM-SS/
 ```
 
-Session logs are timestamped and written using the framework logging abstraction.
-
-Customer-facing reports are written to:
-
-```text
-debug/reports/
-```
+The bundle contains exactly two files: `migration_report.md` (customer-facing)
+and `session.log` (ESS-engineer diagnostics). Session logs are written using the
+framework logging abstraction; the report is rendered by the Reporter service.
 
 Business logic must never write files directly.
 

--- a/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/TESTING.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/TESTING.md
@@ -246,7 +246,7 @@ tests/golden/
 
     expected/
 
-    debug/reports/
+    expected_report/
 ```
 
 Every Golden Test consists of:

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
@@ -12,6 +12,13 @@ task (`TASK-XXX`) where applicable, per `IMPLEMENTATION_GUIDE.md`.
 
 ## [Unreleased]
 
+- **Customer-channel method rename (clarity).** Renamed the two customer-channel
+  Logger methods to be intent-revealing: `LogFancy` → **`LogChange`** (records a
+  successful transformation → `context.Changes` → `## Changes`) and
+  `LogCustomer` → **`LogAdvisory`** (records a manual-review advisory →
+  `context.Warnings`/`Errors`/`Logs` by `severity` → `## Warnings`). Engineer
+  channel (`LogDebug`/`LogInfo`/`LogWarning`/`LogError`) unchanged. Updated
+  `03_ENGINEERING/DIAGNOSTICS.md` (section 6.2 + mapping table) and TASK-005.
 - **Pipeline framework redesign (super-pipeline + typed stages).** Reworked
   `02_ARCHITECTURE/PIPELINES.md` to v2.0: the toolkit is now a fluent
   **super-pipeline** of three stage pipelines — **Input → Migration → Output** —

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
@@ -109,13 +109,14 @@ task (`TASK-XXX`) where applicable, per `IMPLEMENTATION_GUIDE.md`.
   `02_ARCHITECTURE/SERVICES.md`,
   `03_ENGINEERING/REPOSITORY_STRUCTURE.md`,
   `03_ENGINEERING/CODING_STANDARDS.md`, and `AGENTS.md` accordingly.
-- **Source tree finalized around core, service modules, and debug output.**
+- **Source tree finalized around core, service modules, and output.**
   Moved canonical models under `src/core/models/`; renamed the Dataverse
   integration folder to `src/core/outbound/` and the concept to the Dataverse
   client; changed `services/` to singular `service/`; introduced
   `src/service/modules/` for preprocessing, migration, and postprocessing;
-  relocated generated logs and reports to `debug/logs/` and
-  `debug/reports/`; and updated the architecture spec index to use
+  relocated generated output to `output/session-<timestamp>/`
+  (later refined to the two-file session bundle); and updated the architecture
+  spec index to use
   `02_ARCHITECTURE/DATAVERSE_CLIENT.md`. Relaxed the old service-layer physical
   boundary: migration rules now live exclusively in
   `src/service/modules/migration/steps/`, while reusable service capabilities

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
@@ -12,12 +12,37 @@ task (`TASK-XXX`) where applicable, per `IMPLEMENTATION_GUIDE.md`.
 
 ## [Unreleased]
 
+- **Pipeline framework redesign (super-pipeline + typed stages).** Reworked
+  `02_ARCHITECTURE/PIPELINES.md` to v2.0: the toolkit is now a fluent
+  **super-pipeline** of three stage pipelines — **Input → Migration → Output** —
+  over a shared, typed `MigrationContext`. The framework is generic
+  (`Pipeline[TInput, TOutput]`, `PipelineStep[TInput, TOutput]`) with a
+  type-threading Builder (mapping the C# `KeyedComputeUnitBase` /
+  `HeterogenousPipelineStepComputeUnitBase<TIn,TOut>` reference; C# runtime
+  concerns — Autofac keyed registration, epoch versioning, per-step
+  Equals/GetHashCode — intentionally not ported). The **Migration Orchestrator
+  is only the composition root**. Added `PIPE-008/009/010` (PIPELINES) and
+  `PIPE-007` (INVARIANTS). Added the keyed `ComponentSet` (ComponentType →
+  Component[]) to `MigrationContext`. Updated TASK-002/003/006/007.
+- **Session bundle diagnostics (two-file UX).** Reworked
+  `03_ENGINEERING/DIAGNOSTICS.md`: every execution produces exactly one
+  timestamped **session bundle** `output/session-<timestamp>/` with two files —
+  `migration_report.md` (customer-facing; summary + changes + warnings sections)
+  and `session.log` (ESS-engineer diagnostics). Steps accumulate into
+  `MigrationContext` collectors (`Logs`, `Warnings`, `Errors`, `Changes`); a
+  terminal `GenerateMigrationReport()` step renders the report via the Reporter
+  service (no direct file I/O in steps). Added `DIAG-004`.
+- **`debug/` → `output/` rename.** Replaced the `debug/logs` + `debug/reports`
+  split with the single `output/session-<timestamp>/` bundle across specs
+  (REPOSITORY_STRUCTURE, IMPLEMENTATION_GUIDE, TESTING, AGENTS, TASK-001/005/007)
+  and the physical scaffold (`tools/…/output/.gitkeep`, `.gitignore`, README,
+  toolkit `AGENTS.md`). Updated the instructions mirror.
 - **TASK-001 — Repository Scaffold.** Created the frozen repository structure
   under `tools/ess-nextgen-migration-toolkit/` per
   `dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/REPOSITORY_STRUCTURE.md`
   section 2: `src/` layout (`mtk.py`, constants, core with pipeline,
   orchestrator, logging, models, and outbound; service with utils and modules
-  for preprocessing, migration, and postprocessing; debug with logs and reports),
+  for preprocessing, migration, and postprocessing; output for session bundles),
   `tests/` layout (unit, integration, golden, e2e), `scripts/`, plus
   `pyproject.toml`, `.pre-commit-config.yaml`, `.gitignore`, and `README.md`.
   No business logic introduced.

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
@@ -125,7 +125,7 @@ Instead, it establishes the complete framework, wiring, and developer experience
 | -------------------------------------------------------- | ------------------------------ | ------ | -------- |
 | [TASK-001](tasks/TASK-001-repository-scaffold.md)        | Repository Scaffold            | DONE   | —        |
 | [TASK-002](tasks/TASK-002-pipeline-framework.md)         | Pipeline Framework             | ACTIVE | —        |
-| [TASK-003](tasks/TASK-003-migration-orchestrator.md)     | Migration Orchestrator         | TODO   | —        |
+| [TASK-003](tasks/TASK-003-migration-orchestrator.md)     | Migration Orchestrator         | TODO   | TASK-002, TASK-005 |
 | [TASK-004](tasks/TASK-004-dataverse-client.md)           | Dataverse Client               | TODO   | —        |
 | [TASK-005](tasks/TASK-005-diagnostics-framework.md)      | Diagnostics Framework          | ACTIVE | —        |
 | [TASK-006](tasks/TASK-006-preprocessing-pipeline.md)     | Preprocessing Pipeline         | TODO   | —        |

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
@@ -52,22 +52,20 @@ Implementation must never precede specification.
 
 # 2. Task Lifecycle
 
-Every task progresses through the following lifecycle.
+Every task uses **exactly one** of these four canonical statuses (no other
+values are permitted in a task header or the index table below):
+
+| Status    | Meaning                                                            |
+| --------- | ----------------------------------------------------------------- |
+| `TODO`    | Not started; ready to be picked up once its `Consumes` are met.    |
+| `ACTIVE`  | Being implemented right now (a worktree/branch is in flight).      |
+| `BLOCKED` | Cannot proceed until a dependency or decision is resolved.         |
+| `DONE`    | Merged and meets the Definition of Done (section 5).               |
 
 ```text
-TODO
-
-↓
-
-IN PROGRESS
-
-↓
-
-BLOCKED
-
-↓
-
-DONE
+TODO  →  ACTIVE  →  DONE
+             ↕
+          BLOCKED
 ```
 
 Completed tasks shall remain in this document for traceability.
@@ -126,13 +124,13 @@ Instead, it establishes the complete framework, wiring, and developer experience
 | Task                                                     | Title                          | Status | Consumes |
 | -------------------------------------------------------- | ------------------------------ | ------ | -------- |
 | [TASK-001](tasks/TASK-001-repository-scaffold.md)        | Repository Scaffold            | DONE   | —        |
-| [TASK-002](tasks/TASK-002-pipeline-framework.md)         | Pipeline Framework             | TODO   | —        |
+| [TASK-002](tasks/TASK-002-pipeline-framework.md)         | Pipeline Framework             | ACTIVE | —        |
 | [TASK-003](tasks/TASK-003-migration-orchestrator.md)     | Migration Orchestrator         | TODO   | —        |
 | [TASK-004](tasks/TASK-004-dataverse-client.md)           | Dataverse Client               | TODO   | —        |
-| [TASK-005](tasks/TASK-005-diagnostics-framework.md)      | Diagnostics Framework          | TODO   | —        |
+| [TASK-005](tasks/TASK-005-diagnostics-framework.md)      | Diagnostics Framework          | ACTIVE | —        |
 | [TASK-006](tasks/TASK-006-preprocessing-pipeline.md)     | Preprocessing Pipeline         | TODO   | —        |
 | [TASK-007](tasks/TASK-007-postprocessing-pipeline.md)    | Postprocessing Pipeline        | TODO   | —        |
-| [TASK-008](tasks/TASK-008-authentication-token-provider.md) | Authentication Token Provider | IN PROGRESS | —   |
+| [TASK-008](tasks/TASK-008-authentication-token-provider.md) | Authentication Token Provider | ACTIVE | —   |
 | [TASK-009](tasks/TASK-009-end-to-end-framework-validation.md) | End-to-End Framework Validation | TODO | —      |
 
 ---

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-001-repository-scaffold.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-001-repository-scaffold.md
@@ -18,10 +18,10 @@ logic is introduced.
 
 - [ ] The `src/` layout exists exactly as specified in
   `03_ENGINEERING/REPOSITORY_STRUCTURE.md` (`constants/`, `core/`, `modules/`,
-  `service/`, `debug/`, and `service/mtk_orchestrator.py`).
+  `service/`, `output/`, and `service/mtk_orchestrator.py`).
 - [ ] The `tests/` layout exists (`unit/`, `integration/`, `golden/`, `e2e/`).
-- [ ] The toolkit-root `debug/` folder is present with `logs/` and `reports/`
-  subfolders (generated, gitignored, kept via `.gitkeep`).
+- [ ] The toolkit-root `output/` folder is present (generated, gitignored, kept
+  via `.gitkeep`) for per-execution session bundles.
 - [ ] `scripts/`, `README.md`, and `pyproject.toml` are present.
 - [ ] No business logic or migration transformation is implemented.
 
@@ -30,7 +30,7 @@ logic is introduced.
 - Folder scaffold
 - Source layout
 - Test layout
-- `debug/` folder (logs and reports)
+- `output/` folder (session bundles)
 - Scripts folder
 - README
 - `pyproject.toml`

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-002-pipeline-framework.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-002-pipeline-framework.md
@@ -4,7 +4,7 @@
 | ---------- | ------------------------- |
 | ID         | TASK-002                  |
 | Workstream | 0 — Repository Foundation |
-| Status     | TODO                      |
+| Status     | ACTIVE                      |
 | Consumes   | —                         |
 
 ## Description

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-002-pipeline-framework.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-002-pipeline-framework.md
@@ -10,26 +10,35 @@
 ## Description
 
 Implement the Pipeline Framework — the deterministic execution engine on which
-all Migration Rules are built. All registered Pipeline Steps may initially be
-no-op implementations.
+all Migration Rules are built. The framework is **generic and typed**:
+`Pipeline[TInput, TOutput]` and `PipelineStep[TInput, TOutput]`. The fluent
+Builder type-threads adjacent steps (the output type of one step is the input
+type of the next) and produces an immutable pipeline. The three ESS stage
+pipelines instantiate the framework over the shared `MigrationContext`. All
+registered Pipeline Steps may initially be no-op implementations.
 
 ## Acceptance Criteria
 
-- [ ] A Pipeline Builder constructs an ordered pipeline from registered steps.
+- [ ] A generic `Pipeline[TInput, TOutput]` and `PipelineStep[TInput, TOutput]`
+  abstraction defines the typed contract every step implements.
+- [ ] A fluent Pipeline Builder constructs an ordered, immutable pipeline and
+  type-threads adjacent steps (incompatible composition fails at build time).
 - [ ] A Pipeline Registry holds the ordered set of Pipeline Steps.
-- [ ] A Pipeline Context carries state across steps without hidden global state.
-- [ ] A Pipeline Step abstraction defines the contract every step implements.
-- [ ] A fluent API expresses pipeline construction.
-- [ ] The framework executes end-to-end with no-op steps and is deterministic
+- [ ] A Pipeline Context threads through steps without hidden global state; a
+  step enriches and returns the context (never replaces it with an unrelated
+  type).
+- [ ] A stage pipeline runs end-to-end with no-op steps and is deterministic
   (identical inputs produce identical ordering and output).
+- [ ] The framework supports composing stage pipelines into the super-pipeline
+  (`EssMigrationToolkit().input(...).migrate(...).output(...)`).
 
 ## Deliverables
 
-- Pipeline Builder
+- Generic `Pipeline[TInput, TOutput]` and `PipelineStep[TInput, TOutput]`
+- Fluent, type-threading Pipeline Builder
 - Pipeline Registry
-- Pipeline Context
-- Pipeline Step abstraction
-- Fluent API
+- Pipeline Context contract
+- Super-pipeline composition (`EssMigrationToolkit`)
 
 ## References
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-003-migration-orchestrator.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-003-migration-orchestrator.md
@@ -9,27 +9,35 @@
 
 ## Description
 
-Implement the Migration Orchestrator (`src/service/mtk_orchestrator.py`), which
-coordinates a migration session from user interaction through pipeline
-execution. It is the application entry point and top of the dependency graph.
-The orchestrator contains no migration logic.
+Implement the Migration Orchestrator (`src/service/mtk_orchestrator.py`). The
+orchestrator is the **composition root** only: it assembles the three stage
+pipelines into the fluent super-pipeline
+(`EssMigrationToolkit().input(...).migrate(...).output(...)`), configures the
+execution mode (Discover / Preview / Migrate), executes it, and returns the
+session bundle (reports and diagnostics). It is the application entry point and
+top of the dependency graph. The orchestrator contains no migration logic and no
+pipeline behaviour — those belong to the stages and steps.
 
 ## Acceptance Criteria
 
-- [ ] The orchestrator handles user interaction and gathers the session inputs.
-- [ ] The orchestrator initializes the pipeline from the registry.
+- [ ] The orchestrator gathers session inputs and selects the execution mode.
+- [ ] The orchestrator composes the super-pipeline from the Input, Migration,
+  and Output stage pipelines.
 - [ ] The orchestrator manages the session lifecycle (start, run, finish).
-- [ ] The orchestrator executes the pipeline and surfaces results.
-- [ ] No migration transformation logic exists in the orchestrator.
+- [ ] The orchestrator executes the super-pipeline and returns the session
+  bundle (`output/session-<timestamp>/`).
+- [ ] No migration transformation logic or pipeline-step behaviour exists in the
+  orchestrator.
 
 ## Deliverables
 
-- User interaction handling
-- Pipeline initialization
+- Session input handling and mode selection
+- Super-pipeline composition (composition root)
 - Session lifecycle management
-- Pipeline execution
+- Super-pipeline execution and result surfacing
 
 ## References
 
 - 02_ARCHITECTURE/ARCHITECTURE.md
 - 02_ARCHITECTURE/DOMAIN_MODEL.md
+- 02_ARCHITECTURE/PIPELINES.md

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-003-migration-orchestrator.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-003-migration-orchestrator.md
@@ -1,11 +1,11 @@
 # TASK-003 — Migration Orchestrator
 
-| Field      | Value                     |
-| ---------- | ------------------------- |
-| ID         | TASK-003                  |
-| Workstream | 0 — Repository Foundation |
-| Status     | TODO                      |
-| Consumes   | —                         |
+| Field      | Value                                                              |
+| ---------- | ------------------------------------------------------------------ |
+| ID         | TASK-003                                                           |
+| Workstream | 0 — Repository Foundation                                          |
+| Status     | TODO                                                               |
+| Consumes   | TASK-002 (pipeline framework), TASK-005 (diagnostics + `MigrationContext`); stage pipelines from TASK-006 (Input) and TASK-007 (Output) via the stage-builder seam below |
 
 ## Description
 
@@ -13,31 +13,186 @@ Implement the Migration Orchestrator (`src/service/mtk_orchestrator.py`). The
 orchestrator is the **composition root** only: it assembles the three stage
 pipelines into the fluent super-pipeline
 (`EssMigrationToolkit().input(...).migrate(...).output(...)`), configures the
-execution mode (Discover / Preview / Migrate), executes it, and returns the
-session bundle (reports and diagnostics). It is the application entry point and
-top of the dependency graph. The orchestrator contains no migration logic and no
-pipeline behaviour — those belong to the stages and steps.
+execution mode (Discover / Preview / Migrate), owns the diagnostics **session
+lifecycle**, executes the super-pipeline, and surfaces the resulting session
+bundle (`output/session-<timestamp>/`). It is the application entry point (run
+by `scripts/mtk.sh start` → `uv run python src/service/mtk_orchestrator.py`) and
+the top of the dependency graph. The orchestrator contains **no** migration
+logic and **no** pipeline-step behaviour — those belong to the stages and steps
+(TASK-006/007 and the migration-rule tasks).
+
+This task was de-risked by a throwaway runtime spike that wired the TASK-002
+pipeline framework to the TASK-005 diagnostics framework end-to-end and ran
+successfully through `mtk.sh start`, producing a valid two-file bundle. The
+**Proven blueprint** section below is that spike distilled into the contract to
+build against; the spike code itself is discarded and is not the deliverable.
+
+## Layer boundary (what belongs where)
+
+- **Orchestrator (this task)** — owns process wiring: build `MigrationContext`,
+  select `ExecutionMode`, `Logger.start_session(...)`, compose the toolkit, call
+  `.run(ctx)`, guarantee `logger.close()` in a `finally`, and surface the bundle
+  path. Nothing else.
+- **Output pipeline terminal step (TASK-007)** — `GenerateMigrationReport()`
+  runs last in the Output stage and calls `Reporter(logger.session_manager)
+  .render(ctx)`. Report rendering is **not** done by the orchestrator (keeps
+  DIAG-005 / PIPE-006 intact — only the Logger and Reporter write files).
+- **Stage steps (TASK-006/007 + rule tasks)** — report exclusively through the
+  injected `Logger` (`LogInfo`/`LogChange`/`LogAdvisory`, etc.); never
+  `print()`, never touch the filesystem.
+
+## Stage-builder seam (integration contract with TASK-006 / TASK-007)
+
+The three stage pipelines are provided by other tasks, but their steps need the
+`Logger` injected. Define the composition seam as three builder functions the
+orchestrator calls, each returning a context-preserving stage pipeline and
+receiving the active `Logger` for dependency injection:
+
+```python
+# provided by the modules packages (TASK-006 / TASK-007 / migration-rule tasks)
+def build_input_pipeline(logger: Logger)     -> Pipeline[MigrationContext, MigrationContext]: ...
+def build_migration_pipeline(logger: Logger) -> Pipeline[MigrationContext, MigrationContext]: ...
+def build_output_pipeline(logger: Logger)    -> Pipeline[MigrationContext, MigrationContext]: ...
+```
+
+- Input builder → `src/service/modules/preprocessing/` (TASK-006).
+- Migration builder → `src/service/modules/migration/` (migration-rule tasks).
+- Output builder → `src/service/modules/postprocessing/` (TASK-007); its LAST
+  `use(...)` is `GenerateMigrationReport()`.
+
+Until those tasks land, each builder may return a minimal pipeline (a single
+trivial pass-through step) so `mtk.sh start` runs the real composition root
+end-to-end. Adding real stage behaviour must require only editing the builders /
+adding steps — **the orchestrator must not change** when stages evolve (this is
+the PIPE-008/009 open/closed guarantee at the composition level).
+
+## Proven blueprint (from the runtime spike — exact contracts)
+
+Framework surface actually available (do not re-derive):
+
+- `from core.models import MigrationContext` — `@dataclass` with
+  `ExecutionMode: str = "DISCOVER"` and mutable collectors `Logs`, `Warnings`,
+  `Errors` (`list[DiagnosticEntry]`), `Changes` (`list[ChangeEntry]`). This IS
+  the shared context threaded as `Pipeline[MigrationContext, MigrationContext]`.
+- `from core.pipeline import EssMigrationToolkit, Pipeline, PipelineStep` —
+  `EssMigrationToolkit` is **immutable/fluent**: `.input(p)`, `.migrate(p)`,
+  `.output(p)` each return a NEW toolkit; `.run(ctx)` executes Input → Migration
+  → Output threading the SAME context and raises `PipelineConfigurationError`
+  if any stage is unconfigured. Build a stage with
+  `Pipeline.builder("input", input_type=MigrationContext).use(step).build()`.
+- `from core.logging import Logger, Reporter` — `Logger.start_session(output_root:
+  Path, context: MigrationContext, *, level: LogLevel = LogLevel.INFO) -> Logger`
+  creates the bundle folder AND installs the stdout/stderr tee; `logger.close()`
+  restores streams and closes `session.log`; `logger.session_manager.paths
+  .session_dir` is the bundle directory (contains `migration_report.md` +
+  `session.log`).
+
+Reference composition-root shape (skeleton — not the final code):
+
+```python
+from pathlib import Path
+from core.models import MigrationContext
+from core.pipeline import EssMigrationToolkit
+from core.logging import Logger
+
+_OUTPUT_ROOT = Path(__file__).resolve().parents[2] / "output"  # <toolkit>/output
+
+def main() -> None:
+    mode = _select_mode()                       # default "DISCOVER" for now
+    context = MigrationContext(ExecutionMode=mode)
+    logger = Logger.start_session(_OUTPUT_ROOT, context)
+    try:
+        toolkit = (
+            EssMigrationToolkit()
+            .input(build_input_pipeline(logger))
+            .migrate(build_migration_pipeline(logger))
+            .output(build_output_pipeline(logger))   # terminal step renders report
+        )
+        toolkit.run(context)
+    finally:
+        logger.close()                          # ALWAYS restore streams / flush log
+    _announce_bundle(logger.session_manager.paths.session_dir)
+
+if __name__ == "__main__":
+    main()
+```
+
+Verified in the spike: stages execute in order over one shared context;
+`session.log` captures the full CLI transcript (engineer channel); the customer
+channel (`LogChange`/`LogAdvisory`) lands only in `migration_report.md`; and the
+report title is mode-aware ("Migration Readiness Report" for DISCOVER).
+
+## Execution-mode selection
+
+- `ExecutionMode` is currently a plain `str` on `MigrationContext` with values
+  `DISCOVER` / `PREVIEW` / `MIGRATE`; there is no enum yet. Introducing a small
+  mode constant/enum (e.g. in `src/constants/`) is permitted and encouraged, but
+  keep the on-context value a `str` so the Reporter's mode check keeps working.
+- `scripts/mtk.sh` presently forwards **no arguments** to the orchestrator
+  (`exec uv run python src/service/mtk_orchestrator.py`). For this task, default
+  the mode to `DISCOVER`. Wiring a real CLI surface (e.g. `--mode`, and updating
+  `mtk.sh` to forward `"$@"`) is an allowed minimal extension **only if** it does
+  not add migration logic; otherwise leave it to a follow-up and keep the default.
 
 ## Acceptance Criteria
 
-- [ ] The orchestrator gathers session inputs and selects the execution mode.
-- [ ] The orchestrator composes the super-pipeline from the Input, Migration,
-  and Output stage pipelines.
-- [ ] The orchestrator manages the session lifecycle (start, run, finish).
-- [ ] The orchestrator executes the super-pipeline and returns the session
-  bundle (`output/session-<timestamp>/`).
-- [ ] No migration transformation logic or pipeline-step behaviour exists in the
-  orchestrator.
+- [ ] `main()` in `src/service/mtk_orchestrator.py` is the composition root and
+  the module runs via `scripts/mtk.sh start` (both `--dev` and default paths).
+- [ ] The orchestrator selects the execution mode (default `DISCOVER`) and
+  constructs a single shared `MigrationContext(ExecutionMode=...)`.
+- [ ] The orchestrator opens the diagnostics session with
+  `Logger.start_session(output_root, context)` where `output_root` resolves to
+  the toolkit's `output/` directory, and **guarantees** `logger.close()` runs in
+  a `finally` even if a stage raises.
+- [ ] The orchestrator composes the super-pipeline
+  (`EssMigrationToolkit().input(...).migrate(...).output(...)`) exclusively from
+  the three stage-builder functions (the seam above), injecting the `Logger`, and
+  executes it with `.run(context)`.
+- [ ] The orchestrator surfaces the produced session bundle
+  (`output/session-<timestamp>/`) to the user — at minimum by logging/announcing
+  the `session_dir` (the two files `migration_report.md` + `session.log` are the
+  product); it does **not** render the report itself.
+- [ ] Adding/altering stage behaviour requires no change to the orchestrator
+  (open/closed at the composition level; PIPE-008/009).
+- [ ] No migration-transformation logic, no pipeline-step behaviour, and no
+  direct file I/O or `print()` from business paths exist in the orchestrator
+  (DIAG-005 / PIPE-006).
+- [ ] Running `mtk.sh start` end-to-end produces a bundle with exactly
+  `migration_report.md` and `session.log`, and `session.log` contains the run
+  transcript.
+- [ ] Quality gates pass in `tools/ess-nextgen-migration-toolkit/`:
+  `uv run ruff format --check .`, `uv run ruff check .`, `uv run mypy src`,
+  `uv run pytest -q` (add orchestrator unit tests: mode selection, `close()` in
+  `finally` on stage exception, bundle-path surfacing, and "no report render in
+  orchestrator").
 
 ## Deliverables
 
-- Session input handling and mode selection
-- Super-pipeline composition (composition root)
-- Session lifecycle management
-- Super-pipeline execution and result surfacing
+- `src/service/mtk_orchestrator.py` composition root implementing the blueprint
+  (mode selection, `MigrationContext` construction, `Logger` session lifecycle
+  with `finally`-guaranteed `close()`, toolkit composition via the stage seam,
+  `.run()`, bundle-path surfacing).
+- The stage-builder seam consumed from the modules packages (with minimal
+  pass-through stage pipelines if TASK-006/007 have not yet landed, so the entry
+  point runs end-to-end).
+- Optional: a small `ExecutionMode` constant/enum in `src/constants/`.
+- Optional-minimal: `mtk.sh` argument forwarding + `--mode` parsing (only if it
+  introduces no business logic).
+- Unit tests under `tests/unit/service/` covering the criteria above.
 
 ## References
 
-- 02_ARCHITECTURE/ARCHITECTURE.md
-- 02_ARCHITECTURE/DOMAIN_MODEL.md
-- 02_ARCHITECTURE/PIPELINES.md
+- 00_META/INVARIANTS.md — PIPE-006/007, DIAG-004 (supreme). Note: PIPE-008/009/010
+  are defined in PIPELINES.md and DIAG-005 in DIAGNOSTICS.md (referenced below).
+- 02_ARCHITECTURE/ARCHITECTURE.md — layering / dependency graph (orchestrator =
+  composition root at the top)
+- 02_ARCHITECTURE/PIPELINES.md — v2.0 super-pipeline, `EssMigrationToolkit`,
+  `Pipeline[TIn,TOut]`, `PipelineStep[TIn,TOut]`, composition-root role
+- 02_ARCHITECTURE/DOMAIN_MODEL.md — `MigrationContext`, `ExecutionMode`,
+  `DiagnosticEntry` / `ChangeEntry`
+- 03_ENGINEERING/DIAGNOSTICS.md — sections 5 (two-file bundle), 6 (Logger session
+  lifecycle + tee + two channels), 9 (Reporter / terminal `GenerateMigrationReport`)
+- 04_EXECUTION/tasks/TASK-002-pipeline-framework.md — framework this consumes
+- 04_EXECUTION/tasks/TASK-005-diagnostics-framework.md — logging/reporter this consumes
+- 04_EXECUTION/tasks/TASK-006-preprocessing-pipeline.md — Input stage builder (`preprocessing`)
+- 04_EXECUTION/tasks/TASK-007-postprocessing-pipeline.md — Output stage builder (`postprocessing`, terminal report step)

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
@@ -34,7 +34,7 @@ The Logger has two responsibilities that define this framework:
    `migration_report.md`. `LogChange` records a successful transformation
    (`ChangeEntry` → `context.Changes` → `## Changes`); `LogAdvisory` records a
    manual-review advisory (`DiagnosticEntry` → `context.Warnings`/`Errors`/`Logs`
-   by `severity` → `## Warnings — Manual Review Required`).
+   by `severity` → `## Warnings — Manual Review Required` or `## Errors`).
 
 ## Acceptance Criteria
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
@@ -11,25 +11,31 @@
 
 Implement the diagnostics infrastructure. All toolkit output shall flow through
 the framework Logger; direct `print()` is prohibited. Logging code lives in
-`src/core/logging/`; generated output is written to `debug/logs/` and
-`debug/reports/`.
+`src/core/logging/`. Each execution produces one timestamped **session bundle**
+under `output/session-<timestamp>/` containing exactly two files:
+`migration_report.md` (customer-facing) and `session.log` (ESS-engineer
+diagnostics). Steps accumulate into the `MigrationContext` collectors; the
+Reporter renders the report — steps never write files.
 
 ## Acceptance Criteria
 
-- [ ] A Logger is implemented and is the single output channel for the toolkit.
-- [ ] A Session Manager tracks per-session diagnostics.
-- [ ] A Report Writer emits reports to `debug/reports/`.
-- [ ] Console output and log files are produced; log files are written to
-  `debug/logs/`.
-- [ ] No component bypasses the framework Logger with direct prints.
+- [ ] A Logger is implemented and is the single output channel for the toolkit;
+  it streams `session.log` live across all stages.
+- [ ] A Session Manager tracks per-session diagnostics and owns the
+  `output/session-<timestamp>/` bundle folder.
+- [ ] A Reporter renders `migration_report.md` (summary, changes, warnings
+  sections) from the `MigrationContext` collectors.
+- [ ] `MigrationContext` exposes the diagnostic collectors (`Logs`, `Warnings`,
+  `Errors`, `Changes`) that steps append to.
+- [ ] No component bypasses the framework Logger/Reporter with direct prints or
+  file writes.
 
 ## Deliverables
 
-- Logger
-- Session Manager
-- Report Writer
-- Console output
-- Log files
+- Logger (streams `session.log`)
+- Session Manager (owns the session bundle)
+- Reporter (renders `migration_report.md`)
+- MigrationContext diagnostic collectors
 
 ## References
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
@@ -28,10 +28,13 @@ The Logger has two responsibilities that define this framework:
 2. **Two channels** — the Logger exposes an **engineer channel**
    (`LogDebug`/`LogInfo`/`LogWarning`/`LogError`) that prints to the CLI as usual
    (and is mirrored to `session.log` by the tee), and a **customer channel**
-   (`LogCustomer`/`LogFancy`) that does **not** touch the CLI or `session.log`
+   (`LogChange`/`LogAdvisory`) that does **not** touch the CLI or `session.log`
    but instead appends structured entries to the report model (the
    `MigrationContext` collectors) that the Reporter later renders into the fancy
-   `migration_report.md`.
+   `migration_report.md`. `LogChange` records a successful transformation
+   (`ChangeEntry` → `context.Changes` → `## Changes`); `LogAdvisory` records a
+   manual-review advisory (`DiagnosticEntry` → `context.Warnings`/`Errors`/`Logs`
+   by `severity` → `## Warnings — Manual Review Required`).
 
 ## Acceptance Criteria
 
@@ -41,7 +44,7 @@ The Logger has two responsibilities that define this framework:
   run (Logger output, incidental library output, and tracebacks alike).
 - [ ] The Logger exposes an **engineer channel** (`LogDebug`/`LogInfo`/… →
   console + `session.log`, honoring log levels) and a **customer channel**
-  (`LogCustomer`/`LogFancy` → report model only, never console/`session.log`).
+  (`LogChange`/`LogAdvisory` → report model only, never console/`session.log`).
 - [ ] A Session Manager tracks per-session diagnostics and owns the
   `output/session-<timestamp>/` bundle folder.
 - [ ] A Reporter renders `migration_report.md` (summary, changes, warnings

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
@@ -17,14 +17,35 @@ under `output/session-<timestamp>/` containing exactly two files:
 diagnostics). Steps accumulate into the `MigrationContext` collectors; the
 Reporter renders the report — steps never write files.
 
+The Logger has two responsibilities that define this framework:
+
+1. **Transcript capture** — when the Logger initializes at the application entry
+   point (before the pipeline runs), it installs a **stdout/stderr tee** so that
+   from that point on **every byte written to the CLI** is mirrored into
+   `session.log`. `session.log` is therefore a complete, replayable transcript of
+   the run, not just selected log lines. Capture begins at the **Python app
+   entry** (migration run only); shell provisioning output is out of scope.
+2. **Two channels** — the Logger exposes an **engineer channel**
+   (`LogDebug`/`LogInfo`/`LogWarning`/`LogError`) that prints to the CLI as usual
+   (and is mirrored to `session.log` by the tee), and a **customer channel**
+   (`LogCustomer`/`LogFancy`) that does **not** touch the CLI or `session.log`
+   but instead appends structured entries to the report model (the
+   `MigrationContext` collectors) that the Reporter later renders into the fancy
+   `migration_report.md`.
+
 ## Acceptance Criteria
 
-- [ ] A Logger is implemented and is the single output channel for the toolkit;
-  it streams `session.log` live across all stages.
+- [ ] A Logger is implemented and is the single output channel for the toolkit.
+- [ ] On initialization at the application entry, the Logger installs a
+  stdout/stderr tee so `session.log` captures the **entire CLI transcript** of the
+  run (Logger output, incidental library output, and tracebacks alike).
+- [ ] The Logger exposes an **engineer channel** (`LogDebug`/`LogInfo`/… →
+  console + `session.log`, honoring log levels) and a **customer channel**
+  (`LogCustomer`/`LogFancy` → report model only, never console/`session.log`).
 - [ ] A Session Manager tracks per-session diagnostics and owns the
   `output/session-<timestamp>/` bundle folder.
 - [ ] A Reporter renders `migration_report.md` (summary, changes, warnings
-  sections) from the `MigrationContext` collectors.
+  sections) from the `MigrationContext` collectors (the report model).
 - [ ] `MigrationContext` exposes the diagnostic collectors (`Logs`, `Warnings`,
   `Errors`, `Changes`) that steps append to.
 - [ ] No component bypasses the framework Logger/Reporter with direct prints or
@@ -32,9 +53,9 @@ Reporter renders the report — steps never write files.
 
 ## Deliverables
 
-- Logger (streams `session.log`)
+- Logger — dual-channel (engineer + customer) with stdout/stderr transcript tee
 - Session Manager (owns the session bundle)
-- Reporter (renders `migration_report.md`)
+- Reporter (renders `migration_report.md` from the report model)
 - MigrationContext diagnostic collectors
 
 ## References

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md
@@ -4,7 +4,7 @@
 | ---------- | ------------------------- |
 | ID         | TASK-005                  |
 | Workstream | 0 — Repository Foundation |
-| Status     | TODO                      |
+| Status     | ACTIVE                      |
 | Consumes   | —                         |
 
 ## Description

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-006-preprocessing-pipeline.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-006-preprocessing-pipeline.md
@@ -9,29 +9,36 @@
 
 ## Description
 
-Implement discovery and preprocessing — the stages that gather and prepare data
-before any migration transformation. Implemented under
-`src/modules/preprocessing/`. No migration transformations occur here.
+Implement the **Input Pipeline** (`src/modules/preprocessing/`) — the stage
+pipeline that discovers customer-owned artifacts and prepares the canonical
+`MigrationContext` consumed by the migration engine. It is built fluently over
+the shared `MigrationContext` and composed into the super-pipeline by the
+orchestrator. No migration transformations occur here.
 
 ## Acceptance Criteria
 
+- [ ] The Input Pipeline is built fluently: `InputPipeline().use(...)`.
 - [ ] The ESS Agent is discovered from the selected environment.
 - [ ] `DependenciesForUninstall` is retrieved.
 - [ ] Solution Component Layers are retrieved.
 - [ ] Migration candidates are determined deterministically.
-- [ ] Raw payloads are converted into canonical Domain Models.
+- [ ] Raw payloads are converted into canonical Domain Models and loaded into the
+  `MigrationContext`, including the keyed `ComponentSet` (ComponentType →
+  Component[]).
 - [ ] No migration transformation logic is performed in this stage.
 
 ## Deliverables
 
+- Input Pipeline (fluent, over `MigrationContext`)
 - Discover ESS Agent
 - Retrieve DependenciesForUninstall
 - Retrieve Solution Component Layers
 - Determine migration candidates
-- Load canonical components
+- Load canonical components and build the keyed `ComponentSet`
 
 ## References
 
+- 02_ARCHITECTURE/PIPELINES.md
 - 02_ARCHITECTURE/SERVICES.md
 - 02_ARCHITECTURE/DATAVERSE_CLIENT.md
 - 02_ARCHITECTURE/DOMAIN_MODEL.md

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-007-postprocessing-pipeline.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-007-postprocessing-pipeline.md
@@ -9,24 +9,35 @@
 
 ## Description
 
-Implement post-processing — the stages that run after migration transformations
-to validate, persist, and report results. Implemented under
-`src/modules/postprocessing/`. Migration logic is out of scope.
+Implement the **Output Pipeline** (`src/modules/postprocessing/`) — the stage
+pipeline that runs after migration transformations to validate, persist, and
+render the session bundle. It is built fluently over the shared
+`MigrationContext` and composed into the super-pipeline by the orchestrator.
+Migration logic is out of scope.
 
 ## Acceptance Criteria
 
-- [ ] Migrated components are validated against the required rules.
-- [ ] Writeback persists results through the Dataverse client only.
-- [ ] Reports are generated through the Report Writer to `debug/reports/`.
+- [ ] The Output Pipeline is built fluently: `OutputPipeline().use(...)`.
+- [ ] Migrated components are validated against the required rules
+  (`ValidateMigration`).
+- [ ] Writeback persists results through the Dataverse client only, in Migrate
+  mode (`Writeback`).
+- [ ] A terminal `GenerateMigrationReport` step renders the customer-facing
+  `migration_report.md` from the `MigrationContext` collectors, via the Reporter
+  service (no direct file I/O in steps).
+- [ ] Output lands in the single session bundle `output/session-<timestamp>/`
+  (`migration_report.md` + `session.log`).
 - [ ] No migration transformation logic exists in this stage.
 
 ## Deliverables
 
-- Validation
-- Writeback
-- Report generation
+- Output Pipeline (fluent, over `MigrationContext`)
+- `ValidateMigration` step
+- `Writeback` step (Migrate mode only)
+- `GenerateMigrationReport` step
 
 ## References
 
+- 02_ARCHITECTURE/PIPELINES.md
 - 02_ARCHITECTURE/SERVICES.md
 - 03_ENGINEERING/DIAGNOSTICS.md

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-008-authentication-token-provider.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-008-authentication-token-provider.md
@@ -4,7 +4,7 @@
 | ---------- | ------------------------- |
 | ID         | TASK-008                  |
 | Workstream | 0 — Repository Foundation |
-| Status     | IN PROGRESS               |
+| Status     | ACTIVE                     |
 | Consumes   | —                         |
 
 ## Description

--- a/dev-specs/ess-nextgen-migration-toolkit/AGENTS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/AGENTS.md
@@ -257,7 +257,7 @@ Always respect module ownership.
 | Orchestration entry   | `src/service/mtk_orchestrator.py`               |
 | Utilities             | `src/core/utils/`                               |
 | Diagnostics code      | `src/core/logging/`                             |
-| Generated output      | `debug/logs/`, `debug/reports/`         |
+| Generated output      | `output/session-<timestamp>/`           |
 
 ---
 

--- a/tools/ess-nextgen-migration-toolkit/.gitignore
+++ b/tools/ess-nextgen-migration-toolkit/.gitignore
@@ -13,8 +13,6 @@ venv/
 .mypy_cache/
 .ruff_cache/
 
-# Generated execution artifacts (keep folders, ignore contents)
-debug/logs/*
-debug/reports/*
-!debug/logs/.gitkeep
-!debug/reports/.gitkeep
+# Generated execution artifacts (keep folder, ignore contents)
+output/*
+!output/.gitkeep

--- a/tools/ess-nextgen-migration-toolkit/AGENTS.md
+++ b/tools/ess-nextgen-migration-toolkit/AGENTS.md
@@ -45,7 +45,7 @@
 | Pipeline Registration | `src/modules/migration/`                        |
 | Utilities             | `src/core/utils/`                               |
 | Diagnostics code      | `src/core/logging/`                             |
-| Generated output      | `debug/logs/`, `debug/reports/`                 |
+| Generated output      | `output/session-<timestamp>/`                   |
 
 ---
 

--- a/tools/ess-nextgen-migration-toolkit/AGENTS.md
+++ b/tools/ess-nextgen-migration-toolkit/AGENTS.md
@@ -32,7 +32,7 @@
 
 * **The buildable toolkit (implementation)** lives here under
   `tools/ess-nextgen-migration-toolkit/` (`src/`, `tests/`, `scripts/`, etc.),
-  with generated output under `debug/logs/` and `debug/reports/`, as defined by
+  with generated output under `output/session-<timestamp>/`, as defined by
   [`REPOSITORY_STRUCTURE.md`](../../dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/REPOSITORY_STRUCTURE.md).
 
 ## Implementation navigation

--- a/tools/ess-nextgen-migration-toolkit/README.md
+++ b/tools/ess-nextgen-migration-toolkit/README.md
@@ -29,9 +29,8 @@ src/
             migration/      migration_pipeline.py, steps/
             postprocessing/
     service/         Orchestration (mtk_orchestrator.py)
-debug/               Generated, gitignored output
-    logs/
-    reports/
+output/              Generated, gitignored output
+    session-<timestamp>/   migration_report.md, session.log
 tests/
     unit/            Mirror src/
     integration/     Dataverse interactions


### PR DESCRIPTION
Rework the ESS NextGen Migration Toolkit specs around a fluent super-pipeline and a two-file session-bundle output.

- Pipeline framework (PIPELINES.md v2.0): the toolkit is a fluent super-pipeline of three stage pipelines (Input -> Migration -> Output) over a shared, typed MigrationContext; generic Pipeline[TIn,TOut] / PipelineStep[TIn,TOut] with a type-threading Builder; the Migration Orchestrator is only the composition root. Add PIPE-008/009/010 and the keyed ComponentSet.
- Diagnostics (DIAGNOSTICS.md): every run produces exactly one session bundle output/session-<timestamp>/ with two files: migration_report.md (customer) and session.log (ESS engineer). Steps accumulate into MigrationContext collectors; a terminal GenerateMigrationReport() renders via the Reporter service. Dropped the optional support.json sidecar entirely.
- INVARIANTS: add PIPE-007 (typed super-pipeline, orchestrator-as-composition- root) and DIAG-004 (exactly one session bundle = two files).
- Rename debug/ -> output/ across specs, tasks, instructions mirror, and the physical scaffold (.gitignore, README, output/.gitkeep).
- Update DOMAIN_MODEL (MigrationContext collectors + ComponentSet), REPOSITORY_STRUCTURE, IMPLEMENTATION_GUIDE, TESTING, AGENTS, CHANGELOG, and TASK-001/002/003/005/006/007.

## Description
<!-- What does this PR do? Why is it needed? -->

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor / cleanup

## Testing
<!-- How was this change tested? -->

## Checklist
- [x] My code follows the existing style
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation as needed

## Static validation (samples/ only)
<!--
If this PR touches anything under samples/, paste the summary block from
`python -m tools.validate_samples --diff-base origin/main` below, or rely on
the "Validate samples" GitHub Action which posts/refreshes the same block as a
PR comment. Runtime validation in Power Platform is a manual follow-up — see
`tools/validate_samples/README.md` and `docs/validation.md`.
-->

```text
Validation
- YAML parse: PASS|FAIL|N-A
- AdaptiveDialog kind: PASS|FAIL|N-A
- XML parse: PASS|FAIL|N-A
- Filename convention (new): PASS|FAIL|N-A
- Folder convention (new, incl. README.md): PASS|FAIL|N-A
- Diff scope (samples/ only): PASS|FAIL|N-A
- Secrets / internal URLs: PASS|FAIL|N-A
```

<!-- The Microsoft CLA bot will comment automatically if a CLA signature is required. No checkbox needed. -->