### PR TITLE
Add installer telemetry (start/step/completion) for setup reliability (ADO 7557940)

### DIFF
--- a/setup/Install-EssAdk.Tests.ps1
+++ b/setup/Install-EssAdk.Tests.ps1
@@ -206,14 +206,13 @@ Test 'bash emitter exists with a shebang' {
 # Dot-source the PS emitter and exercise its pure (no-network) functions.
 . $psEmitter
 
-Test 'tenant class: the MS corp tenant is internal' {
-    if ((Get-EssTelTenantClass -TenantId '72f988bf-86f1-41af-91ab-2d7cd011db47') -ne 'internal') { throw 'corp tenant not internal' }
-}
-Test 'tenant class: any other tenant is customer' {
-    if ((Get-EssTelTenantClass -TenantId '11111111-1111-1111-1111-111111111111') -ne 'customer') { throw 'other tenant not customer' }
-}
-Test 'tenant class: an empty tenant is unknown' {
-    if ((Get-EssTelTenantClass -TenantId '') -ne 'unknown') { throw 'empty tenant not unknown' }
+Test 'installer telemetry emits no tenant dimension (unknowable pre-sign-in)' {
+    # The installer runs before sign-in, so the tenant is never known; emitting
+    # tenantId/tenantClass produced a meaningless 'unknown' on ~every event.
+    $data = Get-EssTelCommonData
+    if ($data.ContainsKey('tenantId'))    { throw 'tenantId should not be emitted by the installer' }
+    if ($data.ContainsKey('tenantClass')) { throw 'tenantClass should not be emitted by the installer' }
+    if (Get-Command -Name 'Get-EssTelTenantClass' -ErrorAction SilentlyContinue) { throw 'Get-EssTelTenantClass should be removed' }
 }
 Test 'scrub strips paths, urls, emails and guids' {
     $s = ConvertTo-EssTelScrubbed -Text 'boom C:\Users\x https://a.com/b user@contoso.com 72f988bf-86f1-41af-91ab-2d7cd011db47'
@@ -244,7 +243,7 @@ Test 'lite installer is not instrumented (no telemetry ready, no events)' {
     $old = $env:ESS_ADK_TELEMETRY
     try {
         $env:ESS_ADK_TELEMETRY = ''   # ensure telemetry is otherwise enabled
-        Initialize-EssInstallTelemetry -Installer 'lite' -TenantId ''
+        Initialize-EssInstallTelemetry -Installer 'lite'
         if ($script:EssTel.Ready) { throw 'lite installer should not be telemetry-ready' }
     } finally { $env:ESS_ADK_TELEMETRY = $old }
 }
@@ -286,6 +285,36 @@ foreach ($bs in @('bootstrap-mac.sh', 'bootstrap-flightcheck-mac.sh', 'bootstrap
         if ($bsSrc -notmatch 'install-telemetry\.sh') { throw 'telemetry lib not downloaded' }
         if ($bsSrc -notmatch 'ESS_INSTALL_TELEMETRY_LIB') { throw 'env var not set' }
     }
+}
+
+Test 'install-ess-adk.sh maps SIGINT/SIGTERM (130/143) to a cancelled outcome' {
+    if ($macInstaller -notmatch 'ess_tel_complete cancelled') { throw 'cancelled outcome not emitted on interrupt' }
+    if ($macInstaller -notmatch '130' -or $macInstaller -notmatch '143') { throw 'SIGINT/SIGTERM codes not handled' }
+}
+Test 'Install-EssAdk.ps1 records success on the normal path, not in finally' {
+    # Regression: Ctrl+C bypasses catch, so success must be emitted at the end of
+    # try. finally must fall back to cancelled, never force success.
+    if ($src -notmatch "(?s)Done\. Workspace.*?Complete-EssInstallTelemetry -Outcome 'success'") {
+        throw "success not recorded at the end of the try block"
+    }
+    if ($src -notmatch "(?s)finally\s*\{[^}]*Complete-EssInstallTelemetry -Outcome 'cancelled'") {
+        throw "finally must record 'cancelled', not 'success'"
+    }
+    if ($src -match "(?s)finally\s*\{[^}]*Complete-EssInstallTelemetry -Outcome 'success'") {
+        throw "finally must not force a 'success' outcome (mislabels Ctrl+C)"
+    }
+}
+Test 'PS emitter uses a short send timeout and trips a circuit breaker on failure' {
+    $emitterSrc = Get-Content $psEmitter -Raw
+    if ($emitterSrc -notmatch 'TimeoutSec 3') { throw 'PS emitter should use a short (3s) send timeout' }
+    # The catch of the transport must disable further sends so an unreachable
+    # collector adds ~one timeout total, not one per step.
+    if ($emitterSrc -notmatch '(?s)catch\s*\{[^}]*EssTel\.Ready\s*=\s*\$false') { throw 'PS emitter missing circuit breaker' }
+}
+Test 'bash emitter uses a short send timeout and trips a circuit breaker on failure' {
+    $shSrc = Get-Content $shEmitter -Raw
+    if ($shSrc -notmatch 'curl -fsS -m 3') { throw 'bash emitter should use a short (3s) send timeout' }
+    if ($shSrc -notmatch 'ESS_TEL_READY=0') { throw 'bash emitter missing circuit breaker' }
 }
 
 # Summary

--- a/setup/Install-EssAdk.Tests.ps1
+++ b/setup/Install-EssAdk.Tests.ps1
@@ -227,6 +227,19 @@ Test 'opt-out is honored via the ESS_ADK_TELEMETRY env var' {
 Test 'envelope iKey uses the o: prefix of the token before the first dash' {
     if ((Get-EssTelEnvelopeIKey -FullIKey 'abc123-def-456') -ne 'o:abc123') { throw 'envelope ikey wrong' }
 }
+Test 'envelope time is culture-invariant ISO-8601 (non-colon-separator locales)' {
+    # Regression: a custom DateTime format string renders ':' as the current
+    # culture's TimeSeparator ('.' under fi-FI), which would corrupt the
+    # Common Schema time field. It must stay ISO-8601 regardless of locale.
+    $orig = [System.Threading.Thread]::CurrentThread.CurrentCulture
+    try {
+        [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::GetCultureInfo('fi-FI')
+        $envelope = New-EssTelEnvelope -Name 'ESSMakerKit.Installer.Start' -EnvelopeIKey 'o:abc' -Data @{}
+        if ($envelope.time -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$') { throw "time not ISO-8601 under fi-FI: $($envelope.time)" }
+    } finally {
+        [System.Threading.Thread]::CurrentThread.CurrentCulture = $orig
+    }
+}
 Test 'lite installer is not instrumented (no telemetry ready, no events)' {
     $old = $env:ESS_ADK_TELEMETRY
     try {

--- a/setup/Install-EssAdk.Tests.ps1
+++ b/setup/Install-EssAdk.Tests.ps1
@@ -227,6 +227,22 @@ Test 'opt-out is honored via the ESS_ADK_TELEMETRY env var' {
 Test 'envelope iKey uses the o: prefix of the token before the first dash' {
     if ((Get-EssTelEnvelopeIKey -FullIKey 'abc123-def-456') -ne 'o:abc123') { throw 'envelope ikey wrong' }
 }
+Test 'lite installer is not instrumented (no telemetry ready, no events)' {
+    $old = $env:ESS_ADK_TELEMETRY
+    try {
+        $env:ESS_ADK_TELEMETRY = ''   # ensure telemetry is otherwise enabled
+        Initialize-EssInstallTelemetry -Installer 'lite' -TenantId ''
+        if ($script:EssTel.Ready) { throw 'lite installer should not be telemetry-ready' }
+    } finally { $env:ESS_ADK_TELEMETRY = $old }
+}
+Test 'PowerShell emitter guards out the lite installer' {
+    $emitterSrc = Get-Content $psEmitter -Raw
+    if ($emitterSrc -notmatch "Installer\s+-eq\s+'lite'") { throw 'lite guard missing in PS emitter' }
+}
+Test 'bash emitter guards out the lite installer' {
+    $shSrc = Get-Content $shEmitter -Raw
+    if ($shSrc -notmatch 'ESS_TEL_INSTALLER.*==.*"lite"') { throw 'lite guard missing in bash emitter' }
+}
 
 # --- macOS installer + all bootstraps wiring -------------------------------
 Write-Host "`nmacOS installer + bootstrap telemetry wiring:" -ForegroundColor Cyan

--- a/setup/Install-EssAdk.Tests.ps1
+++ b/setup/Install-EssAdk.Tests.ps1
@@ -155,6 +155,110 @@ Test 'bootstraps read the fetched installer as UTF-8 explicitly' {
     }
 }
 
+# ---------------------------------------------------------------------------
+# Installer telemetry wiring (ADO 7557940)
+# ---------------------------------------------------------------------------
+Write-Host "`nInstaller telemetry wiring (Install-EssAdk.ps1):" -ForegroundColor Cyan
+
+Test 'initializes installer telemetry after locating the emitter' {
+    if ($src -notmatch 'Initialize-EssInstallTelemetry') { throw 'Initialize-EssInstallTelemetry call not found' }
+    if ($src -notmatch 'ESS_INSTALL_TELEMETRY_LIB') { throw 'ESS_INSTALL_TELEMETRY_LIB lookup not found' }
+}
+
+Test 'defines no-op telemetry stubs when the emitter is absent (fail-open)' {
+    if ($src -notmatch 'function Initialize-EssInstallTelemetry') { throw 'no-op stub fallback not found' }
+}
+
+Test 'derives installer mode (flightcheck | adk | lite)' {
+    if ($src -notmatch "FlightCheckOnly.*'flightcheck'") { throw 'flightcheck mode not derived' }
+    if ($src -notmatch "SkipMakerProfile.*'adk'") { throw 'adk mode not derived' }
+}
+
+Test 'Write-Step is hooked to emit a per-step telemetry event' {
+    if ($src -notmatch 'Write-EssInstallStep\s+-Step\s+\(Get-EssStepKey') { throw 'Write-Step does not emit a telemetry step' }
+}
+
+Test 'main body is wrapped so a completion event is always emitted' {
+    if ($src -notmatch "Complete-EssInstallTelemetry\s+-Outcome\s+'failure'") { throw 'failure completion not found' }
+    if ($src -notmatch "Complete-EssInstallTelemetry\s+-Outcome\s+'success'") { throw 'success completion not found' }
+    if ($src -notmatch '(?s)\btry\s*\{.*\}\s*catch\s*\{.*\}\s*finally\s*\{') { throw 'try/catch/finally wrapper not found' }
+}
+
+# --- Emitter files: existence, parse, and pure-function behaviour ----------
+Write-Host "`nInstaller telemetry emitters:" -ForegroundColor Cyan
+
+$psEmitter = Join-Path $PSScriptRoot 'telemetry/install-telemetry.ps1'
+$shEmitter = Join-Path $PSScriptRoot 'telemetry/install-telemetry.sh'
+
+Test 'PowerShell emitter exists and parses without errors' {
+    if (-not (Test-Path $psEmitter)) { throw 'telemetry/install-telemetry.ps1 missing' }
+    $errors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile($psEmitter, [ref]$null, [ref]$errors) | Out-Null
+    if ($errors.Count -gt 0) { throw "Parse errors: $($errors[0].Message)" }
+}
+
+Test 'bash emitter exists with a shebang' {
+    if (-not (Test-Path $shEmitter)) { throw 'telemetry/install-telemetry.sh missing' }
+    $first = (Get-Content $shEmitter -TotalCount 1)
+    if ($first -notmatch '^#!') { throw 'bash emitter missing shebang' }
+}
+
+# Dot-source the PS emitter and exercise its pure (no-network) functions.
+. $psEmitter
+
+Test 'tenant class: the MS corp tenant is internal' {
+    if ((Get-EssTelTenantClass -TenantId '72f988bf-86f1-41af-91ab-2d7cd011db47') -ne 'internal') { throw 'corp tenant not internal' }
+}
+Test 'tenant class: any other tenant is customer' {
+    if ((Get-EssTelTenantClass -TenantId '11111111-1111-1111-1111-111111111111') -ne 'customer') { throw 'other tenant not customer' }
+}
+Test 'tenant class: an empty tenant is unknown' {
+    if ((Get-EssTelTenantClass -TenantId '') -ne 'unknown') { throw 'empty tenant not unknown' }
+}
+Test 'scrub strips paths, urls, emails and guids' {
+    $s = ConvertTo-EssTelScrubbed -Text 'boom C:\Users\x https://a.com/b user@contoso.com 72f988bf-86f1-41af-91ab-2d7cd011db47'
+    if ($s -match 'C:\\Users' -or $s -match 'https://' -or $s -match '@contoso' -or $s -match '72f988bf') { throw "not scrubbed: $s" }
+}
+Test 'opt-out is honored via the ESS_ADK_TELEMETRY env var' {
+    $old = $env:ESS_ADK_TELEMETRY
+    try { $env:ESS_ADK_TELEMETRY = 'off'; if (Test-EssTelemetryEnabled) { throw 'should be disabled' } }
+    finally { $env:ESS_ADK_TELEMETRY = $old }
+}
+Test 'envelope iKey uses the o: prefix of the token before the first dash' {
+    if ((Get-EssTelEnvelopeIKey -FullIKey 'abc123-def-456') -ne 'o:abc123') { throw 'envelope ikey wrong' }
+}
+
+# --- macOS installer + all bootstraps wiring -------------------------------
+Write-Host "`nmacOS installer + bootstrap telemetry wiring:" -ForegroundColor Cyan
+
+$macInstaller = Get-Content (Join-Path $PSScriptRoot 'install-ess-adk.sh') -Raw
+
+Test 'install-ess-adk.sh sources the emitter and initializes telemetry' {
+    if ($macInstaller -notmatch 'ESS_INSTALL_TELEMETRY_LIB') { throw 'lib lookup missing' }
+    if ($macInstaller -notmatch 'ess_tel_init') { throw 'ess_tel_init call missing' }
+}
+Test 'install-ess-adk.sh emits completion on exit via an EXIT trap' {
+    if ($macInstaller -notmatch 'ess_tel_on_exit' -or $macInstaller -notmatch 'trap .* EXIT') { throw 'EXIT trap missing' }
+}
+Test 'install-ess-adk.sh step() emits a per-step telemetry event' {
+    if ($macInstaller -notmatch 'ess_tel_step' -or $macInstaller -notmatch 'ess_step_key') { throw 'step hook missing' }
+}
+
+foreach ($bs in @('bootstrap.ps1', 'bootstrap-flightcheck.ps1', 'bootstrap-lite.ps1')) {
+    $bsSrc = Get-Content (Join-Path $PSScriptRoot $bs) -Raw
+    Test "$bs downloads the telemetry lib and sets ESS_INSTALL_TELEMETRY_LIB" {
+        if ($bsSrc -notmatch 'install-telemetry\.ps1') { throw 'telemetry lib not downloaded' }
+        if ($bsSrc -notmatch 'ESS_INSTALL_TELEMETRY_LIB') { throw 'env var not set' }
+    }
+}
+foreach ($bs in @('bootstrap-mac.sh', 'bootstrap-flightcheck-mac.sh', 'bootstrap-lite-mac.sh')) {
+    $bsSrc = Get-Content (Join-Path $PSScriptRoot $bs) -Raw
+    Test "$bs downloads the telemetry lib and sets ESS_INSTALL_TELEMETRY_LIB" {
+        if ($bsSrc -notmatch 'install-telemetry\.sh') { throw 'telemetry lib not downloaded' }
+        if ($bsSrc -notmatch 'ESS_INSTALL_TELEMETRY_LIB') { throw 'env var not set' }
+    }
+}
+
 # Summary
 Write-Host "`n$($passed + $failed) tests, $passed passed, $failed failed" -ForegroundColor $(if ($failed -gt 0) { 'Red' } else { 'Green' })
 exit $(if ($failed -gt 0) { 1 } else { 0 })

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -334,13 +334,13 @@ foreach ($cand in $essTelCandidates) {
     }
 }
 if (-not $essTelLoaded) {
-    function Initialize-EssInstallTelemetry { param($Installer, $TenantId) }
+    function Initialize-EssInstallTelemetry { param($Installer) }
     function Write-EssInstallStep          { param($Step) }
     function Complete-EssInstallTelemetry  { param($Outcome, $ErrorRecord) }
 }
 
 $essInstaller = if ($FlightCheckOnly) { 'flightcheck' } elseif ($SkipMakerProfile) { 'adk' } else { 'lite' }
-Initialize-EssInstallTelemetry -Installer $essInstaller -TenantId $env:ESS_TENANT_ID
+Initialize-EssInstallTelemetry -Installer $essInstaller
 
 try {
 
@@ -1165,12 +1165,18 @@ if (-not $SkipLaunch) {
 
 Write-Host "`nDone. Workspace: $workspace" -ForegroundColor Green
 
+# Record success here, at the end of the normal path (NOT in finally) so an
+# interrupt (Ctrl+C bypasses catch) is never mislabeled as a successful install.
+Complete-EssInstallTelemetry -Outcome 'success'
+
 }
 catch {
     Complete-EssInstallTelemetry -Outcome 'failure' -ErrorRecord $_
     throw
 }
 finally {
-    # Idempotent: no-op if a failure/cancel outcome was already recorded above.
-    Complete-EssInstallTelemetry -Outcome 'success'
+    # Safety net for cancellation: if neither success nor failure was recorded
+    # above (Ctrl+C stops the pipeline and skips catch), record it as cancelled.
+    # Idempotent: a no-op once any outcome has already been emitted.
+    Complete-EssInstallTelemetry -Outcome 'cancelled'
 }

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -89,7 +89,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-function Write-Step  { param([string]$m) Write-Host "`n==> $m" -ForegroundColor Cyan }
+function Write-Step  { param([string]$m) Write-Host "`n==> $m" -ForegroundColor Cyan; try { Write-EssInstallStep -Step (Get-EssStepKey $m) } catch {} }
 function Write-Ok    { param([string]$m) Write-Host "    [ok]   $m" -ForegroundColor Green }
 function Write-Warn2 { param([string]$m) Write-Host "    [warn] $m" -ForegroundColor Yellow }
 function Write-Err2  { param([string]$m) Write-Host "    [err]  $m" -ForegroundColor Red }
@@ -294,6 +294,55 @@ function Install-PipRequirements {
 
     return $pipExit
 }
+
+# ---------------------------------------------------------------------------
+# Installer telemetry (Aria/1DS). Fail-open: never breaks the install.
+# ---------------------------------------------------------------------------
+function Get-EssStepKey {
+    param([string]$m)
+    switch -regex ($m) {
+        'Preflight'                { 'preflight'; break }
+        'winget|toolchain'         { 'toolchain'; break }
+        'pip'                      { 'pip_dependencies'; break }
+        'extension'                { 'vscode_extensions'; break }
+        'Clon|clone|repo'          { 'clone'; break }
+        'Maker Profile'            { 'maker_profile'; break }
+        'FlightCheck environment|environment'  { 'flightcheck_config'; break }
+        'agent solution|Fetch'     { 'fetch_agent'; break }
+        'Running FlightCheck|Run FlightCheck'  { 'flightcheck_run'; break }
+        'workspace|Launch|Open'    { 'launch'; break }
+        default {
+            # Fall back to a scrubbed slug of the first few words.
+            $slug = ($m -replace '[^A-Za-z0-9 ]', '' ).Trim().ToLower() -replace '\s+', '_'
+            if ($slug.Length -gt 40) { $slug = $slug.Substring(0, 40) }
+            if ([string]::IsNullOrWhiteSpace($slug)) { 'step' } else { $slug }
+        }
+    }
+}
+
+# Locate + dot-source the emitter: env var set by the bootstrap (one-liner
+# install), else the copy shipped alongside this script in a clone. If it can't
+# be found, define no-op stubs so every telemetry call below is always safe.
+$essTelLoaded = $false
+$essTelCandidates = @()
+if ($env:ESS_INSTALL_TELEMETRY_LIB) { $essTelCandidates += $env:ESS_INSTALL_TELEMETRY_LIB }
+if ($PSScriptRoot)  { $essTelCandidates += (Join-Path $PSScriptRoot 'telemetry\install-telemetry.ps1') }
+if ($PSCommandPath) { $essTelCandidates += (Join-Path (Split-Path -Parent $PSCommandPath) 'telemetry\install-telemetry.ps1') }
+foreach ($cand in $essTelCandidates) {
+    if ($cand -and (Test-Path $cand)) {
+        try { . $cand; $essTelLoaded = $true; break } catch { }
+    }
+}
+if (-not $essTelLoaded) {
+    function Initialize-EssInstallTelemetry { param($Installer, $TenantId) }
+    function Write-EssInstallStep          { param($Step) }
+    function Complete-EssInstallTelemetry  { param($Outcome, $ErrorRecord) }
+}
+
+$essInstaller = if ($FlightCheckOnly) { 'flightcheck' } elseif ($SkipMakerProfile) { 'adk' } else { 'lite' }
+Initialize-EssInstallTelemetry -Installer $essInstaller -TenantId $env:ESS_TENANT_ID
+
+try {
 
 # ---------------------------------------------------------------------------
 # 1. Preflight
@@ -1115,3 +1164,13 @@ if (-not $SkipLaunch) {
 }
 
 Write-Host "`nDone. Workspace: $workspace" -ForegroundColor Green
+
+}
+catch {
+    Complete-EssInstallTelemetry -Outcome 'failure' -ErrorRecord $_
+    throw
+}
+finally {
+    # Idempotent: no-op if a failure/cancel outcome was already recorded above.
+    Complete-EssInstallTelemetry -Outcome 'success'
+}

--- a/setup/README.md
+++ b/setup/README.md
@@ -127,7 +127,19 @@ cd ~/source/Employee-Self-Service-Agent-Developer-Kit/solutions/ess-maker-skills
 | `bootstrap-lite-mac.sh` | macOS one-liner entry point (lite mode — chat-first layout). |
 | `bootstrap-flightcheck-mac.sh` | macOS one-liner entry point (FlightCheck only). |
 | `ess-adk-setup.winget.yaml` | Declarative DSC config consumed by `winget configure` (optional Windows path). |
+| `telemetry/install-telemetry.ps1` | Installer telemetry emitter (PowerShell). Fail-open; emits install start/step/completion to Aria/1DS. |
+| `telemetry/install-telemetry.sh` | Installer telemetry emitter (bash) — macOS/Linux mirror of the PowerShell emitter. |
 | `.devcontainer/devcontainer.json` | Codespace configuration. Pre-installs Python 3.12, pip dependencies, and Copilot extensions. |
+
+**Installer telemetry.** The installers emit pseudonymous setup-reliability
+telemetry (install start / per-step / success-failure-cancelled completion, with
+the installer variant, platform, failing step and a scrubbed error category)
+natively from PowerShell/bash, because they run before Python exists. It is
+fail-open — a telemetry issue never affects the install — and honors the unified
+opt-out (`ESS_ADK_TELEMETRY=off`, or `python scripts/adk_telemetry.py off`). The
+bootstraps download the emitter into their temp dir and pass its path via
+`ESS_INSTALL_TELEMETRY_LIB`; if it can't be fetched, the install proceeds with
+no-op stubs. See the ADK "Telemetry & Privacy" section for the full data model.
 
 ## Dependencies
 

--- a/setup/bootstrap-flightcheck-mac.sh
+++ b/setup/bootstrap-flightcheck-mac.sh
@@ -42,6 +42,12 @@ if [[ ! -s "$TEMP_DIR/install-ess-adk.sh" ]] || ! head -1 "$TEMP_DIR/install-ess
     exit 1
 fi
 
+# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# download failure must never block the install).
+if curl -fsSL "$SOURCE_BASE_URL/telemetry/install-telemetry.sh" -o "$TEMP_DIR/install-telemetry.sh" 2>/dev/null; then
+    export ESS_INSTALL_TELEMETRY_LIB="$TEMP_DIR/install-telemetry.sh"
+fi
+
 # Run in-memory (source) to avoid any permission issues
 export ESS_ADK_BRANCH="$BRANCH"
 bash "$TEMP_DIR/install-ess-adk.sh"

--- a/setup/bootstrap-flightcheck.ps1
+++ b/setup/bootstrap-flightcheck.ps1
@@ -58,7 +58,7 @@ foreach ($f in $files) {
     }
 }
 
-# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# Best-effort: fetch the installer telemetry emitter (fail-open - a telemetry
 # download failure must never block the install).
 $telLib = Join-Path $tempDir 'install-telemetry.ps1'
 try {

--- a/setup/bootstrap-flightcheck.ps1
+++ b/setup/bootstrap-flightcheck.ps1
@@ -58,6 +58,16 @@ foreach ($f in $files) {
     }
 }
 
+# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# download failure must never block the install).
+$telLib = Join-Path $tempDir 'install-telemetry.ps1'
+try {
+    Invoke-WebRequest -Uri "$SourceBaseUrl/telemetry/install-telemetry.ps1" -OutFile $telLib -UseBasicParsing -TimeoutSec 30
+    $env:ESS_INSTALL_TELEMETRY_LIB = $telLib
+} catch {
+    Write-Host "  [warn] Installer telemetry unavailable (continuing)" -ForegroundColor DarkYellow
+}
+
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'
 
 # Run the installer in-memory (as a script block) so execution policy never

--- a/setup/bootstrap-lite-mac.sh
+++ b/setup/bootstrap-lite-mac.sh
@@ -45,6 +45,12 @@ if [[ ! -s "$TEMP_DIR/install-ess-adk.sh" ]] || ! head -1 "$TEMP_DIR/install-ess
     exit 1
 fi
 
+# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# download failure must never block the install).
+if curl -fsSL "$SOURCE_BASE_URL/telemetry/install-telemetry.sh" -o "$TEMP_DIR/install-telemetry.sh" 2>/dev/null; then
+    export ESS_INSTALL_TELEMETRY_LIB="$TEMP_DIR/install-telemetry.sh"
+fi
+
 # Run the downloaded installer in a subshell to avoid issues if it calls exit
 export ESS_ADK_BRANCH="$BRANCH"
 bash "$TEMP_DIR/install-ess-adk.sh"

--- a/setup/bootstrap-lite.ps1
+++ b/setup/bootstrap-lite.ps1
@@ -60,6 +60,16 @@ foreach ($f in $files) {
     }
 }
 
+# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# download failure must never block the install).
+$telLib = Join-Path $tempDir 'install-telemetry.ps1'
+try {
+    Invoke-WebRequest -Uri "$SourceBaseUrl/telemetry/install-telemetry.ps1" -OutFile $telLib -UseBasicParsing -TimeoutSec 30
+    $env:ESS_INSTALL_TELEMETRY_LIB = $telLib
+} catch {
+    Write-Host "  [warn] Installer telemetry unavailable (continuing)" -ForegroundColor DarkYellow
+}
+
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'
 
 # Run the installer in-memory (as a script block) so execution policy never

--- a/setup/bootstrap-lite.ps1
+++ b/setup/bootstrap-lite.ps1
@@ -60,7 +60,7 @@ foreach ($f in $files) {
     }
 }
 
-# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# Best-effort: fetch the installer telemetry emitter (fail-open - a telemetry
 # download failure must never block the install).
 $telLib = Join-Path $tempDir 'install-telemetry.ps1'
 try {

--- a/setup/bootstrap-mac.sh
+++ b/setup/bootstrap-mac.sh
@@ -42,6 +42,12 @@ if [[ ! -s "$TEMP_DIR/install-ess-adk.sh" ]] || ! head -1 "$TEMP_DIR/install-ess
     exit 1
 fi
 
+# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# download failure must never block the install).
+if curl -fsSL "$SOURCE_BASE_URL/telemetry/install-telemetry.sh" -o "$TEMP_DIR/install-telemetry.sh" 2>/dev/null; then
+    export ESS_INSTALL_TELEMETRY_LIB="$TEMP_DIR/install-telemetry.sh"
+fi
+
 # Run the downloaded installer in a subshell to avoid issues if it calls exit
 export ESS_ADK_BRANCH="$BRANCH"
 bash "$TEMP_DIR/install-ess-adk.sh"

--- a/setup/bootstrap.ps1
+++ b/setup/bootstrap.ps1
@@ -56,7 +56,7 @@ foreach ($f in $files) {
     }
 }
 
-# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# Best-effort: fetch the installer telemetry emitter (fail-open - a telemetry
 # download failure must never block the install).
 $telLib = Join-Path $tempDir 'install-telemetry.ps1'
 try {

--- a/setup/bootstrap.ps1
+++ b/setup/bootstrap.ps1
@@ -56,6 +56,16 @@ foreach ($f in $files) {
     }
 }
 
+# Best-effort: fetch the installer telemetry emitter (fail-open — a telemetry
+# download failure must never block the install).
+$telLib = Join-Path $tempDir 'install-telemetry.ps1'
+try {
+    Invoke-WebRequest -Uri "$SourceBaseUrl/telemetry/install-telemetry.ps1" -OutFile $telLib -UseBasicParsing -TimeoutSec 30
+    $env:ESS_INSTALL_TELEMETRY_LIB = $telLib
+} catch {
+    Write-Host "  [warn] Installer telemetry unavailable (continuing)" -ForegroundColor DarkYellow
+}
+
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'
 
 # Run the installer in-memory (as a script block) so execution policy never

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -87,15 +87,19 @@ elif [[ "$SKIP_MAKER_PROFILE" == "true" ]]; then
 else
     _ess_installer=lite
 fi
-ess_tel_init "$_ess_installer" "${ESS_TENANT_ID:-}" || true
+ess_tel_init "$_ess_installer" || true
 
-# Emit a completion event on any exit (success on 0, failure otherwise). The
-# FlightCheck-only path records success explicitly before it exits, so a
-# non-zero FlightCheck *result* isn't misreported as an install failure.
+# Emit a completion event on any exit (success on 0, cancelled on Ctrl+C/term,
+# failure otherwise). The FlightCheck-only path records success explicitly
+# before it exits, so a non-zero FlightCheck *result* isn't misreported as an
+# install failure.
 ess_tel_on_exit() {
     local code="${1:-0}"
     if [[ "$code" -eq 0 ]]; then
         ess_tel_complete success || true
+    elif [[ "$code" -eq 130 || "$code" -eq 143 ]]; then
+        # 130 = SIGINT (Ctrl+C), 143 = SIGTERM — the user cancelled the install.
+        ess_tel_complete cancelled || true
     else
         ess_tel_complete failure "installer exited with code $code" || true
     fi

--- a/setup/install-ess-adk.sh
+++ b/setup/install-ess-adk.sh
@@ -38,7 +38,69 @@ NC='\033[0m' # No Color
 ok()   { echo -e "    ${GREEN}[ok]${NC}   $1"; }
 warn() { echo -e "    ${YELLOW}[warn]${NC} $1"; }
 err()  { echo -e "    ${RED}[ERR]${NC}  $1"; }
-step() { echo -e "\n${CYAN}==> $1${NC}"; }
+step() { echo -e "\n${CYAN}==> $1${NC}"; ess_tel_step "$(ess_step_key "$1")" || true; }
+
+# ---------------------------------------------------------------------------
+# Installer telemetry (Aria / 1DS). Fail-open: never breaks the install.
+# ---------------------------------------------------------------------------
+# Map a human step message to a short, stable step key for dashboards.
+ess_step_key() {
+    case "$1" in
+        *Checking*)             echo preflight ;;
+        *toolchain*|*Homebrew*) echo toolchain ;;
+        *pip*)                  echo pip_dependencies ;;
+        *Resolving\ Python*)    echo resolve_python ;;
+        *Cloning*|*repository*) echo clone ;;
+        *extension*)            echo vscode_extensions ;;
+        *Maker\ Profile*)       echo maker_profile ;;
+        *FlightCheck\ environ*) echo flightcheck_config ;;
+        *agent\ solution*)      echo fetch_agent ;;
+        *Running\ FlightCheck*) echo flightcheck_run ;;
+        *workspace*|*Opening*)  echo launch ;;
+        *) echo "$1" | tr '[:upper:] ' '[:lower:]_' | tr -cd 'a-z0-9_' | cut -c1-40 ;;
+    esac
+}
+
+# Locate + source the emitter: env var set by the bootstrap (one-liner install),
+# else the copy shipped alongside this script in a clone. If it can't be found,
+# define no-op stubs so every telemetry call below is always safe.
+_ess_tel_lib="${ESS_INSTALL_TELEMETRY_LIB:-}"
+if [[ -z "$_ess_tel_lib" ]]; then
+    _ess_tel_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || echo .)"
+    _ess_tel_lib="$_ess_tel_dir/telemetry/install-telemetry.sh"
+fi
+if [[ -n "$_ess_tel_lib" && -f "$_ess_tel_lib" ]]; then
+    # shellcheck disable=SC1090
+    source "$_ess_tel_lib" || true
+fi
+if ! declare -f ess_tel_init >/dev/null 2>&1; then
+    ess_tel_init()     { :; }
+    ess_tel_step()     { :; }
+    ess_tel_complete() { :; }
+fi
+
+# Installer identity: flightcheck | adk (full, maker profile skipped) | lite.
+if [[ "$FLIGHTCHECK_ONLY" == "true" ]]; then
+    _ess_installer=flightcheck
+elif [[ "$SKIP_MAKER_PROFILE" == "true" ]]; then
+    _ess_installer=adk
+else
+    _ess_installer=lite
+fi
+ess_tel_init "$_ess_installer" "${ESS_TENANT_ID:-}" || true
+
+# Emit a completion event on any exit (success on 0, failure otherwise). The
+# FlightCheck-only path records success explicitly before it exits, so a
+# non-zero FlightCheck *result* isn't misreported as an install failure.
+ess_tel_on_exit() {
+    local code="${1:-0}"
+    if [[ "$code" -eq 0 ]]; then
+        ess_tel_complete success || true
+    else
+        ess_tel_complete failure "installer exited with code $code" || true
+    fi
+}
+trap 'ess_tel_on_exit $?' EXIT
 
 # ---------------------------------------------------------------------------
 # 1. Homebrew
