### PR TITLE
fix(installer): make one-shot installer ASCII-safe for Windows PowerShell 5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,18 @@ jobs:
         PATHS: ${{ steps.discover.outputs.paths }}
       run: |
         python -m compileall -q $PATHS
+
+  installer-scripts:
+    name: Installer script smoke tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    # pwsh is preinstalled on GitHub-hosted ubuntu runners. The harness only
+    # parses and string-matches the setup scripts (no OS-specific execution),
+    # so it runs cross-platform. Guards against the Windows PowerShell 5.1
+    # parse crash by asserting the scripts stay ASCII-only. See PR #185.
+    - name: Run installer smoke tests
+      shell: pwsh
+      run: ./setup/Install-EssAdk.Tests.ps1

--- a/setup/Install-EssAdk.Tests.ps1
+++ b/setup/Install-EssAdk.Tests.ps1
@@ -28,7 +28,7 @@ Write-Host "Install-EssAdk.ps1 validation:" -ForegroundColor Cyan
 
 Test 'script parses without syntax errors' {
     $tokens = $null; $errors = $null
-    [System.Management.Automation.Language.Parser]::ParseFile($installerPath, [ref]$tokens, [ref]$errors)
+    $null = [System.Management.Automation.Language.Parser]::ParseFile($installerPath, [ref]$tokens, [ref]$errors)
     if ($errors.Count -gt 0) {
         throw "Parse errors: $($errors[0].Message)"
     }
@@ -88,7 +88,7 @@ $bootstrapSrc = Get-Content $bootstrapPath -Raw
 
 Test 'bootstrap.ps1 parses without errors' {
     $tokens = $null; $errors = $null
-    [System.Management.Automation.Language.Parser]::ParseFile($bootstrapPath, [ref]$tokens, [ref]$errors)
+    $null = [System.Management.Automation.Language.Parser]::ParseFile($bootstrapPath, [ref]$tokens, [ref]$errors)
     if ($errors.Count -gt 0) { throw "Parse errors: $($errors[0].Message)" }
 }
 
@@ -105,7 +105,7 @@ $liteSrc = Get-Content $litePath -Raw
 
 Test 'bootstrap-lite.ps1 parses without errors' {
     $tokens = $null; $errors = $null
-    [System.Management.Automation.Language.Parser]::ParseFile($litePath, [ref]$tokens, [ref]$errors)
+    $null = [System.Management.Automation.Language.Parser]::ParseFile($litePath, [ref]$tokens, [ref]$errors)
     if ($errors.Count -gt 0) { throw "Parse errors: $($errors[0].Message)" }
 }
 
@@ -113,6 +113,45 @@ Test 'bootstrap-lite.ps1 does NOT pass SkipMakerProfile as an argument' {
     # It may mention SkipMakerProfile in a comment, but the actual args hash should not include it
     if ($liteSrc -match 'SkipMakerProfile\s*=\s*\$true') {
         throw 'bootstrap-lite.ps1 should not set SkipMakerProfile = $true'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Encoding safety - regression guard for the Windows PowerShell 5.1 crash.
+#
+# 5.1 decodes a no-BOM script as ANSI (CP1252), so any non-ASCII byte (e.g. an
+# em-dash U+2014) is mangled and [ScriptBlock]::Create parsing fails with a
+# cascade of "Unexpected token" errors. The 'parses without errors' tests above
+# use the running PowerShell (7 in CI), which defaults to UTF-8 and therefore
+# does NOT catch this - so we assert ASCII-only bytes directly (parser- and
+# version-independent), and check the bootstraps decode as UTF-8 explicitly.
+# See PR #185.
+# ---------------------------------------------------------------------------
+Write-Host "`nEncoding safety:" -ForegroundColor Cyan
+
+Test 'all setup/*.ps1 are ASCII-only (Windows PowerShell 5.1 safe)' {
+    $offenders = @()
+    Get-ChildItem (Join-Path $PSScriptRoot '*.ps1') | ForEach-Object {
+        $lines = [System.IO.File]::ReadAllLines($_.FullName, [System.Text.Encoding]::UTF8)
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match '[^\x00-\x7F]') {
+                $offenders += "$($_.Name):$($i + 1)"
+            }
+        }
+    }
+    if ($offenders.Count -gt 0) {
+        throw "Non-ASCII characters found (replace with ASCII to keep the installer 5.1-safe): $($offenders -join ', ')"
+    }
+}
+
+Test 'bootstraps read the fetched installer as UTF-8 explicitly' {
+    foreach ($name in @('bootstrap.ps1', 'bootstrap-lite.ps1', 'bootstrap-flightcheck.ps1')) {
+        $path = Join-Path $PSScriptRoot $name
+        if (-not (Test-Path $path)) { continue }
+        $text = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+        if ($text -notmatch 'ReadAllText\(\$installer,\s*\[System\.Text\.Encoding\]::UTF8\)') {
+            throw "$name does not read the installer via [IO.File]::ReadAllText(`$installer, [System.Text.Encoding]::UTF8) - Get-Content -Raw can mis-decode under 5.1"
+        }
     }
 }
 

--- a/setup/Install-EssAdk.Tests.ps1
+++ b/setup/Install-EssAdk.Tests.ps1
@@ -12,10 +12,10 @@ function Test([string]$Name, [scriptblock]$Block) {
     try {
         & $Block
         $script:passed++
-        Write-Host "  ✓ $Name" -ForegroundColor Green
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
     } catch {
         $script:failed++
-        Write-Host "  ✗ $Name" -ForegroundColor Red
+        Write-Host "  [FAIL] $Name" -ForegroundColor Red
         Write-Host "    $($_.Exception.Message)" -ForegroundColor Yellow
     }
 }

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -57,7 +57,7 @@
     Skip installing the bundled "ESS Maker Profile" VS Code extension. The
     profile hides developer chrome (file tree, tabs, status bar, etc.) and
     drops the user into a chat-first surface tailored to the HR/IT admin
-    persona. Use this switch to keep the stock VS Code layout — typically
+    persona. Use this switch to keep the stock VS Code layout - typically
     only relevant for developers iterating on the kit itself.
 
 .EXAMPLE
@@ -183,11 +183,11 @@ function Test-IsWindowsArm64 {
 # appear (one per tenant/realm); dedupe.
 #
 # Output contract: pipeline-emits zero or more username strings. Callers
-# MUST wrap the result with `@( ... )` to get a proper array — bare
+# MUST wrap the result with `@( ... )` to get a proper array - bare
 # assignment of a single-element pipeline output collapses to a string in
 # PowerShell (and `.Count` on that string then throws under
 # `Set-StrictMode -Version Latest`, which some users have in their
-# profile). Returns nothing on any parse failure — callers treat that as
+# profile). Returns nothing on any parse failure - callers treat that as
 # "unknown user" and fall back to a generic prompt.
 function Get-CachedUsernames {
     param([Parameter(Mandatory)] [string] $CachePath)
@@ -212,7 +212,7 @@ function Get-CachedUsernames {
 }
 
 # Helper: install pip requirements with ARM64-aware guardrails.
-#   - Upgrades pip first (failures are warnings, not fatal — older pip can still install).
+#   - Upgrades pip first (failures are warnings, not fatal - older pip can still install).
 #   - Uses --prefer-binary so resolution favors wheels over sdists when possible.
 #   - On Windows ARM64, adds --only-binary cryptography. cryptography source
 #     builds need Rust + the MSVC linker (link.exe), which most ARM64 dev
@@ -587,7 +587,7 @@ if (-not $SkipClone) {
             # Self-heal --single-branch clones from earlier installer versions.
             # Without this, `git fetch origin` only refreshes the originally-
             # cloned branch and `git checkout $Branch` fails for any other
-            # branch — pinning users to whatever branch they first installed
+            # branch - pinning users to whatever branch they first installed
             # from. Idempotent: no-op if the refspec is already broad.
             $null = Invoke-Native { & git remote set-branches origin '*' }
 
@@ -664,7 +664,7 @@ if ($deferPip) {
 # ---------------------------------------------------------------------------
 # The bundled extension at tools/ess-maker-profile/extension/ hides developer
 # chrome and surfaces a big-button "Quick actions" rail tied to the kit's
-# slash commands. We install it from the cloned repo (not the marketplace —
+# slash commands. We install it from the cloned repo (not the marketplace -
 # this is a POC build that isn't published) so it auto-activates the next
 # time `code` launches. When the maker profile is installed, the extension
 # itself opens chat and injects /setup (section 7 just opens the workspace).
@@ -716,7 +716,7 @@ if (-not $FlightCheckOnly -and -not $SkipExtensions) {
             }
 
             if ($vsix_exit -eq 0) {
-                Write-Ok "ESS Maker Profile installed ($($vsix.Name)) — $modeLabel mode"
+                Write-Ok "ESS Maker Profile installed ($($vsix.Name)) - $modeLabel mode"
             } else {
                 Write-Warn2 "ess-maker-profile vsix install returned exit $vsix_exit (non-fatal)"
                 ($out | Out-String).TrimEnd() -split "`r?`n" | ForEach-Object { Write-Warn2 "  $_" }
@@ -739,7 +739,7 @@ if (-not $FlightCheckOnly -and -not $SkipExtensions) {
                 # Insert after opening brace
                 $raw = $raw -replace '^\s*\{', "{ $modeEntry,"
             } else {
-                # Malformed — create fresh
+                # Malformed - create fresh
                 $raw = "{ $modeEntry }"
             }
             Set-Content -Path $settingsFile -Value $raw -Encoding UTF8 -NoNewline
@@ -765,7 +765,7 @@ if ($FlightCheckOnly) {
     $localDir = Join-Path $workspace '.local'
     $configPath = Join-Path $localDir 'config.json'
 
-    # Resolve python command early — needed for both discovery and fetch
+    # Resolve python command early - needed for both discovery and fetch
     $pythonExe = Resolve-Python
     if (-not $pythonExe) {
         throw 'Python not found on PATH or known locations. Cannot run FlightCheck.'
@@ -798,13 +798,13 @@ if ($FlightCheckOnly) {
     # prompt covers every code path that hits the MSAL cache.
     # All FlightCheck clients share .local/.token_cache.bin. The cached
     # tokens silently sign the next run in as whichever user authenticated
-    # last — desirable most of the time, but bites users who installed
+    # last - desirable most of the time, but bites users who installed
     # under one account and now need to FlightCheck a different tenant /
     # different user (e.g. customer-engineer scenarios). Offer an explicit
     # switch rather than making them hunt for the cache file.
     $tokenCacheFile = Join-Path $localDir '.token_cache.bin'
     if (Test-Path $tokenCacheFile) {
-        # Force array context with @(...) — Get-CachedUsernames returns a
+        # Force array context with @(...) - Get-CachedUsernames returns a
         # [string[]] guarded by the unary comma operator, but belt-and-
         # suspenders here in case the function output ever changes.
         $cachedUsers = @(Get-CachedUsernames -CachePath $tokenCacheFile)
@@ -1025,7 +1025,7 @@ if ($FlightCheckOnly) {
         }
     } else {
         Write-Host ''
-        Write-Host '    [info] No agent selected — skipping solution fetch (local file checks will be skipped).' -ForegroundColor Gray
+        Write-Host '    [info] No agent selected - skipping solution fetch (local file checks will be skipped).' -ForegroundColor Gray
     }
 
     # --- Run FlightCheck ---
@@ -1080,7 +1080,7 @@ if (-not $SkipLaunch) {
         Push-Location $workspace
         try {
             if ($SkipMakerProfile) {
-                # Standard mode — use code chat to open /setup in sidebar panel
+                # Standard mode - use code chat to open /setup in sidebar panel
                 Write-Step 'Opening workspace in VS Code and requesting /setup in Copilot Chat'
                 $chatOutput = Invoke-Native { & $codePath chat '/setup' }
                 $chatExit = $LASTEXITCODE
@@ -1097,7 +1097,7 @@ if (-not $SkipLaunch) {
                     Write-Host "If /setup does not start after trust/sign-in, open Copilot Chat manually and run /setup." -ForegroundColor Yellow
                 }
             } else {
-                # Lite mode — extension handles /setup after welcome wizard
+                # Lite mode - extension handles /setup after welcome wizard
                 Write-Step 'Opening workspace in VS Code'
                 Start-Process -FilePath $codePath -ArgumentList @('.') | Out-Null
                 Write-Ok "Launched VS Code at $workspace"

--- a/setup/bootstrap-flightcheck.ps1
+++ b/setup/bootstrap-flightcheck.ps1
@@ -61,8 +61,10 @@ foreach ($f in $files) {
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'
 
 # Run the installer in-memory (as a script block) so execution policy never
-# applies — the script content is never "executed from disk".
-$scriptContent = Get-Content $installer -Raw
+# applies - the script content is never "executed from disk". Read as UTF-8
+# explicitly: Windows PowerShell 5.1 otherwise decodes a no-BOM file as ANSI
+# (CP1252), which mangles any non-ASCII byte and breaks ScriptBlock parsing.
+$scriptContent = [System.IO.File]::ReadAllText($installer, [System.Text.Encoding]::UTF8)
 $scriptBlock = [ScriptBlock]::Create($scriptContent)
 
 $installerArgs = @{ Branch = $Branch; FlightCheckOnly = $true }

--- a/setup/bootstrap-lite.ps1
+++ b/setup/bootstrap-lite.ps1
@@ -63,8 +63,10 @@ foreach ($f in $files) {
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'
 
 # Run the installer in-memory (as a script block) so execution policy never
-# applies — the script content is never "executed from disk".
-$scriptContent = Get-Content $installer -Raw
+# applies - the script content is never "executed from disk". Read as UTF-8
+# explicitly: Windows PowerShell 5.1 otherwise decodes a no-BOM file as ANSI
+# (CP1252), which mangles any non-ASCII byte and breaks ScriptBlock parsing.
+$scriptContent = [System.IO.File]::ReadAllText($installer, [System.Text.Encoding]::UTF8)
 $scriptBlock = [ScriptBlock]::Create($scriptContent)
 
 # Lite mode: do NOT pass -SkipMakerProfile so the chat-first profile installs.

--- a/setup/bootstrap.ps1
+++ b/setup/bootstrap.ps1
@@ -59,8 +59,10 @@ foreach ($f in $files) {
 $installer = Join-Path $tempDir 'Install-EssAdk.ps1'
 
 # Run the installer in-memory (as a script block) so execution policy never
-# applies — the script content is never "executed from disk".
-$scriptContent = Get-Content $installer -Raw
+# applies - the script content is never "executed from disk". Read as UTF-8
+# explicitly: Windows PowerShell 5.1 otherwise decodes a no-BOM file as ANSI
+# (CP1252), which mangles any non-ASCII byte and breaks ScriptBlock parsing.
+$scriptContent = [System.IO.File]::ReadAllText($installer, [System.Text.Encoding]::UTF8)
 $scriptBlock = [ScriptBlock]::Create($scriptContent)
 
 $installerArgs = @{ Branch = $Branch; SkipMakerProfile = $true }


### PR DESCRIPTION
## Description

The one-shot `winget` installer crashes under **Windows PowerShell 5.1** (the default shell on Windows) with a cascade of parse errors:

```
iex : Exception calling "Create" with "1" argument(s): "At line:740 char:39
+                 $raw = $raw -replace '^\s*\{', "{ $modeEntry,"
Unexpected token '^\s*\' in expression or statement.
```

Reported by a customer running the documented `iex (irm .../setup/bootstrap.ps1)` one-liner.

## Root cause

The setup scripts contain **em-dash characters** (`—`, U+2014) in comments and a few messages. Windows PowerShell 5.1 decodes a no-BOM file as **ANSI (CP1252)** rather than UTF-8, so each 3-byte UTF-8 em-dash is mangled into a byte sequence that derails `[ScriptBlock]::Create()` inside `bootstrap.ps1`. The visible error at line 740 is a cascade — the real trigger is the mis-decoded non-ASCII bytes earlier in the file. PowerShell 7 (what maintainers run) defaults to UTF-8, so the bug was invisible in dev.

Confirmed empirically: the script parses **clean** under 5.1 once non-ASCII characters are removed; real UTF-8 em-dashes parse fine when decoded correctly.

## Fix (defense in depth)

1. **Make all `setup/*.ps1` ASCII-only** — replace em-dashes with hyphens (and the `✓`/`✗` marks in the Pester test file with `[PASS]`/`[FAIL]`). With pure ASCII, every decode path (ANSI, UTF-8, Latin-1) yields identical bytes, so the parser can never break on encoding.
2. **Force UTF-8 in the bootstraps** — the three `bootstrap*.ps1` now read the fetched installer via `[System.IO.File]::ReadAllText($installer, [System.Text.Encoding]::UTF8)` instead of `Get-Content -Raw`, so the decode is explicit regardless of BOM. Prevents this class of bug from recurring if non-ASCII is reintroduced.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Reproduced the exact customer error by parsing the current `main` `Install-EssAdk.ps1` under Windows PowerShell 5.1.
- After the fix, **all 5 `setup/*.ps1` parse clean** under Windows PowerShell 5.1 (`[Parser]::ParseFile` → no errors).
- Verified the UTF-8 read path executes a non-ASCII-containing script under 5.1 where the intent is to be encoding-agnostic.
- No functional/logic changes — only character substitutions in comments/strings and the file-read encoding.

## Static validation (samples/ only)

Does not touch `samples/` (changes under `setup/`), so static sample validation is not applicable.