@@ -511,6 +573,7 @@ with open(sys.argv[6], 'w', encoding='utf-8') as f:
 
     # --- Run FlightCheck ---
     step "Running FlightCheck"
+    ess_tel_complete success || true
     "$FLIGHTCHECK_PYTHON" scripts/flightcheck/cli.py --scope full --invocation-source installer
     exit $?
 fi

--- a/setup/telemetry/install-telemetry.ps1
+++ b/setup/telemetry/install-telemetry.ps1
@@ -191,7 +191,7 @@ function New-EssTelEnvelope {
     return @{
         ver  = '4.0'
         name = $Name
-        time = $now.ToString('yyyy-MM-ddTHH:mm:ss.') + ('{0:000}' -f $now.Millisecond) + 'Z'
+        time = $now.ToString('yyyy-MM-ddTHH:mm:ss.', [System.Globalization.CultureInfo]::InvariantCulture) + ('{0:000}' -f $now.Millisecond) + 'Z'
         iKey = $EnvelopeIKey
         data = $Data
     }

--- a/setup/telemetry/install-telemetry.ps1
+++ b/setup/telemetry/install-telemetry.ps1
@@ -251,6 +251,9 @@ function Initialize-EssInstallTelemetry {
     )
     try {
         if (-not (Test-EssTelemetryEnabled)) { $script:EssTel.Ready = $false; return }
+        # The Lite-mode installer is being merged into the standard ADK installer
+        # (mode will become an onboarding prompt), so it is no longer instrumented.
+        if ($Installer -eq 'lite') { $script:EssTel.Ready = $false; return }
         Show-EssTelemetryNotice | Out-Null
 
         $envName = "$env:ESS_ADK_ARIA_ENV".Trim().ToLowerInvariant()

--- a/setup/telemetry/install-telemetry.ps1
+++ b/setup/telemetry/install-telemetry.ps1
@@ -1,0 +1,339 @@
+<#
+.SYNOPSIS
+    Installer telemetry emitter (Aria / 1DS OneCollector) for the ESS ADK
+    installers — Windows / PowerShell.
+
+.DESCRIPTION
+    Emits install start / per-step / completion events so we can measure
+    install success and failure rates and see which stage fails, per installer
+    (ADK, ADK-lite, standalone FlightCheck). This is a dependency-light,
+    self-contained mirror of the Python telemetry SDK
+    (solutions/ess-maker-skills/scripts/flightcheck/telemetry.py): the
+    installers run PowerShell/bash BEFORE Python is guaranteed to exist (the
+    ADK installer's job is partly to install Python), so we cannot shell out to
+    the Python emitter — the OneCollector envelope + POST are reproduced here.
+
+    Design rules (deliberate — read before changing):
+
+    * Fail-open, NEVER break the install. Every function swallows its own
+      errors; nothing here throws, and telemetry never changes the installer's
+      exit code. A telemetry bug must never break a customer's setup.
+    * Same privacy model as the ADK/FlightCheck telemetry: no developer/user
+      identity; a random per-install ``instance_id`` for dedup; the raw tenant
+      GUID (OII) only where available; enums + scrubbed errors only. Error
+      text is scrubbed of paths, URLs, emails/UPNs and GUIDs.
+    * Same unified opt-out: ``ESS_ADK_TELEMETRY=off`` or
+      ``python scripts/adk_telemetry.py off`` (which writes ~/.adk/config).
+      The one-time consent notice is shown on first install.
+
+    The iKeys are 1DS *ingestion* keys: write-only, safe to embed (the same
+    keys ship in flightcheck/telemetry.py and the VS Code extension).
+
+    This file only DEFINES functions; dot-source it, then call
+    Initialize-EssInstallTelemetry / Write-EssInstallStep /
+    Complete-EssInstallTelemetry.
+#>
+
+# --- Constants -------------------------------------------------------------
+$script:EssTelIKeys = @{
+    dev  = '08e397b2c6c243eeaeb341e111c36167-294d89f6-c806-4c65-adf3-dea3bb44f949-7206'
+    prod = '311254257bbc417e860c76781d4863c8-8cff75a4-47b7-4675-9646-45a4ca9bc138-7062'
+}
+$script:EssTelCollectorUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0/?cors=true&content-type=application/x-json-stream'
+$script:EssTelSchemaVersion = '1.0'
+# Microsoft corporate Entra tenant — the only internal tenancy by default
+# (mirrors flightcheck/telemetry.py classify_tenant; ADO 7558661).
+$script:EssTelCorpTenant = '72f988bf-86f1-41af-91ab-2d7cd011db47'
+
+# Per-process state, populated by Initialize-EssInstallTelemetry.
+$script:EssTel = @{
+    Ready        = $false
+    Installer    = 'adk'
+    Env          = 'prod'
+    IKey         = ''
+    InstanceId   = ''
+    TenantId     = ''
+    FirstRun     = $true
+    Platform     = 'Windows'
+    OsVersion    = ''
+    AdkVersion   = 'unknown'
+    Stopwatch    = $null
+    CurrentStep  = ''
+    StepIndex    = 0
+    Completed    = $false
+}
+
+$script:EssTelConfigDir  = Join-Path $HOME '.adk'
+$script:EssTelConfigPath = Join-Path $script:EssTelConfigDir 'config'
+
+$script:EssTelNotice = @'
+------------------------------------------------------------------------
+ESS Agent Developer Kit collects pseudonymous installation telemetry
+(install success/failure, which step failed, scrubbed error categories,
+duration, platform) to help us improve setup reliability. It does NOT
+collect your identity, credentials, file contents, or agent content.
+Opt out any time:  python scripts/adk_telemetry.py off   (or set
+ESS_ADK_TELEMETRY=off). Details: https://aka.ms/adk-telemetry
+------------------------------------------------------------------------
+'@
+
+# --- Config / consent (mirrors adk_telemetry.py) ---------------------------
+function Get-EssTelConfig {
+    try {
+        if (Test-Path $script:EssTelConfigPath) {
+            $raw = Get-Content $script:EssTelConfigPath -Raw -ErrorAction Stop
+            if ($raw) { return ($raw | ConvertFrom-Json -ErrorAction Stop) }
+        }
+    } catch { }
+    return [pscustomobject]@{}
+}
+
+function Set-EssTelConfigValue {
+    param([string]$Name, $Value)
+    try {
+        $cfg = Get-EssTelConfig
+        $ht = @{}
+        foreach ($p in $cfg.PSObject.Properties) { $ht[$p.Name] = $p.Value }
+        $ht[$Name] = $Value
+        if (-not (Test-Path $script:EssTelConfigDir)) {
+            New-Item -ItemType Directory -Path $script:EssTelConfigDir -Force | Out-Null
+        }
+        ($ht | ConvertTo-Json -Depth 5) | Set-Content -Path $script:EssTelConfigPath -Encoding UTF8
+    } catch { }
+}
+
+function Test-EssTelemetryEnabled {
+    # True unless opted out via env var or ~/.adk/config.
+    $val = "$env:ESS_ADK_TELEMETRY".Trim().ToLowerInvariant()
+    if ($val -in @('0', 'off', 'false', 'no', 'disabled')) { return $false }
+    if ($val -in @('1', 'on', 'true', 'yes', 'enabled'))  { return $true }
+    $cfg = Get-EssTelConfig
+    return ($cfg.telemetry -ne 'disabled')
+}
+
+function Show-EssTelemetryNotice {
+    # One-time consent notice, idempotent via config.noticeShown. Returns $true
+    # if it was shown this time.
+    $cfg = Get-EssTelConfig
+    if ($cfg.noticeShown) { return $false }
+    [Console]::Error.WriteLine("`n$script:EssTelNotice`n")
+    Set-EssTelConfigValue -Name 'noticeShown' -Value $true
+    if (-not $cfg.telemetry) { Set-EssTelConfigValue -Name 'telemetry' -Value 'enabled' }
+    return $true
+}
+
+# --- Identity --------------------------------------------------------------
+function Get-EssTelInstanceInfo {
+    # Returns @{ Id = <guid>; FirstRun = <bool> }. Reuses an existing per-install
+    # id (repo .local/.instance_id first so it matches the Python runtime, then
+    # ~/.adk/.instance_id), else mints one. FirstRun is $true only when no id
+    # existed before this install.
+    $candidates = @()
+    if ($env:ESS_ADK_INSTALL_ROOT) {
+        $candidates += (Join-Path (Join-Path $env:ESS_ADK_INSTALL_ROOT 'Employee-Self-Service-Agent-Developer-Kit') '.local\.instance_id')
+    }
+    $candidates += (Join-Path $script:EssTelConfigDir '.instance_id')
+    foreach ($p in $candidates) {
+        try {
+            if (Test-Path $p) {
+                $existing = (Get-Content $p -Raw -ErrorAction Stop).Trim()
+                if ($existing) { return @{ Id = $existing; FirstRun = $false } }
+            }
+        } catch { }
+    }
+    $newId = [guid]::NewGuid().ToString()
+    $target = Join-Path $script:EssTelConfigDir '.instance_id'
+    try {
+        if (-not (Test-Path $script:EssTelConfigDir)) {
+            New-Item -ItemType Directory -Path $script:EssTelConfigDir -Force | Out-Null
+        }
+        Set-Content -Path $target -Value $newId -Encoding UTF8 -ErrorAction Stop
+    } catch { }
+    return @{ Id = $newId; FirstRun = $true }
+}
+
+function Get-EssTelTenantClass {
+    param([string]$TenantId)
+    if ([string]::IsNullOrWhiteSpace($TenantId)) { return 'unknown' }
+    $t = $TenantId.Trim().ToLowerInvariant()
+    $internal = @($script:EssTelCorpTenant.ToLowerInvariant())
+    if ($env:ESS_ADK_INTERNAL_TENANTS) {
+        foreach ($x in ($env:ESS_ADK_INTERNAL_TENANTS -split ',')) {
+            $x = $x.Trim().ToLowerInvariant()
+            if ($x) { $internal += $x }
+        }
+    }
+    if ($internal -contains $t) { return 'internal' }
+    return 'customer'
+}
+
+# --- Scrub (mirrors adk_telemetry._scrub) ----------------------------------
+function ConvertTo-EssTelScrubbed {
+    param([string]$Text, [int]$Limit = 200)
+    if ([string]::IsNullOrEmpty($Text)) { return '' }
+    $s = $Text -replace "`r", ' ' -replace "`n", ' '
+    $s = $s.Trim()
+    $s = [regex]::Replace($s, '[A-Za-z]:\\[^\s]+', '<path>')
+    $s = [regex]::Replace($s, 'https?://[^\s]+', '<url>')
+    $s = [regex]::Replace($s, '(?<!\w)/[^\s]+', '<path>')
+    $s = [regex]::Replace($s, '[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}', '<email>')
+    $s = [regex]::Replace($s, '\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b', '<guid>')
+    if ($s.Length -gt $Limit) { $s = $s.Substring(0, $Limit) }
+    return $s
+}
+
+# --- Envelope + transport (mirrors telemetry.py) ---------------------------
+function Get-EssTelEnvelopeIKey { param([string]$FullIKey) return 'o:' + ($FullIKey -split '-', 2)[0] }
+
+function New-EssTelEnvelope {
+    param([string]$Name, [string]$EnvelopeIKey, [hashtable]$Data)
+    $now = [DateTime]::UtcNow
+    return @{
+        ver  = '4.0'
+        name = $Name
+        time = $now.ToString('yyyy-MM-ddTHH:mm:ss.') + ('{0:000}' -f $now.Millisecond) + 'Z'
+        iKey = $EnvelopeIKey
+        data = $Data
+    }
+}
+
+function Send-EssTelEvent {
+    # Fail-open POST of a single Common Schema 4.0 envelope as x-json-stream.
+    param([hashtable]$Envelope)
+    if (-not $script:EssTel.Ready) { return $null }
+    try {
+        $line = ($Envelope | ConvertTo-Json -Depth 12 -Compress)
+        $now = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+        $headers = @{
+            'apikey'         = $script:EssTel.IKey
+            'Client-Id'      = 'NO_AUTH'
+            'client-version' = "ess-maker-installer-$($script:EssTel.AdkVersion)"
+            'upload-time'    = "$now"
+            'cache-control'  = 'no-cache, no-store'
+            'NoResponseBody' = 'true'
+        }
+        $resp = Invoke-WebRequest -Uri $script:EssTelCollectorUrl -Method Post `
+            -Body ($line + "`n") -ContentType 'application/x-json-stream' `
+            -Headers $headers -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+        return [int]$resp.StatusCode
+    } catch {
+        return $null
+    }
+}
+
+# --- Public API ------------------------------------------------------------
+function Get-EssTelCommonData {
+    return @{
+        schemaVersion    = $script:EssTelSchemaVersion
+        env              = $script:EssTel.Env
+        installer        = $script:EssTel.Installer
+        invocationSource = 'installer'
+        platform         = $script:EssTel.Platform
+        os               = $script:EssTel.OsVersion
+        instanceId       = $script:EssTel.InstanceId
+        tenantId         = $script:EssTel.TenantId
+        tenantClass      = (Get-EssTelTenantClass -TenantId $script:EssTel.TenantId)
+        adkVersion       = $script:EssTel.AdkVersion
+        firstRun         = $script:EssTel.FirstRun
+    }
+}
+
+function Initialize-EssInstallTelemetry {
+    <#
+    .SYNOPSIS Begin installer telemetry: notice, identity, and the start event.
+    .PARAMETER Installer  One of adk | lite | flightcheck.
+    .PARAMETER TenantId   Raw Entra tenant GUID if known (optional).
+    #>
+    param(
+        [ValidateSet('adk', 'lite', 'flightcheck')]
+        [string]$Installer = 'adk',
+        [string]$TenantId = ''
+    )
+    try {
+        if (-not (Test-EssTelemetryEnabled)) { $script:EssTel.Ready = $false; return }
+        Show-EssTelemetryNotice | Out-Null
+
+        $envName = "$env:ESS_ADK_ARIA_ENV".Trim().ToLowerInvariant()
+        if (-not $envName) { $envName = "$env:ESS_FLIGHTCHECK_ARIA_ENV".Trim().ToLowerInvariant() }
+        if ($envName -ne 'dev') { $envName = 'prod' }
+
+        $inst = Get-EssTelInstanceInfo
+        $adkVer = "$env:ESS_ADK_VERSION".Trim(); if (-not $adkVer) { $adkVer = 'unknown' }
+
+        $script:EssTel.Installer   = $Installer
+        $script:EssTel.Env         = $envName
+        $script:EssTel.IKey        = $script:EssTelIKeys[$envName]
+        $script:EssTel.InstanceId  = $inst.Id
+        $script:EssTel.FirstRun    = $inst.FirstRun
+        $script:EssTel.TenantId    = $TenantId
+        $script:EssTel.Platform    = 'Windows'
+        $script:EssTel.OsVersion   = [string][Environment]::OSVersion.Version
+        $script:EssTel.AdkVersion  = $adkVer
+        $script:EssTel.Stopwatch   = [System.Diagnostics.Stopwatch]::StartNew()
+        $script:EssTel.StepIndex   = 0
+        $script:EssTel.CurrentStep = 'start'
+        $script:EssTel.Completed   = $false
+        $script:EssTel.Ready       = $true
+
+        $data = Get-EssTelCommonData
+        $env2 = Get-EssTelEnvelopeIKey -FullIKey $script:EssTel.IKey
+        Send-EssTelEvent -Envelope (New-EssTelEnvelope -Name 'ESSMakerKit.Installer.Start' -EnvelopeIKey $env2 -Data $data) | Out-Null
+    } catch {
+        $script:EssTel.Ready = $false
+    }
+}
+
+function Write-EssInstallStep {
+    <#
+    .SYNOPSIS Record the current install step and emit a step event.
+    .PARAMETER Step Short stable step key (e.g. 'preflight', 'toolchain').
+    #>
+    param([string]$Step)
+    try {
+        if (-not $script:EssTel.Ready) { return }
+        $script:EssTel.StepIndex++
+        $script:EssTel.CurrentStep = $Step
+        $data = Get-EssTelCommonData
+        $data.step = $Step
+        $data.stepIndex = $script:EssTel.StepIndex
+        $data.outcome = 'reached'
+        $env2 = Get-EssTelEnvelopeIKey -FullIKey $script:EssTel.IKey
+        Send-EssTelEvent -Envelope (New-EssTelEnvelope -Name 'ESSMakerKit.Installer.Step' -EnvelopeIKey $env2 -Data $data) | Out-Null
+    } catch { }
+}
+
+function Complete-EssInstallTelemetry {
+    <#
+    .SYNOPSIS Emit the completion event exactly once.
+    .PARAMETER Outcome One of success | failure | cancelled.
+    .PARAMETER ErrorRecord The caught error (optional; scrubbed).
+    #>
+    param(
+        [ValidateSet('success', 'failure', 'cancelled')]
+        [string]$Outcome = 'success',
+        $ErrorRecord = $null
+    )
+    try {
+        if (-not $script:EssTel.Ready -or $script:EssTel.Completed) { return }
+        $script:EssTel.Completed = $true
+        $dur = 0.0
+        if ($script:EssTel.Stopwatch) { $dur = [math]::Round($script:EssTel.Stopwatch.Elapsed.TotalSeconds, 1) }
+        $data = Get-EssTelCommonData
+        $data.outcome = $Outcome
+        $data.failedStep = if ($Outcome -eq 'success') { '' } else { $script:EssTel.CurrentStep }
+        $data.durationSecs = $dur
+        if ($ErrorRecord) {
+            $msg = ''; $code = ''; $cat = ''
+            try {
+                $msg  = ConvertTo-EssTelScrubbed -Text ([string]$ErrorRecord.Exception.Message)
+                $code = ConvertTo-EssTelScrubbed -Text ([string]$ErrorRecord.FullyQualifiedErrorId) -Limit 80
+                $cat  = ConvertTo-EssTelScrubbed -Text ([string]$ErrorRecord.CategoryInfo.Category) -Limit 60
+            } catch { }
+            $data.errorMessage  = $msg
+            $data.errorCode     = $code
+            $data.errorCategory = $cat
+        }
+        $env2 = Get-EssTelEnvelopeIKey -FullIKey $script:EssTel.IKey
+        Send-EssTelEvent -Envelope (New-EssTelEnvelope -Name 'ESSMakerKit.Installer.Complete' -EnvelopeIKey $env2 -Data $data) | Out-Null
+    } catch { }
+}

--- a/setup/telemetry/install-telemetry.ps1
+++ b/setup/telemetry/install-telemetry.ps1
@@ -19,9 +19,11 @@
       errors; nothing here throws, and telemetry never changes the installer's
       exit code. A telemetry bug must never break a customer's setup.
     * Same privacy model as the ADK/FlightCheck telemetry: no developer/user
-      identity; a random per-install ``instance_id`` for dedup; the raw tenant
-      GUID (OII) only where available; enums + scrubbed errors only. Error
-      text is scrubbed of paths, URLs, emails/UPNs and GUIDs.
+      identity; a random per-install ``instance_id`` for dedup; enums +
+      scrubbed errors only. The installer runs BEFORE sign-in, so the tenant
+      is unknown here — no tenant dimension is emitted from the installer (the
+      internal-vs-external split lives in the post-auth ADK/FlightCheck
+      telemetry). Error text is scrubbed of paths, URLs, emails/UPNs and GUIDs.
     * Same unified opt-out: ``ESS_ADK_TELEMETRY=off`` or
       ``python scripts/adk_telemetry.py off`` (which writes ~/.adk/config).
       The one-time consent notice is shown on first install.
@@ -41,9 +43,6 @@ $script:EssTelIKeys = @{
 }
 $script:EssTelCollectorUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0/?cors=true&content-type=application/x-json-stream'
 $script:EssTelSchemaVersion = '1.0'
-# Microsoft corporate Entra tenant — the only internal tenancy by default
-# (mirrors flightcheck/telemetry.py classify_tenant; ADO 7558661).
-$script:EssTelCorpTenant = '72f988bf-86f1-41af-91ab-2d7cd011db47'
 
 # Per-process state, populated by Initialize-EssInstallTelemetry.
 $script:EssTel = @{
@@ -52,7 +51,6 @@ $script:EssTel = @{
     Env          = 'prod'
     IKey         = ''
     InstanceId   = ''
-    TenantId     = ''
     FirstRun     = $true
     Platform     = 'Windows'
     OsVersion    = ''
@@ -152,21 +150,6 @@ function Get-EssTelInstanceInfo {
     return @{ Id = $newId; FirstRun = $true }
 }
 
-function Get-EssTelTenantClass {
-    param([string]$TenantId)
-    if ([string]::IsNullOrWhiteSpace($TenantId)) { return 'unknown' }
-    $t = $TenantId.Trim().ToLowerInvariant()
-    $internal = @($script:EssTelCorpTenant.ToLowerInvariant())
-    if ($env:ESS_ADK_INTERNAL_TENANTS) {
-        foreach ($x in ($env:ESS_ADK_INTERNAL_TENANTS -split ',')) {
-            $x = $x.Trim().ToLowerInvariant()
-            if ($x) { $internal += $x }
-        }
-    }
-    if ($internal -contains $t) { return 'internal' }
-    return 'customer'
-}
-
 # --- Scrub (mirrors adk_telemetry._scrub) ----------------------------------
 function ConvertTo-EssTelScrubbed {
     param([string]$Text, [int]$Limit = 200)
@@ -214,9 +197,14 @@ function Send-EssTelEvent {
         }
         $resp = Invoke-WebRequest -Uri $script:EssTelCollectorUrl -Method Post `
             -Body ($line + "`n") -ContentType 'application/x-json-stream' `
-            -Headers $headers -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+            -Headers $headers -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop
         return [int]$resp.StatusCode
     } catch {
+        # Circuit breaker: an unreachable or slow collector must not add its
+        # timeout to every remaining step. After the first failed send, disable
+        # telemetry for the rest of the process so the total added latency is
+        # bounded to ~one timeout, not (number-of-steps x timeout).
+        $script:EssTel.Ready = $false
         return $null
     }
 }
@@ -231,8 +219,6 @@ function Get-EssTelCommonData {
         platform         = $script:EssTel.Platform
         os               = $script:EssTel.OsVersion
         instanceId       = $script:EssTel.InstanceId
-        tenantId         = $script:EssTel.TenantId
-        tenantClass      = (Get-EssTelTenantClass -TenantId $script:EssTel.TenantId)
         adkVersion       = $script:EssTel.AdkVersion
         firstRun         = $script:EssTel.FirstRun
     }
@@ -242,12 +228,10 @@ function Initialize-EssInstallTelemetry {
     <#
     .SYNOPSIS Begin installer telemetry: notice, identity, and the start event.
     .PARAMETER Installer  One of adk | lite | flightcheck.
-    .PARAMETER TenantId   Raw Entra tenant GUID if known (optional).
     #>
     param(
         [ValidateSet('adk', 'lite', 'flightcheck')]
-        [string]$Installer = 'adk',
-        [string]$TenantId = ''
+        [string]$Installer = 'adk'
     )
     try {
         if (-not (Test-EssTelemetryEnabled)) { $script:EssTel.Ready = $false; return }
@@ -268,7 +252,6 @@ function Initialize-EssInstallTelemetry {
         $script:EssTel.IKey        = $script:EssTelIKeys[$envName]
         $script:EssTel.InstanceId  = $inst.Id
         $script:EssTel.FirstRun    = $inst.FirstRun
-        $script:EssTel.TenantId    = $TenantId
         $script:EssTel.Platform    = 'Windows'
         $script:EssTel.OsVersion   = [string][Environment]::OSVersion.Version
         $script:EssTel.AdkVersion  = $adkVer

--- a/setup/telemetry/install-telemetry.sh
+++ b/setup/telemetry/install-telemetry.sh
@@ -190,6 +190,9 @@ ess_tel_init() {
     ESS_TEL_INSTALLER="${1:-adk}"
     ESS_TEL_TENANT="${2:-}"
     ess_tel_enabled || { ESS_TEL_READY=0; return 0; }
+    # The Lite-mode installer is being merged into the standard ADK installer
+    # (mode will become an onboarding prompt), so it is no longer instrumented.
+    [[ "$ESS_TEL_INSTALLER" == "lite" ]] && { ESS_TEL_READY=0; return 0; }
     ess_tel_notice
     local envname
     envname="$(printf '%s' "${ESS_ADK_ARIA_ENV:-${ESS_FLIGHTCHECK_ARIA_ENV:-}}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"

--- a/setup/telemetry/install-telemetry.sh
+++ b/setup/telemetry/install-telemetry.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Installer telemetry emitter (Aria / 1DS OneCollector) for the ESS ADK
+# installers — macOS / Linux (bash).
+#
+# Dependency-light, self-contained mirror of the Python telemetry SDK
+# (solutions/ess-maker-skills/scripts/flightcheck/telemetry.py) and of the
+# PowerShell emitter (setup/telemetry/install-telemetry.ps1). The installers
+# run bash BEFORE Python is guaranteed to exist, so we reproduce the
+# OneCollector envelope + POST here with curl.
+#
+# Design rules (deliberate — read before changing):
+#   * Fail-open, NEVER break the install. Every function returns 0 and
+#     swallows its own errors; telemetry never changes the installer's exit.
+#   * Same privacy model: no developer/user identity; random per-install
+#     instance_id for dedup; raw tenant GUID (OII) only where available;
+#     enums + scrubbed errors only (paths/URLs/emails/GUIDs stripped).
+#   * Same unified opt-out: ESS_ADK_TELEMETRY=off or ~/.adk/config
+#     {"telemetry":"disabled"}; one-time notice on first install.
+#
+# The iKeys are 1DS ingestion keys: write-only, safe to embed.
+#
+# Source this file, then call: ess_tel_init <adk|lite|flightcheck> [tenant_id]
+#   ess_tel_step <step>; ess_tel_complete <success|failure|cancelled> [msg]
+# ---------------------------------------------------------------------------
+
+ESS_TEL_IKEY_DEV='08e397b2c6c243eeaeb341e111c36167-294d89f6-c806-4c65-adf3-dea3bb44f949-7206'
+ESS_TEL_IKEY_PROD='311254257bbc417e860c76781d4863c8-8cff75a4-47b7-4675-9646-45a4ca9bc138-7062'
+ESS_TEL_COLLECTOR='https://mobile.events.data.microsoft.com/OneCollector/1.0/?cors=true&content-type=application/x-json-stream'
+ESS_TEL_SCHEMA='1.0'
+# Microsoft corporate Entra tenant — the only internal tenancy by default.
+ESS_TEL_CORP_TENANT='72f988bf-86f1-41af-91ab-2d7cd011db47'
+ESS_TEL_CONFIG_DIR="$HOME/.adk"
+ESS_TEL_CONFIG="$ESS_TEL_CONFIG_DIR/config"
+
+ESS_TEL_READY=0
+ESS_TEL_INSTALLER='adk'
+ESS_TEL_ENV='prod'
+ESS_TEL_IKEY=''
+ESS_TEL_INSTANCE=''
+ESS_TEL_TENANT=''
+ESS_TEL_FIRSTRUN='true'
+ESS_TEL_PLATFORM='macOS'
+ESS_TEL_OS=''
+ESS_TEL_ADKVER='unknown'
+ESS_TEL_START=0
+ESS_TEL_STEP=''
+ESS_TEL_STEPIDX=0
+ESS_TEL_COMPLETED=0
+
+# --- consent / opt-out -----------------------------------------------------
+ess_tel_enabled() {
+    local v
+    v="$(printf '%s' "${ESS_ADK_TELEMETRY:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    case "$v" in
+        0|off|false|no|disabled) return 1 ;;
+        1|on|true|yes|enabled)   return 0 ;;
+    esac
+    if [[ -f "$ESS_TEL_CONFIG" ]] && grep -Eq '"telemetry"[[:space:]]*:[[:space:]]*"disabled"' "$ESS_TEL_CONFIG" 2>/dev/null; then
+        return 1
+    fi
+    return 0
+}
+
+ess_tel_notice() {
+    # One-time notice, idempotent via config noticeShown (best-effort).
+    if [[ -f "$ESS_TEL_CONFIG" ]] && grep -Eq '"noticeShown"[[:space:]]*:[[:space:]]*true' "$ESS_TEL_CONFIG" 2>/dev/null; then
+        return 0
+    fi
+    cat >&2 <<'EOF'
+
+------------------------------------------------------------------------
+ESS Agent Developer Kit collects pseudonymous installation telemetry
+(install success/failure, which step failed, scrubbed error categories,
+duration, platform) to help us improve setup reliability. It does NOT
+collect your identity, credentials, file contents, or agent content.
+Opt out any time:  python scripts/adk_telemetry.py off   (or set
+ESS_ADK_TELEMETRY=off). Details: https://aka.ms/adk-telemetry
+------------------------------------------------------------------------
+
+EOF
+    mkdir -p "$ESS_TEL_CONFIG_DIR" 2>/dev/null || true
+    if [[ -f "$ESS_TEL_CONFIG" ]] && grep -q '"telemetry"' "$ESS_TEL_CONFIG" 2>/dev/null; then
+        # append noticeShown without clobbering (best-effort minimal edit)
+        if ! grep -q '"noticeShown"' "$ESS_TEL_CONFIG" 2>/dev/null; then
+            # insert before the closing brace
+            local tmp="$ESS_TEL_CONFIG.tmp.$$"
+            sed 's/}[[:space:]]*$/, "noticeShown": true }/' "$ESS_TEL_CONFIG" > "$tmp" 2>/dev/null && mv "$tmp" "$ESS_TEL_CONFIG" 2>/dev/null || true
+        fi
+    else
+        printf '{ "telemetry": "enabled", "noticeShown": true }\n' > "$ESS_TEL_CONFIG" 2>/dev/null || true
+    fi
+    return 0
+}
+
+# --- identity --------------------------------------------------------------
+ess_tel_instance_info() {
+    # Sets ESS_TEL_INSTANCE + ESS_TEL_FIRSTRUN.
+    local candidates=() p existing
+    if [[ -n "${ESS_ADK_INSTALL_ROOT:-}" ]]; then
+        candidates+=("$ESS_ADK_INSTALL_ROOT/Employee-Self-Service-Agent-Developer-Kit/.local/.instance_id")
+    fi
+    candidates+=("$ESS_TEL_CONFIG_DIR/.instance_id")
+    for p in "${candidates[@]}"; do
+        if [[ -f "$p" ]]; then
+            existing="$(tr -d '[:space:]' < "$p" 2>/dev/null)"
+            if [[ -n "$existing" ]]; then
+                ESS_TEL_INSTANCE="$existing"; ESS_TEL_FIRSTRUN='false'; return 0
+            fi
+        fi
+    done
+    local newid
+    if command -v uuidgen >/dev/null 2>&1; then
+        newid="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    else
+        newid="$(cat /proc/sys/kernel/random/uuid 2>/dev/null || date +%s%N)"
+    fi
+    ESS_TEL_INSTANCE="$newid"; ESS_TEL_FIRSTRUN='true'
+    mkdir -p "$ESS_TEL_CONFIG_DIR" 2>/dev/null || true
+    printf '%s' "$newid" > "$ESS_TEL_CONFIG_DIR/.instance_id" 2>/dev/null || true
+    return 0
+}
+
+ess_tel_tenant_class() {
+    local t="$1"
+    if [[ -z "$t" ]]; then printf 'unknown'; return 0; fi
+    t="$(printf '%s' "$t" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    local corp; corp="$(printf '%s' "$ESS_TEL_CORP_TENANT" | tr '[:upper:]' '[:lower:]')"
+    local internal=",$corp,"
+    if [[ -n "${ESS_ADK_INTERNAL_TENANTS:-}" ]]; then
+        local extra; extra="$(printf '%s' "$ESS_ADK_INTERNAL_TENANTS" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+        internal="$internal$extra,"
+    fi
+    if [[ "$internal" == *",$t,"* ]]; then printf 'internal'; else printf 'customer'; fi
+    return 0
+}
+
+# --- scrub (mirrors adk_telemetry._scrub) ----------------------------------
+ess_tel_scrub() {
+    local s="$1"
+    s="${s//$'\n'/ }"; s="${s//$'\r'/ }"
+    s="$(printf '%s' "$s" \
+        | sed -E 's#[A-Za-z]:\\[^[:space:]]+#<path>#g' \
+        | sed -E 's#https?://[^[:space:]]+#<url>#g' \
+        | sed -E 's#(^|[^A-Za-z0-9_])/[^[:space:]]+#\1<path>#g' \
+        | sed -E 's#[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}#<email>#g' \
+        | sed -E 's#[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}#<guid>#g')"
+    printf '%s' "${s:0:200}"
+}
+
+# --- json helper -----------------------------------------------------------
+_ess_tel_jesc() {
+    # Escape a string for embedding in JSON.
+    local s="$1"
+    s="${s//\\/\\\\}"; s="${s//\"/\\\"}"
+    s="${s//$'\n'/ }"; s="${s//$'\r'/ }"; s="${s//$'\t'/ }"
+    printf '%s' "$s"
+}
+
+# --- transport -------------------------------------------------------------
+ess_tel_send() {
+    # $1 = event name, $2 = extra JSON fields (already ",key:val,..." or empty)
+    [[ "$ESS_TEL_READY" == "1" ]] || return 0
+    local name="$1" extra="$2"
+    local envtoken="o:${ESS_TEL_IKEY%%-*}"
+    local ts ns ms
+    ns="$(date +%N 2>/dev/null || echo 0)"; ns="${ns//[!0-9]/}"; [[ -n "$ns" ]] || ns=0
+    ms=$(( (10#$ns / 1000000) % 1000 ))
+    ts="$(date -u +%Y-%m-%dT%H:%M:%S).$(printf '%03d' "$ms")Z"
+    local tclass; tclass="$(ess_tel_tenant_class "$ESS_TEL_TENANT")"
+    local data
+    data="{\"schemaVersion\":\"$ESS_TEL_SCHEMA\",\"env\":\"$ESS_TEL_ENV\",\"installer\":\"$ESS_TEL_INSTALLER\",\"invocationSource\":\"installer\",\"platform\":\"$ESS_TEL_PLATFORM\",\"os\":\"$(_ess_tel_jesc "$ESS_TEL_OS")\",\"instanceId\":\"$ESS_TEL_INSTANCE\",\"tenantId\":\"$(_ess_tel_jesc "$ESS_TEL_TENANT")\",\"tenantClass\":\"$tclass\",\"adkVersion\":\"$(_ess_tel_jesc "$ESS_TEL_ADKVER")\",\"firstRun\":$ESS_TEL_FIRSTRUN$extra}"
+    local body="{\"ver\":\"4.0\",\"name\":\"$name\",\"time\":\"$ts\",\"iKey\":\"$envtoken\",\"data\":$data}"
+    local uploadms; uploadms="$(( $(date +%s) * 1000 ))"
+    curl -fsS -m 5 -X POST "$ESS_TEL_COLLECTOR" \
+        -H "apikey: $ESS_TEL_IKEY" \
+        -H 'Client-Id: NO_AUTH' \
+        -H "client-version: ess-maker-installer-$ESS_TEL_ADKVER" \
+        -H "upload-time: $uploadms" \
+        -H 'cache-control: no-cache, no-store' \
+        -H 'NoResponseBody: true' \
+        -H 'Content-Type: application/x-json-stream' \
+        --data-binary "$body"$'\n' >/dev/null 2>&1 || true
+    return 0
+}
+
+# --- public API ------------------------------------------------------------
+ess_tel_init() {
+    # $1 = installer (adk|lite|flightcheck), $2 = tenant_id (optional)
+    ESS_TEL_INSTALLER="${1:-adk}"
+    ESS_TEL_TENANT="${2:-}"
+    ess_tel_enabled || { ESS_TEL_READY=0; return 0; }
+    ess_tel_notice
+    local envname
+    envname="$(printf '%s' "${ESS_ADK_ARIA_ENV:-${ESS_FLIGHTCHECK_ARIA_ENV:-}}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    if [[ "$envname" == "dev" ]]; then ESS_TEL_ENV='dev'; ESS_TEL_IKEY="$ESS_TEL_IKEY_DEV"; else ESS_TEL_ENV='prod'; ESS_TEL_IKEY="$ESS_TEL_IKEY_PROD"; fi
+    ess_tel_instance_info
+    case "$(uname -s 2>/dev/null)" in
+        Darwin) ESS_TEL_PLATFORM='macOS' ;;
+        Linux)  ESS_TEL_PLATFORM='Linux' ;;
+        *)      ESS_TEL_PLATFORM='Unix' ;;
+    esac
+    ESS_TEL_OS="$(uname -sr 2>/dev/null || echo unknown)"
+    ESS_TEL_ADKVER="${ESS_ADK_VERSION:-unknown}"
+    ESS_TEL_START="$(date +%s)"
+    ESS_TEL_STEPIDX=0
+    ESS_TEL_STEP='start'
+    ESS_TEL_COMPLETED=0
+    ESS_TEL_READY=1
+    ess_tel_send 'ESSMakerKit.Installer.Start' ''
+    return 0
+}
+
+ess_tel_step() {
+    [[ "$ESS_TEL_READY" == "1" ]] || return 0
+    ESS_TEL_STEPIDX=$((ESS_TEL_STEPIDX + 1))
+    ESS_TEL_STEP="$1"
+    ess_tel_send 'ESSMakerKit.Installer.Step' ",\"step\":\"$(_ess_tel_jesc "$1")\",\"stepIndex\":$ESS_TEL_STEPIDX,\"outcome\":\"reached\""
+    return 0
+}
+
+ess_tel_complete() {
+    # $1 = outcome (success|failure|cancelled), $2 = error message (optional)
+    [[ "$ESS_TEL_READY" == "1" ]] || return 0
+    [[ "$ESS_TEL_COMPLETED" == "0" ]] || return 0
+    ESS_TEL_COMPLETED=1
+    local outcome="${1:-success}" msg="${2:-}"
+    local dur=0
+    if [[ "$ESS_TEL_START" -gt 0 ]]; then dur=$(( $(date +%s) - ESS_TEL_START )); fi
+    local failed=''
+    [[ "$outcome" == "success" ]] || failed="$ESS_TEL_STEP"
+    local extra=",\"outcome\":\"$outcome\",\"failedStep\":\"$(_ess_tel_jesc "$failed")\",\"durationSecs\":$dur"
+    if [[ -n "$msg" ]]; then
+        extra="$extra,\"errorMessage\":\"$(_ess_tel_jesc "$(ess_tel_scrub "$msg")")\""
+    fi
+    ess_tel_send 'ESSMakerKit.Installer.Complete' "$extra"
+    return 0
+}

--- a/setup/telemetry/install-telemetry.sh
+++ b/setup/telemetry/install-telemetry.sh
@@ -13,14 +13,16 @@
 #   * Fail-open, NEVER break the install. Every function returns 0 and
 #     swallows its own errors; telemetry never changes the installer's exit.
 #   * Same privacy model: no developer/user identity; random per-install
-#     instance_id for dedup; raw tenant GUID (OII) only where available;
-#     enums + scrubbed errors only (paths/URLs/emails/GUIDs stripped).
+#     instance_id for dedup; enums + scrubbed errors only (paths/URLs/emails/
+#     GUIDs stripped). The installer runs BEFORE sign-in, so the tenant is
+#     unknown here and no tenant dimension is emitted (the internal-vs-external
+#     split lives in the post-auth ADK/FlightCheck telemetry).
 #   * Same unified opt-out: ESS_ADK_TELEMETRY=off or ~/.adk/config
 #     {"telemetry":"disabled"}; one-time notice on first install.
 #
 # The iKeys are 1DS ingestion keys: write-only, safe to embed.
 #
-# Source this file, then call: ess_tel_init <adk|lite|flightcheck> [tenant_id]
+# Source this file, then call: ess_tel_init <adk|lite|flightcheck>
 #   ess_tel_step <step>; ess_tel_complete <success|failure|cancelled> [msg]
 # ---------------------------------------------------------------------------
 
@@ -28,8 +30,6 @@ ESS_TEL_IKEY_DEV='08e397b2c6c243eeaeb341e111c36167-294d89f6-c806-4c65-adf3-dea3b
 ESS_TEL_IKEY_PROD='311254257bbc417e860c76781d4863c8-8cff75a4-47b7-4675-9646-45a4ca9bc138-7062'
 ESS_TEL_COLLECTOR='https://mobile.events.data.microsoft.com/OneCollector/1.0/?cors=true&content-type=application/x-json-stream'
 ESS_TEL_SCHEMA='1.0'
-# Microsoft corporate Entra tenant — the only internal tenancy by default.
-ESS_TEL_CORP_TENANT='72f988bf-86f1-41af-91ab-2d7cd011db47'
 ESS_TEL_CONFIG_DIR="$HOME/.adk"
 ESS_TEL_CONFIG="$ESS_TEL_CONFIG_DIR/config"
 
@@ -38,7 +38,6 @@ ESS_TEL_INSTALLER='adk'
 ESS_TEL_ENV='prod'
 ESS_TEL_IKEY=''
 ESS_TEL_INSTANCE=''
-ESS_TEL_TENANT=''
 ESS_TEL_FIRSTRUN='true'
 ESS_TEL_PLATFORM='macOS'
 ESS_TEL_OS=''
@@ -121,20 +120,6 @@ ess_tel_instance_info() {
     return 0
 }
 
-ess_tel_tenant_class() {
-    local t="$1"
-    if [[ -z "$t" ]]; then printf 'unknown'; return 0; fi
-    t="$(printf '%s' "$t" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
-    local corp; corp="$(printf '%s' "$ESS_TEL_CORP_TENANT" | tr '[:upper:]' '[:lower:]')"
-    local internal=",$corp,"
-    if [[ -n "${ESS_ADK_INTERNAL_TENANTS:-}" ]]; then
-        local extra; extra="$(printf '%s' "$ESS_ADK_INTERNAL_TENANTS" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
-        internal="$internal$extra,"
-    fi
-    if [[ "$internal" == *",$t,"* ]]; then printf 'internal'; else printf 'customer'; fi
-    return 0
-}
-
 # --- scrub (mirrors adk_telemetry._scrub) ----------------------------------
 ess_tel_scrub() {
     local s="$1"
@@ -167,12 +152,14 @@ ess_tel_send() {
     ns="$(date +%N 2>/dev/null || echo 0)"; ns="${ns//[!0-9]/}"; [[ -n "$ns" ]] || ns=0
     ms=$(( (10#$ns / 1000000) % 1000 ))
     ts="$(date -u +%Y-%m-%dT%H:%M:%S).$(printf '%03d' "$ms")Z"
-    local tclass; tclass="$(ess_tel_tenant_class "$ESS_TEL_TENANT")"
     local data
-    data="{\"schemaVersion\":\"$ESS_TEL_SCHEMA\",\"env\":\"$ESS_TEL_ENV\",\"installer\":\"$ESS_TEL_INSTALLER\",\"invocationSource\":\"installer\",\"platform\":\"$ESS_TEL_PLATFORM\",\"os\":\"$(_ess_tel_jesc "$ESS_TEL_OS")\",\"instanceId\":\"$ESS_TEL_INSTANCE\",\"tenantId\":\"$(_ess_tel_jesc "$ESS_TEL_TENANT")\",\"tenantClass\":\"$tclass\",\"adkVersion\":\"$(_ess_tel_jesc "$ESS_TEL_ADKVER")\",\"firstRun\":$ESS_TEL_FIRSTRUN$extra}"
+    data="{\"schemaVersion\":\"$ESS_TEL_SCHEMA\",\"env\":\"$ESS_TEL_ENV\",\"installer\":\"$ESS_TEL_INSTALLER\",\"invocationSource\":\"installer\",\"platform\":\"$ESS_TEL_PLATFORM\",\"os\":\"$(_ess_tel_jesc "$ESS_TEL_OS")\",\"instanceId\":\"$ESS_TEL_INSTANCE\",\"adkVersion\":\"$(_ess_tel_jesc "$ESS_TEL_ADKVER")\",\"firstRun\":$ESS_TEL_FIRSTRUN$extra}"
     local body="{\"ver\":\"4.0\",\"name\":\"$name\",\"time\":\"$ts\",\"iKey\":\"$envtoken\",\"data\":$data}"
     local uploadms; uploadms="$(( $(date +%s) * 1000 ))"
-    curl -fsS -m 5 -X POST "$ESS_TEL_COLLECTOR" \
+    # Circuit breaker: an unreachable/slow collector must not add its timeout to
+    # every remaining step. On the first failed send, disable telemetry for the
+    # rest of the process so total added latency is bounded to ~one timeout.
+    if curl -fsS -m 3 -X POST "$ESS_TEL_COLLECTOR" \
         -H "apikey: $ESS_TEL_IKEY" \
         -H 'Client-Id: NO_AUTH' \
         -H "client-version: ess-maker-installer-$ESS_TEL_ADKVER" \
@@ -180,15 +167,18 @@ ess_tel_send() {
         -H 'cache-control: no-cache, no-store' \
         -H 'NoResponseBody: true' \
         -H 'Content-Type: application/x-json-stream' \
-        --data-binary "$body"$'\n' >/dev/null 2>&1 || true
+        --data-binary "$body"$'\n' >/dev/null 2>&1; then
+        :
+    else
+        ESS_TEL_READY=0
+    fi
     return 0
 }
 
 # --- public API ------------------------------------------------------------
 ess_tel_init() {
-    # $1 = installer (adk|lite|flightcheck), $2 = tenant_id (optional)
+    # $1 = installer (adk|lite|flightcheck)
     ESS_TEL_INSTALLER="${1:-adk}"
-    ESS_TEL_TENANT="${2:-}"
     ess_tel_enabled || { ESS_TEL_READY=0; return 0; }
     # The Lite-mode installer is being merged into the standard ADK installer
     # (mode will become an onboarding prompt), so it is no longer instrumented.

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -371,7 +371,8 @@ CLI command.
   available) emit the same kind of event natively from PowerShell/bash: an
   install **start**, **per-step** progress, and a **completion**
   (`success` / `failure` / `cancelled`) carrying the installer variant
-  (ADK / ADK-lite / FlightCheck), platform, which step failed, and a scrubbed
+  (ADK or FlightCheck — the ADK-lite installer is not instrumented), platform,
+  which step failed, and a scrubbed
   error category. This measures setup reliability. It is fail-open (a telemetry
   problem never breaks your install) and honors the same opt-out below.
 

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -367,6 +367,13 @@ CLI command.
 - Non-identifying context: ADK version, surface, session ID, event name, and
   per-event enums/metrics (e.g. FlightCheck verdicts, durations, check categories).
 - Scrubbed, non-sensitive **error categories** when something fails.
+- During **installation**, the one-shot installers (which run before Python is
+  available) emit the same kind of event natively from PowerShell/bash: an
+  install **start**, **per-step** progress, and a **completion**
+  (`success` / `failure` / `cancelled`) carrying the installer variant
+  (ADK / ADK-lite / FlightCheck), platform, which step failed, and a scrubbed
+  error category. This measures setup reliability. It is fail-open (a telemetry
+  problem never breaks your install) and honors the same opt-out below.
 
 **What is _not_ collected**
 


### PR DESCRIPTION
## Summary

Adds pseudonymous **installer telemetry** so we can measure setup reliability
for the ESS ADK one-shot installers (ADK, ADK-lite, standalone FlightCheck) and
split Microsoft-internal dogfood installs from external customer installs.

Because the installers run PowerShell/bash **before Python is guaranteed to
exist** (installing Python is part of their job), this adds two dependency-light
native emitters that reproduce the 1DS OneCollector envelope + POST used by the
Python SDK — rather than shelling out to Python.

## What it collects

`ESSMakerKit.Installer.Start` / `.Step` / `.Complete` events with:
- installer variant (`adk` | `lite` | `flightcheck`), platform + OS
- random per-install `instance_id` (dedup; **not** identity)
- raw tenant GUID (OII) + derived `tenant_class` (`internal` | `customer` | `unknown`), where available
- step reached / `stepIndex`, completion `outcome` (`success` | `failure` | `cancelled`), failing step, duration
- scrubbed error message / code / category (paths, URLs, emails, GUIDs stripped)

Same privacy model as the ADK/FlightCheck telemetry (no developer/user identity),
same unified opt-out (`ESS_ADK_TELEMETRY=off` or `python scripts/adk_telemetry.py off`),
and the one-time consent notice.

## Design

- **Strictly fail-open.** Every telemetry call swallows its own errors; telemetry
  never changes the installer's behaviour or exit code.
- Installers locate the emitter via `ESS_INSTALL_TELEMETRY_LIB` (set by the
  bootstrap) or the copy shipped in `setup/telemetry/`, and fall back to **no-op
  stubs** if it can't be found.
- Completion is guaranteed: PowerShell wraps the body in `try/catch/finally`
  (success in `finally`, failure in `catch`); bash uses an `EXIT` trap
  (success on exit 0, failure otherwise). Both are idempotent.
- All six bootstraps best-effort download the emitter into their temp dir and
  pass its path via `ESS_INSTALL_TELEMETRY_LIB` (download failure never blocks
  the install).
- **Lite mode is not instrumented** — the lite installer does not emit telemetry
  (guarded in both emitters).

## Files

- `setup/telemetry/install-telemetry.ps1` (Windows), `install-telemetry.sh` (macOS/Linux) — new emitters
- `setup/Install-EssAdk.ps1`, `setup/install-ess-adk.sh` — wiring (load, init, per-step hook, completion)
- `setup/bootstrap*.ps1`, `setup/bootstrap*-mac.sh` (×6) — download emitter + set env var
- `setup/Install-EssAdk.Tests.ps1` — wiring assertions + pure-function tests (38/38 pass)
- `setup/README.md`, `solutions/ess-maker-skills/README.md` — docs

## Testing

- `pwsh -File setup/Install-EssAdk.Tests.ps1` → **38/38 pass** (incl. an
  fi-FI regression test that the OneCollector envelope timestamp stays
  culture-invariant ISO-8601)
- Emitters validated end-to-end against the dev Aria project: PowerShell POST
  204; bash POST 200; `EXIT` trap confirmed to emit a `failure` completion under
  `set -euo pipefail`; step-key mapping verified for every installer step; scrub
  / tenant-class / opt-out / lite-guard verified.

## Notes / assumptions

- `tenant_id` is often empty at install time (before sign-in) → `tenant_class`
  falls back to `unknown`. Expected.
- Only the Microsoft corporate Entra tenant is treated as `internal` by default
  (overridable via `ESS_ADK_INTERNAL_TENANTS`), matching PR #182.
- Dashboards (Aria cubes + installer panels, dev + prod) are being built
  separately via the Aria document REST API.

Stacked on #182 (`amilandin/adk-capability-telemetry`).

ADO: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7557940
