### PR TITLE
feat(review): advisory authoring-time conformance review skill (/review)

### DIFF
--- a/solutions/ess-maker-skills/.github/prompts/menu.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/menu.prompt.md
@@ -18,7 +18,7 @@ Here's what I can help you with:
 | `/update` | Type Enter to modify an existing topic or workflow |
 | `/delete` | Type Enter to delete a topic or workflow from your agent |
 | `/scan` | Type Enter to scan your agent for compile errors and fix them |
-| `/review` | Type Enter to review a topic for issues before publishing |
+| `/review` | Type Enter to review a topic (or a whole module's topics) for issues before publishing |
 | `/evaluate` | Type Enter to generate evaluation test sets for your agent |
 | `/flightcheck` | Type Enter to run a pre-deployment readiness check |
 | `/push` | Type Enter to push all local changes to Copilot Studio |

--- a/solutions/ess-maker-skills/.github/prompts/menu.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/menu.prompt.md
@@ -18,6 +18,7 @@ Here's what I can help you with:
 | `/update` | Type Enter to modify an existing topic or workflow |
 | `/delete` | Type Enter to delete a topic or workflow from your agent |
 | `/scan` | Type Enter to scan your agent for compile errors and fix them |
+| `/review` | Type Enter to review a topic for issues before publishing |
 | `/evaluate` | Type Enter to generate evaluation test sets for your agent |
 | `/flightcheck` | Type Enter to run a pre-deployment readiness check |
 | `/push` | Type Enter to push all local changes to Copilot Studio |

--- a/solutions/ess-maker-skills/.github/prompts/review.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/review.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: agent
-description: "Type Enter to review a topic for issues before publishing"
+description: "Type Enter to review a topic (or a whole module's topics) for issues before publishing"
 ---
 
 # Review
@@ -11,7 +11,8 @@ description: "Type Enter to review a topic for issues before publishing"
 
 and STOP. Otherwise proceed with the skill instructions below.
 
-You are helping a customer review an authored topic for issues **before they publish it**. This review is
+You are helping a customer review authored topics for issues **before they publish them** — either a single
+topic, or all the topics for a backend module (e.g. "review all the Workday topics"). This review is
 **advisory** — it surfaces findings and lets the customer decide; it never blocks.
 
 Read the skill instructions at `src/skills/topics/review/SKILL.md`, then follow the steps in order.

--- a/solutions/ess-maker-skills/.github/prompts/review.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/review.prompt.md
@@ -1,0 +1,17 @@
+---
+mode: agent
+description: "Type Enter to review a topic for issues before publishing"
+---
+
+# Review
+
+**Setup-state check.** Read `.local/config.json`. If it does not exist, OR `setup` is not `"complete"`, show:
+
+> Welcome to the ESS Maker Kit. Before running `/review`, type `/setup` to set up your environment.
+
+and STOP. Otherwise proceed with the skill instructions below.
+
+You are helping a customer review an authored topic for issues **before they publish it**. This review is
+**advisory** — it surfaces findings and lets the customer decide; it never blocks.
+
+Read the skill instructions at `src/skills/topics/review/SKILL.md`, then follow the steps in order.

--- a/solutions/ess-maker-skills/.gitignore
+++ b/solutions/ess-maker-skills/.gitignore
@@ -13,8 +13,8 @@ workspace/**
 # from the scripts dir (e.g. `python adk_telemetry.py --selftest`). Never commit.
 scripts/.local/
 
-# ISV reference docs synced from an ESSVivaCopilot checkout (internal; never committed)
+# ISV reference docs synced from an internal ESS reference source (never committed)
 src/reference/ess-docs/isv/
 
-# Runtime-heuristics docs synced from an ESSVivaCopilot checkout (internal; never committed)
+# Runtime-heuristics docs synced from an internal ESS reference source (never committed)
 src/reference/ess-docs/runtime/

--- a/solutions/ess-maker-skills/.gitignore
+++ b/solutions/ess-maker-skills/.gitignore
@@ -15,3 +15,6 @@ scripts/.local/
 
 # ISV reference docs synced from an ESSVivaCopilot checkout (internal; never committed)
 src/reference/ess-docs/isv/
+
+# Runtime-heuristics docs synced from an ESSVivaCopilot checkout (internal; never committed)
+src/reference/ess-docs/runtime/

--- a/solutions/ess-maker-skills/.gitignore
+++ b/solutions/ess-maker-skills/.gitignore
@@ -12,3 +12,6 @@ workspace/**
 # Kit-internal state can also land under scripts/.local/ when tools are run
 # from the scripts dir (e.g. `python adk_telemetry.py --selftest`). Never commit.
 scripts/.local/
+
+# ISV reference docs synced from an ESSVivaCopilot checkout (internal; never committed)
+src/reference/ess-docs/isv/

--- a/solutions/ess-maker-skills/scripts/check_isv_coverage.py
+++ b/solutions/ess-maker-skills/scripts/check_isv_coverage.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+check_isv_coverage.py — Deterministically decide ISV field-conformance coverage.
+
+The review's ISV field-conformance check (Step 6) can only run when the reference
+doc for the in-scope topic's *specific backend* is present at
+src/reference/ess-docs/isv/isv-<backend>.md. Those docs are synced from an ESS
+reference source and are gitignored, so they may be absent for an external maker.
+
+Deciding presence by asking the agent to "run a Test-Path" is model-dependent: it
+was observed to be skipped mid-flow on some models, producing a *false* coverage
+note (claiming a present doc was absent, or vice versa). This script removes that
+variable: it resolves each in-scope topic's backend from its scenarioName and
+checks the doc's presence via a path anchored on __file__ (cwd-immune), then emits
+a machine-readable verdict the skill reads verbatim into the coverage note.
+
+The check is presence-only — it does not read or judge the doc's contents.
+
+Usage (from solutions/ess-maker-skills/):
+    python scripts/check_isv_coverage.py --agent employee-self-service-hr --topic workday-get-basecompensation
+    python scripts/check_isv_coverage.py --agent employee-self-service-hr --module workday
+    python scripts/check_isv_coverage.py --agent employee-self-service-hr            # whole agent
+
+Emits a human-readable summary plus a machine-readable block behind a sentinel:
+
+    ###ISV_COVERAGE_JSON###{"mode": "reduced", "backends": [...], ...}
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+_SENTINEL = "###ISV_COVERAGE_JSON###"
+# Every backend reference in a topic is an `msdyn_...` identifier — either a
+# scenarioName the UI topic passes (Workday: msdyn_HRWorkdayHCMEmployee...) or a
+# `dialog:` reference into the shared system topic (ServiceNow:
+# msdyn_...topic.ServiceNowHRSDSystemUpdateCase). Collect all of them, then match
+# the backend token against each — so both the direct-scenario (Workday) and the
+# delegate-to-system-topic (ServiceNow) shapes are recognized.
+_MSDYN_REF_RE = re.compile(r"msdyn_[\w.]+")
+
+# Backend identity token found inside an `msdyn_...` reference. Tokens are chosen
+# to appear in BOTH the scenarioName and the system-topic dialog form and not to
+# collide with each other. `Workday` (not `WorkdayHCM`) because the Workday system
+# dialog is `WorkdaySystemGetCommonExecution`, which omits the HCM qualifier.
+_BACKEND_BY_TOKEN = (
+    ("ServiceNowHRSD", ("servicenow-hrsd", "isv-servicenow-hrsd.md")),
+    ("ServiceNowITSM", ("servicenow-itsm", "isv-servicenow-itsm.md")),
+    ("SuccessFactors", ("successfactors", "isv-successfactors-hcm.md")),
+    ("Workday", ("workday", "isv-workday-hcm.md")),
+)
+
+_ISV_DIR = Path(__file__).resolve().parent.parent / "src" / "reference" / "ess-docs" / "isv"
+
+
+def _reject_pathy(flag: str, value: str) -> None:
+    if value and ("/" in value or "\\" in value or ".." in value or Path(value).is_absolute()):
+        print(f"ERROR: invalid {flag} '{value}': must be a bare name, not a path.", file=sys.stderr)
+        sys.exit(1)
+
+
+def backend_of_topic(topic_path: Path) -> "tuple[str, str] | None":
+    """Return (backend_id, doc_filename) for a topic, or None if it calls no ISV backend."""
+    try:
+        text = topic_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    refs = _MSDYN_REF_RE.findall(text)
+    if not refs:
+        return None
+    for token, backend in _BACKEND_BY_TOKEN:
+        if any(token in ref for ref in refs):
+            return backend
+    return None
+
+
+def in_scope_topics(topics_dir: Path, topic: "str | None", module: "str | None") -> list[Path]:
+    if topic:
+        stem = topic[:-len(".mcs.yml")] if topic.endswith(".mcs.yml") else topic
+        p = topics_dir / f"{stem}.mcs.yml"
+        return [p] if p.is_file() else []
+    files = sorted(topics_dir.glob("*.mcs.yml"))
+    if module:
+        files = [f for f in files if f.name.startswith(module)]
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Decide ISV field-conformance coverage for a review scope.")
+    parser.add_argument("--agent", "-a", help="Agent folder under workspace/agents/. Auto-detected if only one.")
+    parser.add_argument("--topic", "-t", help="Single topic stem.")
+    parser.add_argument("--module", help="Restrict to topics whose name starts with this module id. Ignored if --topic is given.")
+    args = parser.parse_args()
+
+    for flag, val in (("--agent", args.agent), ("--topic", args.topic), ("--module", args.module)):
+        _reject_pathy(flag, val)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    agents_dir = repo_root / "workspace" / "agents"
+    if not agents_dir.is_dir():
+        print(f"ERROR: no workspace/agents/ folder at {agents_dir}", file=sys.stderr)
+        return 1
+
+    if args.agent:
+        agent_dir = agents_dir / args.agent
+    else:
+        candidates = [d for d in agents_dir.iterdir() if d.is_dir()]
+        if len(candidates) != 1:
+            print("ERROR: specify --agent (zero or multiple agents found).", file=sys.stderr)
+            return 1
+        agent_dir = candidates[0]
+    topics_dir = agent_dir / "topics"
+    if not topics_dir.is_dir():
+        print(f"ERROR: no topics/ folder in {agent_dir}", file=sys.stderr)
+        return 1
+
+    topics = in_scope_topics(topics_dir, args.topic, args.module)
+
+    # Resolve each in-scope backend and its doc presence (present-only check).
+    backends: dict[str, dict] = {}
+    for tp in topics:
+        b = backend_of_topic(tp)
+        if b is None:
+            continue
+        backend_id, doc_name = b
+        present = (_ISV_DIR / doc_name).is_file()
+        entry = backends.setdefault(backend_id, {"doc": doc_name, "present": present, "topics": []})
+        entry["topics"].append(tp.name)
+
+    missing = sorted(bid for bid, e in backends.items() if not e["present"])
+    covered = sorted(bid for bid, e in backends.items() if e["present"])
+    mode = "reduced" if missing else "full"
+
+    # Human-readable summary.
+    if not backends:
+        print("No in-scope topic calls an ISV backend — ISV conformance is not applicable (full coverage).")
+    else:
+        for bid in sorted(backends):
+            e = backends[bid]
+            state = "present" if e["present"] else "MISSING"
+            print(f"  {bid}: {e['doc']} {state} ({len(e['topics'])} topic(s))")
+        if mode == "reduced":
+            print(f"Coverage: REDUCED — missing reference doc(s) for: {', '.join(missing)}")
+        else:
+            print("Coverage: FULL — every in-scope backend has its reference doc.")
+
+    verdict = {
+        "mode": mode,
+        "missing_backends": missing,
+        "covered_backends": covered,
+        "isv_dir": str(_ISV_DIR),
+        "backends": {bid: {"doc": e["doc"], "present": e["present"], "topics": e["topics"]}
+                     for bid, e in backends.items()},
+    }
+    print(_SENTINEL + json.dumps(verdict))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/check_isv_coverage.py
+++ b/solutions/ess-maker-skills/scripts/check_isv_coverage.py
@@ -55,6 +55,17 @@ _BACKEND_BY_TOKEN = (
     ("Workday", ("workday", "isv-workday-hcm.md")),
 )
 
+# Plain, maker-facing name for each backend id, emitted in the verdict so the
+# coverage note is read verbatim rather than hand-translated from the probe id
+# (which was a model-dependent step). HRSD and ITSM stay distinct — their docs
+# are separate, so coverage can differ between them.
+_BACKEND_DISPLAY = {
+    "servicenow-hrsd": "ServiceNow HRSD",
+    "servicenow-itsm": "ServiceNow ITSM",
+    "successfactors": "SAP SuccessFactors",
+    "workday": "Workday",
+}
+
 _ISV_DIR = Path(__file__).resolve().parent.parent / "src" / "reference" / "ess-docs" / "isv"
 
 
@@ -145,14 +156,18 @@ def main() -> int:
             state = "present" if e["present"] else "MISSING"
             print(f"  {bid}: {e['doc']} {state} ({len(e['topics'])} topic(s))")
         if mode == "reduced":
-            print(f"Coverage: REDUCED — missing reference doc(s) for: {', '.join(missing)}")
+            missing_names = ", ".join(_BACKEND_DISPLAY.get(bid, bid) for bid in missing)
+            print(f"Coverage: REDUCED — missing reference doc(s) for: {missing_names}")
         else:
             print("Coverage: FULL — every in-scope backend has its reference doc.")
 
     verdict = {
         "mode": mode,
         "missing_backends": missing,
+        "missing_backends_display": [_BACKEND_DISPLAY.get(bid, bid) for bid in missing],
         "covered_backends": covered,
+        "covered_backends_display": [_BACKEND_DISPLAY.get(bid, bid) for bid in covered],
+        "backend_display": {bid: _BACKEND_DISPLAY.get(bid, bid) for bid in backends},
         "isv_dir": str(_ISV_DIR),
         "backends": {bid: {"doc": e["doc"], "present": e["present"], "topics": e["topics"]}
                      for bid, e in backends.items()},

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -71,6 +71,14 @@ _SEVERITY_RANK = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
 # location / fix instead of root_cause / files / concrete_fix) fails loudly instead
 # of persisting a schema-broken catalog. `verification` is optional (defaults static).
 _REQUIRED_FINDING_KEYS = ("id", "title", "severity", "reachability", "root_cause", "concrete_fix")
+# Canonical reachability enum (see finding-contract.md). Drives severity/report
+# logic downstream, so a malformed value must be rejected, not persisted.
+_REACHABILITY_KINDS = {
+    "REACHABLE_NORMAL_UI",
+    "REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION",
+    "NOT_REACHABLE_VIA_BOT_UI",
+    "OPERATOR_OR_HYGIENE_ONLY",
+}
 # Maker-facing resolutions are fixed / not-a-bug / wont-fix; the other two are
 # retained for compatibility with the analyzer ledger enum (v1.2.0).
 _RESOLUTION_KINDS = {"fixed", "wont-fix", "not-a-bug", "defense-in-depth", "false-positive"}
@@ -248,13 +256,50 @@ def validate_current_findings(findings: list[dict]) -> list[str]:
         sev = str(f.get("severity", "")).strip()
         if sev and sev not in _SEVERITY_RANK:
             errors.append(f"[{where}] severity '{sev}' is not one of HIGH/MEDIUM/LOW")
-        if not _file_paths(f):
+        reach = str(f.get("reachability", "")).strip()
+        if reach and reach not in _REACHABILITY_KINDS:
+            errors.append(
+                f"[{where}] reachability '{reach}' is not one of "
+                f"{'/'.join(sorted(_REACHABILITY_KINDS))}"
+            )
+        verif = str(f.get("verification", "")).strip()
+        if verif and verif not in _VERIFICATION_KINDS:
+            errors.append(
+                f"[{where}] verification '{verif}' is not one of {'/'.join(sorted(_VERIFICATION_KINDS))}"
+            )
+        paths = _file_paths(f)
+        if not paths:
             errors.append(f"[{where}] files[] is missing or has no usable path (evidence_hashes would be empty)")
+        else:
+            for p in paths:
+                if _safe_read_path(p) is None:
+                    errors.append(
+                        f"[{where}] files[].path '{p}' is absolute or escapes the workspace; "
+                        "evidence hashing would store sha256 null and misfire staleness"
+                    )
         fid = str(f.get("id", "")).strip()
         if fid:
             if fid in seen_ids:
                 errors.append(f"[{fid}] duplicate id within this run (ids are the cross-run identity)")
             seen_ids.add(fid)
+    return errors
+
+
+def validate_resolutions(resolved: list[dict]) -> list[str]:
+    """Errors for `--resolve` findings whose `resolution` is present but not a valid
+    kind. An absent `resolution` is fine (it legitimately defaults to `fixed`); a
+    *wrong* value must be rejected, not coerced — the ledger is append-only, so a
+    silent coercion of e.g. `not-a-bug` to `fixed` would permanently misrecord why
+    the finding was resolved.
+    """
+    errors: list[str] = []
+    for i, f in enumerate(resolved):
+        where = str(f.get("id", "")).strip() or f"#{i}"
+        res = str(f.get("resolution", "")).strip()
+        if res and res not in _RESOLUTION_KINDS:
+            errors.append(
+                f"[{where}] resolution '{res}' is not one of {'/'.join(sorted(_RESOLUTION_KINDS))}"
+            )
     return errors
 
 
@@ -272,13 +317,24 @@ def evidence_hashes(finding: dict) -> list[dict]:
 
 
 def _hashes_match(stored: list[dict]) -> bool:
-    """True if every stored evidence hash still equals the file's current hash."""
+    """True if every stored evidence hash still equals the file's current hash.
+
+    Resolve each stored path through `_safe_read_path` (the same skill-root
+    anchoring `evidence_hashes` used to compute the stored value) so the check is
+    independent of the current working directory. A path that no longer resolves
+    inside the tree, or a stored hash of None (the file was unreadable at store
+    time), counts as a mismatch — never as "unchanged".
+    """
     if not stored:
         return False
     for entry in stored:
         if not isinstance(entry, dict):
             return False
-        if sha256_file(Path(entry.get("file", ""))) != entry.get("sha256"):
+        stored_sha = entry.get("sha256")
+        if not stored_sha:
+            return False
+        safe = _safe_read_path(str(entry.get("file", "")))
+        if safe is None or sha256_file(safe) != stored_sha:
             return False
     return True
 
@@ -449,6 +505,17 @@ def main() -> int:
     resolved_findings: list[dict] = []
     if args.resolve:
         resolved_findings = _issues_of(_read_json(Path(args.resolve)) or [])
+        res_errors = validate_resolutions(resolved_findings)
+        if res_errors:
+            src = args.resolve
+            print(
+                f"ERROR: {len(res_errors)} resolution(s) from {src} use an invalid kind. "
+                "Nothing was written to the ledger (it is append-only). Fix and re-run.",
+                file=sys.stderr,
+            )
+            for e in res_errors:
+                print(f"  - {e}", file=sys.stderr)
+            return 2
 
     if cpath.is_file():
         try:

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -42,16 +42,19 @@ or hand-written catalog fails loudly instead of persisting schema-broken state.
 
 Scope invariant: a finding belongs to exactly one catalog per review scope (the
 `solution` value). The same semantic id can legitimately appear under different
-scopes, so the shared ledger is keyed by (solution, issue_id) — any future
-resolution match against the ledger MUST scope by solution, never by issue_id
-alone, or one scope's resolution would wrongly clear another's. (This merge does
-not read the ledger back to set status, so the risk is latent, not live.)
+scopes, so the shared ledger is keyed by (solution, issue_id) — any resolution
+match against the ledger MUST scope by solution, never by issue_id alone, or one
+scope's resolution would wrongly clear another's. (This merge reads the ledger
+back to suppress dismissed findings and scopes that lookup by (solution, issue_id)
+via _latest_ledger_record, so the requirement is enforced, not latent.)
 
 Usage:
-    # findings from stdin (preferred — no temp file, no shell heredoc):
-    Get-Content run.json | python scripts/merge_findings.py --solution <id> --current -
+    # findings from a file (preferred — the command text is identical across runs,
+    # so an approval sticks; the run-specific data lives in the file, not the command):
     python scripts/merge_findings.py --solution <id> --current run.json
     python scripts/merge_findings.py --solution <id> --current run.json --resolve resolved.json
+    # or piped on stdin (also valid; no temp file, no shell heredoc):
+    Get-Content run.json | python scripts/merge_findings.py --solution <id> --current -
     python scripts/merge_findings.py --solution <id> --show
 """
 

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -1,0 +1,353 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Maker Kit - Review Findings Catalog + Ledger
+
+Persists /review findings and reconciles them across runs, following the ESS
+hardening-analyzer's model (issue-catalog + resolved-issue-ledger) scoped to the
+maker workflow. Two artifacts under .local/review-findings/ (gitignored):
+
+  <solution>-catalog.json         per-scope findings catalog (this run's state)
+  resolved-issue-ledger.jsonl     shared, append-only resolution evidence
+
+The `solution` field is the review scope identifier — a single topic today, a
+whole ISV or solution later. Nothing here assumes a single topic; a finding's
+files[] can span several files, so widening the review needs no schema change.
+(The field is named `solution` to stay valid against the ESS analyzer's ledger
+schema; its value is whatever scope was reviewed.)
+
+Why a script (not the agent): /review's lenses are agentic and LLM coverage is
+nondeterministic — a finding missing from a later run is NOT evidence it was
+fixed. Two things must therefore be mechanical: the carry-forward rule ("absence
+is not resolution"), and staleness. This script computes a sha256 evidence hash of
+each file a finding implicates; on a later run, a finding that was not re-detected
+is still 'active' if its files are unchanged (hash matches), and is flagged
+evidence-stale if any file changed (hash mismatch) — an objective signal to
+re-verify, not an LLM guess.
+
+Finding identity across runs is the semantic id (a stable kebab-case slug the
+agent reuses). Status is 'active' or 'resolved'; 'resolved' requires a matching
+resolved-issue-ledger.jsonl entry (written when /update confirms a fix, or when
+/review confirms an evidence-stale finding's node is gone).
+
+Scope invariant: a finding belongs to exactly one catalog per review scope (the
+`solution` value). The same semantic id can legitimately appear under different
+scopes, so the shared ledger is keyed by (solution, issue_id) — any future
+resolution match against the ledger MUST scope by solution, never by issue_id
+alone, or one scope's resolution would wrongly clear another's. (This merge does
+not read the ledger back to set status, so the risk is latent, not live.)
+
+Usage:
+    python scripts/merge_findings.py --solution <id> --current run.json
+    python scripts/merge_findings.py --solution <id> --current run.json --resolve resolved.json
+    python scripts/merge_findings.py --solution <id> --show
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+_SCHEMA_VERSION = "1.0.0"
+_SEVERITY_RANK = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
+# Maker-facing resolutions are fixed / not-a-bug / wont-fix; the other two are
+# retained for compatibility with the analyzer ledger enum (v1.2.0).
+_RESOLUTION_KINDS = {"fixed", "wont-fix", "not-a-bug", "defense-in-depth", "false-positive"}
+_VERIFICATION_KINDS = {"static", "needs-runtime-test"}
+_REVIEW_DIR = Path(".local") / "review-findings"
+
+
+def _resolution_of(finding: dict) -> str:
+    val = str(finding.get("resolution", "fixed")).strip()
+    return val if val in _RESOLUTION_KINDS else "fixed"
+
+
+def _verification_of(finding: dict) -> str:
+    val = str(finding.get("verification", "static")).strip()
+    return val if val in _VERIFICATION_KINDS else "static"
+
+
+def _resolved_by_of(finding: dict) -> str:
+    val = str(finding.get("resolved_by", "")).strip()
+    return val or "review-skill"
+
+
+def load_config() -> dict:
+    config_path = Path(".local") / "config.json"
+    if not config_path.is_file():
+        print("ERROR: .local/config.json not found. Run /setup first.", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(config_path.read_text(encoding="utf-8"))
+
+
+def catalog_path(solution: str) -> Path:
+    return _REVIEW_DIR / f"{solution}-catalog.json"
+
+
+def ledger_path() -> Path:
+    return _REVIEW_DIR / "resolved-issue-ledger.jsonl"
+
+
+def _read_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    out: list[dict] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    obj = json.loads(line)
+                    if isinstance(obj, dict):
+                        out.append(obj)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return out
+
+
+def _issues_of(doc) -> list[dict]:
+    """Accept a bare list, {issues:[...]}, or {findings:[...]}."""
+    if isinstance(doc, list):
+        return [f for f in doc if isinstance(f, dict)]
+    if isinstance(doc, dict):
+        for key in ("issues", "findings"):
+            if isinstance(doc.get(key), list):
+                return [f for f in doc[key] if isinstance(f, dict)]
+    return []
+
+
+def sha256_file(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _file_paths(finding: dict) -> list[str]:
+    files = finding.get("files")
+    paths: list[str] = []
+    if isinstance(files, list):
+        for f in files:
+            if isinstance(f, dict) and isinstance(f.get("path"), str):
+                paths.append(f["path"])
+            elif isinstance(f, str):
+                paths.append(f)
+    return paths
+
+
+def evidence_hashes(finding: dict) -> list[dict]:
+    """Current sha256 of every file the finding implicates (files[].path)."""
+    out: list[dict] = []
+    for p in _file_paths(finding):
+        out.append({"file": p, "sha256": sha256_file(Path(p))})
+    return out
+
+
+def _hashes_match(stored: list[dict]) -> bool:
+    """True if every stored evidence hash still equals the file's current hash."""
+    if not stored:
+        return False
+    for entry in stored:
+        if not isinstance(entry, dict):
+            return False
+        if sha256_file(Path(entry.get("file", ""))) != entry.get("sha256"):
+            return False
+    return True
+
+
+def _higher_severity(a: str, b: str) -> str:
+    return a if _SEVERITY_RANK.get(a, 0) >= _SEVERITY_RANK.get(b, 0) else b
+
+
+def _next_resolution_ref(issue_id: str, ledger: list[dict]) -> str:
+    n = sum(1 for e in ledger if e.get("issue_id") == issue_id) + 1
+    return f"{issue_id}:r{n}"
+
+
+def merge(
+    prior: list[dict], current: list[dict], resolutions: dict[str, dict], run_date: str,
+) -> list[dict]:
+    prior_by_id = {str(f.get("id", "")).strip(): f for f in prior}
+    current_by_id = {str(f.get("id", "")).strip(): f for f in current}
+    merged: list[dict] = []
+
+    # Current findings are active. A re-detected finding that was previously
+    # resolved reopens automatically here (the code came back).
+    for issue_id, cur in current_by_id.items():
+        rec = dict(cur)
+        rec["status"] = "active"
+        rec["evidence_stale"] = False
+        rec["evidence_hashes"] = evidence_hashes(cur)
+        rec["verification"] = _verification_of(cur)
+        rec.pop("resolution", None)
+        rec.pop("resolution_ref", None)
+        old = prior_by_id.get(issue_id)
+        if old is not None:
+            rec["severity"] = _higher_severity(
+                str(rec.get("severity", "LOW")), str(old.get("severity", "LOW"))
+            )
+            rec["first_seen"] = old.get("first_seen", run_date)
+        else:
+            rec["first_seen"] = run_date
+        rec["last_seen"] = run_date
+        merged.append(rec)
+
+    # Prior findings not re-detected this run.
+    for issue_id, old in prior_by_id.items():
+        if issue_id in current_by_id:
+            continue
+        rec = dict(old)
+        if issue_id in resolutions:
+            # Resolved this run (fixed, or dismissed as not-a-bug / wont-fix).
+            rec["status"] = "resolved"
+            rec["resolution"] = resolutions[issue_id]["resolution"]
+            rec["resolution_ref"] = resolutions[issue_id]["ref"]
+        elif old.get("status") == "resolved":
+            # Resolved in a prior run — prune from the catalog (the ledger is the
+            # permanent record). Re-detection reopens it as active via the loop above.
+            continue
+        else:
+            # Absence is not resolution. Keep the original evidence hashes so the
+            # staleness signal persists; a file change flips it to evidence-stale.
+            rec["status"] = "active"
+            rec["evidence_stale"] = not _hashes_match(old.get("evidence_hashes", []))
+        merged.append(rec)
+
+    return merged
+
+
+def append_resolutions(
+    resolved_findings: list[dict], lookups: list[list[dict]], solution: str, run_date: str,
+    ledger: list[dict],
+) -> dict[str, dict]:
+    """Append one ledger line per resolved issue; return issue_id -> {ref, resolution}.
+
+    Each resolved finding may carry a `resolution` kind (default `fixed`; a maker
+    dismisses a false positive with `not-a-bug` or declines with `wont-fix`) and a
+    `resolved_by` identity (default `review-skill`; e.g. `update-skill` for a fix,
+    `maker` for a dismissal). A resolved finding's files[] (for the evidence hash)
+    are taken from its own entry if present, else from the first lookup list that
+    has it (prior catalog, then current run).
+    """
+    resolved = {str(f.get("id", "")).strip(): f for f in resolved_findings if str(f.get("id", "")).strip()}
+    if not resolved:
+        return {}
+    by_id: dict[str, dict] = {}
+    for source in [resolved_findings, *lookups]:
+        for f in source:
+            fid = str(f.get("id", "")).strip()
+            if fid and (fid not in by_id or not _file_paths(by_id[fid])):
+                if _file_paths(f) or fid not in by_id:
+                    by_id[fid] = f
+    out: dict[str, dict] = {}
+    lines: list[str] = []
+    for issue_id in sorted(resolved):
+        ref = _next_resolution_ref(issue_id, ledger + [{"issue_id": i} for i in out])
+        resolution = _resolution_of(resolved[issue_id])
+        out[issue_id] = {"ref": ref, "resolution": resolution}
+        finding = by_id.get(issue_id, {})
+        hashes = evidence_hashes(finding) if finding else []
+        entry = {
+            "id": ref,
+            "solution": solution,
+            "issue_id": issue_id,
+            "resolution": resolution,
+            "resolved_date": run_date,
+            "resolved_by": _resolved_by_of(resolved[issue_id]),
+            "evidence_hash": hashes[0]["sha256"] if hashes else None,
+        }
+        lines.append(json.dumps(entry))
+    path = ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for line in lines:
+            fh.write(line + "\n")
+    return out
+
+
+def summarize(issues: list[dict]) -> dict[str, int]:
+    counts = {"active": 0, "resolved": 0, "evidence_stale": 0}
+    for f in issues:
+        counts[f.get("status", "active")] = counts.get(f.get("status", "active"), 0) + 1
+        if f.get("evidence_stale"):
+            counts["evidence_stale"] += 1
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Merge a /review run into the findings catalog + ledger.")
+    parser.add_argument("--solution", "-s", required=True, help="Review scope id (a topic stem today; an ISV/solution later).")
+    parser.add_argument("--current", "-c", help="JSON of this run's findings (list, or {issues:[...]}).")
+    parser.add_argument("--resolve", "-r", help="JSON listing findings resolved this run (appended to the ledger).")
+    parser.add_argument("--show", action="store_true", help="Print the catalog and exit.")
+    args = parser.parse_args()
+
+    load_config()
+    cpath = catalog_path(args.solution)
+
+    if args.show:
+        existing = _read_json(cpath)
+        if existing is None:
+            print(f"No findings catalog for '{args.solution}'.")
+            return 0
+        print(json.dumps(existing, indent=2))
+        return 0
+
+    if not args.current:
+        print("ERROR: --current is required unless --show is used.", file=sys.stderr)
+        return 1
+
+    current_doc = _read_json(Path(args.current))
+    if current_doc is None:
+        print(f"ERROR: could not read current findings from {args.current}", file=sys.stderr)
+        return 1
+    current = _issues_of(current_doc)
+
+    resolved_findings: list[dict] = []
+    if args.resolve:
+        resolved_findings = _issues_of(_read_json(Path(args.resolve)) or [])
+
+    prior_doc = _read_json(cpath)
+    prior = _issues_of(prior_doc) if prior_doc is not None else []
+
+    run_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    ledger = _read_jsonl(ledger_path())
+    resolutions = append_resolutions(
+        resolved_findings, [prior, current], args.solution, run_date, ledger
+    )
+
+    merged = merge(prior, current, resolutions, run_date)
+
+    catalog = {
+        "schema_version": _SCHEMA_VERSION,
+        "solution": args.solution,
+        "date": run_date,
+        "mode": "review",
+        "issues": merged,
+    }
+    cpath.parent.mkdir(parents=True, exist_ok=True)
+    cpath.write_text(json.dumps(catalog, indent=2) + "\n", encoding="utf-8")
+
+    counts = summarize(merged)
+    print(f"Catalog updated: {cpath}")
+    print(f"  active={counts.get('active', 0)}  resolved={counts.get('resolved', 0)}  evidence-stale={counts.get('evidence_stale', 0)}")
+    if counts.get("evidence_stale"):
+        print("  NOTE: evidence-stale findings had their files change but were not re-detected — re-verify (likely fixed).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -76,6 +76,41 @@ _REQUIRED_FINDING_KEYS = ("id", "title", "severity", "reachability", "root_cause
 _RESOLUTION_KINDS = {"fixed", "wont-fix", "not-a-bug", "defense-in-depth", "false-positive"}
 _VERIFICATION_KINDS = {"static", "needs-runtime-test"}
 _REVIEW_DIR = Path(".local") / "review-findings"
+# Anchor for validating agent-supplied paths stay inside the maker-skills tree
+# (scripts/ lives directly under it). Used to reject path traversal in --solution
+# and in finding files[].path before any filesystem read/write.
+_SKILL_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _safe_scope_id(value: str) -> str:
+    """A review scope id (`--solution`) must be a bare stem, not a path.
+
+    Rejects separators / `..` / absolute paths so it cannot steer catalog_path()
+    to read or write a `*-catalog.json` outside _REVIEW_DIR.
+    """
+    if not value or "/" in value or "\\" in value or ".." in value or Path(value).is_absolute():
+        print(
+            f"ERROR: invalid --solution '{value}': must be a bare topic/scope id, not a path.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return value
+
+
+def _safe_read_path(p: str) -> "Path | None":
+    """Resolve a finding's files[].path inside the skill tree, or None if it escapes.
+
+    Guards evidence hashing against reading an arbitrary file via an absolute or
+    `..`-laden files[].path in agent-supplied findings.
+    """
+    if Path(p).is_absolute():
+        return None
+    resolved = (_SKILL_ROOT / p).resolve()
+    try:
+        resolved.relative_to(_SKILL_ROOT)
+    except ValueError:
+        return None
+    return resolved
 
 
 def _resolution_of(finding: dict) -> str:
@@ -120,9 +155,10 @@ def read_findings_source(value: str) -> tuple[object, str | None]:
     """Read a findings document from a file path or stdin.
 
     `value` of "-" reads from stdin, so the caller can pipe findings JSON
-    directly (no temp file to mis-path, no shell heredoc) — the temp-file seam
-    was a live failure source on Windows. Returns (doc, None) on success or
-    (None, error) with a message that distinguishes not-found from invalid JSON.
+    directly, with no temp file to mis-path (a Unix `/tmp` path does not exist on
+    Windows) and no shell heredoc (unsupported in PowerShell). Returns (doc, None)
+    on success or (None, error) with a message that distinguishes not-found from
+    invalid JSON.
     """
     if value == "-":
         raw = sys.stdin.read()
@@ -223,10 +259,15 @@ def validate_current_findings(findings: list[dict]) -> list[str]:
 
 
 def evidence_hashes(finding: dict) -> list[dict]:
-    """Current sha256 of every file the finding implicates (files[].path)."""
+    """Current sha256 of every file the finding implicates (files[].path).
+
+    Only paths that resolve inside the skill tree are read; a path that escapes
+    (absolute or via `..`) is recorded with sha256 None rather than being read.
+    """
     out: list[dict] = []
     for p in _file_paths(finding):
-        out.append({"file": p, "sha256": sha256_file(Path(p))})
+        safe = _safe_read_path(p)
+        out.append({"file": p, "sha256": sha256_file(safe) if safe else None})
     return out
 
 
@@ -370,6 +411,7 @@ def main() -> int:
     args = parser.parse_args()
 
     load_config()
+    _safe_scope_id(args.solution)
     cpath = catalog_path(args.solution)
 
     if args.show:
@@ -408,7 +450,19 @@ def main() -> int:
     if args.resolve:
         resolved_findings = _issues_of(_read_json(Path(args.resolve)) or [])
 
-    prior_doc = _read_json(cpath)
+    if cpath.is_file():
+        try:
+            prior_doc = json.loads(cpath.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(
+                f"ERROR: existing catalog {cpath} is unreadable/corrupt ({e}). "
+                "Refusing to overwrite it, which would silently drop the tracked findings "
+                "and resolution history. Fix or remove the file, then re-run.",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        prior_doc = None
     prior = _issues_of(prior_doc) if prior_doc is not None else []
 
     run_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -46,6 +46,8 @@ alone, or one scope's resolution would wrongly clear another's. (This merge does
 not read the ledger back to set status, so the risk is latent, not live.)
 
 Usage:
+    # findings from stdin (preferred — no temp file, no shell heredoc):
+    Get-Content run.json | python scripts/merge_findings.py --solution <id> --current -
     python scripts/merge_findings.py --solution <id> --current run.json
     python scripts/merge_findings.py --solution <id> --current run.json --resolve resolved.json
     python scripts/merge_findings.py --solution <id> --show
@@ -112,6 +114,33 @@ def _read_json(path: Path):
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def read_findings_source(value: str) -> tuple[object, str | None]:
+    """Read a findings document from a file path or stdin.
+
+    `value` of "-" reads from stdin, so the caller can pipe findings JSON
+    directly (no temp file to mis-path, no shell heredoc) — the temp-file seam
+    was a live failure source on Windows. Returns (doc, None) on success or
+    (None, error) with a message that distinguishes not-found from invalid JSON.
+    """
+    if value == "-":
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return None, "no findings JSON received on stdin"
+        try:
+            return json.loads(raw), None
+        except json.JSONDecodeError as e:
+            return None, f"invalid JSON on stdin ({e})"
+    path = Path(value)
+    if not path.is_file():
+        return None, f"file not found: {value}"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except json.JSONDecodeError as e:
+        return None, f"invalid JSON in {value} ({e})"
+    except OSError as e:
+        return None, f"could not read {value} ({e})"
 
 
 def _read_jsonl(path: Path) -> list[dict]:
@@ -335,7 +364,7 @@ def summarize(issues: list[dict]) -> dict[str, int]:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Merge a /review run into the findings catalog + ledger.")
     parser.add_argument("--solution", "-s", required=True, help="Review scope id (a topic stem today; an ISV/solution later).")
-    parser.add_argument("--current", "-c", help="JSON of this run's findings (list, or {issues:[...]}).")
+    parser.add_argument("--current", "-c", help="Findings for this run: a file path, or '-' to read JSON from stdin (list, or {issues:[...]}).")
     parser.add_argument("--resolve", "-r", help="JSON listing findings resolved this run (appended to the ledger).")
     parser.add_argument("--show", action="store_true", help="Print the catalog and exit.")
     args = parser.parse_args()
@@ -355,16 +384,17 @@ def main() -> int:
         print("ERROR: --current is required unless --show is used.", file=sys.stderr)
         return 1
 
-    current_doc = _read_json(Path(args.current))
-    if current_doc is None:
-        print(f"ERROR: could not read current findings from {args.current}", file=sys.stderr)
+    current_doc, read_err = read_findings_source(args.current)
+    if read_err is not None:
+        print(f"ERROR: could not read current findings ({read_err})", file=sys.stderr)
         return 1
     current = _issues_of(current_doc)
 
     errors = validate_current_findings(current)
     if errors:
+        src = "stdin" if args.current == "-" else args.current
         print(
-            f"ERROR: {len(errors)} finding(s) in {args.current} do not match the finding contract "
+            f"ERROR: {len(errors)} finding(s) from {src} do not match the finding contract "
             "(id/title/severity/reachability/root_cause/concrete_fix + files[]). "
             "Catalog NOT written. A catalog may only be produced by this script from contract-shaped findings; "
             "do not hand-write catalogs or improvise a scanner.",

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -27,9 +27,11 @@ evidence-stale if any file changed (hash mismatch) — an objective signal to
 re-verify, not an LLM guess.
 
 Finding identity across runs is the semantic id (a stable kebab-case slug the
-agent reuses). Status is 'active' or 'resolved'; 'resolved' requires a matching
-resolved-issue-ledger.jsonl entry (written when /update confirms a fix, or when
-/review confirms an evidence-stale finding's node is gone).
+agent reuses). Status is 'active', 'suppressed', or 'resolved'; 'resolved' requires
+a matching resolved-issue-ledger.jsonl entry (written when /update confirms a fix,
+or when /review confirms an evidence-stale finding's node is gone). 'suppressed' is
+a re-detected finding the maker dismissed (not-a-bug/wont-fix/false-positive), kept
+out of the active report until its evidence changes.
 
 Catalog integrity: this script is the ONLY sanctioned way to write a catalog, and
 it validates every catalog-bound finding against the finding contract (required
@@ -82,6 +84,12 @@ _REACHABILITY_KINDS = {
 # Maker-facing resolutions are fixed / not-a-bug / wont-fix; the other two are
 # retained for compatibility with the analyzer ledger enum (v1.2.0).
 _RESOLUTION_KINDS = {"fixed", "wont-fix", "not-a-bug", "defense-in-depth", "false-positive"}
+# Resolutions that mean "this is not a defect the maker will act on." A
+# deterministic detector re-emits the same pattern every run, so once dismissed
+# these must stay suppressed (not resurface as active) until the topic's evidence
+# changes. `fixed` / `defense-in-depth` are code-change intents, so re-detection of
+# those legitimately reopens the finding (a regression) and they are NOT dismissals.
+_DISMISSAL_KINDS = {"not-a-bug", "wont-fix", "false-positive"}
 _VERIFICATION_KINDS = {"static", "needs-runtime-test"}
 _REVIEW_DIR = Path(".local") / "review-findings"
 # Anchor for validating agent-supplied paths stay inside the maker-skills tree
@@ -348,20 +356,62 @@ def _next_resolution_ref(issue_id: str, ledger: list[dict]) -> str:
     return f"{issue_id}:r{n}"
 
 
+def _latest_ledger_record(issue_id: str, solution: str, ledger: list[dict]) -> "dict | None":
+    """The most recent ledger line for this (solution, issue_id), or None.
+
+    The ledger is append-only, so the last matching line wins.
+    """
+    match = None
+    for entry in ledger:
+        if entry.get("issue_id") == issue_id and entry.get("solution") == solution:
+            match = entry
+    return match
+
+
+def _active_dismissal(
+    issue_id: str, solution: str, ledger: list[dict],
+    resolutions: dict[str, dict], current_hashes: list[dict],
+) -> "dict | None":
+    """Return {ref, resolution} if a re-detected finding should stay suppressed.
+
+    A finding is suppressed when it was dismissed (not-a-bug / wont-fix /
+    false-positive) and its evidence is unchanged since the dismissal:
+
+    - dismissed *this* run (in `resolutions`): evidence is current by definition;
+    - dismissed in a *prior* run (latest ledger line): only while the stored
+      evidence hash still matches the finding's current first-file hash. A topic
+      edit moves the hash and reopens the finding as active for re-review.
+    """
+    this_run = resolutions.get(issue_id)
+    if this_run is not None and this_run.get("resolution") in _DISMISSAL_KINDS:
+        return {"ref": this_run.get("ref"), "resolution": this_run["resolution"]}
+
+    latest = _latest_ledger_record(issue_id, solution, ledger)
+    if latest is not None and latest.get("resolution") in _DISMISSAL_KINDS:
+        stored_hash = latest.get("evidence_hash")
+        current_hash = current_hashes[0]["sha256"] if current_hashes else None
+        if stored_hash is not None and stored_hash == current_hash:
+            return {"ref": latest.get("id"), "resolution": latest["resolution"]}
+    return None
+
+
 def merge(
     prior: list[dict], current: list[dict], resolutions: dict[str, dict], run_date: str,
+    ledger: list[dict], solution: str,
 ) -> list[dict]:
     prior_by_id = {str(f.get("id", "")).strip(): f for f in prior}
     current_by_id = {str(f.get("id", "")).strip(): f for f in current}
     merged: list[dict] = []
 
-    # Current findings are active. A re-detected finding that was previously
-    # resolved reopens automatically here (the code came back).
+    # Current findings are active — unless the maker dismissed them and the
+    # evidence is unchanged, in which case they stay suppressed rather than
+    # resurfacing every run. A re-detected finding that was previously *fixed*
+    # reopens automatically here (the code came back).
     for issue_id, cur in current_by_id.items():
         rec = dict(cur)
-        rec["status"] = "active"
+        cur_hashes = evidence_hashes(cur)
         rec["evidence_stale"] = False
-        rec["evidence_hashes"] = evidence_hashes(cur)
+        rec["evidence_hashes"] = cur_hashes
         rec["verification"] = _verification_of(cur)
         rec.pop("resolution", None)
         rec.pop("resolution_ref", None)
@@ -374,6 +424,13 @@ def merge(
         else:
             rec["first_seen"] = run_date
         rec["last_seen"] = run_date
+        dismissal = _active_dismissal(issue_id, solution, ledger, resolutions, cur_hashes)
+        if dismissal is not None:
+            rec["status"] = "suppressed"
+            rec["resolution"] = dismissal["resolution"]
+            rec["resolution_ref"] = dismissal["ref"]
+        else:
+            rec["status"] = "active"
         merged.append(rec)
 
     # Prior findings not re-detected this run.
@@ -390,6 +447,10 @@ def merge(
             # Resolved in a prior run — prune from the catalog (the ledger is the
             # permanent record). Re-detection reopens it as active via the loop above.
             continue
+        elif old.get("status") == "suppressed":
+            # A dismissed finding that is no longer re-detected: keep it suppressed
+            # rather than flipping it back to active on absence.
+            rec["status"] = "suppressed"
         else:
             # Absence is not resolution. Keep the original evidence hashes so the
             # staleness signal persists; a file change flips it to evidence-stale.
@@ -426,11 +487,23 @@ def append_resolutions(
     out: dict[str, dict] = {}
     lines: list[str] = []
     for issue_id in sorted(resolved):
-        ref = _next_resolution_ref(issue_id, ledger + [{"issue_id": i} for i in out])
         resolution = _resolution_of(resolved[issue_id])
-        out[issue_id] = {"ref": ref, "resolution": resolution}
         finding = by_id.get(issue_id, {})
         hashes = evidence_hashes(finding) if finding else []
+        ev_hash = hashes[0]["sha256"] if hashes else None
+        latest = _latest_ledger_record(issue_id, solution, ledger)
+        if (
+            latest is not None
+            and latest.get("resolution") == resolution
+            and latest.get("evidence_hash") == ev_hash
+        ):
+            # Idempotent: an identical resolution with identical evidence is already
+            # recorded. Reuse the existing ref instead of appending a duplicate :rN
+            # line (prevents append-only bloat when the same dismissal is re-passed).
+            out[issue_id] = {"ref": latest.get("id"), "resolution": resolution}
+            continue
+        ref = _next_resolution_ref(issue_id, ledger + [{"issue_id": i} for i in out])
+        out[issue_id] = {"ref": ref, "resolution": resolution}
         entry = {
             "id": ref,
             "solution": solution,
@@ -438,7 +511,7 @@ def append_resolutions(
             "resolution": resolution,
             "resolved_date": run_date,
             "resolved_by": _resolved_by_of(resolved[issue_id]),
-            "evidence_hash": hashes[0]["sha256"] if hashes else None,
+            "evidence_hash": ev_hash,
         }
         lines.append(json.dumps(entry))
     path = ledger_path()
@@ -450,9 +523,10 @@ def append_resolutions(
 
 
 def summarize(issues: list[dict]) -> dict[str, int]:
-    counts = {"active": 0, "resolved": 0, "evidence_stale": 0}
+    counts = {"active": 0, "resolved": 0, "suppressed": 0, "evidence_stale": 0}
     for f in issues:
-        counts[f.get("status", "active")] = counts.get(f.get("status", "active"), 0) + 1
+        status = f.get("status", "active")
+        counts[status] = counts.get(status, 0) + 1
         if f.get("evidence_stale"):
             counts["evidence_stale"] += 1
     return counts
@@ -538,7 +612,7 @@ def main() -> int:
         resolved_findings, [prior, current], args.solution, run_date, ledger
     )
 
-    merged = merge(prior, current, resolutions, run_date)
+    merged = merge(prior, current, resolutions, run_date, ledger, args.solution)
 
     catalog = {
         "schema_version": _SCHEMA_VERSION,
@@ -552,7 +626,10 @@ def main() -> int:
 
     counts = summarize(merged)
     print(f"Catalog updated: {cpath}")
-    print(f"  active={counts.get('active', 0)}  resolved={counts.get('resolved', 0)}  evidence-stale={counts.get('evidence_stale', 0)}")
+    print(
+        f"  active={counts.get('active', 0)}  resolved={counts.get('resolved', 0)}  "
+        f"suppressed={counts.get('suppressed', 0)}  evidence-stale={counts.get('evidence_stale', 0)}"
+    )
     if counts.get("evidence_stale"):
         print("  NOTE: evidence-stale findings had their files change but were not re-detected — re-verify (likely fixed).")
     return 0

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -31,6 +31,13 @@ agent reuses). Status is 'active' or 'resolved'; 'resolved' requires a matching
 resolved-issue-ledger.jsonl entry (written when /update confirms a fix, or when
 /review confirms an evidence-stale finding's node is gone).
 
+Catalog integrity: this script is the ONLY sanctioned way to write a catalog, and
+it validates every catalog-bound finding against the finding contract (required
+fields id/title/severity/reachability/root_cause/concrete_fix + a non-empty files[]
+for the evidence hash). A run whose findings use the wrong field names or omit
+files[] is REJECTED (exit 2) and no catalog is written — so an improvised scanner
+or hand-written catalog fails loudly instead of persisting schema-broken state.
+
 Scope invariant: a finding belongs to exactly one catalog per review scope (the
 `solution` value). The same semantic id can legitimately appear under different
 scopes, so the shared ledger is keyed by (solution, issue_id) — any future
@@ -56,6 +63,12 @@ if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
 
 _SCHEMA_VERSION = "1.0.0"
 _SEVERITY_RANK = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
+# Keys the agent must supply on every catalog-bound finding (the script assigns
+# status / evidence_stale / evidence_hashes / first_seen / last_seen itself).
+# Enforced so an improvised writer using the wrong field names (e.g. description /
+# location / fix instead of root_cause / files / concrete_fix) fails loudly instead
+# of persisting a schema-broken catalog. `verification` is optional (defaults static).
+_REQUIRED_FINDING_KEYS = ("id", "title", "severity", "reachability", "root_cause", "concrete_fix")
 # Maker-facing resolutions are fixed / not-a-bug / wont-fix; the other two are
 # retained for compatibility with the analyzer ledger enum (v1.2.0).
 _RESOLUTION_KINDS = {"fixed", "wont-fix", "not-a-bug", "defense-in-depth", "false-positive"}
@@ -146,6 +159,38 @@ def _file_paths(finding: dict) -> list[str]:
             elif isinstance(f, str):
                 paths.append(f)
     return paths
+
+
+def _nonempty_str(val) -> bool:
+    return isinstance(val, str) and val.strip() != ""
+
+
+def validate_current_findings(findings: list[dict]) -> list[str]:
+    """Return a list of human-readable errors for catalog-bound findings.
+
+    A finding must carry every _REQUIRED_FINDING_KEYS field as a non-empty string,
+    a severity in {HIGH, MEDIUM, LOW}, and a non-empty files[] that yields at least
+    one path (so evidence_hashes can be computed — an empty files[] silently breaks
+    the whole staleness / /update-locate design). Empty in → empty error list.
+    """
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    for i, f in enumerate(findings):
+        where = str(f.get("id", "")).strip() or f"#{i}"
+        for key in _REQUIRED_FINDING_KEYS:
+            if not _nonempty_str(f.get(key)):
+                errors.append(f"[{where}] missing or empty required field '{key}'")
+        sev = str(f.get("severity", "")).strip()
+        if sev and sev not in _SEVERITY_RANK:
+            errors.append(f"[{where}] severity '{sev}' is not one of HIGH/MEDIUM/LOW")
+        if not _file_paths(f):
+            errors.append(f"[{where}] files[] is missing or has no usable path (evidence_hashes would be empty)")
+        fid = str(f.get("id", "")).strip()
+        if fid:
+            if fid in seen_ids:
+                errors.append(f"[{fid}] duplicate id within this run (ids are the cross-run identity)")
+            seen_ids.add(fid)
+    return errors
 
 
 def evidence_hashes(finding: dict) -> list[dict]:
@@ -315,6 +360,19 @@ def main() -> int:
         print(f"ERROR: could not read current findings from {args.current}", file=sys.stderr)
         return 1
     current = _issues_of(current_doc)
+
+    errors = validate_current_findings(current)
+    if errors:
+        print(
+            f"ERROR: {len(errors)} finding(s) in {args.current} do not match the finding contract "
+            "(id/title/severity/reachability/root_cause/concrete_fix + files[]). "
+            "Catalog NOT written. A catalog may only be produced by this script from contract-shaped findings; "
+            "do not hand-write catalogs or improvise a scanner.",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 2
 
     resolved_findings: list[dict] = []
     if args.resolve:

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -11,6 +11,11 @@ maker workflow. Two artifacts under .local/review-findings/ (gitignored):
   <solution>-catalog.json         per-scope findings catalog (this run's state)
   resolved-issue-ledger.jsonl     shared, append-only resolution evidence
 
+The catalog carries two collections: `issues` (contract-shaped findings, the set
+the report and /update read) and `suppressions` (lightweight per-run audit
+breadcrumbs for would-be findings a runtime heuristic capped to unreachable — kept
+out of `issues`, never shown to the maker; see _suppressions_of).
+
 The `solution` field is the review scope identifier — a single topic today, a
 whole ISV or solution later. Nothing here assumes a single topic; a finding's
 files[] can span several files, so widening the review needs no schema change.
@@ -71,6 +76,9 @@ _SEVERITY_RANK = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
 # location / fix instead of root_cause / files / concrete_fix) fails loudly instead
 # of persisting a schema-broken catalog. `verification` is optional (defaults static).
 _REQUIRED_FINDING_KEYS = ("id", "title", "severity", "reachability", "root_cause", "concrete_fix")
+# Audit breadcrumb for a would-be finding a runtime heuristic capped to unreachable.
+# Lightweight by design (not the finding contract) — see _suppressions_of.
+_SUPPRESSION_KEYS = ("id", "site", "suppressed_by", "date")
 # Maker-facing resolutions are fixed / not-a-bug / wont-fix; the other two are
 # retained for compatibility with the analyzer ledger enum (v1.2.0).
 _RESOLUTION_KINDS = {"fixed", "wont-fix", "not-a-bug", "defense-in-depth", "false-positive"}
@@ -169,6 +177,33 @@ def _issues_of(doc) -> list[dict]:
             if isinstance(doc.get(key), list):
                 return [f for f in doc[key] if isinstance(f, dict)]
     return []
+
+
+def _suppressions_of(doc, run_date: str) -> list[dict]:
+    """Per-run suppression breadcrumbs from the current input (overwrite, not merged).
+
+    Each is a lightweight audit stub — a would-be finding a runtime heuristic capped
+    to unreachable/LOW, recorded so a 0-findings run is auditable (evaluated-and-
+    suppressed vs never-looked). Deliberately NOT the finding contract: no severity /
+    root_cause / concrete_fix (a suppressed site is not an actionable problem), no
+    evidence_hashes, no validation-gating, and never merged or carried forward — the
+    lens re-derives suppressions every run, so this is simply overwritten. Kept out of
+    `issues` so no report / `/update` / summarize consumer ever sees it. Malformed
+    entries are dropped (this must never block persistence of real findings).
+    """
+    raw = doc.get("suppressions") if isinstance(doc, dict) else None
+    if not isinstance(raw, list):
+        return []
+    out: list[dict] = []
+    for s in raw:
+        if not isinstance(s, dict):
+            continue
+        rec = {k: s[k] for k in _SUPPRESSION_KEYS if k in s and s[k] is not None}
+        if not (rec.get("id") or rec.get("site")):
+            continue  # need at least a locator to be a useful breadcrumb
+        rec.setdefault("date", run_date)
+        out.append(rec)
+    return out
 
 
 def sha256_file(path: Path) -> str | None:
@@ -418,6 +453,7 @@ def main() -> int:
     )
 
     merged = merge(prior, current, resolutions, run_date)
+    suppressions = _suppressions_of(current_doc, run_date)
 
     catalog = {
         "schema_version": _SCHEMA_VERSION,
@@ -425,13 +461,14 @@ def main() -> int:
         "date": run_date,
         "mode": "review",
         "issues": merged,
+        "suppressions": suppressions,
     }
     cpath.parent.mkdir(parents=True, exist_ok=True)
     cpath.write_text(json.dumps(catalog, indent=2) + "\n", encoding="utf-8")
 
     counts = summarize(merged)
     print(f"Catalog updated: {cpath}")
-    print(f"  active={counts.get('active', 0)}  resolved={counts.get('resolved', 0)}  evidence-stale={counts.get('evidence_stale', 0)}")
+    print(f"  active={counts.get('active', 0)}  resolved={counts.get('resolved', 0)}  evidence-stale={counts.get('evidence_stale', 0)}  suppressed={len(suppressions)}")
     if counts.get("evidence_stale"):
         print("  NOTE: evidence-stale findings had their files change but were not re-detected — re-verify (likely fixed).")
     return 0

--- a/solutions/ess-maker-skills/scripts/merge_findings.py
+++ b/solutions/ess-maker-skills/scripts/merge_findings.py
@@ -11,11 +11,6 @@ maker workflow. Two artifacts under .local/review-findings/ (gitignored):
   <solution>-catalog.json         per-scope findings catalog (this run's state)
   resolved-issue-ledger.jsonl     shared, append-only resolution evidence
 
-The catalog carries two collections: `issues` (contract-shaped findings, the set
-the report and /update read) and `suppressions` (lightweight per-run audit
-breadcrumbs for would-be findings a runtime heuristic capped to unreachable — kept
-out of `issues`, never shown to the maker; see _suppressions_of).
-
 The `solution` field is the review scope identifier — a single topic today, a
 whole ISV or solution later. Nothing here assumes a single topic; a finding's
 files[] can span several files, so widening the review needs no schema change.
@@ -76,9 +71,6 @@ _SEVERITY_RANK = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
 # location / fix instead of root_cause / files / concrete_fix) fails loudly instead
 # of persisting a schema-broken catalog. `verification` is optional (defaults static).
 _REQUIRED_FINDING_KEYS = ("id", "title", "severity", "reachability", "root_cause", "concrete_fix")
-# Audit breadcrumb for a would-be finding a runtime heuristic capped to unreachable.
-# Lightweight by design (not the finding contract) — see _suppressions_of.
-_SUPPRESSION_KEYS = ("id", "site", "suppressed_by", "date")
 # Maker-facing resolutions are fixed / not-a-bug / wont-fix; the other two are
 # retained for compatibility with the analyzer ledger enum (v1.2.0).
 _RESOLUTION_KINDS = {"fixed", "wont-fix", "not-a-bug", "defense-in-depth", "false-positive"}
@@ -177,33 +169,6 @@ def _issues_of(doc) -> list[dict]:
             if isinstance(doc.get(key), list):
                 return [f for f in doc[key] if isinstance(f, dict)]
     return []
-
-
-def _suppressions_of(doc, run_date: str) -> list[dict]:
-    """Per-run suppression breadcrumbs from the current input (overwrite, not merged).
-
-    Each is a lightweight audit stub — a would-be finding a runtime heuristic capped
-    to unreachable/LOW, recorded so a 0-findings run is auditable (evaluated-and-
-    suppressed vs never-looked). Deliberately NOT the finding contract: no severity /
-    root_cause / concrete_fix (a suppressed site is not an actionable problem), no
-    evidence_hashes, no validation-gating, and never merged or carried forward — the
-    lens re-derives suppressions every run, so this is simply overwritten. Kept out of
-    `issues` so no report / `/update` / summarize consumer ever sees it. Malformed
-    entries are dropped (this must never block persistence of real findings).
-    """
-    raw = doc.get("suppressions") if isinstance(doc, dict) else None
-    if not isinstance(raw, list):
-        return []
-    out: list[dict] = []
-    for s in raw:
-        if not isinstance(s, dict):
-            continue
-        rec = {k: s[k] for k in _SUPPRESSION_KEYS if k in s and s[k] is not None}
-        if not (rec.get("id") or rec.get("site")):
-            continue  # need at least a locator to be a useful breadcrumb
-        rec.setdefault("date", run_date)
-        out.append(rec)
-    return out
 
 
 def sha256_file(path: Path) -> str | None:
@@ -453,7 +418,6 @@ def main() -> int:
     )
 
     merged = merge(prior, current, resolutions, run_date)
-    suppressions = _suppressions_of(current_doc, run_date)
 
     catalog = {
         "schema_version": _SCHEMA_VERSION,
@@ -461,14 +425,13 @@ def main() -> int:
         "date": run_date,
         "mode": "review",
         "issues": merged,
-        "suppressions": suppressions,
     }
     cpath.parent.mkdir(parents=True, exist_ok=True)
     cpath.write_text(json.dumps(catalog, indent=2) + "\n", encoding="utf-8")
 
     counts = summarize(merged)
     print(f"Catalog updated: {cpath}")
-    print(f"  active={counts.get('active', 0)}  resolved={counts.get('resolved', 0)}  evidence-stale={counts.get('evidence_stale', 0)}  suppressed={len(suppressions)}")
+    print(f"  active={counts.get('active', 0)}  resolved={counts.get('resolved', 0)}  evidence-stale={counts.get('evidence_stale', 0)}")
     if counts.get("evidence_stale"):
         print("  NOTE: evidence-stale findings had their files change but were not re-detected — re-verify (likely fixed).")
     return 0

--- a/solutions/ess-maker-skills/scripts/scan_bindings.py
+++ b/solutions/ess-maker-skills/scripts/scan_bindings.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+scan_bindings.py — Detect card/topic binding mismatches in an agent's topics.
+
+An adaptive card in a topic renders `Topic.X` values. If a card references a
+`Topic.*` value that the topic never populates, that field renders blank at
+runtime with no error. This detects those references by reconciling what the
+card consumes against what the topic populates.
+
+What a topic populates:
+  - ParseValue targets, expanded through their declared record/table schema
+    (so `Topic.CaseDetails.ShortDescription` counts as populated when the
+    ParseValue schema for `Topic.CaseDetails` declares `ShortDescription`);
+  - SetVariable / SetTextVariable targets;
+  - BeginDialog output bindings;
+  - Question variables.
+
+What a card consumes: every `Topic.*` path referenced inside an adaptive card
+body (`AdaptiveCardTemplate.cardContent` / `AdaptiveCardPrompt.card`).
+
+Two anomaly classes are reported, both high precision:
+  - unpopulated variable: a card reads `Topic.X` whose root variable is never
+    populated anywhere in the topic;
+  - unknown field: a card reads `Topic.X.Y` where `Topic.X` is populated by a
+    ParseValue record schema that does not declare `Y`.
+
+Output is bounded: anomalies to stdout (capped), full detail to --output. This
+script only detects; it assigns no severity and makes no judgement.
+
+Usage:
+    python scripts/scan_bindings.py --agent employee-self-service-hr --topic servicenow-hrsd-get-case-details
+    python scripts/scan_bindings.py --agent employee-self-service-hr --output results/bindings.json
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# A Topic.* path reference, e.g. Topic.CaseDetails.ShortDescription.
+_TOPIC_REF_RE = re.compile(r"\bTopic\.([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)")
+# Keys whose string value is an adaptive card body.
+_CARD_KEYS = ("cardContent", "card")
+
+_MAX_LISTED = 20
+
+
+def _load(path: Path):
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return None
+
+
+def _strip_topic(ref: str) -> str:
+    """`Topic.A.B` -> `A.B`; leave a non-Topic ref unchanged."""
+    return ref[len("Topic."):] if ref.startswith("Topic.") else ref
+
+
+def _walk(node):
+    """Yield every dict found anywhere in a parsed topic tree."""
+    if isinstance(node, dict):
+        yield node
+        for v in node.values():
+            yield from _walk(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk(item)
+
+
+def _expand_schema(schema, prefix: str, populated: set[str], schema_roots: set[str]) -> None:
+    """Add every dotted path declared by a ParseValue valueType schema."""
+    if not isinstance(schema, dict):
+        return
+    props = schema.get("properties")
+    if props is None:
+        inner = schema.get("type")
+        if isinstance(inner, dict):
+            _expand_schema(inner, prefix, populated, schema_roots)
+        return
+    schema_roots.add(prefix)
+    if not isinstance(props, dict):
+        return
+    for name, sub in props.items():
+        path = f"{prefix}.{name}"
+        populated.add(path)
+        inner = sub.get("type", sub) if isinstance(sub, dict) else None
+        if isinstance(inner, dict):
+            _expand_schema(inner, path, populated, schema_roots)
+
+
+def collect(topic) -> tuple[set[str], set[str], list[str]]:
+    """Return (populated paths, schema-known roots, card-consumed paths)."""
+    populated: set[str] = set()
+    schema_roots: set[str] = set()
+    consumed: list[str] = []
+
+    # Declared inputs are populated by the caller.
+    if isinstance(topic, dict):
+        input_props = (topic.get("inputType") or {}).get("properties")
+        if isinstance(input_props, dict):
+            populated.update(input_props.keys())
+
+    for node in _walk(topic):
+        kind = node.get("kind")
+        # Input parameters (AutomaticTaskInput / inputs) declare an available Topic value.
+        pn = node.get("propertyName")
+        if isinstance(pn, str):
+            populated.add(pn)
+        var = node.get("variable")
+        if isinstance(var, str) and var.startswith("Topic."):
+            path = _strip_topic(var)
+            populated.add(path)
+            if kind == "ParseValue" and isinstance(node.get("valueType"), dict):
+                _expand_schema(node["valueType"], path, populated, schema_roots)
+        # BeginDialog output bindings: {OutName: Topic.X}
+        if kind == "BeginDialog":
+            binding = (node.get("output") or {}).get("binding")
+            if isinstance(binding, dict):
+                for target in binding.values():
+                    if isinstance(target, str) and target.startswith("Topic."):
+                        populated.add(_strip_topic(target))
+        # Card bodies.
+        for key in _CARD_KEYS:
+            body = node.get(key)
+            if isinstance(body, str) and "AdaptiveCard" in body:
+                consumed.extend(_strip_topic(m.group(0)) for m in _TOPIC_REF_RE.finditer(body))
+
+    return populated, schema_roots, consumed
+
+
+def reconcile(
+    populated: set[str], schema_roots: set[str], consumed: list[str]
+) -> dict[str, list[str]]:
+    """Map each dangling consumed path to a one-line reason."""
+    populated_roots = {p.split(".")[0] for p in populated}
+    findings: dict[str, list[str]] = {}
+    for path in sorted(set(consumed)):
+        root = path.split(".")[0]
+        if root not in populated_roots:
+            findings[path] = ["unpopulated variable (never set anywhere in the topic)"]
+        elif path in populated:
+            continue
+        elif root in schema_roots:
+            findings[path] = ["unknown field (not declared by the record's ParseValue schema)"]
+        # else: root populated by an opaque means; sub-field cannot be verified — not flagged.
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect card/topic binding mismatches in an agent's topics."
+    )
+    parser.add_argument("--agent", "-a", help="Agent folder under workspace/agents/. Auto-detected if only one.")
+    parser.add_argument("--topic", "-t", help="Topic file stem to review. Reviews all topics if omitted.")
+    parser.add_argument("--output", "-o", help="Write the full per-topic detail to this JSON file.")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent
+    agents_dir = repo_root / "workspace" / "agents"
+    if not agents_dir.is_dir():
+        print(f"ERROR: no workspace/agents/ folder at {agents_dir}", file=sys.stderr)
+        return 1
+
+    if args.agent:
+        agent_dir = agents_dir / args.agent
+    else:
+        candidates = [d for d in agents_dir.iterdir() if d.is_dir()]
+        if len(candidates) != 1:
+            print("ERROR: specify --agent (zero or multiple agents found).", file=sys.stderr)
+            return 1
+        agent_dir = candidates[0]
+    topics_dir = agent_dir / "topics"
+    if not topics_dir.is_dir():
+        print(f"ERROR: no topics/ folder in {agent_dir}", file=sys.stderr)
+        return 1
+
+    if args.topic:
+        stem = args.topic.removesuffix(".mcs.yml")
+        topic_files = [topics_dir / f"{stem}.mcs.yml"]
+    else:
+        topic_files = sorted(topics_dir.glob("*.mcs.yml"))
+
+    detail: dict[str, dict] = {}
+    total = 0
+    for topic_file in topic_files:
+        if not topic_file.is_file():
+            print(f"ERROR: topic not found: {topic_file}", file=sys.stderr)
+            return 1
+        parsed = _load(topic_file)
+        if parsed is None:
+            continue
+        populated, schema_roots, consumed = collect(parsed)
+        findings = reconcile(populated, schema_roots, consumed)
+        if findings:
+            detail[topic_file.name] = {
+                "dangling": {k: v for k, v in sorted(findings.items())},
+                "populated": sorted(populated),
+                "consumed": sorted(set(consumed)),
+            }
+            total += len(findings)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(detail, indent=2) + "\n", encoding="utf-8")
+
+    if not total:
+        print("No card/topic binding mismatches found.")
+        return 0
+
+    print(f"Card/topic binding mismatches ({total}):")
+    listed = 0
+    for topic_name in sorted(detail):
+        for path, reasons in sorted(detail[topic_name]["dangling"].items()):
+            if listed >= _MAX_LISTED:
+                print(f"  +{total - listed} more")
+                return 0
+            print(f"  {topic_name}: Topic.{path} — {reasons[0]}")
+            listed += 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/scan_bindings.py
+++ b/solutions/ess-maker-skills/scripts/scan_bindings.py
@@ -51,10 +51,29 @@ _CARD_KEYS = ("cardContent", "card")
 _MAX_LISTED = 20
 
 
+# PyYAML rejects plain scalars that begin with a reserved indicator. Workday WSDL/XML
+# topics carry @-prefixed mapping keys (@Public, @Primary, @Descriptor, @type); quote
+# such bare keys so the topic parses instead of being silently skipped.
+_RESERVED_KEY_RE = re.compile(
+    r'^(?P<indent>[ \t]*(?:-[ \t]+)?)(?P<key>@[^\s:#]+)(?P<sep>[ \t]*:(?:[ \t]|$))',
+    re.MULTILINE,
+)
+
+
+def _quote_reserved_keys(text: str) -> str:
+    return _RESERVED_KEY_RE.sub(
+        lambda m: f'{m.group("indent")}"{m.group("key")}"{m.group("sep")}', text
+    )
+
+
 def _load(path: Path):
     try:
-        return yaml.safe_load(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        return yaml.safe_load(_quote_reserved_keys(text))
+    except yaml.YAMLError:
         return None
 
 
@@ -163,6 +182,11 @@ def main() -> int:
     parser.add_argument("--output", "-o", help="Write the full per-topic detail to this JSON file.")
     args = parser.parse_args()
 
+    for _flag, _val in (("--agent", args.agent), ("--topic", args.topic), ("--module", args.module)):
+        if _val and ("/" in _val or "\\" in _val or ".." in _val or Path(_val).is_absolute()):
+            print(f"ERROR: invalid {_flag} '{_val}': must be a bare name, not a path.", file=sys.stderr)
+            return 1
+
     repo_root = Path(__file__).parent.parent
     agents_dir = repo_root / "workspace" / "agents"
     if not agents_dir.is_dir():
@@ -198,6 +222,10 @@ def main() -> int:
             return 1
         parsed = _load(topic_file)
         if parsed is None:
+            print(
+                f"WARNING: could not parse {topic_file.name}; it was NOT analyzed "
+                f"(a clean result does not cover this topic)."
+            )
             continue
         populated, schema_roots, consumed = collect(parsed)
         findings = reconcile(populated, schema_roots, consumed)

--- a/solutions/ess-maker-skills/scripts/scan_bindings.py
+++ b/solutions/ess-maker-skills/scripts/scan_bindings.py
@@ -159,6 +159,7 @@ def main() -> int:
     )
     parser.add_argument("--agent", "-a", help="Agent folder under workspace/agents/. Auto-detected if only one.")
     parser.add_argument("--topic", "-t", help="Topic file stem to review. Reviews all topics if omitted.")
+    parser.add_argument("--module", help="Restrict to topics whose name starts with this module id (e.g. workday, servicenow-hrsd). Ignored if --topic is given.")
     parser.add_argument("--output", "-o", help="Write the full per-topic detail to this JSON file.")
     args = parser.parse_args()
 
@@ -184,6 +185,8 @@ def main() -> int:
     if args.topic:
         stem = args.topic.removesuffix(".mcs.yml")
         topic_files = [topics_dir / f"{stem}.mcs.yml"]
+    elif args.module:
+        topic_files = sorted(f for f in topics_dir.glob(f"{args.module}*.mcs.yml"))
     else:
         topic_files = sorted(topics_dir.glob("*.mcs.yml"))
 

--- a/solutions/ess-maker-skills/scripts/scan_bindings.py
+++ b/solutions/ess-maker-skills/scripts/scan_bindings.py
@@ -216,6 +216,7 @@ def main() -> int:
 
     detail: dict[str, dict] = {}
     total = 0
+    skipped = 0
     for topic_file in topic_files:
         if not topic_file.is_file():
             print(f"ERROR: topic not found: {topic_file}", file=sys.stderr)
@@ -223,9 +224,11 @@ def main() -> int:
         parsed = _load(topic_file)
         if parsed is None:
             print(
-                f"WARNING: could not parse {topic_file.name}; it was NOT analyzed "
-                f"(a clean result does not cover this topic)."
+                f"WARNING: could not read/parse {topic_file.name}; it was NOT analyzed "
+                f"(a clean result does not cover this topic).",
+                file=sys.stderr,
             )
+            skipped += 1
             continue
         populated, schema_roots, consumed = collect(parsed)
         findings = reconcile(populated, schema_roots, consumed)
@@ -243,7 +246,13 @@ def main() -> int:
         out.write_text(json.dumps(detail, indent=2) + "\n", encoding="utf-8")
 
     if not total:
-        print("No card/topic binding mismatches found.")
+        if skipped:
+            print(
+                f"No card/topic binding mismatches found in the topics that were read "
+                f"({skipped} skipped — see warnings above; coverage is incomplete)."
+            )
+        else:
+            print("No card/topic binding mismatches found.")
         return 0
 
     print(f"Card/topic binding mismatches ({total}):")

--- a/solutions/ess-maker-skills/scripts/scan_config.py
+++ b/solutions/ess-maker-skills/scripts/scan_config.py
@@ -269,6 +269,7 @@ def main() -> int:
 
     detail: dict[str, dict] = {}
     total = 0
+    skipped = 0
     for topic_file in topic_files:
         if not topic_file.is_file():
             print(f"ERROR: topic not found: {topic_file}", file=sys.stderr)
@@ -276,9 +277,11 @@ def main() -> int:
         parsed = _load(topic_file)
         if parsed is None:
             print(
-                f"WARNING: could not parse {topic_file.name}; it was NOT analyzed "
-                f"(a clean result does not cover this topic)."
+                f"WARNING: could not read/parse {topic_file.name}; it was NOT analyzed "
+                f"(a clean result does not cover this topic).",
+                file=sys.stderr,
             )
+            skipped += 1
             continue
         findings = reconcile(parsed, component_map, configs_dir, base_keys)
         if findings:
@@ -291,7 +294,13 @@ def main() -> int:
         out.write_text(json.dumps(detail, indent=2) + "\n", encoding="utf-8")
 
     if not total:
-        print("No config/topic silent-blank mismatches found.")
+        if skipped:
+            print(
+                f"No config/topic silent-blank mismatches found in the topics that were read "
+                f"({skipped} skipped — see warnings above; coverage is incomplete)."
+            )
+        else:
+            print("No config/topic silent-blank mismatches found.")
         return 0
 
     print(f"Config/topic silent-blank mismatches ({total}):")

--- a/solutions/ess-maker-skills/scripts/scan_config.py
+++ b/solutions/ess-maker-skills/scripts/scan_config.py
@@ -208,6 +208,7 @@ def main() -> int:
     )
     parser.add_argument("--agent", "-a", help="Agent folder under workspace/agents/. Auto-detected if only one.")
     parser.add_argument("--topic", "-t", help="Topic file stem to review. Reviews all topics if omitted.")
+    parser.add_argument("--module", help="Restrict to topics whose name starts with this module id (e.g. workday, servicenow-hrsd). Ignored if --topic is given.")
     parser.add_argument("--output", "-o", help="Write the full per-topic detail to this JSON file.")
     args = parser.parse_args()
 
@@ -237,6 +238,8 @@ def main() -> int:
     if args.topic:
         stem = args.topic.removesuffix(".mcs.yml")
         topic_files = [topics_dir / f"{stem}.mcs.yml"]
+    elif args.module:
+        topic_files = sorted(topics_dir.glob(f"{args.module}*.mcs.yml"))
     else:
         topic_files = sorted(topics_dir.glob("*.mcs.yml"))
 

--- a/solutions/ess-maker-skills/scripts/scan_config.py
+++ b/solutions/ess-maker-skills/scripts/scan_config.py
@@ -153,11 +153,99 @@ def produced_fields(scenario: str, configs_dir: Path, base_keys: set[str]) -> se
     return names | base_keys
 
 
+# Depth guard for following a delegation chain (a topic that routes its backend
+# call through another component/system topic). The observed ESS chains are one
+# hop (UI topic -> component topic -> system topic); a small bound keeps a
+# malformed or cyclic map from recursing without end.
+_MAX_HOP = 4
+
+
+def _scenario_literals(value) -> list[str]:
+    """Every `msdyn_<Scenario>` literal in a binding/Switch value string, in order."""
+    return re.findall(r"msdyn_\w+", value) if isinstance(value, str) else []
+
+
+def _switch_scenarios(topic, var_name: str) -> list[str]:
+    """Scenario literals a `SetVariable` assigns to `Topic.<var_name>` via a Switch.
+
+    A create-case topic builds its scenario per user selection, e.g.
+    `ScenarioName: =Topic.MappedScenario` where `MappedScenario` is
+    `=Switch(Topic.user_selected_coe, "…", "msdyn_ServiceNowHRSDCreateCasePayroll", …)`.
+    The *selection* is runtime, but the *set* of reachable scenarios is static, so
+    return every branch literal. The caller unions their produced fields and flags
+    only fields absent from ALL branches (a guaranteed blank for every selection);
+    per-selection reachability is left to the agentic lens.
+    """
+    for node in _walk(topic):
+        if node.get("kind") == "SetVariable" and node.get("variable") == f"Topic.{var_name}":
+            lits = _scenario_literals(node.get("value"))
+            if lits:
+                return lits
+    return []
+
+
+def _resolve_scenarios(node, system_file, topic, component_map, depth: int = 0) -> list[str]:
+    """Every ServiceNow scenario reachable from a `BeginDialog`, or [] if unresolved.
+
+    Resolution order, most explicit first:
+      1. one or more `msdyn_` literals passed inline on this call's `ScenarioName`;
+      2. an inline `ScenarioName: =Topic.<var>` built by a Switch (fan-out — all branches);
+      3. a literal `ScenarioName` declared in the directly-called topic;
+      4. a transitive hop — the called topic delegates to a system topic that resolves
+         (bounded by `_MAX_HOP`).
+    """
+    binding = (node.get("input") or {}).get("binding")
+    raw = binding.get("ScenarioName") if isinstance(binding, dict) else None
+
+    lits = _scenario_literals(raw)
+    if lits:
+        return lits
+
+    if isinstance(raw, str):
+        m = re.fullmatch(r"=?\s*Topic\.([A-Za-z_]\w*)\s*", raw)
+        if m:
+            switched = _switch_scenarios(topic, m.group(1))
+            if switched:
+                return switched
+
+    literal = scenario_of(system_file) if system_file is not None else None
+    if literal:
+        return [literal]
+
+    if depth < _MAX_HOP and system_file is not None:
+        called = _load(system_file)
+        if called is not None:
+            for inner in _walk(called):
+                if inner.get("kind") != "BeginDialog":
+                    continue
+                inner_file = component_map.get(_schema_suffix(inner.get("dialog", "") or ""))
+                if inner_file is None:
+                    continue
+                resolved = _resolve_scenarios(inner, inner_file, called, component_map, depth + 1)
+                if resolved:
+                    return resolved
+    return []
+
+
 def resolve_response_vars(
     topic, component_map: dict[str, Path], configs_dir: Path, base_keys: set[str]
-) -> dict[str, set[str]]:
-    """Map each response variable to the produced-field set of its scenario."""
+) -> tuple[dict[str, set[str]], dict[str, str]]:
+    """Map each response variable to the produced-field set of its scenario.
+
+    Also returns `var_unresolved`, mapping a response variable bound by a
+    ServiceNow system dialog whose scenario could NOT be resolved statically (or
+    resolved but whose template config could not be loaded) to that dialog's
+    suffix — e.g. a topic that `BeginDialog`s into the shared `*SystemCommonExecution`
+    without an inline `ScenarioName` the reader can see. The caller uses it to
+    disclose incomplete coverage only when such a variable is actually parsed (an
+    unchecked field), rather than reporting clean.
+
+    A response variable bound by more than one dialog gets the **union** of every
+    producer's fields, so a field produced by any binding path is not spuriously
+    flagged.
+    """
     var_to_produced: dict[str, set[str]] = {}
+    var_unresolved: dict[str, str] = {}
     for node in _walk(topic):
         if node.get("kind") != "BeginDialog":
             continue
@@ -165,18 +253,43 @@ def resolve_response_vars(
         system_file = component_map.get(suffix)
         if system_file is None:
             continue
-        scenario = scenario_of(system_file)
-        if scenario is None:
-            continue
-        produced = produced_fields(scenario, configs_dir, base_keys)
-        if produced is None:
-            continue
         binding = (node.get("output") or {}).get("binding")
-        if isinstance(binding, dict):
-            for target in binding.values():
-                if isinstance(target, str) and target.startswith("Topic."):
-                    var_to_produced[target[len("Topic."):]] = produced
-    return var_to_produced
+        targets = [
+            t[len("Topic."):]
+            for t in (binding.values() if isinstance(binding, dict) else [])
+            if isinstance(t, str) and t.startswith("Topic.")
+        ]
+        if not targets:
+            continue
+        scenarios = _resolve_scenarios(node, system_file, topic, component_map)
+        if not scenarios:
+            if "servicenow" in suffix.lower():
+                for target in targets:
+                    var_unresolved.setdefault(target, suffix)
+            continue
+        # Union the produced fields across every reachable scenario (one for a
+        # direct/inline/transitive call, several for a Switch fan-out). A parsed
+        # field absent from the union is a guaranteed blank for every selection;
+        # a field produced by only some branches is left for the agentic lens.
+        produced: set[str] = set()
+        any_resolved = False
+        for scenario in scenarios:
+            fields = produced_fields(scenario, configs_dir, base_keys)
+            if fields is not None:
+                produced |= fields
+                any_resolved = True
+        if not any_resolved:
+            # Scenario(s) resolved but no template config could be loaded, so the
+            # response fields went unchecked — disclose rather than report clean.
+            if "servicenow" in suffix.lower():
+                for target in targets:
+                    var_unresolved.setdefault(target, suffix)
+            continue
+        # Union with any producer already recorded for this variable (a response
+        # var bound by more than one dialog), never overwrite.
+        for target in targets:
+            var_to_produced[target] = var_to_produced.get(target, set()) | produced
+    return var_to_produced, var_unresolved
 
 
 def _value_source(value) -> str | None:
@@ -205,20 +318,29 @@ def parsed_records(topic) -> list[tuple[str, set[str]]]:
     return records
 
 
-def reconcile(topic, component_map, configs_dir, base_keys) -> dict[str, list[str]]:
-    """Map each parsed-but-not-produced field to a one-line reason."""
-    var_to_produced = resolve_response_vars(topic, component_map, configs_dir, base_keys)
+def reconcile(topic, component_map, configs_dir, base_keys) -> tuple[dict[str, list[str]], list[str]]:
+    """Map each parsed-but-not-produced field to a one-line reason.
+
+    Returns `(findings, unresolved)` where `unresolved` lists the ServiceNow
+    dialog suffixes whose response a variable in THIS topic parses but whose
+    scenario could not be resolved (so those fields went unchecked). The caller
+    discloses them as incomplete coverage rather than reporting clean.
+    """
+    var_to_produced, var_unresolved = resolve_response_vars(topic, component_map, configs_dir, base_keys)
     findings: dict[str, list[str]] = {}
+    unresolved: list[str] = []
     for source, fields in parsed_records(topic):
         produced = var_to_produced.get(source)
         if produced is None:
+            if source in var_unresolved:
+                unresolved.append(var_unresolved[source])
             continue
         for field in sorted(fields):
             if field not in produced:
                 findings[f"{source}.{field}"] = [
                     "parsed but not produced (config never returns this field; renders blank)"
                 ]
-    return findings
+    return findings, unresolved
 
 
 def main() -> int:
@@ -270,6 +392,7 @@ def main() -> int:
     detail: dict[str, dict] = {}
     total = 0
     skipped = 0
+    incomplete: list[str] = []
     for topic_file in topic_files:
         if not topic_file.is_file():
             print(f"ERROR: topic not found: {topic_file}", file=sys.stderr)
@@ -283,7 +406,16 @@ def main() -> int:
             )
             skipped += 1
             continue
-        findings = reconcile(parsed, component_map, configs_dir, base_keys)
+        findings, unresolved = reconcile(parsed, component_map, configs_dir, base_keys)
+        if unresolved:
+            incomplete.append(topic_file.name)
+            print(
+                f"WARNING: {topic_file.name} routes ServiceNow dialog(s) "
+                f"({', '.join(sorted(set(unresolved)))}) whose scenario could not be resolved "
+                f"statically (inline scenarioName via shared execution); their response fields "
+                f"were NOT checked (coverage is incomplete for this topic).",
+                file=sys.stderr,
+            )
         if findings:
             detail[topic_file.name] = {"mismatched": dict(sorted(findings.items()))}
             total += len(findings)
@@ -291,13 +423,19 @@ def main() -> int:
     if args.output:
         out = Path(args.output)
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(detail, indent=2) + "\n", encoding="utf-8")
+        payload = {"detail": detail, "skipped": skipped, "incomplete": sorted(set(incomplete))}
+        out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
     if not total:
-        if skipped:
+        if skipped or incomplete:
+            notes = []
+            if skipped:
+                notes.append(f"{skipped} skipped")
+            if incomplete:
+                notes.append(f"{len(incomplete)} with unresolved ServiceNow scenarios")
             print(
-                f"No config/topic silent-blank mismatches found in the topics that were read "
-                f"({skipped} skipped — see warnings above; coverage is incomplete)."
+                f"No config/topic silent-blank mismatches found in the topics that were fully "
+                f"checked ({'; '.join(notes)} — see warnings above; coverage is incomplete)."
             )
         else:
             print("No config/topic silent-blank mismatches found.")

--- a/solutions/ess-maker-skills/scripts/scan_config.py
+++ b/solutions/ess-maker-skills/scripts/scan_config.py
@@ -55,10 +55,29 @@ _BASE_CONFIG_RE = re.compile(r"^msdyn-servicenow(?:hrsd|itsm)\.json$")
 _MAX_LISTED = 20
 
 
+# PyYAML rejects plain scalars that begin with a reserved indicator. Workday WSDL/XML
+# topics carry @-prefixed mapping keys (@Public, @Primary, @Descriptor, @type); quote
+# such bare keys so the topic parses instead of being silently skipped.
+_RESERVED_KEY_RE = re.compile(
+    r'^(?P<indent>[ \t]*(?:-[ \t]+)?)(?P<key>@[^\s:#]+)(?P<sep>[ \t]*:(?:[ \t]|$))',
+    re.MULTILINE,
+)
+
+
+def _quote_reserved_keys(text: str) -> str:
+    return _RESERVED_KEY_RE.sub(
+        lambda m: f'{m.group("indent")}"{m.group("key")}"{m.group("sep")}', text
+    )
+
+
 def _load(path: Path):
     try:
-        return yaml.safe_load(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        return yaml.safe_load(_quote_reserved_keys(text))
+    except yaml.YAMLError:
         return None
 
 
@@ -212,6 +231,11 @@ def main() -> int:
     parser.add_argument("--output", "-o", help="Write the full per-topic detail to this JSON file.")
     args = parser.parse_args()
 
+    for _flag, _val in (("--agent", args.agent), ("--topic", args.topic), ("--module", args.module)):
+        if _val and ("/" in _val or "\\" in _val or ".." in _val or Path(_val).is_absolute()):
+            print(f"ERROR: invalid {_flag} '{_val}': must be a bare name, not a path.", file=sys.stderr)
+            return 1
+
     repo_root = Path(__file__).parent.parent
     agents_dir = repo_root / "workspace" / "agents"
     if not agents_dir.is_dir():
@@ -251,6 +275,10 @@ def main() -> int:
             return 1
         parsed = _load(topic_file)
         if parsed is None:
+            print(
+                f"WARNING: could not parse {topic_file.name}; it was NOT analyzed "
+                f"(a clean result does not cover this topic)."
+            )
             continue
         findings = reconcile(parsed, component_map, configs_dir, base_keys)
         if findings:

--- a/solutions/ess-maker-skills/scripts/scan_config.py
+++ b/solutions/ess-maker-skills/scripts/scan_config.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+scan_config.py — Detect ServiceNow config/topic silent-blank mismatches.
+
+A ServiceNow topic parses an integration response into a record whose fields it
+later renders. The set of fields the integration actually returns is fixed by the
+scenario's template config (`OutputFieldMapping[].OutputName`, plus the connector
+base config). If a topic parses a field the config never produces, that field is
+silently blank at runtime with no error. This reconciles the two sets.
+
+Resolution (ServiceNow's two-hop wiring):
+  - A user topic reaches its integration through a BeginDialog into a system topic,
+    referenced by schema name (`dialog: ...topic.<SchemaName>`).
+  - `.component-map.json` maps that schema name to the system topic file.
+  - The system topic declares `ScenarioName: msdyn_<Scenario>`, from which the
+    config filename derives (`msdyn_X` -> `msdyn-x.json`, lowercase, `_`->`-`).
+  - The BeginDialog output binding names the response variable; the ParseValue that
+    reads that variable declares the fields the topic consumes.
+
+Produced set = the scenario config's `OutputFieldMapping[].OutputName` union the
+connector base-config keys (e.g. `ServiceNowPortalBaseURI`, injected downstream).
+
+One anomaly class is reported, high precision:
+  - parsed-but-not-produced: a ParseValue record field with no matching config
+    output — the field renders blank at runtime.
+
+Only scenarios that resolve to a JSON ServiceNow config are reconciled. Producers
+whose scenario cannot be resolved locally are skipped, not flagged (Workday's XML
+configs, which declare only a top-level key, are out of scope).
+
+Output is bounded: anomalies to stdout (capped), full detail to --output. This
+script only detects; it assigns no severity and makes no judgement.
+
+Usage:
+    python scripts/scan_config.py --agent employee-self-service-hr --topic servicenow-hrsd-get-case-details
+    python scripts/scan_config.py --agent employee-self-service-hr --output results/config.json
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# A ScenarioName value, e.g. ="msdyn_ServiceNowHRSDGetCaseDetails".
+_SCENARIO_RE = re.compile(r"ScenarioName['\"\s:=]+.*?(msdyn_\w+)")
+# A bare connector base config, e.g. msdyn-servicenowhrsd.json (no scenario suffix).
+_BASE_CONFIG_RE = re.compile(r"^msdyn-servicenow(?:hrsd|itsm)\.json$")
+
+_MAX_LISTED = 20
+
+
+def _load(path: Path):
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return None
+
+
+def _walk(node):
+    """Yield every dict found anywhere in a parsed topic tree."""
+    if isinstance(node, dict):
+        yield node
+        for v in node.values():
+            yield from _walk(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk(item)
+
+
+def _schema_suffix(schema_name: str) -> str:
+    """`msdyn_...topic.ServiceNowHRSDSystemGetCaseDetails` -> the trailing segment."""
+    return schema_name.rsplit(".", 1)[-1] if schema_name else ""
+
+
+def load_component_map(agent_dir: Path) -> dict[str, Path]:
+    """Map each component's short schema-name suffix to its topic file."""
+    raw = _load(agent_dir / ".component-map.json")
+    result: dict[str, Path] = {}
+    if isinstance(raw, dict):
+        for rel_path, meta in raw.items():
+            if isinstance(meta, dict):
+                suffix = _schema_suffix(meta.get("schemaname", ""))
+                if suffix:
+                    result[suffix] = agent_dir / rel_path
+    return result
+
+
+def load_base_keys(configs_dir: Path) -> set[str]:
+    """Top-level keys of every connector base config, always injected downstream."""
+    keys: set[str] = set()
+    if configs_dir.is_dir():
+        for cfg in configs_dir.glob("msdyn-servicenow*.json"):
+            if _BASE_CONFIG_RE.match(cfg.name):
+                data = _load(cfg)
+                if isinstance(data, dict):
+                    keys.update(data.keys())
+    return keys
+
+
+def scenario_of(system_topic_file: Path) -> str | None:
+    """Read a system topic's ScenarioName, e.g. msdyn_ServiceNowHRSDGetCaseDetails."""
+    if not system_topic_file.is_file():
+        return None
+    try:
+        text = system_topic_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    match = _SCENARIO_RE.search(text)
+    return match.group(1) if match else None
+
+
+def produced_fields(scenario: str, configs_dir: Path, base_keys: set[str]) -> set[str] | None:
+    """Config output names for a ServiceNow scenario, or None if not resolvable here."""
+    if "servicenow" not in scenario.lower():
+        return None
+    config_file = configs_dir / (scenario.lower().replace("_", "-") + ".json")
+    data = _load(config_file)
+    if not isinstance(data, dict):
+        return None
+    mappings = data.get("OutputFieldMapping")
+    if not isinstance(mappings, list):
+        return None
+    names = {
+        m["OutputName"]
+        for m in mappings
+        if isinstance(m, dict) and isinstance(m.get("OutputName"), str)
+    }
+    return names | base_keys
+
+
+def resolve_response_vars(
+    topic, component_map: dict[str, Path], configs_dir: Path, base_keys: set[str]
+) -> dict[str, set[str]]:
+    """Map each response variable to the produced-field set of its scenario."""
+    var_to_produced: dict[str, set[str]] = {}
+    for node in _walk(topic):
+        if node.get("kind") != "BeginDialog":
+            continue
+        suffix = _schema_suffix(node.get("dialog", "") or "")
+        system_file = component_map.get(suffix)
+        if system_file is None:
+            continue
+        scenario = scenario_of(system_file)
+        if scenario is None:
+            continue
+        produced = produced_fields(scenario, configs_dir, base_keys)
+        if produced is None:
+            continue
+        binding = (node.get("output") or {}).get("binding")
+        if isinstance(binding, dict):
+            for target in binding.values():
+                if isinstance(target, str) and target.startswith("Topic."):
+                    var_to_produced[target[len("Topic."):]] = produced
+    return var_to_produced
+
+
+def _value_source(value) -> str | None:
+    """`=Topic.ServiceNowData` -> `ServiceNowData` (a single-variable source)."""
+    if not isinstance(value, str):
+        return None
+    match = re.fullmatch(r"=?\s*Topic\.([A-Za-z_][A-Za-z0-9_]*)\s*", value)
+    return match.group(1) if match else None
+
+
+def parsed_records(topic) -> list[tuple[str, set[str]]]:
+    """Return (response variable, top-level field names) for each ParseValue record."""
+    records: list[tuple[str, set[str]]] = []
+    for node in _walk(topic):
+        if node.get("kind") != "ParseValue":
+            continue
+        source = _value_source(node.get("value"))
+        if source is None:
+            continue
+        value_type = node.get("valueType")
+        if not isinstance(value_type, dict):
+            continue
+        props = value_type.get("properties")
+        if isinstance(props, dict):
+            records.append((source, set(props.keys())))
+    return records
+
+
+def reconcile(topic, component_map, configs_dir, base_keys) -> dict[str, list[str]]:
+    """Map each parsed-but-not-produced field to a one-line reason."""
+    var_to_produced = resolve_response_vars(topic, component_map, configs_dir, base_keys)
+    findings: dict[str, list[str]] = {}
+    for source, fields in parsed_records(topic):
+        produced = var_to_produced.get(source)
+        if produced is None:
+            continue
+        for field in sorted(fields):
+            if field not in produced:
+                findings[f"{source}.{field}"] = [
+                    "parsed but not produced (config never returns this field; renders blank)"
+                ]
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect ServiceNow config/topic silent-blank mismatches."
+    )
+    parser.add_argument("--agent", "-a", help="Agent folder under workspace/agents/. Auto-detected if only one.")
+    parser.add_argument("--topic", "-t", help="Topic file stem to review. Reviews all topics if omitted.")
+    parser.add_argument("--output", "-o", help="Write the full per-topic detail to this JSON file.")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent
+    agents_dir = repo_root / "workspace" / "agents"
+    if not agents_dir.is_dir():
+        print(f"ERROR: no workspace/agents/ folder at {agents_dir}", file=sys.stderr)
+        return 1
+
+    if args.agent:
+        agent_dir = agents_dir / args.agent
+    else:
+        candidates = [d for d in agents_dir.iterdir() if d.is_dir()]
+        if len(candidates) != 1:
+            print("ERROR: specify --agent (zero or multiple agents found).", file=sys.stderr)
+            return 1
+        agent_dir = candidates[0]
+    topics_dir = agent_dir / "topics"
+    if not topics_dir.is_dir():
+        print(f"ERROR: no topics/ folder in {agent_dir}", file=sys.stderr)
+        return 1
+
+    configs_dir = agent_dir / "template-configs"
+    component_map = load_component_map(agent_dir)
+    base_keys = load_base_keys(configs_dir)
+
+    if args.topic:
+        stem = args.topic.removesuffix(".mcs.yml")
+        topic_files = [topics_dir / f"{stem}.mcs.yml"]
+    else:
+        topic_files = sorted(topics_dir.glob("*.mcs.yml"))
+
+    detail: dict[str, dict] = {}
+    total = 0
+    for topic_file in topic_files:
+        if not topic_file.is_file():
+            print(f"ERROR: topic not found: {topic_file}", file=sys.stderr)
+            return 1
+        parsed = _load(topic_file)
+        if parsed is None:
+            continue
+        findings = reconcile(parsed, component_map, configs_dir, base_keys)
+        if findings:
+            detail[topic_file.name] = {"mismatched": dict(sorted(findings.items()))}
+            total += len(findings)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(detail, indent=2) + "\n", encoding="utf-8")
+
+    if not total:
+        print("No config/topic silent-blank mismatches found.")
+        return 0
+
+    print(f"Config/topic silent-blank mismatches ({total}):")
+    listed = 0
+    for topic_name in sorted(detail):
+        for path, reasons in sorted(detail[topic_name]["mismatched"].items()):
+            if listed >= _MAX_LISTED:
+                print(f"  +{total - listed} more")
+                return 0
+            print(f"  {topic_name}: Topic.{path} — {reasons[0]}")
+            listed += 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/scan_globals.py
+++ b/solutions/ess-maker-skills/scripts/scan_globals.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+scan_globals.py — Detect dangling Global.* references in an agent's topics.
+
+A "dangling" reference is a `Global.X` that a topic reads but that is never made
+available anywhere in the agent — i.e. no topic writes it (`variable: Global.X`)
+and no variable declares it. These are usually typos or references to a variable
+that was renamed or removed.
+
+Availability is resolved across the whole agent, because a Global written by one
+topic (e.g. a shared system topic that populates a lookup table at runtime) is
+available to every other topic. The reader/writer sets therefore have to be
+aggregated across every topic — which is why this runs as a script rather than by
+reading a single file.
+
+Output is bounded: the dangling references (the anomalies) are printed to stdout,
+capped, with a "+N more" tail. The full reader/writer/declared map is written to
+--output as JSON when requested. This script only detects; it assigns no severity
+and makes no judgement about whether a dangling reference is a real defect.
+
+Usage:
+    python scripts/scan_globals.py
+    python scripts/scan_globals.py --agent employee-self-service-hr
+    python scripts/scan_globals.py --topic servicenow-hrsd-get-user-cases
+    python scripts/scan_globals.py --output results/globals.json
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Ensure UTF-8 output on Windows (avoids cp1252 UnicodeEncodeError).
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# A read: any Global.<name> token in an expression.
+_READ_RE = re.compile(r"\bGlobal\.([A-Za-z_][A-Za-z0-9_]*)")
+# A write: an action assigning to a Global variable (`variable: Global.<name>`).
+_WRITE_RE = re.compile(r"\bvariable:\s*Global\.([A-Za-z_][A-Za-z0-9_]*)")
+# A declaration: a variable definition file's `name: <name>`.
+_DECL_RE = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
+
+# Number of dangling references to list before collapsing into "+N more".
+_MAX_LISTED = 20
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def scan_topics(topics_dir: Path) -> tuple[dict[str, list[str]], set[str]]:
+    """Return (reads, writes) where reads maps Global name -> sorted site list
+    (`file:line`), and writes is the set of Global names assigned anywhere."""
+    reads: dict[str, list[str]] = {}
+    writes: set[str] = set()
+    for topic in sorted(topics_dir.glob("*.mcs.yml")):
+        text = _read(topic)
+        if not text:
+            continue
+        for i, line in enumerate(text.splitlines(), start=1):
+            for m in _WRITE_RE.finditer(line):
+                writes.add(m.group(1))
+            for m in _READ_RE.finditer(line):
+                reads.setdefault(m.group(1), []).append(f"{topic.name}:{i}")
+    return reads, writes
+
+
+def scan_declarations(variables_dir: Path) -> set[str]:
+    """Return the set of Global names declared as variables."""
+    declared: set[str] = set()
+    if not variables_dir.is_dir():
+        return declared
+    for var in variables_dir.glob("*.mcs.yml"):
+        for m in _DECL_RE.finditer(_read(var)):
+            declared.add(m.group(1))
+    return declared
+
+
+def find_dangling(
+    reads: dict[str, list[str]], writes: set[str], declared: set[str]
+) -> dict[str, list[str]]:
+    """A Global is dangling if it is read but neither written nor declared."""
+    available = writes | declared
+    return {name: sites for name, sites in reads.items() if name not in available}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect dangling Global.* references in an agent's topics."
+    )
+    parser.add_argument(
+        "--agent", "-a",
+        help="Agent folder name under workspace/agents/. Auto-detected if only one exists.",
+    )
+    parser.add_argument(
+        "--topic", "-t",
+        help="Report only dangling references read by this topic (file stem). "
+             "Availability is still resolved across the whole agent.",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Write the full reads/writes/declared/dangling map to this JSON file.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent
+    agents_dir = repo_root / "workspace" / "agents"
+    if not agents_dir.is_dir():
+        print(f"ERROR: no workspace/agents/ folder at {agents_dir}", file=sys.stderr)
+        return 1
+
+    if args.agent:
+        agent_dir = agents_dir / args.agent
+    else:
+        candidates = [d for d in agents_dir.iterdir() if d.is_dir()]
+        if len(candidates) != 1:
+            print("ERROR: specify --agent (zero or multiple agents found).", file=sys.stderr)
+            return 1
+        agent_dir = candidates[0]
+    if not (agent_dir / "topics").is_dir():
+        print(f"ERROR: no topics/ folder in {agent_dir}", file=sys.stderr)
+        return 1
+
+    reads, writes = scan_topics(agent_dir / "topics")
+    declared = scan_declarations(agent_dir / "variables")
+    dangling = find_dangling(reads, writes, declared)
+
+    if args.topic:
+        stem = args.topic.removesuffix(".mcs.yml")
+        dangling = {
+            name: [s for s in sites if s.startswith(f"{stem}.mcs.yml:")]
+            for name, sites in dangling.items()
+        }
+        dangling = {name: sites for name, sites in dangling.items() if sites}
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(
+                {
+                    "reads": {k: sorted(v) for k, v in sorted(reads.items())},
+                    "writes": sorted(writes),
+                    "declared": sorted(declared),
+                    "dangling": {k: sorted(v) for k, v in sorted(dangling.items())},
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if not dangling:
+        print("No dangling Global.* references found.")
+        return 0
+
+    total = len(dangling)
+    print(f"Dangling Global.* references ({total}):")
+    for name in sorted(dangling)[:_MAX_LISTED]:
+        sites = dangling[name]
+        shown = ", ".join(sites[:3])
+        extra = f" (+{len(sites) - 3} more sites)" if len(sites) > 3 else ""
+        print(f"  Global.{name}  read at {shown}{extra}")
+    if total > _MAX_LISTED:
+        print(f"  +{total - _MAX_LISTED} more")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/scan_globals.py
+++ b/solutions/ess-maker-skills/scripts/scan_globals.py
@@ -103,6 +103,12 @@ def main() -> int:
              "Availability is still resolved across the whole agent.",
     )
     parser.add_argument(
+        "--module",
+        help="Report only dangling references read by topics whose name starts with this "
+             "module id (e.g. workday, servicenow-hrsd). Availability is still resolved "
+             "across the whole agent. Ignored if --topic is given.",
+    )
+    parser.add_argument(
         "--output", "-o",
         help="Write the full reads/writes/declared/dangling map to this JSON file.",
     )
@@ -134,6 +140,12 @@ def main() -> int:
         stem = args.topic.removesuffix(".mcs.yml")
         dangling = {
             name: [s for s in sites if s.startswith(f"{stem}.mcs.yml:")]
+            for name, sites in dangling.items()
+        }
+        dangling = {name: sites for name, sites in dangling.items() if sites}
+    elif args.module:
+        dangling = {
+            name: [s for s in sites if s.split(":", 1)[0].startswith(args.module)]
             for name, sites in dangling.items()
         }
         dangling = {name: sites for name, sites in dangling.items() if sites}

--- a/solutions/ess-maker-skills/scripts/scan_globals.py
+++ b/solutions/ess-maker-skills/scripts/scan_globals.py
@@ -114,6 +114,11 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    for _flag, _val in (("--agent", args.agent), ("--topic", args.topic), ("--module", args.module)):
+        if _val and ("/" in _val or "\\" in _val or ".." in _val or Path(_val).is_absolute()):
+            print(f"ERROR: invalid {_flag} '{_val}': must be a bare name, not a path.", file=sys.stderr)
+            return 1
+
     repo_root = Path(__file__).parent.parent
     agents_dir = repo_root / "workspace" / "agents"
     if not agents_dir.is_dir():

--- a/solutions/ess-maker-skills/scripts/scan_globals.py
+++ b/solutions/ess-maker-skills/scripts/scan_globals.py
@@ -46,28 +46,34 @@ _DECL_RE = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
 _MAX_LISTED = 20
 
 
-def _read(path: Path) -> str:
+def _read(path: Path) -> str | None:
+    """Return the file text, or None if it could not be read (distinct from an
+    empty file, which returns "")."""
     try:
         return path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
-        return ""
+        return None
 
 
-def scan_topics(topics_dir: Path) -> tuple[dict[str, list[str]], set[str]]:
-    """Return (reads, writes) where reads maps Global name -> sorted site list
-    (`file:line`), and writes is the set of Global names assigned anywhere."""
+def scan_topics(topics_dir: Path) -> tuple[dict[str, list[str]], set[str], list[str]]:
+    """Return (reads, writes, skipped) where reads maps Global name -> sorted site
+    list (`file:line`), writes is the set of Global names assigned anywhere, and
+    skipped lists topics that could not be read (so a read failure is never a
+    silent clean bill)."""
     reads: dict[str, list[str]] = {}
     writes: set[str] = set()
+    skipped: list[str] = []
     for topic in sorted(topics_dir.glob("*.mcs.yml")):
         text = _read(topic)
-        if not text:
+        if text is None:
+            skipped.append(topic.name)
             continue
         for i, line in enumerate(text.splitlines(), start=1):
             for m in _WRITE_RE.finditer(line):
                 writes.add(m.group(1))
             for m in _READ_RE.finditer(line):
                 reads.setdefault(m.group(1), []).append(f"{topic.name}:{i}")
-    return reads, writes
+    return reads, writes, skipped
 
 
 def scan_declarations(variables_dir: Path) -> set[str]:
@@ -76,7 +82,10 @@ def scan_declarations(variables_dir: Path) -> set[str]:
     if not variables_dir.is_dir():
         return declared
     for var in variables_dir.glob("*.mcs.yml"):
-        for m in _DECL_RE.finditer(_read(var)):
+        text = _read(var)
+        if text is None:
+            continue
+        for m in _DECL_RE.finditer(text):
             declared.add(m.group(1))
     return declared
 
@@ -137,9 +146,16 @@ def main() -> int:
         print(f"ERROR: no topics/ folder in {agent_dir}", file=sys.stderr)
         return 1
 
-    reads, writes = scan_topics(agent_dir / "topics")
+    reads, writes, skipped = scan_topics(agent_dir / "topics")
     declared = scan_declarations(agent_dir / "variables")
     dangling = find_dangling(reads, writes, declared)
+
+    if skipped:
+        print(
+            f"WARNING: {len(skipped)} topic(s) could not be read and were NOT analyzed "
+            f"(a clean result does not cover them): {', '.join(sorted(skipped))}",
+            file=sys.stderr,
+        )
 
     if args.topic:
         stem = args.topic.removesuffix(".mcs.yml")
@@ -165,6 +181,7 @@ def main() -> int:
                     "writes": sorted(writes),
                     "declared": sorted(declared),
                     "dangling": {k: sorted(v) for k, v in sorted(dangling.items())},
+                    "skipped": sorted(skipped),
                 },
                 indent=2,
             )
@@ -173,7 +190,13 @@ def main() -> int:
         )
 
     if not dangling:
-        print("No dangling Global.* references found.")
+        if skipped:
+            print(
+                f"No dangling Global.* references found in the topics that were read "
+                f"({len(skipped)} skipped — see warning above; coverage is incomplete)."
+            )
+        else:
+            print("No dangling Global.* references found.")
         return 0
 
     total = len(dangling)

--- a/solutions/ess-maker-skills/scripts/setup.py
+++ b/solutions/ess-maker-skills/scripts/setup.py
@@ -556,7 +556,7 @@ def write_config(agent_info, slug, output_dir, template_configs_discovered,
     }
 
     # Preserve existing connections and other user-set fields
-    for key in ("connections", "workdayTestEmployeeId"):
+    for key in ("connections", "workdayTestEmployeeId", "referenceSource"):
         if key in existing and key not in config:
             config[key] = existing[key]
 

--- a/solutions/ess-maker-skills/scripts/sync_isv_docs.py
+++ b/solutions/ess-maker-skills/scripts/sync_isv_docs.py
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Maker Kit - Sync ISV Reference Docs
+
+Copies the ESS ISV reference docs (isv-*.md) from a local ESSVivaCopilot
+checkout into src/reference/ess-docs/isv/ so the review skill can read them
+from inside the workspace. The destination is gitignored: these docs are not
+part of this repository and are not committed.
+
+Must be run from solutions/ess-maker-skills/ (paths are relative).
+
+Usage:
+    cd solutions/ess-maker-skills
+    python scripts/sync_isv_docs.py
+    python scripts/sync_isv_docs.py --source <path-to-ESSVivaCopilot>
+    python scripts/sync_isv_docs.py --force   - overwrite existing files
+
+If no ESSVivaCopilot checkout is found and none is given with --source, the
+script prints where it looked and exits without error, leaving ISV conformance
+checks to degrade gracefully.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# isv-*.md live here inside an ESSVivaCopilot checkout.
+_DOCS_SUBPATH = Path("skills") / "docs"
+_OUTPUT_DIR = Path("src") / "reference" / "ess-docs" / "isv"
+
+
+def find_source(explicit: str | None) -> Path | None:
+    """Locate an ESSVivaCopilot checkout containing skills/docs/isv-*.md."""
+    candidates: list[Path] = []
+    if explicit:
+        p = Path(explicit).expanduser().resolve()
+        # Accept either the repo root or the docs folder directly.
+        candidates += [p, p / _DOCS_SUBPATH, p.parent]
+    # Walk up from the current directory looking for a sibling ESSVivaCopilot.
+    here = Path.cwd().resolve()
+    for ancestor in [here, *here.parents]:
+        candidates.append(ancestor / "ESSVivaCopilot")
+    for cand in candidates:
+        docs = cand if cand.name == "docs" else cand / _DOCS_SUBPATH
+        if docs.is_dir() and any(docs.glob("isv-*.md")):
+            return docs
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync ESS ISV reference docs into the workspace.")
+    parser.add_argument("--source", help="Path to an ESSVivaCopilot checkout (or its skills/docs folder).")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing files.")
+    args = parser.parse_args()
+
+    source = find_source(args.source)
+    if source is None:
+        print("No ESSVivaCopilot checkout with skills/docs/isv-*.md was found.")
+        print("Looked for an 'ESSVivaCopilot' folder among this directory's ancestors.")
+        print("Pass one explicitly with --source <path>, or skip: ISV conformance will")
+        print("be reported as not checked until the reference docs are available.")
+        return 0
+
+    out_dir = _OUTPUT_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    isv_docs = sorted(source.glob("isv-*.md"))
+    copied = 0
+    skipped = 0
+    for doc in isv_docs:
+        dest = out_dir / doc.name
+        if dest.exists() and not args.force:
+            print(f"  SKIP {dest} (exists, use --force to overwrite)")
+            skipped += 1
+            continue
+        dest.write_text(doc.read_text(encoding="utf-8"), encoding="utf-8")
+        print(f"  {doc.name} -> {dest}")
+        copied += 1
+
+    print(f"\nDone. {copied} copied, {skipped} skipped, from {source}")
+    print(f"Output: {out_dir}/ (gitignored)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/sync_isv_docs.py
+++ b/solutions/ess-maker-skills/scripts/sync_isv_docs.py
@@ -4,69 +4,121 @@
 """
 ESS Maker Kit - Sync ISV Reference Docs
 
-Copies the ESS ISV reference docs (isv-*.md) from a local ESSVivaCopilot
-checkout into src/reference/ess-docs/isv/ so the review skill can read them
-from inside the workspace. The destination is gitignored: these docs are not
-part of this repository and are not committed.
+Copies the ESS ISV reference docs (isv-*.md) from a local ESS reference checkout
+into src/reference/ess-docs/isv/ so the review skill can read them from inside the
+workspace. The destination is gitignored: these docs are not part of this
+repository and are not committed.
 
-Must be run from solutions/ess-maker-skills/ (paths are relative).
+The reference checkout is an internal source; external makers will not have it, in
+which case this sync is skipped and ISV conformance runs in reduced coverage.
+
+Output and config lookup are anchored on the script location, so the sync can be
+run from any directory; only auto-discovery consults the current directory.
 
 Usage:
-    cd solutions/ess-maker-skills
     python scripts/sync_isv_docs.py
-    python scripts/sync_isv_docs.py --source <path-to-ESSVivaCopilot>
+    python scripts/sync_isv_docs.py --source <path-to-reference-checkout>
     python scripts/sync_isv_docs.py --force   - overwrite existing files
 
-If no ESSVivaCopilot checkout is found and none is given with --source, the
-script prints where it looked and exits without error, leaving ISV conformance
-checks to degrade gracefully.
+The reference checkout is located, in order, via: --source, the
+ESS_REFERENCE_SOURCE environment variable, or the `referenceSource` key in
+.local/config.json (a maintained per-environment path that survives /setup
+re-runs). A declared source that does not expose the docs is a hard stop. If no
+source is declared (the external default), the sync is skipped and ISV
+conformance checks degrade gracefully.
 """
 
 import argparse
+import json
+import os
 import sys
 from pathlib import Path
 
-# isv-*.md live here inside an ESSVivaCopilot checkout.
+# Anchor output and config lookup on the script location (not cwd), so a sync run
+# from any directory writes where the review's coverage probe looks. Only
+# auto-discovery consults the cwd.
+_SKILL_ROOT = Path(__file__).resolve().parent.parent
+
+# Within a reference checkout, the docs live under skills/docs/.
 _DOCS_SUBPATH = Path("skills") / "docs"
-_OUTPUT_DIR = Path("src") / "reference" / "ess-docs" / "isv"
+_OUTPUT_DIR = _SKILL_ROOT / "src" / "reference" / "ess-docs" / "isv"
+_DOC_GLOB = "isv-*.md"
+_SOURCE_ENV = "ESS_REFERENCE_SOURCE"
+
+
+def _config_reference_source() -> str | None:
+    """The `referenceSource` path recorded in .local/config.json, or None.
+
+    A missing or unreadable config is not an error here — it simply means no
+    configured source (the default external case). Read directly, not via
+    auth.load_config(), so a config schema change can never break a manual
+    --source / env-var sync.
+    """
+    try:
+        data = json.loads((_SKILL_ROOT / ".local" / "config.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    val = data.get("referenceSource") if isinstance(data, dict) else None
+    return val if isinstance(val, str) and val.strip() else None
+
+
+def _docs_dir(cand: Path) -> Path | None:
+    """If `cand` (a checkout root or a docs folder) exposes the docs, return the
+    docs folder; else None."""
+    docs = cand if cand.name == "docs" else cand / _DOCS_SUBPATH
+    return docs if docs.is_dir() and any(docs.glob(_DOC_GLOB)) else None
 
 
 def find_source(explicit: str | None) -> Path | None:
-    """Locate an ESSVivaCopilot checkout containing skills/docs/isv-*.md."""
-    candidates: list[Path] = []
-    if explicit:
-        p = Path(explicit).expanduser().resolve()
-        # Accept either the repo root or the docs folder directly.
-        candidates += [p, p / _DOCS_SUBPATH, p.parent]
-    # Walk up from the current directory looking for a sibling ESSVivaCopilot.
-    here = Path.cwd().resolve()
-    for ancestor in [here, *here.parents]:
-        candidates.append(ancestor / "ESSVivaCopilot")
-    for cand in candidates:
-        docs = cand if cand.name == "docs" else cand / _DOCS_SUBPATH
-        if docs.is_dir() and any(docs.glob("isv-*.md")):
-            return docs
+    """Locate a local ESS reference checkout exposing skills/docs/isv-*.md.
+
+    Resolution order: --source, the ESS_REFERENCE_SOURCE env var, then the
+    `referenceSource` key in .local/config.json. The path must expose the docs; a
+    source that is set but does not is a hard stop (print an error and exit 1). If
+    no source is declared, returns None — the external default, where the sync is
+    skipped and the review degrades gracefully. No specific repository name is
+    assumed and no directory scan is performed.
+    """
+    declared = [
+        ("--source", explicit),
+        (_SOURCE_ENV, os.environ.get(_SOURCE_ENV)),
+        ("referenceSource in .local/config.json", _config_reference_source()),
+    ]
+    for label, raw in declared:
+        if not raw:
+            continue
+        base = Path(raw).expanduser().resolve()
+        for cand in (base, base / _DOCS_SUBPATH, base.parent):
+            docs = _docs_dir(cand)
+            if docs is not None:
+                return docs
+        print(
+            f"ERROR: {label} is set to '{raw}', but no skills/docs/{_DOC_GLOB} was "
+            f"found there. Fix or clear it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     return None
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Sync ESS ISV reference docs into the workspace.")
-    parser.add_argument("--source", help="Path to an ESSVivaCopilot checkout (or its skills/docs folder).")
+    parser.add_argument("--source", help="Path to a local ESS reference checkout (or its skills/docs folder).")
     parser.add_argument("--force", action="store_true", help="Overwrite existing files.")
     args = parser.parse_args()
 
     source = find_source(args.source)
     if source is None:
-        print("No ESSVivaCopilot checkout with skills/docs/isv-*.md was found.")
-        print("Looked for an 'ESSVivaCopilot' folder among this directory's ancestors.")
-        print("Pass one explicitly with --source <path>, or skip: ISV conformance will")
-        print("be reported as not checked until the reference docs are available.")
+        print("No ESS reference checkout exposing skills/docs/isv-*.md was found.")
+        print("Provide one with --source <path>, set the ESS_REFERENCE_SOURCE environment")
+        print("variable, or skip: ISV conformance will be reported as not checked until the")
+        print("reference docs are available.")
         return 0
 
     out_dir = _OUTPUT_DIR
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    isv_docs = sorted(source.glob("isv-*.md"))
+    isv_docs = sorted(source.glob(_DOC_GLOB))
     copied = 0
     skipped = 0
     for doc in isv_docs:

--- a/solutions/ess-maker-skills/scripts/sync_runtime_heuristics.py
+++ b/solutions/ess-maker-skills/scripts/sync_runtime_heuristics.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Maker Kit - Sync Runtime-Heuristics Docs
+
+Copies the ESS runtime-heuristics docs (confirmed-runtime-heuristics.md and
+pending-runtime-heuristics.md) from a local ESSVivaCopilot checkout into
+src/reference/ess-docs/runtime/ so the review lenses can consult them when
+scoring reachability/severity. The destination is gitignored: these docs are not
+part of this repository and are not committed.
+
+The confirmed catalog is authoritative (e.g. the AI-orchestration "no data"
+rule and the OnError dialog-termination rule cap certain findings at LOW). The
+pending catalog is provisional — apply with caution.
+
+Must be run from solutions/ess-maker-skills/ (paths are relative).
+
+Usage:
+    cd solutions/ess-maker-skills
+    python scripts/sync_runtime_heuristics.py
+    python scripts/sync_runtime_heuristics.py --source <path-to-ESSVivaCopilot>
+    python scripts/sync_runtime_heuristics.py --force   - overwrite existing files
+
+If no ESSVivaCopilot checkout is found and none is given with --source, the
+script prints where it looked and exits without error, leaving the lenses to
+score severity from the finding-contract rubric alone (less calibrated, but the
+review still runs).
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# The runtime-heuristics docs live here inside an ESSVivaCopilot checkout.
+_DOCS_SUBPATH = Path("skills") / "docs"
+_OUTPUT_DIR = Path("src") / "reference" / "ess-docs" / "runtime"
+_DOC_GLOB = "*runtime-heuristics.md"
+
+
+def find_source(explicit: str | None) -> Path | None:
+    """Locate an ESSVivaCopilot checkout containing skills/docs/*runtime-heuristics.md."""
+    candidates: list[Path] = []
+    if explicit:
+        p = Path(explicit).expanduser().resolve()
+        # Accept either the repo root or the docs folder directly.
+        candidates += [p, p / _DOCS_SUBPATH, p.parent]
+    # Walk up from the current directory looking for a sibling ESSVivaCopilot.
+    here = Path.cwd().resolve()
+    for ancestor in [here, *here.parents]:
+        candidates.append(ancestor / "ESSVivaCopilot")
+    for cand in candidates:
+        docs = cand if cand.name == "docs" else cand / _DOCS_SUBPATH
+        if docs.is_dir() and any(docs.glob(_DOC_GLOB)):
+            return docs
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync ESS runtime-heuristics docs into the workspace.")
+    parser.add_argument("--source", help="Path to an ESSVivaCopilot checkout (or its skills/docs folder).")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing files.")
+    args = parser.parse_args()
+
+    source = find_source(args.source)
+    if source is None:
+        print("No ESSVivaCopilot checkout with skills/docs/*runtime-heuristics.md was found.")
+        print("Looked for an 'ESSVivaCopilot' folder among this directory's ancestors.")
+        print("Pass one explicitly with --source <path>, or skip: the lenses will score")
+        print("severity from the finding-contract rubric alone until the docs are available.")
+        return 0
+
+    out_dir = _OUTPUT_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    docs = sorted(source.glob(_DOC_GLOB))
+    copied = 0
+    skipped = 0
+    for doc in docs:
+        dest = out_dir / doc.name
+        if dest.exists() and not args.force:
+            print(f"  SKIP {dest} (exists, use --force to overwrite)")
+            skipped += 1
+            continue
+        dest.write_text(doc.read_text(encoding="utf-8"), encoding="utf-8")
+        print(f"  {doc.name} -> {dest}")
+        copied += 1
+
+    print(f"\nDone. {copied} copied, {skipped} skipped, from {source}")
+    print(f"Output: {out_dir}/ (gitignored)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/sync_runtime_heuristics.py
+++ b/solutions/ess-maker-skills/scripts/sync_runtime_heuristics.py
@@ -5,7 +5,7 @@
 ESS Maker Kit - Sync Runtime-Heuristics Docs
 
 Copies the ESS runtime-heuristics docs (confirmed-runtime-heuristics.md and
-pending-runtime-heuristics.md) from a local ESSVivaCopilot checkout into
+pending-runtime-heuristics.md) from a local ESS reference checkout into
 src/reference/ess-docs/runtime/ so the review lenses can consult them when
 scoring reachability/severity. The destination is gitignored: these docs are not
 part of this repository and are not committed.
@@ -14,60 +14,111 @@ The confirmed catalog is authoritative (e.g. the AI-orchestration "no data"
 rule and the OnError dialog-termination rule cap certain findings at LOW). The
 pending catalog is provisional — apply with caution.
 
-Must be run from solutions/ess-maker-skills/ (paths are relative).
+The reference checkout is an internal source; external makers will not have it,
+in which case this sync is skipped and severity is scored structurally.
+
+Output and config lookup are anchored on the script location, so the sync can be
+run from any directory; only auto-discovery consults the current directory.
 
 Usage:
-    cd solutions/ess-maker-skills
     python scripts/sync_runtime_heuristics.py
-    python scripts/sync_runtime_heuristics.py --source <path-to-ESSVivaCopilot>
+    python scripts/sync_runtime_heuristics.py --source <path-to-reference-checkout>
     python scripts/sync_runtime_heuristics.py --force   - overwrite existing files
 
-If no ESSVivaCopilot checkout is found and none is given with --source, the
-script prints where it looked and exits without error, leaving the lenses to
-score severity from the finding-contract rubric alone (less calibrated, but the
-review still runs).
+The reference checkout is located, in order, via: --source, the
+ESS_REFERENCE_SOURCE environment variable, or the `referenceSource` key in
+.local/config.json (a maintained per-environment path that survives /setup
+re-runs). A declared source that does not expose the docs is a hard stop. If no
+source is declared (the external default), the sync is skipped and severity is
+scored structurally from the finding-contract rubric alone (less calibrated, but
+the review still runs).
 """
 
 import argparse
+import json
+import os
 import sys
 from pathlib import Path
 
-# The runtime-heuristics docs live here inside an ESSVivaCopilot checkout.
+# Anchor output and config lookup on the script location (not cwd), so a sync run
+# from any directory writes where the review's coverage probe looks. Only
+# auto-discovery consults the cwd.
+_SKILL_ROOT = Path(__file__).resolve().parent.parent
+
+# Within a reference checkout, the docs live under skills/docs/.
 _DOCS_SUBPATH = Path("skills") / "docs"
-_OUTPUT_DIR = Path("src") / "reference" / "ess-docs" / "runtime"
+_OUTPUT_DIR = _SKILL_ROOT / "src" / "reference" / "ess-docs" / "runtime"
 _DOC_GLOB = "*runtime-heuristics.md"
+_SOURCE_ENV = "ESS_REFERENCE_SOURCE"
+
+
+def _config_reference_source() -> str | None:
+    """The `referenceSource` path recorded in .local/config.json, or None.
+
+    A missing or unreadable config is not an error here — it simply means no
+    configured source (the default external case). Read directly, not via
+    auth.load_config(), so a config schema change can never break a manual
+    --source / env-var sync.
+    """
+    try:
+        data = json.loads((_SKILL_ROOT / ".local" / "config.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    val = data.get("referenceSource") if isinstance(data, dict) else None
+    return val if isinstance(val, str) and val.strip() else None
+
+
+def _docs_dir(cand: Path) -> Path | None:
+    """If `cand` (a checkout root or a docs folder) exposes the docs, return the
+    docs folder; else None."""
+    docs = cand if cand.name == "docs" else cand / _DOCS_SUBPATH
+    return docs if docs.is_dir() and any(docs.glob(_DOC_GLOB)) else None
 
 
 def find_source(explicit: str | None) -> Path | None:
-    """Locate an ESSVivaCopilot checkout containing skills/docs/*runtime-heuristics.md."""
-    candidates: list[Path] = []
-    if explicit:
-        p = Path(explicit).expanduser().resolve()
-        # Accept either the repo root or the docs folder directly.
-        candidates += [p, p / _DOCS_SUBPATH, p.parent]
-    # Walk up from the current directory looking for a sibling ESSVivaCopilot.
-    here = Path.cwd().resolve()
-    for ancestor in [here, *here.parents]:
-        candidates.append(ancestor / "ESSVivaCopilot")
-    for cand in candidates:
-        docs = cand if cand.name == "docs" else cand / _DOCS_SUBPATH
-        if docs.is_dir() and any(docs.glob(_DOC_GLOB)):
-            return docs
+    """Locate a local ESS reference checkout exposing skills/docs/*runtime-heuristics.md.
+
+    Resolution order: --source, the ESS_REFERENCE_SOURCE env var, then the
+    `referenceSource` key in .local/config.json. The path must expose the docs; a
+    source that is set but does not is a hard stop (print an error and exit 1). If
+    no source is declared, returns None — the external default, where the sync is
+    skipped and severity is scored structurally. No specific repository name is
+    assumed and no directory scan is performed.
+    """
+    declared = [
+        ("--source", explicit),
+        (_SOURCE_ENV, os.environ.get(_SOURCE_ENV)),
+        ("referenceSource in .local/config.json", _config_reference_source()),
+    ]
+    for label, raw in declared:
+        if not raw:
+            continue
+        base = Path(raw).expanduser().resolve()
+        for cand in (base, base / _DOCS_SUBPATH, base.parent):
+            docs = _docs_dir(cand)
+            if docs is not None:
+                return docs
+        print(
+            f"ERROR: {label} is set to '{raw}', but no skills/docs/{_DOC_GLOB} was "
+            f"found there. Fix or clear it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     return None
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Sync ESS runtime-heuristics docs into the workspace.")
-    parser.add_argument("--source", help="Path to an ESSVivaCopilot checkout (or its skills/docs folder).")
+    parser.add_argument("--source", help="Path to a local ESS reference checkout (or its skills/docs folder).")
     parser.add_argument("--force", action="store_true", help="Overwrite existing files.")
     args = parser.parse_args()
 
     source = find_source(args.source)
     if source is None:
-        print("No ESSVivaCopilot checkout with skills/docs/*runtime-heuristics.md was found.")
-        print("Looked for an 'ESSVivaCopilot' folder among this directory's ancestors.")
-        print("Pass one explicitly with --source <path>, or skip: the lenses will score")
-        print("severity from the finding-contract rubric alone until the docs are available.")
+        print("No ESS reference checkout exposing skills/docs/*runtime-heuristics.md was found.")
+        print("Provide one with --source <path>, set the ESS_REFERENCE_SOURCE environment")
+        print("variable, or skip: the lenses will score severity from the finding-contract")
+        print("rubric alone until the docs are available.")
         return 0
 
     out_dir = _OUTPUT_DIR

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/dangling-globals.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/dangling-globals.md
@@ -1,0 +1,46 @@
+# Dangling Global reference check
+
+Analysis guidance for the **cross-topic `Global.*` reference** check used by the `topics/review` skill.
+It surfaces `Global.X` references that a topic reads but that are never made available anywhere in the
+agent — usually a typo, or a reference to a variable that was renamed or removed.
+
+## How availability works
+
+A `Global.*` variable is available to every topic in the agent once **any** topic writes it
+(`variable: Global.X`) or a variable file declares it (`name: X`). Many Globals are populated at runtime
+by shared system topics (for example a reference-data topic that fills lookup tables), so a topic can
+legitimately read a Global it does not write itself. Availability therefore has to be resolved across the
+whole agent, not from the single topic under review.
+
+## Running the check
+
+Run the detector, which aggregates readers, writers, and declarations across the agent and reports the
+references that resolve to nothing:
+
+```
+python scripts/scan_globals.py --agent {agent-slug} --topic {topic-stem}
+```
+
+- `{agent-slug}` is the agent folder name under `workspace/agents/`.
+- `{topic-stem}` restricts the reported anomalies to those read by the topic under review; availability
+  is still resolved across the whole agent.
+
+The detector prints each dangling reference with the sites that read it. It assigns no severity and makes
+no judgement — it only reports references with no writer and no declaration. If the script fails to run,
+skip this check and continue with the rest of the review.
+
+## Turning an anomaly into a finding
+
+For each dangling reference the detector reports, decide whether it is a real defect:
+
+- A reference that is a near-miss of a real variable name (extra/missing letter, wrong casing, wrong
+  separator) is almost certainly a **typo** — the intended variable exists but this reference will always
+  read blank.
+- A reference with no plausible intended target may be a variable that was **renamed or removed**, or a
+  read that was never wired up.
+
+Apply the precision bar and reachability scoring from
+[`powerfx-topic-local.md`](powerfx-topic-local.md) — a dangling read on a path a normal user hits is
+higher severity than one on an unreachable path. Report confirmed findings with the same output format,
+locating each by the reading action's node identity (`id` / `displayName` / `kind`) and naming the
+intended variable in the suggested fix.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/dangling-globals.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/dangling-globals.md
@@ -39,8 +39,8 @@ For each dangling reference the detector reports, decide whether it is a real de
 - A reference with no plausible intended target may be a variable that was **renamed or removed**, or a
   read that was never wired up.
 
-Apply the precision bar and reachability scoring from
-[`powerfx-topic-local.md`](powerfx-topic-local.md) — a dangling read on a path a normal user hits is
-higher severity than one on an unreachable path. Report confirmed findings with the same output format,
-locating each by the reading action's node identity (`id` / `displayName` / `kind`) and naming the
-intended variable in the suggested fix.
+Apply the precision bar and reachability scoring from the shared
+[`finding-contract.md`](finding-contract.md) — a dangling read on a path a normal user hits is
+higher severity than one on an unreachable path. This check uses the `BTDG` finding-ID prefix. Report
+confirmed findings with the shared output format, locating each by the reading action's node identity
+(`id` / `displayName` / `kind`) and naming the intended variable in the suggested fix.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -1,0 +1,82 @@
+# Conformance finding contract
+
+The shared **finding contract** for every conformance lens the `topics/review` skill runs — Power Fx
+topic-local, dangling `Global.*`, UX contract, ISV conformance, ISV integration pattern, and ServiceNow
+config/topic. Each lens produces findings in this one shape so the review can rank, locate, and
+de-duplicate them uniformly. The individual lens docs describe **what** each looks for; this doc defines
+**how** a confirmed finding is scored and reported.
+
+Findings are **advisory prose** in the response — no lens writes anything to disk. This is the internal
+(structured) contract; the customer-facing translation is Step 7 of the `topics/review` skill.
+
+## Precision bar
+
+Report a finding only at **≥80% confidence** that:
+
+1. The cited site actually contains the claimed pattern — re-read the site (expression text, card body, or
+   detector output) before reporting. This is where reviewer hallucinations surface.
+2. The pattern is a real defect, not an intentional design choice.
+3. Either the bug is user-reachable through normal chat UI with normal auth (HIGH/MEDIUM), or it is real
+   code/operator-level damage (LOW).
+
+When the same anti-pattern occurs at multiple sites, **report one finding with all sites listed**, not N
+findings.
+
+## Reachability scoring (dominant input to severity)
+
+- **REACHABLE_NORMAL_UI** — a normal user with normal auth doing what the topic is built to do hits this
+  path. -> HIGH (or MEDIUM if user-visible impact is small).
+- **REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION** — reachable via normal UI but needs a specific data
+  state. -> MEDIUM.
+- **NOT_REACHABLE_VIA_BOT_UI** — upstream-gated; only reachable via flow-direct invocation, a race
+  window, or a future code change. Real bug, no user impact today. -> LOW.
+- **OPERATOR_OR_HYGIENE_ONLY** — dead code, redundant writes, hardcoded IDs with no runtime user impact.
+  -> LOW.
+
+## Finding IDs
+
+Each lens uses its own prefix so findings are distinguishable and stable across runs. IDs are
+`<PREFIX>-NNN` (for example `BTPF-001`).
+
+| Prefix | Lens |
+| --- | --- |
+| `BTPF` | Power Fx topic-local |
+| `BTDG` | Dangling `Global.*` |
+| `BTUX` | UX contract |
+| `BTIC` | ISV conformance |
+| `BTIP` | ISV integration pattern |
+| `BTCF` | ServiceNow config/topic |
+
+## Output format
+
+**Locators (important).** The fix is applied in the chat panel, not by a human navigating to a line — so
+cite each site by its **stable node identity**, which is what a fixer keys on: the action's `id:`, its
+`displayName:` (if present), and its action `kind:`. Include a short excerpt (the expression, the card
+field, or the reported name) so the target is unambiguous. A line number is **best-effort context only**,
+never the primary locator — line numbers drift and the agentic read does not track them reliably.
+
+```text
+<PREFIX>-NNN — <one-line summary>
+  Severity:     HIGH | MEDIUM | LOW
+  Reachability: REACHABLE_NORMAL_UI | REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION | NOT_REACHABLE_VIA_BOT_UI | OPERATOR_OR_HYGIENE_ONLY
+  Site(s):
+    - kind=<action kind>  id=<node id>  displayName=<node displayName, if any>  detail=<short excerpt>  (~line <N>)
+    - (additional sites if multi-site)
+  What's wrong:   <1-3 sentence anti-pattern explanation>
+  Why it matters: <observable user/operator impact>
+  Concrete fix:   <specific proposed change — Power Fx snippet or YAML edit>
+  Fix targets:    <the node id(s) the fix edits or the node it inserts before/after — so the fixer can act>
+```
+
+Sort findings HIGH -> MEDIUM -> LOW. After the list, emit a **Defense-in-depth** section for real
+anti-patterns whose sites all scored `NOT_REACHABLE_VIA_BOT_UI` or `OPERATOR_OR_HYGIENE_ONLY`, so
+reviewers prioritize reachable bugs first:
+
+```text
+## Defense in depth (no reachable user impact today)
+
+DiD-NNN — <one-line summary>
+  Pattern:   <anti-pattern name>
+  Site(s):   <topic file>:<line>, ...
+  Rationale: <why it's worth fixing despite no current reachability>
+```

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -33,14 +33,18 @@ findings.
 - **OPERATOR_OR_HYGIENE_ONLY** — dead code, redundant writes, hardcoded IDs with no runtime user impact.
   -> LOW.
 
-**Check the runtime heuristics before finalizing reachability.** ESS runtime behavior is documented in
+**Runtime heuristics corroborate reachability; structure decides it.** The key LOW-cap — a topic that
+delegates its backend call to a shared `*System*`/OnError orchestrator, so failure is centrally handled and
+code after it is `NOT_REACHABLE_VIA_BOT_UI` — is grounded in a **structurally visible** fact (the delegation),
+so apply it whether or not the runtime docs are present. ESS runtime behavior is further documented in
 `../runtime/confirmed-runtime-heuristics.md` (authoritative) and `../runtime/pending-runtime-heuristics.md`
-(provisional), synced by `scripts/sync_runtime_heuristics.py`. A confirmed rule can move a finding to
-`NOT_REACHABLE_VIA_BOT_UI` (cap at LOW) even when a purely structural read looks HIGH — for example, the
-AI-orchestration layer emitting a "no data" message on an empty parse, or an OnError/`*System*` topic
-terminating the dialog stack so code after it never runs. Apply confirmed rules directly; apply pending
-rules with caution and say so. If the docs are absent, score structurally and note that runtime calibration
-was unavailable.
+(provisional), synced by `scripts/sync_runtime_heuristics.py`; when present, read them to corroborate and
+refine (e.g. the AI-orchestration "no data" behavior, OnError dialog termination) — apply confirmed rules
+directly, pending rules with caution. Check for these docs with a **direct filesystem test of the exact path**,
+not a workspace/indexed search (the `runtime/` folder is gitignored, so an index-respecting search reports a
+present doc as missing). When the docs are absent, still apply the structural caps and note that
+runtime corroboration was unavailable — do **not** revert a delegated-pattern finding to structural-HIGH just
+because the runtime docs are missing.
 
 ## Finding IDs
 

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -42,11 +42,11 @@ terminating the dialog stack so code after it never runs. Apply confirmed rules 
 rules with caution and say so. If the docs are absent, score structurally and note that runtime calibration
 was unavailable.
 
-**When a heuristic caps a finding to unreachable and you drop it, leave a breadcrumb.** If a runtime
-heuristic reclassifies a would-be finding to `NOT_REACHABLE_VIA_BOT_UI` and you decide it is an intentional,
-centrally-handled design (so you surface **no** finding — e.g. an ungated `ParseValue` in a topic that
-delegates to a shared `*System*` orchestrator), record it in the catalog's `suppressions` array rather than
-letting it vanish. Each entry is a lightweight stub — `{ "id", "site", "suppressed_by": "<heuristic-id>" }`
+**When a heuristic caps a finding to unreachable and you drop it, you MUST leave a breadcrumb.** If a runtime
+heuristic reclassifies a would-be finding to `NOT_REACHABLE_VIA_BOT_UI` and you therefore surface **no**
+finding because it is intentional, centrally-handled design (e.g. an ungated `ParseValue` in a topic that
+delegates to a shared `*System*` orchestrator), you **must** record it in the catalog's `suppressions` array
+— never let it silently vanish. Each entry is a lightweight stub — `{ "id", "site", "suppressed_by": "<heuristic-id>" }`
 (the script fills `date`) — **not** a finding: no severity / root_cause / concrete_fix (there is nothing to
 fix), no evidence hash, no cross-run merge. It is written per run (overwritten each time the lens
 re-evaluates), kept out of `issues`, and **never shown to the maker**. Its sole purpose is auditability: it

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -64,9 +64,13 @@ never the primary locator — line numbers drift and the agentic read does not t
     - (additional sites if multi-site)
   What's wrong:   <1-3 sentence anti-pattern explanation>
   Why it matters: <observable user/operator impact>
-  Concrete fix:   <specific proposed change — Power Fx snippet or YAML edit>
+  Concrete fix:   <the canonical Fix for the flagging heuristic (see its lens doc), made specific to this site>
   Fix targets:    <the node id(s) the fix edits or the node it inserts before/after — so the fixer can act>
 ```
+
+Each lens doc carries a canonical **Fix** next to the heuristic that owns it. Fill `Concrete fix` from
+that pattern, specialized to the site — this keeps the suggested fix ESS-correct and lets `/update` apply
+it directly (it maps the finding's `<PREFIX>` back to the lens doc via the table above).
 
 Sort findings HIGH -> MEDIUM -> LOW. After the list, emit a **Defense-in-depth** section for real
 anti-patterns whose sites all scored `NOT_REACHABLE_VIA_BOT_UI` or `OPERATOR_OR_HYGIENE_ONLY`, so

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -154,3 +154,8 @@ Each catalog finding is this contract serialized, plus the analyzer's cross-run 
   node is gone, resolve it by writing a ledger entry). This is objective, not an LLM judgment.
 - The customer-facing report presents the **active** set; call out `evidence_stale` findings as "previously
   flagged, code has since changed — worth confirming."
+
+**Recording a resolution (input).** To mark a finding resolved, pass it (at minimum its `id`) in the
+`merge_findings.py --resolve` file. Each may carry a `resolution` (`fixed` — default; `not-a-bug` or
+`wont-fix` for a maker dismissal) and `resolved_by` (`review-skill` — default; `maker` for a dismissal,
+`update-skill` for a tool fix). Absence from a run is never a resolution.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -6,8 +6,9 @@ config/topic. Each lens produces findings in this one shape so the review can ra
 de-duplicate them uniformly. The individual lens docs describe **what** each looks for; this doc defines
 **how** a confirmed finding is scored and reported.
 
-Findings are **advisory prose** in the response — no lens writes anything to disk. This is the internal
-(structured) contract; the customer-facing translation is Step 7 of the `topics/review` skill.
+Each conformance lens produces **advisory prose** — no lens writes anything to disk itself. The skill's
+Step 8 persists the consolidated findings to the catalog and ledger; this doc is the internal (structured)
+contract, and the customer-facing translation is Step 9 of the `topics/review` skill.
 
 ## Precision bar
 
@@ -147,13 +148,18 @@ Each catalog finding is this contract serialized, plus the analyzer's cross-run 
 - **`id`** is a stable kebab-case behavior-describing slug and is the cross-run identity — reused across
   runs (read the prior catalog with `merge_findings.py --solution <solution> --show` and reuse the exact prior
   slug for a finding you recognize; never invent a new slug for a previously-identified finding).
-- **`status`** (assigned by the script, not the agent) is `active` or `resolved`. `resolved` requires a
-  matching `resolved-issue-ledger.jsonl` entry, whose `resolution` records *why*: `fixed` (the code was
-  corrected), `not-a-bug` (the maker dismissed it as a false positive), or `wont-fix` (acknowledged,
+- **`status`** (assigned by the script, not the agent) is `active`, `suppressed`, or `resolved`. `resolved`
+  requires a matching `resolved-issue-ledger.jsonl` entry, whose `resolution` records *why*: `fixed` (the code
+  was corrected), `not-a-bug` (the maker dismissed it as a false positive), or `wont-fix` (acknowledged,
   declined). A finding not re-detected this run stays `active` (absence is never resolution, because LLM
   coverage is nondeterministic). A finding **resolved this run** appears once as `resolved`, then the **next
   run prunes it** from the catalog — the ledger is its permanent record. A pruned finding reopens as a fresh
-  `active` finding only if its code changes and it is re-detected.
+  `active` finding only if its code changes and it is re-detected. **`suppressed`** is the exception a
+  deterministic detector needs: once a maker dismisses a finding (`not-a-bug` / `wont-fix` / `false-positive`),
+  the detector would otherwise re-emit it every run — so a re-detected dismissed finding is carried as
+  `suppressed` (not `active`) until its evidence hash changes, at which point it reopens as `active`. A `fixed`
+  finding is not suppressed; re-detecting it means the code regressed, so it reopens as `active`. The report
+  presents only `active` findings; `suppressed` and `resolved` are catalog/ledger bookkeeping.
 - **`verification`** is `static` (decidable from the authored files — every current lens) or
   `needs-runtime-test` (only confirmable by running the bot). A `needs-runtime-test` finding is the explicit
   hand-off to Layer-3 runtime testing: generate an assertion case rather than a `/update` edit. The script

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -33,6 +33,15 @@ findings.
 - **OPERATOR_OR_HYGIENE_ONLY** — dead code, redundant writes, hardcoded IDs with no runtime user impact.
   -> LOW.
 
+**Check the runtime heuristics before finalizing reachability.** ESS runtime behavior is documented in
+`../runtime/confirmed-runtime-heuristics.md` (authoritative) and `../runtime/pending-runtime-heuristics.md`
+(provisional), synced by `scripts/sync_runtime_heuristics.py`. A confirmed rule can move a finding to
+`NOT_REACHABLE_VIA_BOT_UI` (cap at LOW) even when a purely structural read looks HIGH — for example, the
+AI-orchestration layer emitting a "no data" message on an empty parse, or an OnError/`*System*` topic
+terminating the dialog stack so code after it never runs. Apply confirmed rules directly; apply pending
+rules with caution and say so. If the docs are absent, score structurally and note that runtime calibration
+was unavailable.
+
 ## Finding IDs
 
 Each lens uses its own prefix so findings are distinguishable and stable across runs. IDs are

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -42,17 +42,6 @@ terminating the dialog stack so code after it never runs. Apply confirmed rules 
 rules with caution and say so. If the docs are absent, score structurally and note that runtime calibration
 was unavailable.
 
-**When a heuristic caps a finding to unreachable and you drop it, you MUST leave a breadcrumb.** If a runtime
-heuristic reclassifies a would-be finding to `NOT_REACHABLE_VIA_BOT_UI` and you therefore surface **no**
-finding because it is intentional, centrally-handled design (e.g. an ungated `ParseValue` in a topic that
-delegates to a shared `*System*` orchestrator), you **must** record it in the catalog's `suppressions` array
-— never let it silently vanish. Each entry is a lightweight stub — `{ "id", "site", "suppressed_by": "<heuristic-id>" }`
-(the script fills `date`) — **not** a finding: no severity / root_cause / concrete_fix (there is nothing to
-fix), no evidence hash, no cross-run merge. It is written per run (overwritten each time the lens
-re-evaluates), kept out of `issues`, and **never shown to the maker**. Its sole purpose is auditability: it
-distinguishes a site that was *evaluated and correctly suppressed* from one that was *never analyzed*, so a
-0-finding review is legible after the fact.
-
 ## Finding IDs
 
 Each lens uses its own prefix so findings are distinguishable and stable across runs. IDs are
@@ -165,6 +154,3 @@ Each catalog finding is this contract serialized, plus the analyzer's cross-run 
   node is gone, resolve it by writing a ledger entry). This is objective, not an LLM judgment.
 - The customer-facing report presents the **active** set; call out `evidence_stale` findings as "previously
   flagged, code has since changed — worth confirming."
-- The catalog also carries a top-level **`suppressions`** array (sibling to `issues`) — the per-run,
-  internal-only audit breadcrumbs described under the reachability rubric above. No report or `/update`
-  consumer reads it; it exists only to make a 0-finding run auditable.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -69,8 +69,9 @@ never the primary locator — line numbers drift and the agentic read does not t
 ```
 
 Each lens doc carries a canonical **Fix** next to the heuristic that owns it. Fill `Concrete fix` from
-that pattern, specialized to the site — this keeps the suggested fix ESS-correct and lets `/update` apply
-it directly (it maps the finding's `<PREFIX>` back to the lens doc via the table above).
+that pattern, specialized to the site — this keeps the suggested fix ESS-correct. The fix travels **with
+the finding** (its `Concrete fix` field), so whoever acts on it — the customer, or `/update` — has the fix
+in hand without re-deriving it.
 
 Sort findings HIGH -> MEDIUM -> LOW. After the list, emit a **Defense-in-depth** section for real
 anti-patterns whose sites all scored `NOT_REACHABLE_VIA_BOT_UI` or `OPERATOR_OR_HYGIENE_ONLY`, so
@@ -84,3 +85,63 @@ DiD-NNN — <one-line summary>
   Site(s):   <topic file>:<line>, ...
   Rationale: <why it's worth fixing despite no current reachability>
 ```
+
+## Persisted form (catalog + resolution ledger)
+
+`/review` persists findings via `scripts/merge_findings.py` into two gitignored, workspace-scoped artifacts
+under `.local/review-findings/`, following the ESS hardening-analyzer's model scoped to the maker workflow:
+
+- **`<solution>-catalog.json`** — the findings catalog for a review **scope** (the `solution` field). The
+  scope is whatever was reviewed: a single topic today, a whole ISV or solution later. Nothing here assumes
+  one topic — a finding's `files[]` can span several files, so widening the review needs no schema change.
+  (The field is named `solution` to stay valid against the ESS analyzer's ledger schema; its value is the
+  scope reviewed.)
+- **`resolved-issue-ledger.jsonl`** — a shared, append-only log of resolution evidence (one JSON line per
+  resolved finding). Each row carries `solution` + `issue_id`, the `resolution` outcome, and `resolved_by`
+  — the actor that produced it (`maker` for a dismissal, `update-skill` for a tool fix, `review-skill` when
+  `/review` confirms a fix during reconcile; caller-settable, default `review-skill`). The same semantic id
+  can legitimately appear under different scopes, so this ledger is keyed by **(`solution`, `issue_id`)**:
+  any future resolution match against it must scope by `solution`, never `issue_id` alone, or one scope's
+  resolution would wrongly clear another's. A finding belongs to exactly one catalog per scope.
+
+Each catalog finding is this contract serialized, plus the analyzer's cross-run fields:
+
+```json
+{
+  "id": "missing-issuccess-branch",
+  "title": "Flow result not checked before parse",
+  "severity": "HIGH",
+  "reachability": "confirmed",
+  "root_cause": "The ParseValue runs without a preceding isSuccess = false branch.",
+  "concrete_fix": "Add an isSuccess = false ConditionGroup before the parse.",
+  "verification": "static",
+  "files": [{ "path": "workspace/agents/<slug>/topics/<name>.mcs.yml", "lines": [188] }],
+  "status": "active",
+  "evidence_stale": false,
+  "evidence_hashes": [{ "file": "workspace/agents/<slug>/topics/<name>.mcs.yml", "sha256": "…" }],
+  "first_seen": "2026-07-08T18:00:00Z",
+  "last_seen": "2026-07-08T19:30:00Z"
+}
+```
+
+- **`id`** is a stable kebab-case behavior-describing slug and is the cross-run identity — reused across
+  runs (read the prior catalog with `merge_findings.py --solution <solution> --show` and reuse the exact prior
+  slug for a finding you recognize; never invent a new slug for a previously-identified finding).
+- **`status`** (assigned by the script, not the agent) is `active` or `resolved`. `resolved` requires a
+  matching `resolved-issue-ledger.jsonl` entry, whose `resolution` records *why*: `fixed` (the code was
+  corrected), `not-a-bug` (the maker dismissed it as a false positive), or `wont-fix` (acknowledged,
+  declined). A finding not re-detected this run stays `active` (absence is never resolution, because LLM
+  coverage is nondeterministic). A finding **resolved this run** appears once as `resolved`, then the **next
+  run prunes it** from the catalog — the ledger is its permanent record. A pruned finding reopens as a fresh
+  `active` finding only if its code changes and it is re-detected.
+- **`verification`** is `static` (decidable from the authored files — every current lens) or
+  `needs-runtime-test` (only confirmable by running the bot). A `needs-runtime-test` finding is the explicit
+  hand-off to Layer-3 runtime testing: generate an assertion case rather than a `/update` edit. The script
+  defaults it to `static` when a finding omits it.
+- **`evidence_hashes` / `evidence_stale`** make staleness deterministic. The script stores a sha256 of each
+  file a finding implicates. When a finding is not re-detected, the script compares the stored hashes to the
+  files' current hashes: all match → still `active` (the code is unchanged, so the finding stands); any
+  mismatch → `active` with `evidence_stale: true` — the code moved, so **re-verify** (read the site; if the
+  node is gone, resolve it by writing a ledger entry). This is objective, not an LLM judgment.
+- The customer-facing report presents the **active** set; call out `evidence_stale` findings as "previously
+  flagged, code has since changed — worth confirming."

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -48,8 +48,15 @@ because the runtime docs are missing.
 
 ## Finding IDs
 
-Each lens uses its own prefix so findings are distinguishable and stable across runs. IDs are
-`<PREFIX>-NNN` (for example `BTPF-001`).
+Two distinct identifiers, do not conflate them:
+
+- The persisted **`id` field** (in the catalog JSON) is a stable **kebab-case, behavior-describing slug**
+  (e.g. `missing-issuccess-branch`). This is the **cross-run identity** the engine keys on — reuse the exact
+  prior slug for a finding you recognize (see the persisted-form notes below).
+- The **`<PREFIX>-NNN`** form (e.g. `BTPF-001`) is a **human-facing reference label** used only in the
+  chat-panel output template below, so a maker can refer to a finding by number in one report. Each lens owns
+  a prefix so findings are distinguishable per report; it is **not** the persisted `id` and is not reused as
+  the cross-run identity.
 
 | Prefix | Lens |
 | --- | --- |
@@ -124,7 +131,7 @@ Each catalog finding is this contract serialized, plus the analyzer's cross-run 
   "id": "missing-issuccess-branch",
   "title": "Flow result not checked before parse",
   "severity": "HIGH",
-  "reachability": "confirmed",
+  "reachability": "REACHABLE_NORMAL_UI",
   "root_cause": "The ParseValue runs without a preceding isSuccess = false branch.",
   "concrete_fix": "Add an isSuccess = false ConditionGroup before the parse.",
   "verification": "static",

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/finding-contract.md
@@ -42,6 +42,17 @@ terminating the dialog stack so code after it never runs. Apply confirmed rules 
 rules with caution and say so. If the docs are absent, score structurally and note that runtime calibration
 was unavailable.
 
+**When a heuristic caps a finding to unreachable and you drop it, leave a breadcrumb.** If a runtime
+heuristic reclassifies a would-be finding to `NOT_REACHABLE_VIA_BOT_UI` and you decide it is an intentional,
+centrally-handled design (so you surface **no** finding — e.g. an ungated `ParseValue` in a topic that
+delegates to a shared `*System*` orchestrator), record it in the catalog's `suppressions` array rather than
+letting it vanish. Each entry is a lightweight stub — `{ "id", "site", "suppressed_by": "<heuristic-id>" }`
+(the script fills `date`) — **not** a finding: no severity / root_cause / concrete_fix (there is nothing to
+fix), no evidence hash, no cross-run merge. It is written per run (overwritten each time the lens
+re-evaluates), kept out of `issues`, and **never shown to the maker**. Its sole purpose is auditability: it
+distinguishes a site that was *evaluated and correctly suppressed* from one that was *never analyzed*, so a
+0-finding review is legible after the fact.
+
 ## Finding IDs
 
 Each lens uses its own prefix so findings are distinguishable and stable across runs. IDs are
@@ -154,3 +165,6 @@ Each catalog finding is this contract serialized, plus the analyzer's cross-run 
   node is gone, resolve it by writing a ledger entry). This is objective, not an LLM judgment.
 - The customer-facing report presents the **active** set; call out `evidence_stale` findings as "previously
   flagged, code has since changed — worth confirming."
+- The catalog also carries a top-level **`suppressions`** array (sibling to `issues`) — the per-run,
+  internal-only audit breadcrumbs described under the reachability rubric above. No report or `/update`
+  consumer reads it; it exists only to make a 0-finding run auditable.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -25,16 +25,14 @@ skip it.
 
 ## Step 2: Locate the ISV reference doc
 
-The ESS ISV reference docs live in an **ESSVivaCopilot** checkout, at `skills/docs/isv-<connector>.md`.
-That checkout is typically cloned **alongside the Employee-Self-Service-Agent-Developer-Kit repo** under
-the same parent folder — so from this kit workspace it is a few levels up (for example
-`../../../ESSVivaCopilot/skills/docs/`). Search upward from the repo for an `ESSVivaCopilot` directory and
-read only the one doc for the ISV determined in Step 1.
+The ISV reference docs are synced into this workspace at `src/reference/ess-docs/isv/isv-<connector>.md`.
+Read the one doc for the ISV determined in Step 1, by its exact path.
 
-If no `ESSVivaCopilot` checkout (or the specific `isv-<connector>.md`) can be found, **skip this check**
-and note it in the report, for example: "ISV conformance was not checked — the ESS ISV reference docs
-were not available in this environment." Do not infer ISV behavior from general knowledge; the reference
-docs are authoritative for how these integrations actually behave.
+If that file is not present, the ISV reference docs have not been synced into this environment. Note in the
+report that ISV conformance was not checked and that the docs can be synced by running
+`python scripts/sync_isv_docs.py` from `solutions/ess-maker-skills/`, then continue. Do not infer ISV
+behavior from general knowledge — the reference docs are authoritative for how these integrations
+actually behave.
 
 ## Step 3: Apply the ISV reference to the topic
 

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -45,6 +45,9 @@ checks the docs support:
 
 - **Field/schema faithfulness** — the topic references response fields that exist in the ISV's documented
   schema, with the documented names; a field the topic reads that the ISV does not produce will be blank.
+- **Config-owned values** — values the topic hardcodes inline (scenario-specific mappings, field or table
+  names, constants) that the template config is meant to own and supply, rather than being fixed in the
+  topic's logic.
 - **Type handling** — the topic handles fields the ISV can return in more than one shape (e.g. a value
   that may be a string or a number/boolean depending on display settings) rather than assuming one type.
 - **Identifier/URL construction** — links and identifiers are built the way the ISV requires (e.g. the

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -26,7 +26,9 @@ skip it.
 ## Step 2: Locate the ISV reference doc
 
 The ISV reference docs are synced into this workspace at `src/reference/ess-docs/isv/isv-<connector>.md`.
-Read the one doc for the ISV determined in Step 1, by its exact path.
+Read the one doc for the ISV determined in Step 1, by its exact path, **in full** — these docs are short,
+so load the entire document into context and treat all of it (field tables, schema conventions,
+type-coercion notes, and pitfalls) as authoritative reference for the analysis.
 
 If that file is not present, the ISV reference docs have not been synced into this environment. Note in the
 report that ISV conformance was not checked and that the docs can be synced by running
@@ -36,9 +38,10 @@ actually behave.
 
 ## Step 3: Apply the ISV reference to the topic
 
-Read the reference doc's field/schema sections and its **Known Pitfall Areas**, and check the authored
-topic against them. The reference doc is the source of what to look for — each documented convention and
-pitfall is a lens on the topic. Typical checks the docs support:
+Using the **full** reference doc you loaded in Step 2 as authoritative context — its field/schema tables,
+type-coercion notes, and Known Pitfall Areas — check the authored topic against it. The reference doc is
+the source of what to look for — each documented convention and pitfall is a lens on the topic. Typical
+checks the docs support:
 
 - **Field/schema faithfulness** — the topic references response fields that exist in the ISV's documented
   schema, with the documented names; a field the topic reads that the ISV does not produce will be blank.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -36,6 +36,12 @@ report that ISV conformance was not checked and that the docs can be synced by r
 behavior from general knowledge — the reference docs are authoritative for how these integrations
 actually behave.
 
+**Determine presence by a direct filesystem check of the exact path** (e.g.
+`Test-Path src/reference/ess-docs/isv/isv-<connector>.md`, or simply attempting to read that exact path) —
+**not** a workspace file-search or codebase-index lookup. The `isv/` folder is gitignored, so an
+index-respecting search reports a present doc as missing; trusting it would wrongly mark ISV conformance as
+not-checked even when the doc is synced.
+
 ## Step 3: Apply the ISV reference to the topic
 
 Using the **full** reference doc you loaded in Step 2 as authoritative context — its field/schema tables,

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -1,0 +1,58 @@
+# ISV conformance check
+
+Analysis guidance for the **ISV conformance** check used by the `topics/review` skill. It checks an
+authored topic against the reference knowledge for the backend system it integrates with — the
+documented field/schema conventions and known integration pitfalls for that ISV.
+
+This check depends on the ESS **ISV reference docs** (`isv-<connector>.md`). Those docs are not part of
+this repository; they are read from an ESS reference source when one is available in the environment. When
+no reference source is available, skip this check and say so — do not guess ISV behavior.
+
+## Step 1: Determine the target ISV
+
+Find the topic's scenario name — either `scenarioName:` in a `BeginDialog` input binding, or `ScenarioName`
+in the system topic the topic calls. Map its prefix to the ISV reference doc:
+
+| Scenario prefix | ISV reference doc |
+| --- | --- |
+| `HRWorkdayHCM…` | `isv-workday-hcm.md` |
+| `ITHelpdeskServiceNowITSM…` | `isv-servicenow-itsm.md` |
+| `ServiceNowHRSD…` | `isv-servicenow-hrsd.md` |
+| `…SuccessFactorsHCM…` | `isv-successfactors-hcm.md` |
+
+If the topic has no ISV scenario (a simple informational or non-ISV topic), this check does not apply —
+skip it.
+
+## Step 2: Locate the ISV reference doc
+
+Look for the ESS ISV reference docs in an ESS reference checkout available in the environment (commonly a
+sibling checkout, e.g. `../ESSVivaCopilot/skills/docs/isv-<connector>.md`). Read only the one doc for the
+ISV determined in Step 1.
+
+If the reference doc cannot be found, **skip this check** and note it in the report, for example: "ISV
+conformance was not checked — the ESS ISV reference docs were not available in this environment." Do not
+infer ISV behavior from general knowledge; the reference docs are authoritative for how these
+integrations actually behave.
+
+## Step 3: Apply the ISV reference to the topic
+
+Read the reference doc's field/schema sections and its **Known Pitfall Areas**, and check the authored
+topic against them. The reference doc is the source of what to look for — each documented convention and
+pitfall is a lens on the topic. Typical checks the docs support:
+
+- **Field/schema faithfulness** — the topic references response fields that exist in the ISV's documented
+  schema, with the documented names; a field the topic reads that the ISV does not produce will be blank.
+- **Type handling** — the topic handles fields the ISV can return in more than one shape (e.g. a value
+  that may be a string or a number/boolean depending on display settings) rather than assuming one type.
+- **Identifier/URL construction** — links and identifiers are built the way the ISV requires (e.g. the
+  correct record identifier and table parameter, not a display number).
+- **Query construction** — user-supplied values placed into the ISV's query language are escaped against
+  that language's operators.
+- **Naming conventions** — table names, mapping keys, and config unique names follow the ISV's documented
+  conventions.
+
+Treat each as a starting question, not a closed rule — the specific conventions come from the reference
+doc for the ISV under review. Apply the same precision bar and reachability scoring as
+[`powerfx-topic-local.md`](powerfx-topic-local.md), and report confirmed findings with the shared output
+format, locating each by the action's node identity and naming the documented convention it conflicts
+with.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -58,7 +58,7 @@ checks the docs support:
   conventions.
 
 Treat each as a starting question, not a closed rule — the specific conventions come from the reference
-doc for the ISV under review. Apply the same precision bar and reachability scoring as
-[`powerfx-topic-local.md`](powerfx-topic-local.md), and report confirmed findings with the shared output
-format, locating each by the action's node identity and naming the documented convention it conflicts
-with.
+doc for the ISV under review. Apply the same precision bar and reachability scoring as the shared
+[`finding-contract.md`](finding-contract.md), and report confirmed findings with the shared output
+format. This check uses the `BTIC` finding-ID prefix. Locate each by the action's node identity and name
+the documented convention it conflicts with.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -25,14 +25,16 @@ skip it.
 
 ## Step 2: Locate the ISV reference doc
 
-Look for the ESS ISV reference docs in an ESS reference checkout available in the environment (commonly a
-sibling checkout, e.g. `../ESSVivaCopilot/skills/docs/isv-<connector>.md`). Read only the one doc for the
-ISV determined in Step 1.
+The ESS ISV reference docs live in an **ESSVivaCopilot** checkout, at `skills/docs/isv-<connector>.md`.
+That checkout is typically cloned **alongside the Employee-Self-Service-Agent-Developer-Kit repo** under
+the same parent folder — so from this kit workspace it is a few levels up (for example
+`../../../ESSVivaCopilot/skills/docs/`). Search upward from the repo for an `ESSVivaCopilot` directory and
+read only the one doc for the ISV determined in Step 1.
 
-If the reference doc cannot be found, **skip this check** and note it in the report, for example: "ISV
-conformance was not checked — the ESS ISV reference docs were not available in this environment." Do not
-infer ISV behavior from general knowledge; the reference docs are authoritative for how these
-integrations actually behave.
+If no `ESSVivaCopilot` checkout (or the specific `isv-<connector>.md`) can be found, **skip this check**
+and note it in the report, for example: "ISV conformance was not checked — the ESS ISV reference docs
+were not available in this environment." Do not infer ISV behavior from general knowledge; the reference
+docs are authoritative for how these integrations actually behave.
 
 ## Step 3: Apply the ISV reference to the topic
 

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-conformance.md
@@ -31,10 +31,11 @@ so load the entire document into context and treat all of it (field tables, sche
 type-coercion notes, and pitfalls) as authoritative reference for the analysis.
 
 If that file is not present, the ISV reference docs have not been synced into this environment. Note in the
-report that ISV conformance was not checked and that the docs can be synced by running
-`python scripts/sync_isv_docs.py` from `solutions/ess-maker-skills/`, then continue. Do not infer ISV
-behavior from general knowledge — the reference docs are authoritative for how these integrations
-actually behave.
+report that ISV conformance was not checked and that an internal dev can sync the docs by running
+`python scripts/sync_isv_docs.py --source <path-to-reference-checkout>` from `solutions/ess-maker-skills/`
+(or by setting `referenceSource` in `.local/config.json` first, then running it with no arguments), then
+continue. Do not infer ISV behavior from general knowledge — the reference docs are authoritative for how
+these integrations actually behave.
 
 **Determine presence by a direct filesystem check of the exact path** (e.g.
 `Test-Path src/reference/ess-docs/isv/isv-<connector>.md`, or simply attempting to read that exact path) —

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-integration-pattern.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-integration-pattern.md
@@ -39,7 +39,8 @@ ESS-orchestrated systems above, which are expected to go through the shared syst
 
 ## Reporting
 
-Apply the same precision bar and reachability scoring as
-[`powerfx-topic-local.md`](powerfx-topic-local.md). When you flag a bypass, locate it by the
-`InvokeFlowAction` node's identity, and the suggested fix is to route the backend call through the shared
-system topic for that backend (passing `scenarioName` + `parameters`) instead of the direct flow call.
+Apply the same precision bar and reachability scoring as the shared
+[`finding-contract.md`](finding-contract.md). This check uses the `BTIP` finding-ID prefix. When you flag
+a bypass, locate it by the `InvokeFlowAction` node's identity, and the suggested fix is to route the
+backend call through the shared system topic for that backend (passing `scenarioName` + `parameters`)
+instead of the direct flow call.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-integration-pattern.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/isv-integration-pattern.md
@@ -1,0 +1,45 @@
+# ISV integration pattern check
+
+Analysis guidance for the **ISV integration pattern** check used by the `topics/review` skill. It verifies
+that a topic integrating an ESS-orchestrated backend (ServiceNow HRSD, ServiceNow ITSM, Workday HCM, SAP
+SuccessFactors HCM) uses the ESS template-config + shared-orchestrator pattern, rather than bypassing it
+with a standalone cloud flow. This check reads only the authored topic — it needs no reference docs.
+
+## The conformant pattern
+
+A user-facing topic for one of these backends collects the user's input and then delegates the backend
+call to a **shared system topic** via `BeginDialog`, passing a `scenarioName` and `parameters`. The shared
+system topic (its name contains `System`, e.g. `WorkdaySystemGetCommonExecution`,
+`ServiceNowHRSDSystemCommonExecution`, `ServiceNowITSMSystemGetTicketDetails`) runs the shared
+orchestrator flow and returns `isSuccess` / response data. The user topic then parses and renders the
+result. The user topic itself does **not** call a cloud flow directly.
+
+## The anti-pattern to flag
+
+A user-facing topic for a ServiceNow / Workday / SAP SuccessFactors scenario that calls its **own**
+cloud flow directly — a `kind: InvokeFlowAction` with a `flowId` — instead of delegating to the shared
+system topic. This bypasses the ESS orchestrator and the template-config mechanism, so the topic no longer
+benefits from the shared request/response mapping, error shaping, and connection handling, and it
+diverges from every other topic for that backend.
+
+Signals that a topic targets an ESS-orchestrated backend:
+
+- it passes a `scenarioName` whose prefix is `HRWorkdayHCM`, `ServiceNowHRSD`, `ITHelpdeskServiceNowITSM`,
+  or a SuccessFactors HCM scenario; or
+- it (or a topic it would normally call) references one of the shared `*System*` execution topics for
+  those backends; or
+- its purpose is clearly to read or write ServiceNow / Workday / SAP SuccessFactors data.
+
+## What NOT to flag
+
+Standalone cloud flows are the **correct** choice for connectors that have no ESS orchestrator — for
+example Jira, a custom HTTP API, or other non-ESS connectors. A topic that calls its own flow for one of
+those is conformant, not a bypass. Only flag a direct flow call when the backend is one of the
+ESS-orchestrated systems above, which are expected to go through the shared system topic.
+
+## Reporting
+
+Apply the same precision bar and reachability scoring as
+[`powerfx-topic-local.md`](powerfx-topic-local.md). When you flag a bypass, locate it by the
+`InvokeFlowAction` node's identity, and the suggested fix is to route the backend call through the shared
+system topic for that backend (passing `scenarioName` + `parameters`) instead of the direct flow call.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -22,7 +22,8 @@ precision bar and reachability rubric in the shared
 
 - **Self-referential record literals.** Record-literal fields where the value is the unqualified field
   name — `{ID: ID, Name: Name}`. Almost always an intended `ID: currentRecord.ID` (or similar) that was
-  left dangling, so the field silently binds to itself / blank.
+  left dangling, so the field silently binds to itself / blank. **Fix:** qualify each value with its source
+  record (e.g. `ID: currentRecord.ID`).
 - **Power Fx string-literal quote-run quirks.** Doubled double-quotes are escape syntax: `"a""b"` is the
   3-char string `a"b`, and `""""""` (six quotes) is the 2-char string `""`, **not** an empty string. An
   equality check `value = """"""` does **not** test for empty. Count quote-runs carefully — miscounting is
@@ -30,17 +31,20 @@ precision bar and reachability rubric in the shared
 - **`ParseValue` / `ParseJSON` without an `isSuccess` gate (structural half).** When a topic calls a
   flow/dialog that returns `isSuccess`, then runs `ParseValue`/`ParseJSON` on the response **without a
   preceding branch on `isSuccess = false`**, a schema mismatch (API drift) silently produces blanks
-  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard.
+  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard. **Fix:** move
+  the parse inside the `isSuccess = true` branch, or add an `isSuccess = false` ConditionGroup before it.
 - **Flow failure-branch gaps (structural half).** A `BeginDialog`/`InvokeFlowAction` call site whose
   result path has **no `isSuccess = false` (or equivalent failure) branch** — the topic continues with
-  empty data on failure and the user gets no error. Flag the missing failure branch.
+  empty data on failure and the user gets no error. Flag the missing failure branch. **Fix:** add an
+  `isSuccess = false` ConditionGroup after the call with an error `SendActivity` that stops the flow.
 - **Hardcoded environment-specific values.** GUID-like literals, agent IDs, environment IDs, connection
   IDs, model IDs (`aIModelId`), and flow IDs (`flowId`) written inline in the topic. These are
   environment-bound and should be resolved by the platform (connection references / solution-aware
-  bindings), not hardcoded — hardcoding breaks on import to another environment.
+  bindings), not hardcoded — hardcoding breaks on import to another environment. **Fix:** replace the
+  literal with a connection reference or environment variable the platform resolves per environment.
 - **String/numeric parsing without explicit guards.** `Find()` / `Substring()` / `Text(Value(...))`
   chains on user-supplied strings with no length/format pre-check — throws or misparses on unexpected
-  input.
+  input. **Fix:** add an `IsBlank`/length/format pre-check before the parse and branch on the invalid case.
 - **Write-then-refetch-then-lookup-by-mutable-key.** A `SetVariable` that writes via an Update call,
   then a later `BeginDialog` re-fetches the list, then a `LookUp` matches by a user-supplied text key —
   a race window between write and refetch plus lookup-key-collision risk.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -15,7 +15,8 @@ You are invoked with the path to one authored topic (`{agent.folder}/topics/{Nam
 whole file. Walk every Power Fx expression (any value beginning with `=`, and expression bodies inside
 `AdaptiveCardPrompt.card` / `AdaptiveCardTemplate.cardContent`). Evaluate each against the heuristics
 below. This is a **judgment lens**, not a closed rule set — each heuristic is a starting question; the
-precision bar and reachability rubric decide what becomes a finding.
+precision bar and reachability rubric in the shared
+[`finding-contract.md`](finding-contract.md) decide what becomes a finding.
 
 ## Heuristics (topic-local)
 
@@ -49,65 +50,11 @@ precision bar and reachability rubric decide what becomes a finding.
   domain-valued quantity (years, count). Domain judgment — only flag if the cap plausibly rejects a
   realistic valid case (retry-counter caps are **not** bugs).
 
-## Precision bar
+## Reporting
 
-Report a finding only at **≥80% confidence** that:
-
-1. The cited expression actually contains the claimed pattern (re-read the expression text before
-   reporting — this is where reviewer hallucinations surface).
-2. The pattern is a real defect, not an intentional design choice.
-3. Either the bug is user-reachable through normal chat UI with normal auth (HIGH/MEDIUM), or it is real
-   code/operator-level damage (LOW).
-
-When the same anti-pattern occurs at multiple sites, **report one finding with all sites listed**, not N
-findings.
-
-## Reachability scoring (dominant input to severity)
-
-- **REACHABLE_NORMAL_UI** — a normal user with normal auth doing what the topic is built to do hits this
-  path. -> HIGH (or MEDIUM if user-visible impact is small).
-- **REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION** — reachable via normal UI but needs a specific data
-  state. -> MEDIUM.
-- **NOT_REACHABLE_VIA_BOT_UI** — upstream-gated; only reachable via flow-direct invocation, a race
-  window, or a future code change. Real bug, no user impact today. -> LOW.
-- **OPERATOR_OR_HYGIENE_ONLY** — dead code, redundant writes, hardcoded IDs with no runtime user impact.
-  -> LOW.
-
-## Output format
-
-Report findings as a numbered list using `BTPF-NNN` IDs (Bot Topic Power Fx).
-
-**Locators (important).** The fix is applied in the chat panel, not by a human navigating to a line —
-so cite each site by its **stable node identity**, which is what a fixer keys on: the action's `id:`,
-its `displayName:` (if present), and its action `kind:`. Include the short expression excerpt so the
-target is unambiguous. A line number is **best-effort context only**, never the primary locator (line
-numbers drift and the agentic read does not track them reliably).
-
-```text
-BTPF-NNN — <one-line summary>
-  Severity:     HIGH | MEDIUM | LOW
-  Reachability: REACHABLE_NORMAL_UI | REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION | NOT_REACHABLE_VIA_BOT_UI | OPERATOR_OR_HYGIENE_ONLY
-  Site(s):
-    - kind=<action kind>  id=<node id>  displayName=<node displayName, if any>  expr=<short excerpt>  (~line <N>)
-    - (additional sites if multi-site)
-  What's wrong:   <1-3 sentence anti-pattern explanation>
-  Why it matters: <observable user/operator impact>
-  Concrete fix:   <specific proposed change — Power Fx snippet or YAML edit>
-  Fix targets:    <the node id(s) the fix edits or the node it inserts before/after — so the fixer can act>
-```
-
-Sort findings HIGH -> MEDIUM -> LOW. After the list, emit a **Defense-in-depth** section for real
-anti-patterns whose sites all scored `NOT_REACHABLE_VIA_BOT_UI` or `OPERATOR_OR_HYGIENE_ONLY`, so
-reviewers prioritize reachable bugs first:
-
-```text
-## Defense in depth (no reachable user impact today)
-
-DiD-NNN — <one-line summary>
-  Pattern:   <anti-pattern name>
-  Site(s):   <topic file>:<line>, ...
-  Rationale: <why it's worth fixing despite no current reachability>
-```
+This lens uses the `BTPF` finding-ID prefix. Apply the precision bar, reachability scoring, output format,
+and Defense-in-depth conventions from the shared [`finding-contract.md`](finding-contract.md). Locate each
+finding by the action's node identity (`id` / `displayName` / `kind`) with a short expression excerpt.
 
 ## What this lens does NOT do
 

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -75,7 +75,7 @@ source, so classify the value **before** applying any string heuristic below:
   on how the response was obtained:** when the topic uses the standard `ParseValue → ForAll → response-table`
   pattern and **delegates the call to a shared `*System*` orchestrator topic** (structurally visible — the ESS
   pattern), failure is handled centrally and the AI-orchestration layer emits a "no data" message, so the
-  finding is `reachable: unreachable`, **cap at LOW** (the confirmed runtime heuristics corroborate this;
+  finding is `NOT_REACHABLE_VIA_BOT_UI`, **cap at LOW** (the confirmed runtime heuristics corroborate this;
   apply the cap even without them). Reserve higher severity for a topic that parses a response it fetched
   **directly** (no shared orchestrator) or that renders a hardcoded card regardless of data. **Fix:** for the
   delegated (LOW) case the shared error path already prevents the blank from reaching the user — the finding is
@@ -87,7 +87,7 @@ source, so classify the value **before** applying any string heuristic below:
   result path has **no `isSuccess = false` (or equivalent failure) branch** — the topic continues with
   empty data on failure. Flag the missing failure branch, but **score on structure**: if the call is a
   `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally handles failure
-  (structurally visible), code after it is `reachable: unreachable` (**cap at LOW**, applied with or without
+  (structurally visible), code after it is `NOT_REACHABLE_VIA_BOT_UI` (**cap at LOW**, applied with or without
   the runtime docs) — do not claim "the user gets no error." Reserve higher severity for a **direct** flow
   call that ignores `isSuccess`, or a **write** that proceeds on unverified success. **Fix:** for the delegated
   (LOW) case the shared error path already handles the failure and stops the dialog — the finding is

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -39,26 +39,20 @@ calibration was unavailable.
 - **`ParseValue` / `ParseJSON` without an `isSuccess` gate (structural half).** When a topic calls a
   flow/dialog that returns `isSuccess`, then runs `ParseValue`/`ParseJSON` on the response **without a
   preceding branch on `isSuccess = false`**, a schema mismatch (API drift) silently produces blanks
-  downstream. Evaluate every parse site that is **not** inside/after an `isSuccess = true` guard, then split
-  on how the response was obtained (per the confirmed runtime heuristics,
-  `../runtime/confirmed-runtime-heuristics.md`):
-  - **Delegated (the ESS pattern) → suppress, do not surface a finding.** The topic uses the standard
-    `ParseValue → ForAll → response-table` pattern and got the response from a shared `*System*` orchestrator;
-    the AI-orchestration layer emits a "no data" message and failure is handled centrally, so this is
-    intentional, centrally-handled design. You **must** record a suppression breadcrumb (see the reachability
-    rubric in `finding-contract.md`) — `{ "id", "site", "suppressed_by": "ai-orchestration-no-data" }` — so
-    the evaluated-and-suppressed decision is auditable, not indistinguishable from never-looked. Do **not**
-    emit a LOW finding for this case; the breadcrumb replaces it.
-  - **Direct / hardcoded-card → real finding.** The topic parses a response it fetched **directly** (no shared
-    orchestrator), or renders a hardcoded card regardless of data. Score by reachability. **Fix:** move the
-    parse inside the `isSuccess = true` branch, or add an `isSuccess = false` ConditionGroup before it.
+  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard. **Severity is
+  governed by the confirmed runtime heuristics** (`../runtime/confirmed-runtime-heuristics.md`): when the
+  topic uses the standard `ParseValue → ForAll → response-table` pattern and delegates the call to a shared
+  `*System*` orchestrator topic (the ESS pattern), the AI-orchestration layer emits a "no data" message and
+  failure is handled centrally — so the finding is `reachable: unreachable`, **cap at LOW**. Reserve
+  higher severity for a topic that parses a response it fetched **directly** (no shared orchestrator) or
+  that renders a hardcoded card regardless of data. **Fix:** move the parse inside the `isSuccess = true`
+  branch, or add an `isSuccess = false` ConditionGroup before it.
 - **Flow failure-branch gaps (structural half).** A `BeginDialog`/`InvokeFlowAction` call site whose
   result path has **no `isSuccess = false` (or equivalent failure) branch** — the topic continues with
-  empty data on failure. Evaluate the site, then split the same way (check the confirmed runtime heuristics):
-  if the call is a `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally handles
-  failure, code after it is `reachable: unreachable` and this is the accepted ESS pattern — **suppress with a
-  breadcrumb** (`suppressed_by: "onerror-termination"`), do not surface a finding or claim "the user gets no
-  error." Reserve a real finding for a **direct** flow call that ignores `isSuccess`, or a **write** that
+  empty data on failure. Flag the missing failure branch, but check the confirmed runtime heuristics before
+  scoring: if the call is a `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally
+  handles failure, code after it is `reachable: unreachable` (**cap at LOW**) — do not claim "the user gets
+  no error." Reserve higher severity for a **direct** flow call that ignores `isSuccess`, or a **write** that
   proceeds on unverified success. **Fix:** add an `isSuccess = false` ConditionGroup after the call with an
   error `SendActivity` that stops the flow.
 - **Hardcoded environment-specific values.** GUID-like literals, agent IDs, environment IDs, connection

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -1,14 +1,13 @@
-# Power Fx topic-local conformance lens
+# Power Fx topic-local conformance analysis
 
-Reviewer instructions for the **topic-local Power Fx** conformance lens used by the `topics/review`
-skill. This lens finds bugs expressed **inside Power Fx expressions of a single authored topic** — read
-directly from the one `.mcs.yml` file, no preprocessing script and no reference repo required.
+Analysis guidance for the **Power Fx expression** checks used by the `topics/review` skill. These checks
+find bugs expressed **inside the Power Fx expressions of a single authored topic** — read directly from
+the one `.mcs.yml` file, needing only the topic itself.
 
-> **Scope (slice 1):** topic-local only. Every heuristic below is decidable from the authored
-> `.mcs.yml` alone (plus, at most, the other topics in the maker's own agent folder). Two Power Fx
-> heuristics that need cross-repo reference data — **dead/dangling `Global.*`** (writers live in the
-> shipped ESS framework) and **upstream/downstream error-code coverage gaps** (needs the shared
-> workflow's emitted error strings) — are **out of scope here** and handled in a later slice.
+> **Scope:** the checks below are each decidable from the authored `.mcs.yml` alone (plus, at most, the
+> other topics in the maker's own agent folder). Do not attempt checks that need data beyond the topic —
+> **dead/dangling `Global.*`** (needs the agent's declared variables) and **upstream/downstream
+> error-code coverage** (needs the shared workflow's emitted error strings) are **not covered here**.
 
 ## How to run this lens
 
@@ -115,6 +114,6 @@ DiD-NNN — <one-line summary>
 - Does not analyze adaptive-card field/visibility contracts (that is the UX lens), plugin C#, or workflow
   JSON action graphs.
 - Does not evaluate dead/dangling `Global.*` or upstream/downstream error-code coverage — those need
-  cross-topic + shipped-framework reference data and land in a later slice.
+  cross-topic + reference data and are handled by a separate reference-aware check.
 - Does not build an AST — token/expression-level reading only.
 - Findings are **advisory prose** in the response; this lens writes nothing to disk.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -18,6 +18,14 @@ below. This is a **judgment lens**, not a closed rule set — each heuristic is 
 precision bar and reachability rubric in the shared
 [`finding-contract.md`](finding-contract.md) decide what becomes a finding.
 
+**Consult the runtime heuristics for severity.** ESS runtime behavior is documented in
+`../runtime/confirmed-runtime-heuristics.md` (authoritative) and `../runtime/pending-runtime-heuristics.md`
+(provisional — apply with caution), synced into the workspace by `scripts/sync_runtime_heuristics.py`. Read
+the confirmed catalog before scoring severity: several rules (notably the AI-orchestration "no data"
+behavior and OnError dialog termination) cap otherwise-alarming findings at LOW / `reachable: unreachable`.
+If the runtime docs are not present, score from the finding-contract rubric alone and note that runtime
+calibration was unavailable.
+
 ## Heuristics (topic-local)
 
 - **Self-referential record literals.** Record-literal fields where the value is the unqualified field
@@ -31,12 +39,22 @@ precision bar and reachability rubric in the shared
 - **`ParseValue` / `ParseJSON` without an `isSuccess` gate (structural half).** When a topic calls a
   flow/dialog that returns `isSuccess`, then runs `ParseValue`/`ParseJSON` on the response **without a
   preceding branch on `isSuccess = false`**, a schema mismatch (API drift) silently produces blanks
-  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard. **Fix:** move
-  the parse inside the `isSuccess = true` branch, or add an `isSuccess = false` ConditionGroup before it.
+  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard. **Severity is
+  governed by the confirmed runtime heuristics** (`../runtime/confirmed-runtime-heuristics.md`): when the
+  topic uses the standard `ParseValue → ForAll → response-table` pattern and delegates the call to a shared
+  `*System*` orchestrator topic (the ESS pattern), the AI-orchestration layer emits a "no data" message and
+  failure is handled centrally — so the finding is `reachable: unreachable`, **cap at LOW**. Reserve
+  higher severity for a topic that parses a response it fetched **directly** (no shared orchestrator) or
+  that renders a hardcoded card regardless of data. **Fix:** move the parse inside the `isSuccess = true`
+  branch, or add an `isSuccess = false` ConditionGroup before it.
 - **Flow failure-branch gaps (structural half).** A `BeginDialog`/`InvokeFlowAction` call site whose
   result path has **no `isSuccess = false` (or equivalent failure) branch** — the topic continues with
-  empty data on failure and the user gets no error. Flag the missing failure branch. **Fix:** add an
-  `isSuccess = false` ConditionGroup after the call with an error `SendActivity` that stops the flow.
+  empty data on failure. Flag the missing failure branch, but check the confirmed runtime heuristics before
+  scoring: if the call is a `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally
+  handles failure, code after it is `reachable: unreachable` (**cap at LOW**) — do not claim "the user gets
+  no error." Reserve higher severity for a **direct** flow call that ignores `isSuccess`, or a **write** that
+  proceeds on unverified success. **Fix:** add an `isSuccess = false` ConditionGroup after the call with an
+  error `SendActivity` that stops the flow.
 - **Hardcoded environment-specific values.** GUID-like literals, agent IDs, environment IDs, connection
   IDs, model IDs (`aIModelId`), and flow IDs (`flowId`) written inline in the topic. These are
   environment-bound and should be resolved by the platform (connection references / solution-aware

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -1,0 +1,113 @@
+# Power Fx topic-local conformance lens
+
+Reviewer instructions for the **topic-local Power Fx** conformance lens used by the `topics/review`
+skill. This lens finds bugs expressed **inside Power Fx expressions of a single authored topic** — read
+directly from the one `.mcs.yml` file, no preprocessing script and no reference repo required.
+
+> **Scope (slice 1):** topic-local only. Every heuristic below is decidable from the authored
+> `.mcs.yml` alone (plus, at most, the other topics in the maker's own agent folder). Two Power Fx
+> heuristics that need cross-repo reference data — **dead/dangling `Global.*`** (writers live in the
+> shipped ESS framework) and **upstream/downstream error-code coverage gaps** (needs the shared
+> workflow's emitted error strings) — are **out of scope here** and handled in a later slice.
+
+## How to run this lens
+
+You are invoked with the path to one authored topic (`{agent.folder}/topics/{Name}.mcs.yml`). Read the
+whole file. Walk every Power Fx expression (any value beginning with `=`, and expression bodies inside
+`AdaptiveCardPrompt.card` / `AdaptiveCardTemplate.cardContent`). Evaluate each against the heuristics
+below. This is a **judgment lens**, not a closed rule set — each heuristic is a starting question; the
+precision bar and reachability rubric decide what becomes a finding.
+
+## Heuristics (topic-local)
+
+- **Self-referential record literals.** Record-literal fields where the value is the unqualified field
+  name — `{ID: ID, Name: Name}`. Almost always an intended `ID: currentRecord.ID` (or similar) that was
+  left dangling, so the field silently binds to itself / blank.
+- **Power Fx string-literal quote-run quirks.** Doubled double-quotes are escape syntax: `"a""b"` is the
+  3-char string `a"b`, and `""""""` (six quotes) is the 2-char string `""`, **not** an empty string. An
+  equality check `value = """"""` does **not** test for empty. Count quote-runs carefully — miscounting is
+  the exact class of error this catches.
+- **`ParseValue` / `ParseJSON` without an `isSuccess` gate (structural half).** When a topic calls a
+  flow/dialog that returns `isSuccess`, then runs `ParseValue`/`ParseJSON` on the response **without a
+  preceding branch on `isSuccess = false`**, a schema mismatch (API drift) silently produces blanks
+  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard.
+- **Flow failure-branch gaps (structural half).** A `BeginDialog`/`InvokeFlowAction` call site whose
+  result path has **no `isSuccess = false` (or equivalent failure) branch** — the topic continues with
+  empty data on failure and the user gets no error. Flag the missing failure branch.
+- **Hardcoded environment-specific values.** GUID-like literals, agent IDs, environment IDs, connection
+  IDs, model IDs (`aIModelId`), and flow IDs (`flowId`) written inline in the topic. These are
+  environment-bound and should be resolved by the platform (connection references / solution-aware
+  bindings), not hardcoded — hardcoding breaks on import to another environment.
+- **String/numeric parsing without explicit guards.** `Find()` / `Substring()` / `Text(Value(...))`
+  chains on user-supplied strings with no length/format pre-check — throws or misparses on unexpected
+  input.
+- **Write-then-refetch-then-lookup-by-mutable-key.** A `SetVariable` that writes via an Update call,
+  then a later `BeginDialog` re-fetches the list, then a `LookUp` matches by a user-supplied text key —
+  a race window between write and refetch plus lookup-key-collision risk.
+- **Brittle name/text matching.** Direct `=` comparison or `Find()` on user-facing text (names, error
+  messages). Domain judgment — flag low-severity unless you can argue a concrete user-visible failure.
+- **Numeric range caps that may reject valid inputs.** `<=` / `<` against a small constant on a
+  domain-valued quantity (years, count). Domain judgment — only flag if the cap plausibly rejects a
+  realistic valid case (retry-counter caps are **not** bugs).
+
+## Precision bar
+
+Report a finding only at **≥80% confidence** that:
+
+1. The cited expression actually contains the claimed pattern (re-read the expression text before
+   reporting — this is where reviewer hallucinations surface).
+2. The pattern is a real defect, not an intentional design choice.
+3. Either the bug is user-reachable through normal chat UI with normal auth (HIGH/MEDIUM), or it is real
+   code/operator-level damage (LOW).
+
+When the same anti-pattern occurs at multiple sites, **report one finding with all sites listed**, not N
+findings.
+
+## Reachability scoring (dominant input to severity)
+
+- **REACHABLE_NORMAL_UI** — a normal user with normal auth doing what the topic is built to do hits this
+  path. -> HIGH (or MEDIUM if user-visible impact is small).
+- **REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION** — reachable via normal UI but needs a specific data
+  state. -> MEDIUM.
+- **NOT_REACHABLE_VIA_BOT_UI** — upstream-gated; only reachable via flow-direct invocation, a race
+  window, or a future code change. Real bug, no user impact today. -> LOW.
+- **OPERATOR_OR_HYGIENE_ONLY** — dead code, redundant writes, hardcoded IDs with no runtime user impact.
+  -> LOW.
+
+## Output format
+
+Report findings as a numbered list using `BTPF-NNN` IDs (Bot Topic Power Fx):
+
+```text
+BTPF-NNN — <one-line summary>
+  Severity:     HIGH | MEDIUM | LOW
+  Reachability: REACHABLE_NORMAL_UI | REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION | NOT_REACHABLE_VIA_BOT_UI | OPERATOR_OR_HYGIENE_ONLY
+  Site(s):
+    - <topic file>:<line>  <short expression excerpt>
+    - (additional sites if multi-site)
+  What's wrong:   <1-3 sentence anti-pattern explanation>
+  Why it matters: <observable user/operator impact>
+  Concrete fix:   <specific proposed change — Power Fx snippet or YAML edit>
+```
+
+Sort findings HIGH -> MEDIUM -> LOW. After the list, emit a **Defense-in-depth** section for real
+anti-patterns whose sites all scored `NOT_REACHABLE_VIA_BOT_UI` or `OPERATOR_OR_HYGIENE_ONLY`, so
+reviewers prioritize reachable bugs first:
+
+```text
+## Defense in depth (no reachable user impact today)
+
+DiD-NNN — <one-line summary>
+  Pattern:   <anti-pattern name>
+  Site(s):   <topic file>:<line>, ...
+  Rationale: <why it's worth fixing despite no current reachability>
+```
+
+## What this lens does NOT do
+
+- Does not analyze adaptive-card field/visibility contracts (that is the UX lens), plugin C#, or workflow
+  JSON action graphs.
+- Does not evaluate dead/dangling `Global.*` or upstream/downstream error-code coverage — those need
+  cross-topic + shipped-framework reference data and land in a later slice.
+- Does not build an AST — token/expression-level reading only.
+- Findings are **advisory prose** in the response; this lens writes nothing to disk.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -76,18 +76,25 @@ findings.
 
 ## Output format
 
-Report findings as a numbered list using `BTPF-NNN` IDs (Bot Topic Power Fx):
+Report findings as a numbered list using `BTPF-NNN` IDs (Bot Topic Power Fx).
+
+**Locators (important).** The fix is applied in the chat panel, not by a human navigating to a line —
+so cite each site by its **stable node identity**, which is what a fixer keys on: the action's `id:`,
+its `displayName:` (if present), and its action `kind:`. Include the short expression excerpt so the
+target is unambiguous. A line number is **best-effort context only**, never the primary locator (line
+numbers drift and the agentic read does not track them reliably).
 
 ```text
 BTPF-NNN — <one-line summary>
   Severity:     HIGH | MEDIUM | LOW
   Reachability: REACHABLE_NORMAL_UI | REACHABLE_NORMAL_UI_WITH_DATA_PRECONDITION | NOT_REACHABLE_VIA_BOT_UI | OPERATOR_OR_HYGIENE_ONLY
   Site(s):
-    - <topic file>:<line>  <short expression excerpt>
+    - kind=<action kind>  id=<node id>  displayName=<node displayName, if any>  expr=<short excerpt>  (~line <N>)
     - (additional sites if multi-site)
   What's wrong:   <1-3 sentence anti-pattern explanation>
   Why it matters: <observable user/operator impact>
   Concrete fix:   <specific proposed change — Power Fx snippet or YAML edit>
+  Fix targets:    <the node id(s) the fix edits or the node it inserts before/after — so the fixer can act>
 ```
 
 Sort findings HIGH -> MEDIUM -> LOW. After the list, emit a **Defense-in-depth** section for real

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -28,10 +28,16 @@ calibration was unavailable.
 
 ## Heuristics (topic-local)
 
-- **Self-referential record literals.** Record-literal fields where the value is the unqualified field
-  name — `{ID: ID, Name: Name}`. Almost always an intended `ID: currentRecord.ID` (or similar) that was
-  left dangling, so the field silently binds to itself / blank. **Fix:** qualify each value with its source
-  record (e.g. `ID: currentRecord.ID`).
+- **Unqualified field value in a record literal (hygiene).** A record-literal field whose value is a bare
+  field name — `{ID: ID}` — while its siblings in the same literal explicitly qualify their source (e.g.
+  `Expiration_Date: currentRecord.Expiration_Date`). A record-literal value is evaluated in the **enclosing**
+  scope, not the record's own fields, so this is **not** self-referential and does **not** silently bind to
+  blank: inside a `ForAll`/`With` row the bare name resolves to that row's in-scope field (it works), and if
+  no such field is in scope Power Fx raises a name error at author time. When a sibling binds
+  `currentRecord: ThisRecord`, the bare `ID` and `currentRecord.ID` are the **same value** — so qualifying it
+  is a no-op for correctness. Treat this as a **LOW / hygiene** consistency nit (bare vs qualified siblings; a
+  future inner-scope binding of the same name could shadow it), never a "comes through blank" data bug, and
+  do not raise severity on it. **Fix:** qualify the value to match its siblings (e.g. `ID: currentRecord.ID`).
 - **Power Fx string-literal quote-run quirks.** Doubled double-quotes are escape syntax: `"a""b"` is the
   3-char string `a"b`, and `""""""` (six quotes) is the 2-char string `""`, **not** an empty string. An
   equality check `value = """"""` does **not** test for empty. Count quote-runs carefully — miscounting is

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -18,13 +18,39 @@ below. This is a **judgment lens**, not a closed rule set — each heuristic is 
 precision bar and reachability rubric in the shared
 [`finding-contract.md`](finding-contract.md) decide what becomes a finding.
 
-**Consult the runtime heuristics for severity.** ESS runtime behavior is documented in
-`../runtime/confirmed-runtime-heuristics.md` (authoritative) and `../runtime/pending-runtime-heuristics.md`
-(provisional — apply with caution), synced into the workspace by `scripts/sync_runtime_heuristics.py`. Read
-the confirmed catalog before scoring severity: several rules (notably the AI-orchestration "no data"
-behavior and OnError dialog termination) cap otherwise-alarming findings at LOW / `reachable: unreachable`.
-If the runtime docs are not present, score from the finding-contract rubric alone and note that runtime
-calibration was unavailable.
+**Severity rests on structure first; runtime heuristics corroborate.** The LOW-caps below are grounded in a
+**structurally visible** fact — that the topic delegates its backend call to a shared `*System*` orchestrator
+(the ESS pattern: a `BeginDialog` into a `*System*` topic that owns the call, failure handling, and response
+shaping). That delegation is readable from the topic itself, so **apply the caps whether or not the runtime
+docs are present**. The cap assumes the delegation target is an **unmodified shared `*System*`/OnError topic
+that follows the ESS pattern** — that is what makes central failure handling a safe inference from the caller
+alone. If the target is not a `*System*`-named shared topic, or the maker has modified the shared system
+topic, that assumption does not hold: score the finding on its own structure rather than applying the cap.
+When `../runtime/confirmed-runtime-heuristics.md` (synced by
+`scripts/sync_runtime_heuristics.py`) is available, read it to corroborate and refine (notably the
+AI-orchestration "no data" behavior and OnError dialog termination); `../runtime/pending-runtime-heuristics.md`
+is provisional — apply with caution. Check for these docs with a **direct filesystem test of the exact path**
+(the `runtime/` folder is gitignored, so a workspace/indexed search reports a present doc as missing — that
+false-absent would silently deny the corroboration to internal makers who have the docs synced). When the
+runtime docs are absent, still apply the structural caps and
+note that runtime corroboration was unavailable — do **not** fall back to structural-HIGH on the delegated
+pattern.
+
+## Value syntax (read before flagging any string)
+
+Copilot Studio node values come in two syntaxes; misreading one for the other is a common false-positive
+source, so classify the value **before** applying any string heuristic below:
+
+- **Power Fx expression** — the value **starts with `=`** (e.g. `value: =Topic.ServiceNowData`,
+  `value: =PlainText(Topic.CaseDetails.Description)`). Only these are Power Fx; the string heuristics apply to
+  their expression text.
+- **Text-with-variables (template string)** — a value that does **not** start with `=` (typical on
+  `SetTextVariable`, and on message `text:` / `speak:`). Here `{Topic.X}`, `{Global.X}`, `{System.X}` are
+  **runtime substitution placeholders**, not literals. `value: "HR Case #{Topic.CaseDetails.CaseNumber}"`
+  dynamically interpolates the case number at runtime — it is **not** "the title hardcoded instead of using
+  the case number," and `{...}` interpolation is **never** a hardcoded/literal-string bug. Do not flag it.
+  (Real hardcoding is a *fixed* value with no `{...}` where a dynamic one is expected, or an environment-bound
+  literal — see "Hardcoded environment-specific values" below.)
 
 ## Heuristics (topic-local)
 
@@ -45,30 +71,44 @@ calibration was unavailable.
 - **`ParseValue` / `ParseJSON` without an `isSuccess` gate (structural half).** When a topic calls a
   flow/dialog that returns `isSuccess`, then runs `ParseValue`/`ParseJSON` on the response **without a
   preceding branch on `isSuccess = false`**, a schema mismatch (API drift) silently produces blanks
-  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard. **Severity is
-  governed by the confirmed runtime heuristics** (`../runtime/confirmed-runtime-heuristics.md`): when the
-  topic uses the standard `ParseValue → ForAll → response-table` pattern and delegates the call to a shared
-  `*System*` orchestrator topic (the ESS pattern), the AI-orchestration layer emits a "no data" message and
-  failure is handled centrally — so the finding is `reachable: unreachable`, **cap at LOW**. Reserve
-  higher severity for a topic that parses a response it fetched **directly** (no shared orchestrator) or
-  that renders a hardcoded card regardless of data. **Fix:** move the parse inside the `isSuccess = true`
-  branch, or add an `isSuccess = false` ConditionGroup before it.
+  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard. **Severity rests
+  on how the response was obtained:** when the topic uses the standard `ParseValue → ForAll → response-table`
+  pattern and **delegates the call to a shared `*System*` orchestrator topic** (structurally visible — the ESS
+  pattern), failure is handled centrally and the AI-orchestration layer emits a "no data" message, so the
+  finding is `reachable: unreachable`, **cap at LOW** (the confirmed runtime heuristics corroborate this;
+  apply the cap even without them). Reserve higher severity for a topic that parses a response it fetched
+  **directly** (no shared orchestrator) or that renders a hardcoded card regardless of data. **Fix:** for the
+  delegated (LOW) case the shared error path already prevents the blank from reaching the user — the finding is
+  informational; optionally gate the parse on `isSuccess = true` for clarity, but do **not** add a local error
+  handler (that duplicates the shared path — see `../customization/authoring-invariants.md`). For the
+  **direct**-call case, move the parse inside an `isSuccess = true` branch or add an `isSuccess = false`
+  ConditionGroup before it.
 - **Flow failure-branch gaps (structural half).** A `BeginDialog`/`InvokeFlowAction` call site whose
   result path has **no `isSuccess = false` (or equivalent failure) branch** — the topic continues with
-  empty data on failure. Flag the missing failure branch, but check the confirmed runtime heuristics before
-  scoring: if the call is a `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally
-  handles failure, code after it is `reachable: unreachable` (**cap at LOW**) — do not claim "the user gets
-  no error." Reserve higher severity for a **direct** flow call that ignores `isSuccess`, or a **write** that
-  proceeds on unverified success. **Fix:** add an `isSuccess = false` ConditionGroup after the call with an
-  error `SendActivity` that stops the flow.
+  empty data on failure. Flag the missing failure branch, but **score on structure**: if the call is a
+  `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally handles failure
+  (structurally visible), code after it is `reachable: unreachable` (**cap at LOW**, applied with or without
+  the runtime docs) — do not claim "the user gets no error." Reserve higher severity for a **direct** flow
+  call that ignores `isSuccess`, or a **write** that proceeds on unverified success. **Fix:** for the delegated
+  (LOW) case the shared error path already handles the failure and stops the dialog — the finding is
+  informational and the topic should **not** add its own failure branch (that reimplements the shared path —
+  see `../customization/authoring-invariants.md`). Only for a **direct** flow call add an `isSuccess = false`
+  ConditionGroup after the call with an error `SendActivity` that stops the flow.
 - **Hardcoded environment-specific values.** GUID-like literals, agent IDs, environment IDs, connection
   IDs, model IDs (`aIModelId`), and flow IDs (`flowId`) written inline in the topic. These are
   environment-bound and should be resolved by the platform (connection references / solution-aware
   bindings), not hardcoded — hardcoding breaks on import to another environment. **Fix:** replace the
   literal with a connection reference or environment variable the platform resolves per environment.
+  (This is about environment-bound IDs only — a `{Topic.X}`/`{Global.X}` placeholder in a text-with-variables
+  value is dynamic substitution, not hardcoding; see "Value syntax" above.)
 - **String/numeric parsing without explicit guards.** `Find()` / `Substring()` / `Text(Value(...))`
-  chains on user-supplied strings with no length/format pre-check — throws or misparses on unexpected
-  input. **Fix:** add an `IsBlank`/length/format pre-check before the parse and branch on the invalid case.
+  chains **on user-supplied strings** with no length/format pre-check — throws or misparses on unexpected
+  input. **Scope this narrowly to user input:** it does **not** fire on `ParseValue` / `ParseJSON` of a
+  trusted orchestrator/backend response (that is the parse-before-success heuristic above — reachability-
+  capped, not this one), nor on outbound request construction like `JSON(Table(...))` in a `BeginDialog`
+  parameter binding (building the request, not parsing input). Flag only a `Find`/`Substring`/`Value`-style
+  parse whose operand traces to a user-entered value. **Fix:** add an `IsBlank`/length/format pre-check before
+  the parse and branch on the invalid case.
 - **Write-then-refetch-then-lookup-by-mutable-key.** A `SetVariable` that writes via an Update call,
   then a later `BeginDialog` re-fetches the list, then a `LookUp` matches by a user-supplied text key —
   a race window between write and refetch plus lookup-key-collision risk.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -39,20 +39,26 @@ calibration was unavailable.
 - **`ParseValue` / `ParseJSON` without an `isSuccess` gate (structural half).** When a topic calls a
   flow/dialog that returns `isSuccess`, then runs `ParseValue`/`ParseJSON` on the response **without a
   preceding branch on `isSuccess = false`**, a schema mismatch (API drift) silently produces blanks
-  downstream. Flag when the parse site is **not** inside/after an `isSuccess = true` guard. **Severity is
-  governed by the confirmed runtime heuristics** (`../runtime/confirmed-runtime-heuristics.md`): when the
-  topic uses the standard `ParseValue → ForAll → response-table` pattern and delegates the call to a shared
-  `*System*` orchestrator topic (the ESS pattern), the AI-orchestration layer emits a "no data" message and
-  failure is handled centrally — so the finding is `reachable: unreachable`, **cap at LOW**. Reserve
-  higher severity for a topic that parses a response it fetched **directly** (no shared orchestrator) or
-  that renders a hardcoded card regardless of data. **Fix:** move the parse inside the `isSuccess = true`
-  branch, or add an `isSuccess = false` ConditionGroup before it.
+  downstream. Evaluate every parse site that is **not** inside/after an `isSuccess = true` guard, then split
+  on how the response was obtained (per the confirmed runtime heuristics,
+  `../runtime/confirmed-runtime-heuristics.md`):
+  - **Delegated (the ESS pattern) → suppress, do not surface a finding.** The topic uses the standard
+    `ParseValue → ForAll → response-table` pattern and got the response from a shared `*System*` orchestrator;
+    the AI-orchestration layer emits a "no data" message and failure is handled centrally, so this is
+    intentional, centrally-handled design. You **must** record a suppression breadcrumb (see the reachability
+    rubric in `finding-contract.md`) — `{ "id", "site", "suppressed_by": "ai-orchestration-no-data" }` — so
+    the evaluated-and-suppressed decision is auditable, not indistinguishable from never-looked. Do **not**
+    emit a LOW finding for this case; the breadcrumb replaces it.
+  - **Direct / hardcoded-card → real finding.** The topic parses a response it fetched **directly** (no shared
+    orchestrator), or renders a hardcoded card regardless of data. Score by reachability. **Fix:** move the
+    parse inside the `isSuccess = true` branch, or add an `isSuccess = false` ConditionGroup before it.
 - **Flow failure-branch gaps (structural half).** A `BeginDialog`/`InvokeFlowAction` call site whose
   result path has **no `isSuccess = false` (or equivalent failure) branch** — the topic continues with
-  empty data on failure. Flag the missing failure branch, but check the confirmed runtime heuristics before
-  scoring: if the call is a `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally
-  handles failure, code after it is `reachable: unreachable` (**cap at LOW**) — do not claim "the user gets
-  no error." Reserve higher severity for a **direct** flow call that ignores `isSuccess`, or a **write** that
+  empty data on failure. Evaluate the site, then split the same way (check the confirmed runtime heuristics):
+  if the call is a `BeginDialog` into a shared `*System*`/OnError topic that terminates or centrally handles
+  failure, code after it is `reachable: unreachable` and this is the accepted ESS pattern — **suppress with a
+  breadcrumb** (`suppressed_by: "onerror-termination"`), do not surface a finding or claim "the user gets no
+  error." Reserve a real finding for a **direct** flow call that ignores `isSuccess`, or a **write** that
   proceeds on unverified success. **Fix:** add an `isSuccess = false` ConditionGroup after the call with an
   error `SendActivity` that stops the flow.
 - **Hardcoded environment-specific values.** GUID-like literals, agent IDs, environment IDs, connection

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
@@ -14,11 +14,20 @@ number.
 
 ### 9a — No findings
 
-If the active set is empty, show only this and stop — no table, no disclaimer, nothing to caveat:
+If the active set is empty:
 
-**Message:**
+**Message (full coverage — nothing was skipped):**
 
-I looked over `{TopicName}` and didn't spot anything to flag — you're good to publish.
+I looked over `{topic-stem}` and didn't spot anything to flag — you're good to publish.
+
+**End message.**
+
+**Message (reduced coverage — ISV conformance was skipped for this topic's backend):** do not say "good to
+publish" unqualified; name the gap, using the backend from the Coverage note rule below:
+
+I looked over `{topic-stem}` and didn't spot anything to flag in what I could check. Note: I don't have the
+`{backend}` conformance reference in this environment, so I couldn't check its field/schema conventions — if
+this topic calls `{backend}`, that part is worth a manual look.
 
 **End message.**
 
@@ -26,9 +35,9 @@ I looked over `{TopicName}` and didn't spot anything to flag — you're good to 
 
 Otherwise show one verdict line, keyed to the highest severity present:
 
-- Any High → `⚠️ **{TopicName}** — I spotted some things that could cause problems; worth a look before you publish.`
-- Any Medium (no High) → `**{TopicName}** — a few things that might be worth a look before you publish.`
-- Only Low → `**{TopicName}** — looks good; a couple of minor things to double-check before publishing.`
+- Any High → `⚠️ **{topic-stem}** — I spotted some things that could cause problems; worth a look before you publish.`
+- Any Medium (no High) → `**{topic-stem}** — a few things that might be worth a look before you publish.`
+- Only Low → `**{topic-stem}** — looks good; a couple of minor things to double-check before publishing.`
 
 Directly under it, this framing line **verbatim**:
 
@@ -54,6 +63,28 @@ End with this **verbatim**:
 > Advisory — you can publish as-is. To fix one, type `/update` and name its step; re-run `/review` after
 > edits to re-check.
 
+**In reduced coverage only**, add a coverage line directly above the close (skip it entirely in full
+coverage):
+
+> Coverage: I checked Power Fx logic, Globals, cards, and the integration pattern. I couldn't check
+> `{backend}` field conformance — its reference doc isn't available in this environment.
+
+### Coverage note (when to show it — single source of truth)
+
+There is exactly **one** skippable check: **ISV field conformance**, and only when the reference doc for the
+in-scope topic's **specific backend** (`isv-<backend>.md`) is absent (see the review skill's "Coverage mode"
+step). That condition — and nothing else — is "reduced coverage." Everything else (Power Fx, Globals, cards,
+integration pattern, ServiceNow response-field integrity) always runs, and missing `runtime/` corroboration
+is **not** reduced coverage. So:
+
+- **Reduced coverage** → show the one honest clause naming the backend: 9a's reduced variant, the 9d coverage
+  line, and the scoped equivalents. Fill `{backend}` with the actual system (Workday, ServiceNow, SAP
+  SuccessFactors, …).
+- **Full coverage** (ISV ran for every in-scope topic, or no topic calls a backend) → show none of it: plain
+  "good to publish" in 9a, no coverage line in 9d, no coverage line in the scoped roll-up. Never pad a clean
+  report with coverage boilerplate when nothing was skipped, and never emit an empty "Coverage: I ran
+  everything" line.
+
 ## Issue detail view (when the maker asks about one issue)
 
 When the maker asks to see or fix a **specific issue** — "more details on X", "explain this one", "how do I
@@ -76,9 +107,18 @@ not improvise the verdict, add prose between sections, or narrate the analysis (
 
 If **no topic** in the scope has an active finding:
 
-**Message:**
+**Message (full coverage):**
 
 I reviewed all {N} `{module-id}` topics and didn't spot anything to flag — you're good to publish.
+
+**End message.**
+
+**Message (reduced coverage — ISV conformance was skipped for one or more backends):** do not say "good to
+publish" unqualified:
+
+I reviewed all {N} `{module-id}` topics and didn't spot anything to flag in what I could check. Note: I don't
+have the {backend(s)} conformance reference here, so I couldn't check field/schema conventions for the topics
+that call {backend(s)} — that part is worth a manual look.
 
 **End message.**
 
@@ -113,6 +153,13 @@ Close with this **verbatim**:
 
 > To see a topic's details, ask to review it by name (e.g. `review {topic-stem}`) — its findings are saved.
 > To fix one, type `/update` and name the topic and step. Re-run to re-check.
+
+**In reduced coverage only**, add a coverage line directly above the close (omit in full coverage; see the
+Coverage note single-source-of-truth rule above):
+
+> Coverage: across these topics I checked Power Fx logic, Globals, cards, and the integration pattern. I
+> couldn't check {backend(s)} field conformance — that reference isn't available here, and it applies to every
+> topic that calls {backend(s)}, not just the ones flagged above.
 
 **Drill-down:** if the maker asks to see one topic, render that topic's 9c table from its
 `{topic-stem}-catalog.json` (active set). If they ask about a **specific issue**, use the **Issue detail

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
@@ -1,0 +1,119 @@
+# Review report format
+
+The maker-facing output templates for the `topics/review` skill — the single-topic report, the single-issue
+detail view, and the scoped roll-up. These are the **exact** shapes to present; follow them verbatim. The
+**Speak the maker's language** rule (in the skill's Rules) governs all of them: hide the review system's
+vocabulary (lens, detector, reachability tags, rule IDs, catalog paths); the maker's own Power Fx, action
+kinds, field names, step names, and `topic.mcs.yml:line` are their language and are allowed where noted.
+
+## Single-topic report (Step 9)
+
+Follow this format exactly. Do **not** add prose between sections, narrate what you checked, or explain the
+process. Locate each finding by the **step/action it lives in** (its display name), never a node id or line
+number.
+
+### 9a — No findings
+
+If the active set is empty, show only this and stop — no table, no disclaimer, nothing to caveat:
+
+**Message:**
+
+I looked over `{TopicName}` and didn't spot anything to flag — you're good to publish.
+
+**End message.**
+
+### 9b — Verdict line
+
+Otherwise show one verdict line, keyed to the highest severity present:
+
+- Any High → `⚠️ **{TopicName}** — I spotted some things that could cause problems; worth a look before you publish.`
+- Any Medium (no High) → `**{TopicName}** — a few things that might be worth a look before you publish.`
+- Only Low → `**{TopicName}** — looks good; a couple of minor things to double-check before publishing.`
+
+Directly under it, this framing line **verbatim**:
+
+> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to your
+> scenario; use your judgment.
+
+### 9c — Findings table
+
+Then this table, one row per finding, sorted High → Medium → Low. Put any "no user impact today" items under
+a short **Minor / cleanup** heading below the main rows.
+
+| #   | Severity | Where (step)        | Potential issue                | Suggested fix   |
+| --- | -------- | ------------------- | ------------------------------ | --------------- |
+| 1   | Medium   | "{step name/label}" | {what might be wrong — hedged} | {suggested fix} |
+
+The table carries each finding — do not restate rows in prose. Add one short line under the table **only**
+when a fix needs a Power Fx snippet or nuance the cell can't hold.
+
+### 9d — Close
+
+End with this **verbatim**:
+
+> Advisory — you can publish as-is. To fix one, type `/update` and name its step; re-run `/review` after
+> edits to re-check.
+
+## Issue detail view (when the maker asks about one issue)
+
+When the maker asks to see or fix a **specific issue** — "more details on X", "explain this one", "how do I
+fix it" — present that finding in this structured shape, **not flowing prose**. Pull the finding from its
+catalog (read the cited `files[].lines` if you need the exact expression to reference — a targeted read, not
+a re-analysis). One block per issue — a bold header line (`{plain-language title}` · {High/Medium/Low} ·
+`{topic-stem}.mcs.yml:{line}` "{step display name}"), then:
+
+- **Proposed fix:** {concise prose; technical language allowed — name the expression/property and the change}
+- **Why fix it this way:** {one or two plain sentences}
+
+This is the one place the maker's own code and `file:line` appear. Still keep the review system's vocabulary
+out (no rule IDs, reachability tags, "lens").
+
+## Scoped roll-up (S-4)
+
+Show a scope-level summary, then a per-topic table and an issue-type rollup — **not** each topic's full
+findings table. Same exact-template discipline as the single-topic report: use the verbatim lines below, do
+not improvise the verdict, add prose between sections, or narrate the analysis (including todo-list activity).
+
+If **no topic** in the scope has an active finding:
+
+**Message:**
+
+I reviewed all {N} `{module-id}` topics and didn't spot anything to flag — you're good to publish.
+
+**End message.**
+
+Otherwise, one verdict line keyed to the highest severity anywhere in the scope (verbatim):
+
+- Any High → `⚠️ **Review — {module-id}** ({N} topics) — some things across these topics could cause problems; worth a look before you publish.`
+- Any Medium (no High) → `**Review — {module-id}** ({N} topics) — a few things across these topics might be worth a look before you publish.`
+- Only Low → `**Review — {module-id}** ({N} topics) — looks good; a few minor things to double-check before publishing.`
+
+Directly under it, this framing line **verbatim**:
+
+> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to your
+> scenario; use your judgment.
+
+Then the **per-topic table** — topics with findings first, worst severity first; omit clean topics but note
+the count below:
+
+| Topic        | High | Medium | Low |
+| ------------ | ---- | ------ | --- |
+| {topic-stem} | {n}  | {n}    | {n} |
+
+`{k} other topics were clean.`
+
+Then the **issue-type rollup** — the same active findings grouped by their plain-language issue type, so the
+maker sees which problems recur across the scope. Order by severity, then count:
+
+| Issue                       | Topics affected | Severity          |
+| --------------------------- | --------------- | ----------------- |
+| {plain-language issue type} | {count}         | {High/Medium/Low} |
+
+Close with this **verbatim**:
+
+> To see a topic's details, ask to review it by name (e.g. `review {topic-stem}`) — its findings are saved.
+> To fix one, type `/update` and name the topic and step. Re-run to re-check.
+
+**Drill-down:** if the maker asks to see one topic, render that topic's 9c table from its
+`{topic-stem}-catalog.json` (active set). If they ask about a **specific issue**, use the **Issue detail
+view** above — no re-analysis, only a targeted read of the cited line to quote the current expression.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
@@ -72,18 +72,20 @@ coverage):
 ### Coverage note (when to show it — single source of truth)
 
 There is exactly **one** skippable check: **ISV field conformance**, and only when the reference doc for the
-in-scope topic's **specific backend** (`isv-<backend>.md`) is absent (see the review skill's "Coverage mode"
-step). That condition — and nothing else — is "reduced coverage." Everything else (Power Fx, Globals, cards,
-integration pattern, ServiceNow response-field integrity) always runs, and missing `runtime/` corroboration
-is **not** reduced coverage. So:
+in-scope topic's **specific backend** (`isv-<backend>.md`) is absent. **This is decided by the coverage probe,
+not by your own judgement** — the review skill's "Coverage mode" step runs `scripts/check_isv_coverage.py`,
+which emits `mode` and `missing_backends`. Drive the coverage note **only** from that verdict; do not infer
+coverage from your impression of the environment. Everything else (Power Fx, Globals, cards, integration
+pattern, ServiceNow response-field integrity) always runs, and missing `runtime/` corroboration is **not**
+reduced coverage. So:
 
-- **Reduced coverage** → show the one honest clause naming the backend: 9a's reduced variant, the 9d coverage
-  line, and the scoped equivalents. Fill `{backend}` with the actual system (Workday, ServiceNow, SAP
-  SuccessFactors, …).
-- **Full coverage** (ISV ran for every in-scope topic, or no topic calls a backend) → show none of it: plain
+- **`mode: reduced`** → show the one honest clause naming each backend in `missing_backends`: 9a's reduced
+  variant, the 9d coverage line, and the scoped equivalents. Fill `{backend}` from `missing_backends` (Workday,
+  ServiceNow, SAP SuccessFactors, …).
+- **`mode: full`** (ISV ran for every in-scope backend, or no topic calls a backend) → show none of it: plain
   "good to publish" in 9a, no coverage line in 9d, no coverage line in the scoped roll-up. Never pad a clean
   report with coverage boilerplate when nothing was skipped, and never emit an empty "Coverage: I ran
-  everything" line.
+  everything" line, and — critically — **never emit a reduced-coverage caveat when the probe says `full`.**
 
 ## Issue detail view (when the maker asks about one issue)
 

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/report-format.md
@@ -80,8 +80,16 @@ pattern, ServiceNow response-field integrity) always runs, and missing `runtime/
 reduced coverage. So:
 
 - **`mode: reduced`** → show the one honest clause naming each backend in `missing_backends`: 9a's reduced
-  variant, the 9d coverage line, and the scoped equivalents. Fill `{backend}` from `missing_backends` (Workday,
-  ServiceNow, SAP SuccessFactors, …).
+  variant, the 9d coverage line, and the scoped equivalents. Fill `{backend}` from
+  `missing_backends_display` — the probe emits the plain, maker-facing name for each id so you do not
+  hand-translate. The mapping (also in the verdict's `backend_display`) is:
+
+  | Probe id | `{backend}` display |
+  | --- | --- |
+  | `servicenow-hrsd` | ServiceNow HRSD |
+  | `servicenow-itsm` | ServiceNow ITSM |
+  | `workday` | Workday |
+  | `successfactors` | SAP SuccessFactors |
 - **`mode: full`** (ISV ran for every in-scope backend, or no topic calls a backend) → show none of it: plain
   "good to publish" in 9a, no coverage line in 9d, no coverage line in the scoped roll-up. Never pad a clean
   report with coverage boilerplate when nothing was skipped, and never emit an empty "Coverage: I ran

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
@@ -88,4 +88,6 @@ Present the **Scoped roll-up** exactly per
 [`report-format.md`](report-format.md) — tabulated **directly from the per-topic summaries the loop returned
 into your context** (counts + per-finding severity/issue-type/id). Do **not** re-read the catalogs to
 aggregate, and do **not** author a script or write a summary JSON to compute it; the roll-up is a presented
-table, not a persisted artifact.
+table, not a persisted artifact. If the run is in **reduced coverage** (see the skill's "Coverage mode" step —
+i.e. an in-scope topic's backend ISV reference doc is absent), include the roll-up's coverage line per
+`report-format.md`, naming the backend(s) whose conformance could not be checked.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
@@ -48,12 +48,12 @@ Dispatch **one subagent for the whole module** (not one per topic, and not one p
       output — do not re-run the detectors.
    2. Consolidate (skill Step 7).
    3. **Persist this topic's catalog — the required last action of the iteration, before moving to the next
-      topic.** Pipe this topic's consolidated findings to the script on stdin, from
-      `solutions/ess-maker-skills/` (see skill Step 8 for the exact stdin form and the `.local\tmp\`
-      workspace-internal staging rule — never `$env:TEMP` / `/tmp`):
+      topic.** Write this topic's consolidated findings to a file and pass its path to the script, from
+      `solutions/ess-maker-skills/` (see skill Step 8 for why the path form is preferred over inlining the
+      JSON, and the `.local\tmp\` workspace-internal staging rule — never `$env:TEMP` / `/tmp`):
 
       ```
-      Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -
+      python scripts/merge_findings.py --solution {topic-stem} --current .local\tmp\findings.json
       ```
 
       This write is **mandatory and per-topic**: do it once for each topic as you finish it. Do **not**

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
@@ -1,0 +1,91 @@
+# Scoped review (a whole module)
+
+The multi-topic sub-workflow for `topics/review` — reached from Step 1 when the maker asks to review a
+**module** (all topics for a backend) rather than one topic. It reuses the per-topic review engine
+(Steps 2–8 of the skill) in a loop, then presents a roll-up. Run the analysis silently (the same
+no-narration rule as a single-topic review); the maker sees only the roll-up.
+
+## Resolve the scope
+
+The scope is a **module id** — a filename prefix shared by a backend's topics (`servicenow-hrsd`,
+`servicenow-itsm`, `workday`).
+
+**Resolve the in-scope set once, by prefix, and use that exact set for everything.** The in-scope topics are
+`{agent.folder}/topics/{module-id}*.mcs.yml` — a **prefix** match (the same `startswith` the detectors'
+`--module` uses), never a substring match. List them and let **N = that count**; both the review loop and the
+S-4 "N topics" figure must come from this one enumerated set, so the reported count always equals what was
+actually reviewed. A broad or non-canonical term can resolve to more than one backend — e.g. `servicenow`
+spans `servicenow-hrsd` **and** `servicenow-itsm`, and does **not** include the differently-prefixed
+`ess-hr-servicenow-*` persona-bundle copies. If the maker's term is ambiguous or matches zero topics, confirm
+the resolved module id and the exact topic list with them before starting.
+
+## S-1: Run the detectors once across the scope
+
+From `solutions/ess-maker-skills/`, run each detector **once** with `--module` (not per topic):
+
+```
+python scripts/scan_globals.py  --agent {agent-slug} --module {module-id}
+python scripts/scan_bindings.py --agent {agent-slug} --module {module-id}
+python scripts/scan_config.py   --agent {agent-slug} --module {module-id}
+```
+
+Each reports findings for every in-scope topic at once (globals availability is still resolved agent-wide;
+`--module` only filters which topics are reported). Their output is authoritative, as in the skill's
+Steps 3/4/6c.
+
+## S-2: Review each topic through the engine (per-topic loop)
+
+Dispatch **one subagent for the whole module** (not one per topic, and not one per lens). That subagent:
+
+1. Reads the shared reference material **once** — the module's ISV reference doc (in full — do not distill
+   it) and the conformance guidance (`powerfx-topic-local.md`, `isv-conformance.md`,
+   `isv-integration-pattern.md`). A module maps to a single ISV, so its topics share one ISV doc; reading it
+   once here is what avoids re-reading it per topic.
+2. **Loops each in-scope topic**, giving each its own full attention (per-topic focus is deliberate —
+   scanning many topics at once for one lens skims and misses per-topic detail like a single hardcoded
+   value). For **each** topic, in order, run the per-topic engine and finish with the mandatory persist:
+   1. Read the topic and apply all six checks (skill Steps 2–6c), using this topic's slice of the S-1 detector
+      output — do not re-run the detectors.
+   2. Consolidate (skill Step 7).
+   3. **Persist this topic's catalog — the required last action of the iteration, before moving to the next
+      topic.** Pipe this topic's consolidated findings to the script on stdin, from
+      `solutions/ess-maker-skills/` (see skill Step 8 for the exact stdin form and the `.local\tmp\`
+      workspace-internal staging rule — never `$env:TEMP` / `/tmp`):
+
+      ```
+      Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -
+      ```
+
+      This write is **mandatory and per-topic**: do it once for each topic as you finish it. Do **not**
+      defer persistence to the end of the loop, do **not** collect all topics and write them together, and
+      do **not** author a helper script to batch-write. `merge_findings.py` is the **only** sanctioned way to
+      write a catalog: it validates each finding against the contract (`id`, `title`, `severity`,
+      `reachability`, `root_cause`, `concrete_fix`, and a non-empty `files[]`) and **exits non-zero without
+      writing** if any is malformed. If it exits non-zero, the finding shape is wrong — correct the field names
+      and re-run for this topic; never hand-write a catalog or improvise a scanner to work around it. The
+      `{topic-stem}-catalog.json` on disk is the only durable record of this topic's findings — the roll-up and
+      drill-down read from it, and skipping the write silently loses the topic's results. Writing as you go also
+      keeps findings from accumulating in context, so a long module does not degrade the review.
+
+The subagent returns a compact per-topic summary — per topic: the High/Medium/Low counts and, for each
+finding, its severity, plain-language issue type, and id. That summary (already in your context) is what the
+roll-up is **tabulated from**; the per-topic catalogs on disk are the durable record and the drill-down
+source, **not** re-read to aggregate. (If a module is very large and the loop risks losing focus late,
+split it into batches of topics across a few subagents — but read the shared docs once within each batch.)
+
+## S-3: Verify every topic persisted
+
+Before presenting, confirm the loop actually wrote a valid catalog for **each** in-scope topic. For every
+topic stem, check that `.local/review-findings/{topic-stem}-catalog.json` exists and parses (has an
+`issues` array). A missing or unparseable catalog means that topic's persist was skipped or its findings
+were rejected — **re-run the per-topic engine for that one topic** (skill Steps 2–8, persisting via
+`merge_findings.py`), then re-check. Do this only for the missing/invalid topics, not the whole module.
+Present the roll-up only once every in-scope topic has a valid catalog.
+
+## S-4: Present the roll-up
+
+Present the **Scoped roll-up** exactly per
+[`report-format.md`](report-format.md) — tabulated **directly from the per-topic summaries the loop returned
+into your context** (counts + per-finding severity/issue-type/id). Do **not** re-read the catalogs to
+aggregate, and do **not** author a script or write a summary JSON to compute it; the roll-up is a presented
+table, not a persisted artifact.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/ux-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/ux-contract.md
@@ -1,0 +1,51 @@
+# UX contract check
+
+Analysis guidance for the **adaptive-card UX contract** checks used by the `topics/review` skill. These
+cover two concerns: whether a card's data bindings resolve, and whether the card handles its own empty,
+error, and confirmation states.
+
+## Part 1 — Card / topic binding integrity (run the detector)
+
+An adaptive card renders `Topic.*` values. If a card references a value the topic never populates, that
+field renders blank at runtime with no error. Run this from the `solutions/ess-maker-skills/` directory:
+
+```
+python scripts/scan_bindings.py --agent {agent-slug} --topic {topic-stem}
+```
+
+The detector's output is **authoritative** on whether a card reference resolves. It reconciles what each
+card consumes against everything the topic populates — declared inputs, `ParseValue` targets (expanded
+through their record schema), `SetVariable` / `SetTextVariable` targets, and `BeginDialog` output
+bindings. It reports two anomaly classes:
+
+- **unpopulated variable** — the card reads `Topic.X` whose root variable is never populated anywhere in
+  the topic. This value will always render blank.
+- **unknown field** — the card reads `Topic.X.Y` where `Topic.X` comes from a `ParseValue` record schema
+  that does not declare `Y` (usually a field-name typo). This value will always render blank.
+
+Every reference the detector reports **will always be blank at runtime** — do not reason about whether it
+"might" be populated. Turn each into a finding, applying the precision bar and reachability scoring from
+[`powerfx-topic-local.md`](powerfx-topic-local.md) to set severity, and name the intended field in the
+suggested fix when there is an obvious near-match. If the script cannot run, say so in the report.
+
+## Part 2 — Empty, error, and confirmation states (read the card)
+
+Read each adaptive card body (`AdaptiveCardTemplate.cardContent` / `AdaptiveCardPrompt.card`) and the
+surrounding actions, and assess:
+
+- **Required-field visibility** — an input marked `isRequired: true` that is also `visible: false` cannot
+  be satisfied by the user; the card can never be submitted.
+- **Empty data sets** — a choice set or repeated section bound to a collection that can be empty renders a
+  blank control with no explanation. Check whether an empty result is handled.
+- **Parse-driven empty UI** — when a card renders data from a `ParseValue`/`ParseJSON` that can fail or
+  return empty, the card shows blank fields with no message unless an empty/error branch handles it.
+- **Missing confirmation** — an action that creates or changes something (a flow call that returns an id
+  or ticket number) but ends without telling the user it succeeded, or without surfacing the returned
+  identifier.
+- **Blank / null field rendering** — fields shown directly (e.g. in a `FactSet`) with no `N/A` fallback or
+  conditional hide, so a null value renders as an empty row.
+- **Links with empty components** — a URL built by concatenating a base and an id where either part can be
+  empty, producing a broken link.
+
+Apply the same precision bar and severity mapping. A gap on a path a normal user reaches is higher
+severity than one behind an unreachable branch.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/ux-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/ux-contract.md
@@ -25,7 +25,7 @@ bindings. It reports two anomaly classes:
 
 Every reference the detector reports **will always be blank at runtime** — do not reason about whether it
 "might" be populated. Turn each into a finding, applying the precision bar and reachability scoring from
-[`powerfx-topic-local.md`](powerfx-topic-local.md) to set severity, and name the intended field in the
+the shared [`finding-contract.md`](finding-contract.md) to set severity, and name the intended field in the
 suggested fix when there is an obvious near-match. If the script cannot run, say so in the report.
 
 ## Part 2 — Empty, error, and confirmation states (read the card)
@@ -47,5 +47,6 @@ surrounding actions, and assess:
 - **Links with empty components** — a URL built by concatenating a base and an id where either part can be
   empty, producing a broken link.
 
-Apply the same precision bar and severity mapping. A gap on a path a normal user reaches is higher
-severity than one behind an unreachable branch.
+Apply the same precision bar and severity mapping from the shared
+[`finding-contract.md`](finding-contract.md). A gap on a path a normal user reaches is higher
+severity than one behind an unreachable branch. This check uses the `BTUX` finding-ID prefix.

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/ux-contract.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/ux-contract.md
@@ -34,18 +34,23 @@ Read each adaptive card body (`AdaptiveCardTemplate.cardContent` / `AdaptiveCard
 surrounding actions, and assess:
 
 - **Required-field visibility** — an input marked `isRequired: true` that is also `visible: false` cannot
-  be satisfied by the user; the card can never be submitted.
+  be satisfied by the user; the card can never be submitted. **Fix:** make the input `visible: true`, or
+  drop `isRequired` if it is genuinely optional.
 - **Empty data sets** — a choice set or repeated section bound to a collection that can be empty renders a
-  blank control with no explanation. Check whether an empty result is handled.
+  blank control with no explanation. Check whether an empty result is handled. **Fix:** add an
+  `IsEmpty(...)` branch that shows an explanatory message instead of the empty control.
 - **Parse-driven empty UI** — when a card renders data from a `ParseValue`/`ParseJSON` that can fail or
   return empty, the card shows blank fields with no message unless an empty/error branch handles it.
+  **Fix:** gate the card render on the parse succeeding and show an empty/error message otherwise.
 - **Missing confirmation** — an action that creates or changes something (a flow call that returns an id
   or ticket number) but ends without telling the user it succeeded, or without surfacing the returned
-  identifier.
+  identifier. **Fix:** add a `SendActivity` confirming success and surfacing the returned identifier.
 - **Blank / null field rendering** — fields shown directly (e.g. in a `FactSet`) with no `N/A` fallback or
-  conditional hide, so a null value renders as an empty row.
+  conditional hide, so a null value renders as an empty row. **Fix:** wrap each field in
+  `Coalesce(field, "N/A")` or add a `visible` condition that hides the row when the value is blank.
 - **Links with empty components** — a URL built by concatenating a base and an id where either part can be
-  empty, producing a broken link.
+  empty, producing a broken link. **Fix:** guard the URL build with `IsBlank` on each component and hide
+  the link when any part is empty.
 
 Apply the same precision bar and severity mapping from the shared
 [`finding-contract.md`](finding-contract.md). A gap on a path a normal user reaches is higher

--- a/solutions/ess-maker-skills/src/reference/ess-docs/customization/authoring-invariants.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/customization/authoring-invariants.md
@@ -1,0 +1,80 @@
+# Authoring invariants for ESS topics
+
+When you extend the ESS agent with a new topic, you are building **on top of** shared infrastructure the ESS
+base solution already ships — the shared system topics, the orchestrator flow, and the agent's response
+orchestration. That infrastructure gives your topic several behaviors **for free**, but only if the topic is
+authored to route through it. This doc lists the **invariants** — the structural patterns to preserve so those
+guarantees hold. Staying inside them means less to get right by hand; working around them silently gives up
+the guarantee.
+
+These are forward-looking authoring guidance (they inform `topics/create` and `topics/update`); the
+`topics/review` skill flags a topic that has broken one of them.
+
+## Invariant 1 — Delegate the backend call to the shared system topic
+
+For any scenario that calls a backend ESS supports (ServiceNow, Workday, SuccessFactors), the topic **calls
+the existing shared system topic** (e.g. `ServiceNowHRSDSystemGetCommonExecution`,
+`WorkdaySystemGetCommonExecution`) via `BeginDialog`, passing a scenario name and parameters. It does **not**
+build its own cloud flow to reach the connector.
+
+This is the umbrella invariant — Invariants 2 and 3 only hold because the call is delegated. The shared system
+topic owns the connector call, the failure handling, and the response shaping; your topic supplies inputs and
+renders outputs. (See `customization/customize.md` for the template-config pattern this uses.)
+
+## Invariant 2 — Render backend data with the standard parse → iterate → table pattern
+
+Take the response the shared system topic returns and shape it with the standard pattern: `ParseValue` the
+response, then `ForAll` over the parsed rows into a response-table variable that the message/card renders.
+
+Preserving this matters because the agent's response orchestration recognizes it: when the backend returns
+**empty or no data**, the orchestration generates an appropriate "no results" message for the user on its own.
+You do not need to hand-author an empty-state branch for the normal data path.
+
+Avoid two shapes that opt out of that behavior:
+
+- A **hardcoded Adaptive Card** that renders regardless of data — it will show an empty/broken card on
+  no-data instead of the generated message.
+- **Concatenating parsed values into a string** (rather than `ForAll` into a table) — a null field can surface
+  a literal `"null"` in the output.
+
+## Invariant 3 — Let failures flow through the shared error path
+
+Because the backend call is delegated (Invariant 1), a failure is handled **centrally**: the shared system
+topic routes errors to the shared error handling, which shows the user an error and stops the dialog. Your
+topic does not need to — and should not — reimplement this.
+
+Two things to preserve:
+
+- **Do not add a custom error handler that returns to your topic and continues** with empty data. Route errors
+  through the shared error path rather than swallowing them and proceeding as if the call succeeded.
+- **Do not show a success message before success is confirmed.** Gate any confirmation on the shared call's
+  `isSuccess = true` result; a message that fires regardless of outcome can tell the user an action succeeded
+  when it failed.
+
+## What you get by staying inside the invariants
+
+| Preserve | You get, for free |
+| --- | --- |
+| Delegate to the shared system topic | The connector call, auth, and response shaping are handled for you |
+| Standard parse → iterate → table | The agent generates the empty/no-data message automatically |
+| Shared error path | Failures show the user an error and stop, without a hand-authored branch |
+
+## Security-critical behavior belongs to the ISV
+
+This tool generates topics — the experience and orchestration layer. Don't use a generated topic as a
+security control:
+
+- **Authorization is the ISV's job.** The ISV (Workday, ServiceNow, SuccessFactors) enforces who can access
+  what through its own permission model. A topic that hides a field or restricts a choice is a usability
+  affordance, not an access boundary — never rely on it to gate data or actions the ISV would otherwise allow.
+- **Parameter encoding for the connector call is handled by the shared execution path** — you do not
+  reimplement connector input-escaping in the topic. If a scenario has security requirements beyond what the
+  ISV's permission model covers, address those in your ISV or connector configuration, not by generating
+  enforcement logic in a topic.
+
+## Note for external makers
+
+The shared system topics, orchestrator flow, and response orchestration are part of the installed ESS base
+solution — they are present in any environment where you installed ESS, so these invariants apply whether or
+not you have access to the ESS source. Build your topics to route through that shared infrastructure and let
+it own the connector call, empty-state messaging, and error surfacing.

--- a/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
@@ -9,8 +9,9 @@ This skill guides the user through creating a new Copilot Studio topic.
 - ALWAYS read `.local/config.json` to get the agent folder name and schema name.
 - Write the new topic file to `{agent.folder}/topics/{TopicName}.mcs.yml`.
 - After writing the file, check for errors using the diagnostics tool on the new file.
-- **TEMPLATE CONFIG IS THE DEFAULT**: For any scenario that calls ServiceNow or Workday, use the **Template Config + Shared Flow** pattern. This is the official ESS extensibility pattern. The topic calls the existing shared system topic (e.g., `ServiceNowHRSDSystemGetCommonExecution`), which invokes the shared orchestrator flow. Do NOT create standalone cloud flows for these connectors.
-  - ALWAYS read `src/reference/ess-docs/customization/customize.md` when the scenario involves ServiceNow or Workday.
+- **PRESERVE THE AUTHORING INVARIANTS**: follow [`authoring-invariants.md`](src/reference/ess-docs/customization/authoring-invariants.md) — the generated topic MUST delegate the backend call to the shared system topic, render backend data with the standard parse → iterate → table pattern, and let failures flow through the shared error path.
+- **TEMPLATE CONFIG IS THE DEFAULT**: For any scenario that calls an ESS-orchestrated backend (ServiceNow, Workday, or SAP SuccessFactors), use the **Template Config + Shared Flow** pattern. This is the official ESS extensibility pattern. The topic calls the existing shared system topic (e.g., `ServiceNowHRSDSystemGetCommonExecution`), which invokes the shared orchestrator flow. Do NOT create standalone cloud flows for these connectors.
+  - ALWAYS read `src/reference/ess-docs/customization/customize.md` when the scenario involves ServiceNow, Workday, or SAP SuccessFactors.
   - Use an existing topic in the agent folder that calls a shared system topic as the starting pattern.
   - Guide the user through creating the template config record in Dataverse as part of the flow.
 - **STANDALONE IS THE EXCEPTION**: Only use the standalone topic + workflow pattern when the scenario requires a connector that does NOT have an existing ESS orchestrator flow (e.g., Jira, custom HTTP APIs, non-ESS connectors). In this case, read `src/skills/workflows/create/SKILL.md` to create the workflow.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -238,16 +238,15 @@ End with this **verbatim**:
 
 When the maker asks to see or fix a **specific issue** — "more details on X", "explain this one", "how do I
 fix it" — present that finding in this structured shape, **not flowing prose**. Pull the finding from its
-catalog and read the cited `files[].lines` to quote the current expression **verbatim** (a targeted read, not
+catalog (read the cited `files[].lines` if you need the exact expression to reference — a targeted read, not
 a re-analysis). One block per issue — a bold header line (`{plain-language title}` · {High/Medium/Low} ·
 `{topic-stem}.mcs.yml:{line}` "{step display name}"), then:
 
-- **Current state:** `{the exact offending expression / property, verbatim from the file}`
-- **Proposed fix:** `{the concrete replacement, verbatim}`
+- **Proposed fix:** {concise prose; technical language allowed — name the expression/property and the change}
 - **Why fix it this way:** {one or two plain sentences}
 
-This is the one place the maker's own code and `file:line` appear in full. Still keep the review system's
-vocabulary out (no rule IDs, reachability tags, "lens").
+This is the one place the maker's own code and `file:line` appear. Still keep the review system's vocabulary
+out (no rule IDs, reachability tags, "lens").
 
 ### Subagent mode
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -30,6 +30,8 @@ This skill analyzes:
 - **ISV integration pattern** (guidance: `src/reference/ess-docs/conformance/isv-integration-pattern.md`) —
   whether a topic for an ESS-orchestrated backend uses the shared template-config pattern rather than a
   standalone flow.
+- **ServiceNow response-field integrity** — response fields the topic parses that the scenario's template
+  config never returns, and which therefore render blank at runtime.
 
 Other checks (cross-component error-code coverage) are not part of this skill; if the
 maker asks about those, say they are not covered rather than guessing.
@@ -107,7 +109,22 @@ integrates an ESS-orchestrated backend (ServiceNow, Workday, SAP SuccessFactors)
 backend call to the shared system topic rather than calling its own cloud flow. This check reads only the
 authored topic and always applies (no reference docs needed).
 
-Steps 3–6b are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
+## Step 6c: Check ServiceNow response-field integrity (run the detector)
+
+If the topic integrates ServiceNow, run this from the `solutions/ess-maker-skills/` directory:
+
+```
+python scripts/scan_config.py --agent {agent-slug} --topic {topic-stem}
+```
+
+Its output is **authoritative** on whether a parsed response field is returned by the scenario's template
+config: every field it reports is one the topic parses but the config never produces, so it **will always
+render blank at runtime**. Turn each reported field into a finding, applying the shared precision bar and
+reachability scoring for severity. The detector covers ServiceNow scenarios only (Workday's config declares
+only a top-level key); if it reports nothing, or the topic is not ServiceNow, this check contributes no
+findings. If the script cannot run, say so rather than silently skipping.
+
+Steps 3–6c are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
 (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
 shown to the customer (see Step 7). Carry each finding's node locators (`id` / `displayName` / `kind`)
 and `Fix targets` through internally so the customer-facing step can name the step and a fixer can act.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -156,17 +156,15 @@ not a line number — that is how you (or `/update`) will find and fix it:
 
 > **Review — `{TopicName}`** — {verdict}
 >
-> This is advisory — it won't block publishing.
->
 > | # | Severity | Where (step) | Potential issue | Suggested fix |
 > |---|----------|--------------|-----------------|---------------|
 > | 1 | Medium | "Redirect to Workday Get Common Execution" | The flow call may not handle a failure, so an error could show the user nothing | Consider adding a branch that handles the failure case and shows an error message |
 
-Below the table, give each finding a short plain explanation, hedged: what **might** be wrong, why it
-**could** matter to the user, and a suggested fix (a Power Fx snippet or YAML edit is fine — that is the
-customer's own content, not internal terminology). Refer to each site by its **step name/label** so it is
-locatable. Order High -> Medium -> Low. Group any "no user impact today" items under a short
-**Minor / cleanup** heading so the customer prioritizes the most likely issues first.
+The table carries each finding — do **not** restate its rows in prose below. Order rows High -> Medium ->
+Low, and group any "no user impact today" items under a short **Minor / cleanup** heading so the customer
+sees the most likely issues first. Add a short explanation under the table **only** for a finding whose
+suggested fix needs a Power Fx snippet or a nuance the table cell can't hold; keep it hedged and refer to
+the site by its **step name/label**. If every finding is self-explanatory from the table, add nothing.
 
 ## Step 8: Close
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -68,11 +68,14 @@ entry paths run this same engine:
 - **Single-topic** (from Step 1) runs it **once**, then presents with Step 9.
 - **Scoped** (the Scoped review section) runs it **per topic in a loop**, then presents with S-4.
 
-**Detector source (Steps 3, 4, 6c).** Those steps need this topic's `scan_globals` / `scan_bindings` /
-`scan_config` results. In a **single-topic** review, run each detector with `--topic {topic-stem}` as shown.
-In a **scoped** review the detectors have already run **once** across the module with `--module` (Scoped
-S-1); use this topic's slice of that output — do **not** re-run them per topic (`scan_globals` re-reads the
-whole agent on each call). Either way the detector output is authoritative.
+**Detector steps (3, 4, 6c) share one contract.** Each runs a script from `solutions/ess-maker-skills/`
+whose output is **authoritative**: every item it reports is a real defect that will always render blank at
+runtime — do **not** second-guess it with "might be blank for some records". Read the step's cited guidance
+doc, turn each reported item into a finding, and apply the precision bar + reachability from
+`finding-contract.md` to set severity. If a script genuinely cannot run, say so in the report rather than
+silently skipping. Sourcing: in a **single-topic** review run each detector with `--topic {topic-stem}`; in
+a **scoped** review they already ran **once** across the module with `--module` (S-1) — use this topic's
+slice, do **not** re-run them per topic (`scan_globals` re-reads the whole agent on each call).
 
 ## Step 2: Read the topic
 
@@ -83,37 +86,17 @@ stable node locators the fix step keys on. Note the approximate line number as s
 
 ## Step 3: Check Global reference integrity (run the detector)
 
-Run this from the `solutions/ess-maker-skills/` directory:
-
-```
-python scripts/scan_globals.py --agent {agent-slug} --topic {topic-stem}
-```
-
-- `{agent-slug}` = the agent folder name under `workspace/agents/` (from `.local/config.json`).
-- `{topic-stem}` = the reviewed topic's filename without `.mcs.yml`.
-
-The detector's output is **authoritative** on whether a `Global.*` reference resolves. Every reference it
-reports as dangling **does not exist** anywhere in this agent — it is neither written by any topic nor
-declared as a variable. Do **not** reason about whether such a reference "might be blank" or "might exist
-for some records": if the detector reports it, it will **always** read blank. Read
-`src/reference/ess-docs/conformance/dangling-globals.md` and turn each reported reference into a finding,
-applying the precision bar and reachability scoring to set severity. If the script genuinely cannot be
-run, say so in the report rather than silently skipping.
+`python scripts/scan_globals.py --agent {agent-slug} --topic {topic-stem}` (`{agent-slug}` = the agent
+folder under `workspace/agents/`, from `.local/config.json`; `{topic-stem}` = the topic filename without
+`.mcs.yml`). Every reference it reports is dangling — it exists nowhere in the agent (no writer, no variable
+declaration), so it will **always** read blank. Guidance: `dangling-globals.md`.
 
 ## Step 4: Check adaptive-card UX contract
 
-If the topic contains an adaptive card, run the binding detector from the
-`solutions/ess-maker-skills/` directory:
-
-```
-python scripts/scan_bindings.py --agent {agent-slug} --topic {topic-stem}
-```
-
-Its output is **authoritative** on whether a card's `Topic.*` reference resolves: every reference it
-reports **will always render blank at runtime**. Then read
-`src/reference/ess-docs/conformance/ux-contract.md` and assess the card's empty/error/confirmation states
-(Part 2). Turn each into a finding with the shared precision bar and severity mapping. If the script
-cannot run, say so rather than silently skipping.
+If the topic contains an adaptive card:
+`python scripts/scan_bindings.py --agent {agent-slug} --topic {topic-stem}`. Every card `Topic.*` reference
+it reports will always render blank. Then read `ux-contract.md` and also assess the card's
+empty/error/confirmation states (Part 2).
 
 ## Step 5: Analyze Power Fx expression logic (internal reasoning)
 
@@ -139,29 +122,19 @@ authored topic and always applies (no reference docs needed).
 
 ## Step 6c: Check ServiceNow response-field integrity (run the detector)
 
-If the topic integrates ServiceNow, run this from the `solutions/ess-maker-skills/` directory:
-
-```
-python scripts/scan_config.py --agent {agent-slug} --topic {topic-stem}
-```
-
-Its output is **authoritative** on whether a parsed response field is returned by the scenario's template
-config: every field it reports is one the topic parses but the config never produces, so it **will always
-render blank at runtime**. Turn each reported field into a finding, applying the precision bar and
-reachability scoring from the shared [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md)
-(this check uses the `BTCF` finding-ID prefix). The detector covers ServiceNow scenarios only (Workday's
-config declares only a top-level key); if it reports nothing, or the topic is not ServiceNow, this check
-contributes no findings. If the script cannot run, say so rather than silently skipping. **Fix** for a
-reported field: remove it from the topic's parse schema, or add it to the scenario config's
+If the topic integrates ServiceNow:
+`python scripts/scan_config.py --agent {agent-slug} --topic {topic-stem}`. Every field it reports is one the
+topic parses but the scenario's template config never produces, so it will always render blank (uses the
+`BTCF` finding-ID prefix per [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md)).
+ServiceNow scenarios only — Workday's config declares just a top-level key, so it contributes nothing there.
+**Fix:** remove the field from the topic's parse schema, or add it to the scenario config's
 `OutputFieldMapping` if the integration should return it.
 
-Steps 3–6c are **internal reasoning**, and every lens reports findings in the one shared shape defined by
-[`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md) — precision bar, severity
-via reachability, finding-ID prefixes, and the structured output format. Their rule IDs (e.g. `BTPF-001`),
-reachability tags (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** —
-they are NOT shown to the customer (see Step 9). Carry each finding's node locators (`id` / `displayName` /
-`kind`) and `Fix targets` through internally so the consolidation and customer-facing steps can name the
-step and a fixer can act.
+Steps 3–6c are **internal reasoning**; every check reports findings in the one shape defined by
+[`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md) (precision bar,
+reachability→severity, finding-ID prefixes, output format). Carry each finding's node locators (`id` /
+`displayName` / `kind`) through internally so consolidation and the report can name the step and a fixer can
+act. That structured vocabulary is internal only — see the **Speak the maker's language** rule.
 
 ## Step 7: Consolidate findings
 
@@ -180,35 +153,23 @@ Carry the consolidated locators, rule IDs, and `Fix targets` to Step 8.
 
 ## Step 8: Persist and reconcile across runs
 
-The lenses are agentic, so coverage varies run to run — **a finding missing from this run is not evidence it
-was fixed.** Persist this run into the findings catalog and let the script reconcile it against the prior
-run, so the report is consistent session to session and `/update` can act on a finding precisely. The
-review scope is passed as `--solution` — the topic stem today (scope-neutral: a wider ISV/solution review
-would pass a different scope with no other change).
+The checks are agentic, so coverage varies run to run — **a finding missing this run is not evidence it was
+fixed.** Persist this run and let the script reconcile it against the prior run so the report is consistent
+across sessions and `/update` can act precisely. The full shape, `id`-reuse, status/resolution, and
+staleness rules live in [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md)
+(Persisted form); this step is the mechanics. The review scope is passed as `--solution` (the topic stem
+today; scope-neutral for a wider review later).
 
-1. Assemble this run's consolidated findings as JSON (`{"issues": [...]}`), each in the
-   finding-contract shape: `id` (a stable kebab-case behavior-describing slug), `title`, `severity`,
-   `reachability`, `root_cause`, `concrete_fix`, `verification` (`static` for all current lenses;
-   `needs-runtime-test` only for a finding that can only be confirmed by running the bot), and `files[]`
-   (`path` relative to `solutions/ess-maker-skills/` — the topic file, plus the config or other topic a
-   finding depends on, so its evidence hash is complete).
-   The **`id` is the cross-run identity** — first read the prior catalog
-   (`python scripts/merge_findings.py --solution {topic-stem} --show`) and **reuse the exact prior `id`** for a
-   finding you recognize, so it is matched as the same finding rather than a new one.
-2. Reconcile prior findings. For each prior finding **not** re-detected this run — especially any the
-   catalog marks `evidence_stale` (its files changed) — read the current topic: if its node/expression is
-   now gone or corrected, add it (at minimum its `id`) to a `--resolve` file under `.local\tmp\` (see step 3
-   for the workspace-internal staging rule). Also add a finding here
-   if the **maker dismisses it** — set `"resolution": "not-a-bug"` when they judge it a false positive, or
-   `"wont-fix"` when they acknowledge it but decline, and set `"resolved_by": "maker"`; the defaults are
-   `"resolution": "fixed"` and `"resolved_by": "review-skill"`. A finding merely being absent this run is
-   **not** resolution. A dismissed finding stays resolved until its code changes and it is re-detected, which
-   reopens it.
-3. Run from the `solutions/ess-maker-skills/` directory. **Pipe the findings JSON to the script on stdin
-   with `--current -`.** Do not pass a temp-file path — a mis-pathed temp file (a Unix `/tmp/...` path on
-   Windows) or shell heredoc is a known failure. If you must stage the JSON in a file first, write it
-   **inside the workspace** under `.local\tmp\` (gitignored) — **never** `$env:TEMP`, `C:\temp`, or `/tmp`,
-   which are outside the workspace and trigger sensitive-file prompts. In PowerShell:
+1. Assemble this run's consolidated findings as `{"issues": [...]}`, each in the finding-contract shape,
+   **reusing the exact prior `id`** for a finding you recognize — read the prior catalog first with
+   `python scripts/merge_findings.py --solution {topic-stem} --show`. `files[].path` is relative to
+   `solutions/ess-maker-skills/`.
+2. Reconcile: for any prior finding now gone or corrected (especially `evidence_stale` ones), or one the
+   maker dismisses, add it to a `--resolve` file per finding-contract's *Recording a resolution*.
+3. Persist from `solutions/ess-maker-skills/`. **Pipe the findings on stdin with `--current -`** — do not
+   pass a temp-file path (a Unix `/tmp/...` path on Windows or a shell heredoc is a known failure). Any
+   staging file goes **inside the workspace** under `.local\tmp\` (gitignored) — never `$env:TEMP`,
+   `C:\temp`, or `/tmp`, which trigger sensitive-file prompts.
 
    ```
    New-Item -ItemType Directory -Force .local\tmp | Out-Null
@@ -216,16 +177,12 @@ would pass a different scope with no other change).
    Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -
    ```
 
-   To record resolutions, add `--resolve .local\tmp\resolved.json` (a workspace-internal path).
-
-   The script writes `.local/review-findings/{topic-stem}-catalog.json` (and appends any resolutions to the
-   shared `.local/review-findings/resolved-issue-ledger.jsonl`), reusing stable ids, keeping the higher
-   severity on a re-found finding, computing each finding's `evidence_hashes`, and setting `status`
-   (`active` / `resolved`) and `evidence_stale`. Its output is **authoritative** on the cross-run set.
-4. Present (Step 9) the **active** set from the merged catalog. A finding not re-detected this run whose
-   files are unchanged still appears (previously flagged, code unchanged). Flag `evidence_stale` findings as
-   "previously flagged, the code has since changed — worth confirming." If the script cannot run, present
-   this run's consolidated findings and say the cross-run catalog was unavailable.
+   Add `--resolve .local\tmp\resolved.json` to record resolutions. The script's catalog is **authoritative**
+   on the cross-run set. If it cannot run, present this run's findings and say the cross-run catalog was
+   unavailable.
+4. Present (Step 9) the **active** set from the merged catalog — including findings not re-detected this run
+   whose files are unchanged; flag `evidence_stale` ones as "previously flagged, code has since changed —
+   worth confirming."
 
 ## Step 9: Present the report
 
@@ -398,3 +355,15 @@ Close with this **verbatim**:
 
 **Drill-down:** if the maker asks to see one topic, render that topic's Step-9c table from its
 `{topic-stem}-catalog.json` (active set) — no re-analysis needed.
+
+## References
+
+Guidance docs under `src/reference/ess-docs/conformance/` (read the one a step cites when you reach it):
+
+- [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md) — shared finding shape,
+  precision bar, reachability→severity, finding-ID prefixes, output format, and the persisted catalog/ledger form.
+- [`powerfx-topic-local.md`](src/reference/ess-docs/conformance/powerfx-topic-local.md) — Power Fx heuristics (Step 5).
+- [`dangling-globals.md`](src/reference/ess-docs/conformance/dangling-globals.md) — `Global.*` integrity (Step 3).
+- [`ux-contract.md`](src/reference/ess-docs/conformance/ux-contract.md) — adaptive-card UX contract (Step 4).
+- [`isv-conformance.md`](src/reference/ess-docs/conformance/isv-conformance.md) — ISV field/schema conformance (Step 6).
+- [`isv-integration-pattern.md`](src/reference/ess-docs/conformance/isv-integration-pattern.md) — shared-orchestrator pattern (Step 6b).

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -55,6 +55,20 @@ Decide whether the maker wants **one topic** or a **module scope** (all topics f
 
 For a single-topic review, state the full path of the file you are about to review.
 
+## The per-topic review engine (Steps 2–8)
+
+Steps 2–8 are the **unit of review** — everything needed to review one topic and persist its catalog. Both
+entry paths run this same engine:
+
+- **Single-topic** (from Step 1) runs it **once**, then presents with Step 9.
+- **Scoped** (the Scoped review section) runs it **per topic in a loop**, then presents with S-4.
+
+**Detector source (Steps 3, 4, 6c).** Those steps need this topic's `scan_globals` / `scan_bindings` /
+`scan_config` results. In a **single-topic** review, run each detector with `--topic {topic-stem}` as shown.
+In a **scoped** review the detectors have already run **once** across the module with `--module` (Scoped
+S-1); use this topic's slice of that output — do **not** re-run them per topic (`scan_globals` re-reads the
+whole agent on each call). Either way the detector output is authoritative.
+
 ## Step 2: Read the topic
 
 Read the entire target `.mcs.yml`. Identify every Power Fx expression: any value beginning with `=`, and
@@ -275,7 +289,7 @@ python scripts/scan_config.py   --agent {agent-slug} --module {module-id}
 Each reports findings for every in-scope topic at once (globals availability is still resolved agent-wide;
 `--module` only filters which topics are reported). Their output is authoritative, as in Steps 3/4/6c.
 
-### S-2: Review each topic in a read-once, per-topic loop
+### S-2: Review each topic through the engine (per-topic loop)
 
 Dispatch **one subagent for the whole module** (not one per topic, and not one per lens). That subagent:
 
@@ -283,24 +297,16 @@ Dispatch **one subagent for the whole module** (not one per topic, and not one p
    it) and the conformance guidance (`powerfx-topic-local.md`, `isv-conformance.md`,
    `isv-integration-pattern.md`). A module maps to a single ISV, so its topics share one ISV doc; reading it
    once here is what avoids re-reading it per topic.
-2. **Loops each in-scope topic**, giving each its own full attention: apply the Power Fx, ISV-conformance,
-   and integration-pattern lenses to that one topic (Steps 5, 6, 6b), exactly as the single-topic path does.
-   Per-topic focus is deliberate — scanning many topics at once for one lens skims and misses per-topic
-   detail (e.g. a single hardcoded value).
-3. **Writes each topic's catalog to disk immediately** after finishing that topic (S-3), before moving to
-   the next. Offloading as it goes keeps findings from accumulating in context, so a long module does not
-   degrade the review. It returns only a compact per-topic summary (counts + finding ids), not full findings.
+2. **Loops each in-scope topic, running the per-topic engine (Steps 2–8) on it** — reading the topic, all
+   six lenses (using this topic's slice of the S-1 detector output, not re-running the detectors),
+   consolidating (Step 7), and persisting its catalog (Step 8) — before moving to the next topic. Give each
+   topic its own full attention; per-topic focus is deliberate, because scanning many topics at once for one
+   lens skims and misses per-topic detail (e.g. a single hardcoded value). Persisting each catalog as it goes
+   keeps findings from accumulating in context, so a long module does not degrade the review.
 
-(If a module is very large and the loop risks losing focus late, split it into batches of topics across a
-few subagents — but read the shared docs once within each batch.)
-
-### S-3: Consolidate and persist per topic (inside the loop)
-
-For each topic, combine that topic's detector findings (from S-1) with its lens findings (from S-2), run the
-Step 7 consolidation, then persist its catalog with `merge_findings.py --solution {topic-stem}` exactly as
-Step 8 does for a single topic. Every topic keeps its own `{topic-stem}-catalog.json`; a topic with no
-findings still gets reconciled (so a previously-flagged finding there is correctly carried forward). These
-per-topic catalogs are the intermediates the roll-up is built from.
+The subagent returns only a compact per-topic summary (counts + finding ids); the per-topic catalogs on disk
+are the source the roll-up is built from. (If a module is very large and the loop risks losing focus late,
+split it into batches of topics across a few subagents — but read the shared docs once within each batch.)
 
 ### S-4: Present the roll-up
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -43,24 +43,38 @@ the expression bodies inside `AdaptiveCardPrompt.card` and `AdaptiveCardTemplate
 capture the enclosing action's **`id:`**, **`displayName:`** (if present), and **`kind:`** — these are the
 stable node locators the fix step keys on. Note the approximate line number as secondary context only.
 
-## Step 3: Analyze the topic (internal reasoning)
+## Step 3: Check Global reference integrity (run the detector)
+
+Run this from the `solutions/ess-maker-skills/` directory:
+
+```
+python scripts/scan_globals.py --agent {agent-slug} --topic {topic-stem}
+```
+
+- `{agent-slug}` = the agent folder name under `workspace/agents/` (from `.local/config.json`).
+- `{topic-stem}` = the reviewed topic's filename without `.mcs.yml`.
+
+The detector's output is **authoritative** on whether a `Global.*` reference resolves. Every reference it
+reports as dangling **does not exist** anywhere in this agent — it is neither written by any topic nor
+declared as a variable. Do **not** reason about whether such a reference "might be blank" or "might exist
+for some records": if the detector reports it, it will **always** read blank. Read
+`src/reference/ess-docs/conformance/dangling-globals.md` and turn each reported reference into a finding,
+applying the precision bar and reachability scoring to set severity. If the script genuinely cannot be
+run, say so in the report rather than silently skipping.
+
+## Step 4: Analyze Power Fx expression logic (internal reasoning)
 
 Read the analysis guidance at
 `src/reference/ess-docs/conformance/powerfx-topic-local.md` and apply every heuristic in it to the
 expressions you gathered. Use its precision bar (>=80% confidence), reachability scoring, and severity
 mapping to decide which candidates are real findings and how serious each is.
 
-Then check `Global.*` reference integrity: read
-`src/reference/ess-docs/conformance/dangling-globals.md` and follow it — run `scripts/scan_globals.py`
-for the agent and topic, and turn each reported dangling reference into a finding using the same precision
-bar and severity mapping. If the script cannot run, skip this check and continue.
-
-This step is **internal reasoning**. Its rule IDs (e.g. `BTPF-001`), reachability tags
+Steps 3–4 are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
 (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
-shown to the customer (see Step 4). Carry each finding's node locators (`id` / `displayName` / `kind`)
+shown to the customer (see Step 5). Carry each finding's node locators (`id` / `displayName` / `kind`)
 and `Fix targets` through internally so the customer-facing step can name the step and a fixer can act.
 
-## Step 4: Present the advisory report (customer-facing)
+## Step 5: Present the advisory report (customer-facing)
 
 Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
 no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
@@ -99,7 +113,7 @@ customer's own content, not internal terminology). Refer to each site by its **s
 locatable. Order High -> Medium -> Low. Group any "no user impact today" items under a short
 **Minor / cleanup** heading so the customer prioritizes the most likely issues first.
 
-## Step 5: Close
+## Step 6: Close
 
 End advisory, never blocking:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -16,11 +16,13 @@ publishing.
 - **Run the analysis silently.** Steps 3–8 are internal: run the detectors, read the reference docs, and
   persist the catalog **without narrating them**. Do not tell the maker what tools you are calling or what
   files you are reading. The only thing the maker sees is the final report in Step 9.
-- **Speak the maker's language.** Everything the maker sees — the Step 9 report and the scoped roll-up — uses
-  plain words: plain severity (High/Medium/Low), the step's **display name** (never a node id or line
-  number), and everyday descriptions. Never surface internal working vocabulary, such as: "lens", "detector",
-  "conformance", "reachability", "ISV", "orchestrator", rule IDs (`BTPF-001`), or catalog/file paths — the
-  list is illustrative; the test is whether a maker who never saw this skill's internals would understand it.
+- **Speak the maker's language.** Hide the *review system's* vocabulary everywhere — "lens", "detector",
+  "conformance", "reachability" tags (`REACHABLE_NORMAL_UI`), rule IDs (`BTPF-001`), catalog paths (the list
+  is illustrative; the test is whether a maker who never saw this skill's internals would understand it). This
+  is **not** a ban on technical content — the maker's own Power Fx, action kinds, field names, step names, and
+  `topic.mcs.yml:line` are *their* language, not ours. The roll-up and report table (Step 9c, S-4) stay plain
+  and scannable (plain severity, step **display name**, everyday description, no line numbers); the
+  **single-issue detail view** shows the maker's own code in full — the exact expression and location.
 - **TRACK PROGRESS**: use the todo list tool to track the steps below so the maker can see where you are.
 
 ## What this checks
@@ -232,6 +234,21 @@ End with this **verbatim**:
 > Advisory — you can publish as-is. To fix one, type `/update` and name its step; re-run `/review` after
 > edits to re-check.
 
+### Issue detail view (when the maker asks about one issue)
+
+When the maker asks to see or fix a **specific issue** — "more details on X", "explain this one", "how do I
+fix it" — present that finding in this structured shape, **not flowing prose**. Pull the finding from its
+catalog and read the cited `files[].lines` to quote the current expression **verbatim** (a targeted read, not
+a re-analysis). One block per issue — a bold header line (`{plain-language title}` · {High/Medium/Low} ·
+`{topic-stem}.mcs.yml:{line}` "{step display name}"), then:
+
+- **Current state:** `{the exact offending expression / property, verbatim from the file}`
+- **Proposed fix:** `{the concrete replacement, verbatim}`
+- **Why fix it this way:** {one or two plain sentences}
+
+This is the one place the maker's own code and `file:line` appear in full. Still keep the review system's
+vocabulary out (no rule IDs, reachability tags, "lens").
+
 ### Subagent mode
 
 **If invoked as a subagent by a parent flow** (not directly by the maker): skip 9a–9d and instead return the
@@ -367,7 +384,8 @@ Close with this **verbatim**:
 > To fix one, type `/update` and name the topic and step. Re-run to re-check.
 
 **Drill-down:** if the maker asks to see one topic, render that topic's Step-9c table from its
-`{topic-stem}-catalog.json` (active set) — no re-analysis needed.
+`{topic-stem}-catalog.json` (active set). If they ask about a **specific issue**, use the **Issue detail
+view** (Step 9) — no re-analysis, only a targeted read of the cited line to quote the current expression.
 
 ## References
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -275,26 +275,32 @@ python scripts/scan_config.py   --agent {agent-slug} --module {module-id}
 Each reports findings for every in-scope topic at once (globals availability is still resolved agent-wide;
 `--module` only filters which topics are reported). Their output is authoritative, as in Steps 3/4/6c.
 
-### S-2: Fan out the agentic lenses over the scope
+### S-2: Review each topic in a read-once, per-topic loop
 
-Dispatch the three agentic lenses as **parallel subagents**, each ranging over the whole scoped topic set,
-not one per topic:
+Dispatch **one subagent for the whole module** (not one per topic, and not one per lens). That subagent:
 
-- Power Fx topic-local (`powerfx-topic-local.md`)
-- ISV conformance (`isv-conformance.md`) — reads the module's ISV reference doc **once** for the whole set
-- ISV integration pattern (`isv-integration-pattern.md`)
+1. Reads the shared reference material **once** — the module's ISV reference doc (in full — do not distill
+   it) and the conformance guidance (`powerfx-topic-local.md`, `isv-conformance.md`,
+   `isv-integration-pattern.md`). A module maps to a single ISV, so its topics share one ISV doc; reading it
+   once here is what avoids re-reading it per topic.
+2. **Loops each in-scope topic**, giving each its own full attention: apply the Power Fx, ISV-conformance,
+   and integration-pattern lenses to that one topic (Steps 5, 6, 6b), exactly as the single-topic path does.
+   Per-topic focus is deliberate — scanning many topics at once for one lens skims and misses per-topic
+   detail (e.g. a single hardcoded value).
+3. **Writes each topic's catalog to disk immediately** after finishing that topic (S-3), before moving to
+   the next. Offloading as it goes keeps findings from accumulating in context, so a long module does not
+   degrade the review. It returns only a compact per-topic summary (counts + finding ids), not full findings.
 
-Each subagent applies its lens to every in-scope topic and returns findings **tagged with the owning
-topic**, in the finding-contract shape. (Reading the ISV doc once per lens — not once per topic — is why
-this fans out by lens.)
+(If a module is very large and the loop risks losing focus late, split it into batches of topics across a
+few subagents — but read the shared docs once within each batch.)
 
-### S-3: Regroup, consolidate, and persist per topic
+### S-3: Consolidate and persist per topic (inside the loop)
 
-Collect all findings (detectors + lens subagents) and **group them by topic**. For each topic with findings,
-run the Step 7 consolidation, then persist that topic's catalog with `merge_findings.py --solution
-{topic-stem}` exactly as Step 8 does for a single topic. Every topic keeps its own
-`{topic-stem}-catalog.json`; a topic with no findings gets an empty active set (still reconciled, so a
-previously-flagged finding there is correctly carried forward).
+For each topic, combine that topic's detector findings (from S-1) with its lens findings (from S-2), run the
+Step 7 consolidation, then persist its catalog with `merge_findings.py --solution {topic-stem}` exactly as
+Step 8 does for a single topic. Every topic keeps its own `{topic-stem}-catalog.json`; a topic with no
+findings still gets reconciled (so a previously-flagged finding there is correctly carried forward). These
+per-topic catalogs are the intermediates the roll-up is built from.
 
 ### S-4: Present the roll-up
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -304,30 +304,46 @@ per-topic catalogs are the intermediates the roll-up is built from.
 
 ### S-4: Present the roll-up
 
-Show a scope-level summary, then a per-topic table — not each topic's full findings table. Follow the
-no-chatter and plain-language rules from Step 9.
+Show a scope-level summary, then a per-topic table and an issue-type rollup — **not** each topic's full
+findings table. Follow the same exact-template discipline as Step 9: use the verbatim lines below, do not
+improvise the verdict, add prose between sections, or narrate the analysis (including todo-list activity).
 
 If **no topic** in the scope has an active finding:
 
 **Message:**
 
-I reviewed all {N} `{module-id}` topics and didn't spot anything to flag.
+I reviewed all {N} `{module-id}` topics and didn't spot anything to flag — you're good to publish.
 
 **End message.**
 
-Otherwise:
+Otherwise, one verdict line keyed to the highest severity anywhere in the scope (verbatim):
 
-> **Review — `{module-id}`** ({N} topics) — {highest severity across the scope, as a Step-9b-style verdict}
+- Any High → `⚠️ **Review — {module-id}** ({N} topics) — some things across these topics could cause problems; worth a look before you publish.`
+- Any Medium (no High) → `**Review — {module-id}** ({N} topics) — a few things across these topics might be worth a look before you publish.`
+- Only Low → `**Review — {module-id}** ({N} topics) — looks good; a few minor things to double-check before publishing.`
+
+Directly under it, this framing line **verbatim**:
 
 > These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to your
 > scenario; use your judgment.
+
+Then the **per-topic table** — topics with findings first, worst severity first; omit clean topics but note
+the count below:
 
 | Topic | High | Medium | Low |
 |-------|------|--------|-----|
 | {topic-stem} | {n} | {n} | {n} |
 
-List topics with findings first (worst severity first); omit clean topics from the table but note the count
-("{k} other topics were clean"). Then:
+`{k} other topics were clean.`
+
+Then the **issue-type rollup** — the same active findings grouped by their plain-language issue type, so the
+maker sees which problems recur across the scope. Order by severity, then count:
+
+| Issue | Topics affected | Severity |
+|-------|-----------------|----------|
+| {plain-language issue type} | {count} | {High/Medium/Low} |
+
+Close with this **verbatim**:
 
 > To see a topic's details, ask to review it by name (e.g. `review {topic-stem}`) — its findings are saved.
 > To fix one, type `/update` and name the topic and step. Re-run to re-check.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -16,6 +16,11 @@ publishing.
 - **Run the analysis silently.** Steps 3–8 are internal: run the detectors, read the reference docs, and
   persist the catalog **without narrating them**. Do not tell the maker what tools you are calling or what
   files you are reading. The only thing the maker sees is the final report in Step 9.
+- **Speak the maker's language.** Everything the maker sees — the Step 9 report and the scoped roll-up — uses
+  plain words: plain severity (High/Medium/Low), the step's **display name** (never a node id or line
+  number), and everyday descriptions. Never surface internal working vocabulary, such as: "lens", "detector",
+  "conformance", "reachability", "ISV", "orchestrator", rule IDs (`BTPF-001`), or catalog/file paths — the
+  list is illustrative; the test is whether a maker who never saw this skill's internals would understand it.
 - **TRACK PROGRESS**: use the todo list tool to track the steps below so the maker can see where you are.
 
 ## What this checks
@@ -225,9 +230,8 @@ would pass a different scope with no other change).
 ## Step 9: Present the report
 
 Follow this format exactly. Do **not** add prose between sections, narrate what you checked, or explain the
-process. Use plain words for severity (**High / Medium / Low**); never show internal terms (rule IDs,
-"lens", reachability tags, file jargon). Locate each finding by the **step/action it lives in**, never a
-line number.
+process. Use plain words per the **Speak the maker's language** rule; locate each finding by the
+**step/action it lives in** (its display name), never a node id or line number.
 
 ### 9a — No findings
 
@@ -348,8 +352,9 @@ the roll-up only once every in-scope topic has a valid catalog.
 ### S-4: Present the roll-up
 
 Show a scope-level summary, then a per-topic table and an issue-type rollup — **not** each topic's full
-findings table. Follow the same exact-template discipline as Step 9: use the verbatim lines below, do not
-improvise the verdict, add prose between sections, or narrate the analysis (including todo-list activity).
+findings table. Follow the same exact-template discipline as Step 9 (including the **Speak the maker's
+language** rule — plain words, step display names, no internal vocabulary): use the verbatim lines below, do
+not improvise the verdict, add prose between sections, or narrate the analysis (including todo-list activity).
 
 If **no topic** in the scope has an active finding:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -53,31 +53,39 @@ maker asks about those, say they are not covered rather than guessing.
 The **ISV field-conformance** check (Step 6) is the one check that can be *skipped* outright: it depends on a
 backend-specific reference doc (`src/reference/ess-docs/isv/isv-<system>.md`) that is synced from an ESS
 reference source and may be absent — an external maker won't have it. Whether it can run depends on the
-**specific backend** the in-scope topic integrates, not on whether any ISV doc happens to exist. Determine
-this per topic, from the topic's backend, when you reach the ISV check:
+**specific backend** the in-scope topic integrates, not on whether any ISV doc happens to exist.
 
-- **ISV conformance runs** for a topic when `isv-<its backend system>.md` is present.
-- **ISV conformance is skipped** for a topic when that specific doc is absent — this is what puts the run in
-  **reduced coverage**, and the report must say so (see `report-format.md`). A topic that calls no backend is
-  fully covered — nothing was skipped.
+**Do not decide coverage by reasoning or by an ad-hoc file check — run the coverage probe and read its
+verdict.** The probe resolves each in-scope topic's backend and checks its reference doc via a path anchored on
+the script location (cwd-immune, `.gitignore`-immune), so the answer is deterministic and does not depend on
+you remembering to run a check correctly mid-flow:
 
-**Check presence with a direct filesystem test, never a workspace/indexed search.** The `isv/` folder is
-**gitignored**, so a file-search or codebase-index lookup will report a present doc as "no match" — a
-false-absent that would silently disable ISV conformance for everyone (including internal makers whose docs
-are correctly synced). Decide presence by directly testing the exact path, e.g.
-`Test-Path src/reference/ess-docs/isv/isv-<backend>.md` (or attempting to read that exact path) — a result
-that does not depend on `.gitignore`.
+```
+python scripts/check_isv_coverage.py --agent {agent-slug} --topic {topic-stem}
+# scoped:  python scripts/check_isv_coverage.py --agent {agent-slug} --module {module-id}
+```
+
+It prints a machine-readable verdict behind `###ISV_COVERAGE_JSON###`:
+`{"mode": "full"|"reduced", "missing_backends": [...], "covered_backends": [...], "backends": {...}}`.
+
+- **`mode: full`** → ISV conformance runs (or no in-scope topic calls a backend). Say **nothing** about coverage.
+- **`mode: reduced`** → the reference doc for a backend in `missing_backends` is absent; ISV conformance is
+  skipped for that backend's topics. The report **must** disclose it (see `report-format.md`), naming the
+  backend(s) from `missing_backends`. Do not run — or claim to have run — ISV conformance for a missing backend.
+
+Treat the probe's verdict as authoritative over any impression you form while reading the topic. If the probe
+cannot run, fall back to a direct filesystem test of the exact path
+(`Test-Path src/reference/ess-docs/isv/isv-<backend>.md`) — never a workspace/indexed search (the `isv/` folder
+is gitignored, so an index-respecting search reports a present doc as a false-absent).
 
 A second synced doc, `runtime/confirmed-runtime-heuristics.md`, only *corroborates* Power Fx severity — it is
 **not** a check and its absence skips nothing. Without it the Power Fx caps still apply structurally (see
 `powerfx-topic-local.md`); score structurally and say nothing to the maker about it. Do **not** report missing
 runtime docs as reduced coverage.
 
-**Disclose reduced coverage in the report, not before it.** The backend a topic integrates is known once you
-read it, so the honest place to name it is the result: the report's coverage note carries it (`report-format.md`
-— the 9a reduced variant for a clean topic, the 9d coverage line otherwise, or the scoped roll-up's coverage
-line). Do not add a separate pre-analysis announcement. When ISV conformance runs for every in-scope topic (or
-no topic calls a backend), say nothing about coverage.
+**Disclose reduced coverage in the report, not before it** — the report's coverage note carries it
+(`report-format.md`: the 9a reduced variant for a clean topic, the 9d coverage line otherwise, or the scoped
+roll-up's coverage line). Do not add a separate pre-analysis announcement.
 
 ## Step 1: Identify the scope
 
@@ -141,11 +149,17 @@ mapping to decide which candidates are real findings and how serious each is.
 
 ## Step 6: Check ISV conformance (if the topic integrates a backend system)
 
-If the topic calls an ISV scenario, read
-`src/reference/ess-docs/conformance/isv-conformance.md` and follow it: determine the target ISV from the
-scenario name, read that ISV's reference doc if one is available in the environment, and check the topic
-against the documented field/schema conventions and known pitfalls. If the ISV reference docs are not
-available, note that ISV conformance was not checked and continue — do not guess ISV behavior.
+Gate this step on the **coverage probe verdict** (see "Coverage mode"): the probe already resolved the topic's
+backend and whether its reference doc is present.
+
+- If the topic's backend is in `covered_backends` (`mode: full`, or a covered backend under `mode: reduced`),
+  read `src/reference/ess-docs/conformance/isv-conformance.md` and follow it: read that backend's reference doc
+  by its exact path and check the topic against the documented field/schema conventions and known pitfalls.
+- If the topic's backend is in `missing_backends`, ISV conformance is **skipped** for this topic — do not run
+  it and do not guess ISV behavior. The report's coverage note (driven by the same verdict) discloses it.
+- If no backend was detected, there is nothing to check here.
+
+Do not re-derive doc presence yourself; the probe's verdict is authoritative.
 
 ## Step 6b: Check the ISV integration pattern
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -48,6 +48,37 @@ This skill analyzes:
 Other checks (cross-component error-code coverage) are not part of this skill; if the
 maker asks about those, say they are not covered rather than guessing.
 
+## Coverage mode (ISV docs may be absent)
+
+The **ISV field-conformance** check (Step 6) is the one check that can be *skipped* outright: it depends on a
+backend-specific reference doc (`src/reference/ess-docs/isv/isv-<system>.md`) that is synced from an ESS
+reference source and may be absent — an external maker won't have it. Whether it can run depends on the
+**specific backend** the in-scope topic integrates, not on whether any ISV doc happens to exist. Determine
+this per topic, from the topic's backend, when you reach the ISV check:
+
+- **ISV conformance runs** for a topic when `isv-<its backend system>.md` is present.
+- **ISV conformance is skipped** for a topic when that specific doc is absent — this is what puts the run in
+  **reduced coverage**, and the report must say so (see `report-format.md`). A topic that calls no backend is
+  fully covered — nothing was skipped.
+
+**Check presence with a direct filesystem test, never a workspace/indexed search.** The `isv/` folder is
+**gitignored**, so a file-search or codebase-index lookup will report a present doc as "no match" — a
+false-absent that would silently disable ISV conformance for everyone (including internal makers whose docs
+are correctly synced). Decide presence by directly testing the exact path, e.g.
+`Test-Path src/reference/ess-docs/isv/isv-<backend>.md` (or attempting to read that exact path) — a result
+that does not depend on `.gitignore`.
+
+A second synced doc, `runtime/confirmed-runtime-heuristics.md`, only *corroborates* Power Fx severity — it is
+**not** a check and its absence skips nothing. Without it the Power Fx caps still apply structurally (see
+`powerfx-topic-local.md`); score structurally and say nothing to the maker about it. Do **not** report missing
+runtime docs as reduced coverage.
+
+**Disclose reduced coverage in the report, not before it.** The backend a topic integrates is known once you
+read it, so the honest place to name it is the result: the report's coverage note carries it (`report-format.md`
+— the 9a reduced variant for a clean topic, the 9d coverage line otherwise, or the scoped roll-up's coverage
+line). Do not add a separate pre-analysis announcement. When ISV conformance runs for every in-scope topic (or
+no topic calls a backend), say nothing about coverage.
+
 ## Step 1: Identify the scope
 
 Decide whether the maker wants **one topic** or a **module scope** (all topics for a backend), then branch:
@@ -145,6 +176,11 @@ Before presenting, dedupe the findings from Steps 3–6c so each fix site is sho
 heuristics — and different lenses — can flag the same node (e.g. a hardcoded `flowId` caught by both the
 Power Fx and ISV integration-pattern lenses).
 
+**Finding identity is content, not slug.** Two findings at the **same site** (same topic + node `id`/line)
+describing the **same underlying pattern** are the **same finding** — even if different lenses gave them
+different rule IDs or you'd have named them with different slugs. Never emit or persist the same
+`(site, pattern)` twice under two ids; merge them.
+
 Group findings by **fix-target node id** (fall back to the site `id` / `kind` if a finding has no distinct
 fix target). Within a group:
 
@@ -165,14 +201,17 @@ today; scope-neutral for a wider review later).
 
 1. Assemble this run's consolidated findings as `{"issues": [...]}`, each in the finding-contract shape,
    **reusing the exact prior `id`** for a finding you recognize — read the prior catalog first with
-   `python scripts/merge_findings.py --solution {topic-stem} --show`. `files[].path` is relative to
-   `solutions/ess-maker-skills/`.
+   `python scripts/merge_findings.py --solution {topic-stem} --show`. Match by **content, not name**: if a
+   prior catalog entry is at the **same site** and describes the **same pattern** as one of this run's
+   findings, it **is** that finding — reuse its `id` even if you'd have slugged it differently this run.
+   Minting a new slug for an already-cataloged issue double-counts it (the script keys cross-run identity on
+   `id`). `files[].path` is relative to `solutions/ess-maker-skills/`.
 2. Reconcile: for any prior finding now gone or corrected (especially `evidence_stale` ones), or one the
    maker dismisses, add it to a `--resolve` file per finding-contract's *Recording a resolution*.
 3. Persist from `solutions/ess-maker-skills/`. **Pipe the findings on stdin with `--current -`** — do not
-   pass a temp-file path (a Unix `/tmp/...` path on Windows or a shell heredoc is a known failure). Any
-   staging file goes **inside the workspace** under `.local\tmp\` (gitignored) — never `$env:TEMP`,
-   `C:\temp`, or `/tmp`, which trigger sensitive-file prompts.
+   pass a temp-file path (a Unix `/tmp/...` path does not exist on Windows, and a shell heredoc is not
+   supported in PowerShell). Any staging file goes **inside the workspace** under `.local\tmp\` (gitignored)
+   — never `$env:TEMP`, `C:\temp`, or `/tmp`, which trigger sensitive-file prompts.
 
    ```
    New-Item -ItemType Directory -Force .local\tmp | Out-Null

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -313,14 +313,27 @@ Dispatch **one subagent for the whole module** (not one per topic, and not one p
 
       This write is **mandatory and per-topic**: do it once for each topic as you finish it. Do **not**
       defer persistence to the end of the loop, do **not** collect all topics and write them together, and
-      do **not** author a helper script to batch-write. The `{topic-stem}-catalog.json` on disk is the only
-      durable record of this topic's findings — the roll-up and drill-down read from it, and skipping the
-      write silently loses the topic's results. Writing as you go also keeps findings from accumulating in
-      context, so a long module does not degrade the review.
+      do **not** author a helper script to batch-write. `merge_findings.py` is the **only** sanctioned way to
+      write a catalog: it validates each finding against the contract (`id`, `title`, `severity`,
+      `reachability`, `root_cause`, `concrete_fix`, and a non-empty `files[]`) and **exits non-zero without
+      writing** if any is malformed. If it exits non-zero, the finding shape is wrong — correct the field names
+      and re-run for this topic; never hand-write a catalog or improvise a scanner to work around it. The
+      `{topic-stem}-catalog.json` on disk is the only durable record of this topic's findings — the roll-up and
+      drill-down read from it, and skipping the write silently loses the topic's results. Writing as you go also
+      keeps findings from accumulating in context, so a long module does not degrade the review.
 
 The subagent returns only a compact per-topic summary (counts + finding ids); the per-topic catalogs on disk
 are the source the roll-up is built from. (If a module is very large and the loop risks losing focus late,
 split it into batches of topics across a few subagents — but read the shared docs once within each batch.)
+
+### S-3: Verify every topic persisted
+
+Before presenting, confirm the loop actually wrote a valid catalog for **each** in-scope topic. For every
+topic stem, check that `.local/review-findings/{topic-stem}-catalog.json` exists and parses (has an
+`issues` array). A missing or unparseable catalog means that topic's persist was skipped or its findings
+were rejected — **re-run the per-topic engine for that one topic** (Steps 2–8, persisting via
+`merge_findings.py`), then re-check. Do this only for the missing/invalid topics, not the whole module. Build
+the roll-up only once every in-scope topic has a valid catalog.
 
 ### S-4: Present the roll-up
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -186,7 +186,10 @@ would pass a different scope with no other change).
    `reachability`, `root_cause`, `concrete_fix`, `verification` (`static` for all current lenses;
    `needs-runtime-test` only for a finding that can only be confirmed by running the bot), and `files[]`
    (`path` relative to `solutions/ess-maker-skills/` — the topic file, plus the config or other topic a
-   finding depends on, so its evidence hash is complete).
+   finding depends on, so its evidence hash is complete). When a runtime heuristic **caps a would-be finding
+   to `unreachable`** so you surface **no** finding (see the reachability rubric in `finding-contract.md`),
+   add an internal-only breadcrumb to a sibling `suppressions` array — `{ "id", "site", "suppressed_by" }` —
+   so a 0-finding result stays auditable (evaluated-and-suppressed, not never-looked).
    The **`id` is the cross-run identity** — first read the prior catalog
    (`python scripts/merge_findings.py --solution {topic-stem} --show`) and **reuse the exact prior `id`** for a
    finding you recognize, so it is matched as the same finding rather than a new one.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -42,8 +42,9 @@ State the full path of the file you are about to review.
 ## Step 2: Read the topic
 
 Read the entire target `.mcs.yml`. Identify every Power Fx expression: any value beginning with `=`, and
-the expression bodies inside `AdaptiveCardPrompt.card` and `AdaptiveCardTemplate.cardContent`. Keep track
-of line numbers so findings can cite `file:line`.
+the expression bodies inside `AdaptiveCardPrompt.card` and `AdaptiveCardTemplate.cardContent`. For each,
+capture the enclosing action's **`id:`**, **`displayName:`** (if present), and **`kind:`** — these are the
+stable node locators the fix step keys on. Note the approximate line number as secondary context only.
 
 ## Step 3: Analyze the topic (internal reasoning)
 
@@ -54,7 +55,8 @@ mapping to decide which candidates are real findings and how serious each is.
 
 This step is **internal reasoning**. Its rule IDs (e.g. `BTPF-001`), reachability tags
 (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
-shown to the customer (see Step 4).
+shown to the customer (see Step 4). Carry each finding's node locators (`id` / `displayName` / `kind`)
+and `Fix targets` through internally so the customer-facing step can name the step and a fixer can act.
 
 ## Step 4: Present the advisory report (customer-facing)
 
@@ -77,21 +79,22 @@ Directly under the verdict, include this framing line:
 > These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to
 > your scenario; use your judgment.
 
-Then a plain findings table:
+Then a plain findings table. Locate each finding by the **step/action it lives in** (its name/label),
+not a line number — that is how you (or `/update`) will find and fix it:
 
 > **Review — `{TopicName}`** — {verdict}
 >
 > This is advisory — it won't block publishing.
 >
-> | # | Severity | Where | Potential issue | Suggested fix |
-> |---|----------|-------|-----------------|---------------|
-> | 1 | Medium | `line 157` | The flow call may not handle a failure, so an error could show the user nothing | Consider adding a branch that handles the failure case and shows an error message |
+> | # | Severity | Where (step) | Potential issue | Suggested fix |
+> |---|----------|--------------|-----------------|---------------|
+> | 1 | Medium | "Redirect to Workday Get Common Execution" | The flow call may not handle a failure, so an error could show the user nothing | Consider adding a branch that handles the failure case and shows an error message |
 
 Below the table, give each finding a short plain explanation, hedged: what **might** be wrong, why it
 **could** matter to the user, and a suggested fix (a Power Fx snippet or YAML edit is fine — that is the
-customer's own content, not internal terminology). Order High -> Medium -> Low. Group any "no user impact
-today" items under a short **Minor / cleanup** heading so the customer prioritizes the most likely issues
-first.
+customer's own content, not internal terminology). Refer to each site by its **step name/label** so it is
+locatable. Order High -> Medium -> Low. Group any "no user impact today" items under a short
+**Minor / cleanup** heading so the customer prioritizes the most likely issues first.
 
 ## Step 5: Close
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -26,7 +26,10 @@ This skill analyzes:
   data bindings that resolve to nothing, and empty/error/confirmation-state gaps;
 - **ISV conformance** (guidance: `src/reference/ess-docs/conformance/isv-conformance.md`) — the topic
   against the documented field/schema conventions and known pitfalls of the backend system it integrates
-  with, when ISV reference docs are available.
+  with, when ISV reference docs are available;
+- **ISV integration pattern** (guidance: `src/reference/ess-docs/conformance/isv-integration-pattern.md`) —
+  whether a topic for an ESS-orchestrated backend uses the shared template-config pattern rather than a
+  standalone flow.
 
 Other checks (cross-component error-code coverage) are not part of this skill; if the
 maker asks about those, say they are not covered rather than guessing.
@@ -97,7 +100,14 @@ scenario name, read that ISV's reference doc if one is available in the environm
 against the documented field/schema conventions and known pitfalls. If the ISV reference docs are not
 available, note that ISV conformance was not checked and continue — do not guess ISV behavior.
 
-Steps 3–6 are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
+## Step 6b: Check the ISV integration pattern
+
+Read `src/reference/ess-docs/conformance/isv-integration-pattern.md` and follow it: if the topic
+integrates an ESS-orchestrated backend (ServiceNow, Workday, SAP SuccessFactors), confirm it delegates the
+backend call to the shared system topic rather than calling its own cloud flow. This check reads only the
+authored topic and always applies (no reference docs needed).
+
+Steps 3–6b are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
 (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
 shown to the customer (see Step 7). Carry each finding's node locators (`id` / `displayName` / `kind`)
 and `Fix targets` through internally so the customer-facing step can name the step and a fixer can act.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -129,11 +129,26 @@ Steps 3–6c are **internal reasoning**, and every lens reports findings in the 
 [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md) — precision bar, severity
 via reachability, finding-ID prefixes, and the structured output format. Their rule IDs (e.g. `BTPF-001`),
 reachability tags (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** —
-they are NOT shown to the customer (see Step 7). Carry each finding's node locators (`id` / `displayName` /
-`kind`) and `Fix targets` through internally so the customer-facing step can name the step and a fixer can
-act.
+they are NOT shown to the customer (see Step 8). Carry each finding's node locators (`id` / `displayName` /
+`kind`) and `Fix targets` through internally so the consolidation and customer-facing steps can name the
+step and a fixer can act.
 
-## Step 7: Present the advisory report (customer-facing)
+## Step 7: Consolidate findings
+
+Before presenting, dedupe the findings from Steps 3–6c so each fix site is shown once. Different
+heuristics — and different lenses — can flag the same node (e.g. a hardcoded `flowId` caught by both the
+Power Fx and ISV integration-pattern lenses).
+
+Group findings by **fix-target node id** (fall back to the site `id` / `kind` if a finding has no distinct
+fix target). Within a group:
+
+- If **one fix resolves the group**, merge into a single finding: highest severity, one unified fix,
+  keeping every contributing rule ID.
+- If the node genuinely needs **two independent fixes**, keep both rows and add a short "same step" note.
+
+Carry the consolidated locators, rule IDs, and `Fix targets` to Step 8.
+
+## Step 8: Present the advisory report (customer-facing)
 
 Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
 no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
@@ -170,7 +185,7 @@ sees the most likely issues first. Add a short explanation under the table **onl
 suggested fix needs a Power Fx snippet or a nuance the table cell can't hold; keep it hedged and refer to
 the site by its **step name/label**. If every finding is self-explanatory from the table, add nothing.
 
-## Step 8: Close
+## Step 9: Close
 
 End advisory, never blocking:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -1,0 +1,106 @@
+# Review Topic Skill
+
+This skill runs an **authoring-time conformance review** over a single authored Copilot Studio topic and
+returns an **advisory** report — findings the maker should consider before publishing. It is the static
+half of ESS agent hardening (the runtime half is `topics/test`).
+
+> **Advisory by construction.** This review has no power to block. There is no PR or CI gate at the
+> authoring stage — the skill surfaces findings and the maker decides. Never present a finding as a
+> hard failure or refuse to proceed. This mirrors `evaluations/validate`: a gate, not a blocker.
+
+## Rules
+
+- Do NOT run terminal commands or scripts. Use built-in file reading tools only. This review is
+  **agentic**: you read the authored topic and reason about it, guided by the lens instructions.
+- Do NOT modify the topic. This skill only reads and reports.
+- Operate on the authored `.mcs.yml` in the maker's agent folder (`{agent.folder}/topics/`), i.e. the
+  topic **before publish**. Do not require the published `samples/` copy.
+- Report findings as **advisory prose**; write nothing to disk.
+- **TRACK PROGRESS**: use the todo list tool to track the steps below so the maker can see where you are.
+
+## Scope (current slice)
+
+This slice runs **one lens**: the **topic-local Power Fx** lens. It finds bugs expressed inside the
+topic's Power Fx expressions, decidable from the single authored file alone — no preprocessing and no
+reference repository required.
+
+Lenses NOT yet wired in (planned for later slices, do not attempt them here): UX-contract (adaptive
+cards), logic-and-dataflow, injection-and-auth, hygiene; and the reference-dependent Power Fx checks
+(dead/dangling `Global.*`, upstream/downstream error-code coverage) that need the shipped ESS framework.
+If the maker asks for those, say they are not in this slice yet.
+
+## Step 1: Identify the topic to review
+
+Determine the target `.mcs.yml`:
+
+- If the maker gave a path, use it.
+- Otherwise read `.local/config.json` for the agent folder, list `{agent.folder}/topics/*.mcs.yml`, and
+  ask the maker which topic to review (or offer to review the most recently modified one).
+
+State the full path of the file you are about to review.
+
+## Step 2: Read the topic
+
+Read the entire target `.mcs.yml`. Identify every Power Fx expression: any value beginning with `=`, and
+the expression bodies inside `AdaptiveCardPrompt.card` and `AdaptiveCardTemplate.cardContent`. Keep track
+of line numbers so findings can cite `file:line`.
+
+## Step 3: Analyze the topic (internal reasoning)
+
+Read the analysis guidance at
+`src/reference/ess-docs/conformance/powerfx-topic-local.md` and apply every heuristic in it to the
+expressions you gathered. Use its precision bar (>=80% confidence), reachability scoring, and severity
+mapping to decide which candidates are real findings and how serious each is.
+
+This step is **internal reasoning**. Its rule IDs (e.g. `BTPF-001`), reachability tags
+(`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
+shown to the customer (see Step 4).
+
+## Step 4: Present the advisory report (customer-facing)
+
+Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
+no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
+(**High / Medium / Low**). Cite locations as `line N` of the topic.
+
+Frame every finding as a **potential** issue, not a confirmed bug. These come from common-pattern
+heuristics and can be false positives — hedge accordingly ("this might…", "you may want to check…",
+"this could…"), never "this is broken" or "you must fix". Use the highest-severity finding for the
+verdict:
+
+- No findings -> `I looked over this topic's logic and didn't spot anything to flag.`
+- Only Low / no-impact -> `This topic looks good — a couple of minor things you might want to double-check before publishing.`
+- Any Medium -> `I spotted a few things that might be worth a look before you publish this topic.`
+- Any High -> `I spotted some things that could cause problems — you may want to review these before publishing.`
+
+Directly under the verdict, include this framing line:
+
+> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to
+> your scenario; use your judgment.
+
+Then a plain findings table:
+
+> **Review — `{TopicName}`** — {verdict}
+>
+> This is advisory — it won't block publishing.
+>
+> | # | Severity | Where | Potential issue | Suggested fix |
+> |---|----------|-------|-----------------|---------------|
+> | 1 | Medium | `line 157` | The flow call may not handle a failure, so an error could show the user nothing | Consider adding a branch that handles the failure case and shows an error message |
+
+Below the table, give each finding a short plain explanation, hedged: what **might** be wrong, why it
+**could** matter to the user, and a suggested fix (a Power Fx snippet or YAML edit is fine — that is the
+customer's own content, not internal terminology). Order High -> Medium -> Low. Group any "no user impact
+today" items under a short **Minor / cleanup** heading so the customer prioritizes the most likely issues
+first.
+
+## Step 5: Close
+
+End advisory, never blocking:
+
+> This is advisory — you can publish as-is. Consider addressing the higher-severity items first (use
+> `/update` to edit the topic), then re-run `/review` after edits to re-check.
+
+**If invoked as a subagent by a parent flow** (not directly by the customer): skip the plain-language
+translation and instead return the **structured** findings — rule IDs, severity, reachability, and sites
+from the analysis guidance — so the parent can consume them programmatically. Do not prompt the customer
+directly in that case.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -1,33 +1,26 @@
 # Review Topic Skill
 
 This skill runs an **authoring-time conformance review** over a single authored Copilot Studio topic and
-returns an **advisory** report — findings the maker should consider before publishing. It is the static
-half of ESS agent hardening (the runtime half is `topics/test`).
+returns an **advisory** report — findings the maker should consider before publishing.
 
-> **Advisory by construction.** This review has no power to block. There is no PR or CI gate at the
-> authoring stage — the skill surfaces findings and the maker decides. Never present a finding as a
-> hard failure or refuse to proceed. This mirrors `evaluations/validate`: a gate, not a blocker.
+> **Advisory by construction.** This review has no power to block — it surfaces findings and the maker
+> decides. Never present a finding as a hard failure or refuse to proceed.
 
 ## Rules
 
-- Do NOT run terminal commands or scripts. Use built-in file reading tools only. This review is
-  **agentic**: you read the authored topic and reason about it, guided by the lens instructions.
-- Do NOT modify the topic. This skill only reads and reports.
+- Do NOT modify the topic. This skill only reads and reports; the review output is advisory prose and is
+  not written to disk.
 - Operate on the authored `.mcs.yml` in the maker's agent folder (`{agent.folder}/topics/`), i.e. the
   topic **before publish**. Do not require the published `samples/` copy.
-- Report findings as **advisory prose**; write nothing to disk.
 - **TRACK PROGRESS**: use the todo list tool to track the steps below so the maker can see where you are.
 
-## Scope (current slice)
+## What this checks
 
-This slice runs **one lens**: the **topic-local Power Fx** lens. It finds bugs expressed inside the
-topic's Power Fx expressions, decidable from the single authored file alone — no preprocessing and no
-reference repository required.
-
-Lenses NOT yet wired in (planned for later slices, do not attempt them here): UX-contract (adaptive
-cards), logic-and-dataflow, injection-and-auth, hygiene; and the reference-dependent Power Fx checks
-(dead/dangling `Global.*`, upstream/downstream error-code coverage) that need the shipped ESS framework.
-If the maker asks for those, say they are not in this slice yet.
+This skill analyzes the topic's **Power Fx expression logic** (the checks in the analysis guidance at
+`src/reference/ess-docs/conformance/powerfx-topic-local.md`) — decidable from the authored topic file
+itself. Other checks (adaptive-card UX, cross-topic `Global.*` usage, cross-component error-code
+coverage) are not part of this skill; if the maker asks about those, say they are not covered rather than
+guessing.
 
 ## Step 1: Identify the topic to review
 
@@ -62,7 +55,8 @@ and `Fix targets` through internally so the customer-facing step can name the st
 
 Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
 no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
-(**High / Medium / Low**). Cite locations as `line N` of the topic.
+(**High / Medium / Low**). Locate each finding by the **step/action it lives in** (its name/label), not a
+line number.
 
 Frame every finding as a **potential** issue, not a confirmed bug. These come from common-pattern
 heuristics and can be false positives — hedge accordingly ("this might…", "you may want to check…",

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -241,8 +241,16 @@ parent can consume them programmatically. Do not prompt the maker directly.
 ## Scoped review (a whole module)
 
 Reached from Step 1 when the maker asked to review a module rather than one topic. The scope is a **module
-id** — the leading filename segment shared by a backend's topics (`servicenow-hrsd`, `servicenow-itsm`,
-`workday`). Confirm the resolved module and the count of topics it matches before starting.
+id** — a filename prefix shared by a backend's topics (`servicenow-hrsd`, `servicenow-itsm`, `workday`).
+
+**Resolve the in-scope set once, by prefix, and use that exact set for everything.** The in-scope topics are
+`{agent.folder}/topics/{module-id}*.mcs.yml` — a **prefix** match (the same `startswith` the detectors'
+`--module` uses), never a substring match. List them and let **N = that count**; both the review loop and the
+S-4 "N topics" figure must come from this one enumerated set, so the reported count always equals what was
+actually reviewed. A broad or non-canonical term can resolve to more than one backend — e.g. `servicenow`
+spans `servicenow-hrsd` **and** `servicenow-itsm`, and does **not** include the differently-prefixed
+`ess-hr-servicenow-*` persona-bundle copies. If the maker's term is ambiguous or matches zero topics, confirm
+the resolved module id and the exact topic list with them before starting.
 
 Run the analysis silently (the no-chatter rule still applies); the maker sees only the roll-up in S-4.
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -1,7 +1,8 @@
 # Review Topic Skill
 
-This skill runs an **authoring-time conformance review** over a single authored Copilot Studio topic and
-returns an **advisory** report — findings the maker should consider before publishing.
+This skill runs an **authoring-time conformance review** over an authored Copilot Studio topic — or a whole
+module's topics at once — and returns an **advisory** report of findings the maker should consider before
+publishing.
 
 > **Advisory by construction.** This review has no power to block — it surfaces findings and the maker
 > decides. Never present a finding as a hard failure or refuse to proceed.
@@ -39,15 +40,20 @@ This skill analyzes:
 Other checks (cross-component error-code coverage) are not part of this skill; if the
 maker asks about those, say they are not covered rather than guessing.
 
-## Step 1: Identify the topic to review
+## Step 1: Identify the scope
 
-Determine the target `.mcs.yml`:
+Decide whether the maker wants **one topic** or a **module scope** (all topics for a backend), then branch:
 
-- If the maker gave a path, use it.
-- Otherwise read `.local/config.json` for the agent folder, list `{agent.folder}/topics/*.mcs.yml`, and
-  ask the maker which topic to review (or offer to review the most recently modified one).
+- If the maker named a single topic (a path or one topic name) → **single-topic review**: use it and continue
+  with Steps 2–9 below.
+- If the maker asked to review a **module / backend / "all"** (e.g. "review all the Workday topics", "review
+  ServiceNow HRSD", "review everything") → **scoped review**: resolve the module id, then jump to the
+  **Scoped review** section at the end of this skill (do not run Steps 2–9 directly).
+- If it is ambiguous, read `.local/config.json` for the agent folder, list the module prefixes present in
+  `{agent.folder}/topics/` (the leading `servicenow-hrsd`, `servicenow-itsm`, `workday`, … segment), and ask
+  the maker whether they want one topic or a whole module.
 
-State the full path of the file you are about to review.
+For a single-topic review, state the full path of the file you are about to review.
 
 ## Step 2: Read the topic
 
@@ -247,3 +253,78 @@ End with this **verbatim**:
 **If invoked as a subagent by a parent flow** (not directly by the maker): skip 9a–9d and instead return the
 **structured** findings — rule IDs, severity, reachability, and sites from the analysis guidance — so the
 parent can consume them programmatically. Do not prompt the maker directly.
+
+## Scoped review (a whole module)
+
+Reached from Step 1 when the maker asked to review a module rather than one topic. The scope is a **module
+id** — the leading filename segment shared by a backend's topics (`servicenow-hrsd`, `servicenow-itsm`,
+`workday`). Confirm the resolved module and the count of topics it matches before starting.
+
+Run the analysis silently (the no-chatter rule still applies); the maker sees only the roll-up in S-4.
+
+### S-1: Run the detectors once across the scope
+
+From `solutions/ess-maker-skills/`, run each detector **once** with `--module` (not per topic):
+
+```
+python scripts/scan_globals.py  --agent {agent-slug} --module {module-id}
+python scripts/scan_bindings.py --agent {agent-slug} --module {module-id}
+python scripts/scan_config.py   --agent {agent-slug} --module {module-id}
+```
+
+Each reports findings for every in-scope topic at once (globals availability is still resolved agent-wide;
+`--module` only filters which topics are reported). Their output is authoritative, as in Steps 3/4/6c.
+
+### S-2: Fan out the agentic lenses over the scope
+
+Dispatch the three agentic lenses as **parallel subagents**, each ranging over the whole scoped topic set,
+not one per topic:
+
+- Power Fx topic-local (`powerfx-topic-local.md`)
+- ISV conformance (`isv-conformance.md`) — reads the module's ISV reference doc **once** for the whole set
+- ISV integration pattern (`isv-integration-pattern.md`)
+
+Each subagent applies its lens to every in-scope topic and returns findings **tagged with the owning
+topic**, in the finding-contract shape. (Reading the ISV doc once per lens — not once per topic — is why
+this fans out by lens.)
+
+### S-3: Regroup, consolidate, and persist per topic
+
+Collect all findings (detectors + lens subagents) and **group them by topic**. For each topic with findings,
+run the Step 7 consolidation, then persist that topic's catalog with `merge_findings.py --solution
+{topic-stem}` exactly as Step 8 does for a single topic. Every topic keeps its own
+`{topic-stem}-catalog.json`; a topic with no findings gets an empty active set (still reconciled, so a
+previously-flagged finding there is correctly carried forward).
+
+### S-4: Present the roll-up
+
+Show a scope-level summary, then a per-topic table — not each topic's full findings table. Follow the
+no-chatter and plain-language rules from Step 9.
+
+If **no topic** in the scope has an active finding:
+
+**Message:**
+
+I reviewed all {N} `{module-id}` topics and didn't spot anything to flag.
+
+**End message.**
+
+Otherwise:
+
+> **Review — `{module-id}`** ({N} topics) — {highest severity across the scope, as a Step-9b-style verdict}
+
+> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to your
+> scenario; use your judgment.
+
+| Topic | High | Medium | Low |
+|-------|------|--------|-----|
+| {topic-stem} | {n} | {n} | {n} |
+
+List topics with findings first (worst severity first); omit clean topics from the table but note the count
+("{k} other topics were clean"). Then:
+
+> To see a topic's details, ask to review it by name (e.g. `review {topic-stem}`) — its findings are saved.
+> To fix one, type `/update` and name the topic and step. Re-run to re-check.
+
+**Drill-down:** if the maker asks to see one topic, render that topic's Step-9c table from its
+`{topic-stem}-catalog.json` (active set) — no re-analysis needed.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -14,8 +14,9 @@ publishing.
 - Operate on the authored `.mcs.yml` in the maker's agent folder (`{agent.folder}/topics/`), i.e. the
   topic **before publish**. Do not require the published `samples/` copy.
 - **Run the analysis silently.** Steps 3–8 are internal: run the detectors, read the reference docs, and
-  persist the catalog **without narrating them**. Do not tell the maker what tools you are calling or what
-  files you are reading. The only thing the maker sees is the final report in Step 9.
+  persist the catalog **without narrating them**. Do not rephrase, add commentary, or tell the maker what
+  tools you are calling or what files you are reading. The only thing the maker sees is the final report in
+  Step 9.
 - **Speak the maker's language.** Hide the *review system's* vocabulary everywhere — "lens", "detector",
   "conformance", "reachability" tags (`REACHABLE_NORMAL_UI`), rule IDs (`BTPF-001`), catalog paths (the list
   is illustrative; the test is whether a maker who never saw this skill's internals would understand it). This

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -23,7 +23,10 @@ This skill analyzes:
 - **`Global.*` reference integrity** across the agent (guidance:
   `src/reference/ess-docs/conformance/dangling-globals.md`) — references that resolve to no variable;
 - **adaptive-card UX contract** (guidance: `src/reference/ess-docs/conformance/ux-contract.md`) — card
-  data bindings that resolve to nothing, and empty/error/confirmation-state gaps.
+  data bindings that resolve to nothing, and empty/error/confirmation-state gaps;
+- **ISV conformance** (guidance: `src/reference/ess-docs/conformance/isv-conformance.md`) — the topic
+  against the documented field/schema conventions and known pitfalls of the backend system it integrates
+  with, when ISV reference docs are available.
 
 Other checks (cross-component error-code coverage) are not part of this skill; if the
 maker asks about those, say they are not covered rather than guessing.
@@ -86,12 +89,20 @@ Read the analysis guidance at
 expressions you gathered. Use its precision bar (>=80% confidence), reachability scoring, and severity
 mapping to decide which candidates are real findings and how serious each is.
 
-Steps 3–5 are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
+## Step 6: Check ISV conformance (if the topic integrates a backend system)
+
+If the topic calls an ISV scenario, read
+`src/reference/ess-docs/conformance/isv-conformance.md` and follow it: determine the target ISV from the
+scenario name, read that ISV's reference doc if one is available in the environment, and check the topic
+against the documented field/schema conventions and known pitfalls. If the ISV reference docs are not
+available, note that ISV conformance was not checked and continue — do not guess ISV behavior.
+
+Steps 3–6 are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
 (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
-shown to the customer (see Step 6). Carry each finding's node locators (`id` / `displayName` / `kind`)
+shown to the customer (see Step 7). Carry each finding's node locators (`id` / `displayName` / `kind`)
 and `Fix targets` through internally so the customer-facing step can name the step and a fixer can act.
 
-## Step 6: Present the advisory report (customer-facing)
+## Step 7: Present the advisory report (customer-facing)
 
 Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
 no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
@@ -130,7 +141,7 @@ customer's own content, not internal terminology). Refer to each site by its **s
 locatable. Order High -> Medium -> Low. Group any "no user impact today" items under a short
 **Minor / cleanup** heading so the customer prioritizes the most likely issues first.
 
-## Step 7: Close
+## Step 8: Close
 
 End advisory, never blocking:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -16,11 +16,15 @@ returns an **advisory** report — findings the maker should consider before pub
 
 ## What this checks
 
-This skill analyzes the topic's **Power Fx expression logic** (the checks in the analysis guidance at
-`src/reference/ess-docs/conformance/powerfx-topic-local.md`) — decidable from the authored topic file
-itself. Other checks (adaptive-card UX, cross-topic `Global.*` usage, cross-component error-code
-coverage) are not part of this skill; if the maker asks about those, say they are not covered rather than
-guessing.
+This skill analyzes:
+
+- the topic's **Power Fx expression logic** (guidance:
+  `src/reference/ess-docs/conformance/powerfx-topic-local.md`) — decidable from the authored topic file;
+- **`Global.*` reference integrity** across the agent (guidance:
+  `src/reference/ess-docs/conformance/dangling-globals.md`) — references that resolve to no variable.
+
+Other checks (adaptive-card UX, cross-component error-code coverage) are not part of this skill; if the
+maker asks about those, say they are not covered rather than guessing.
 
 ## Step 1: Identify the topic to review
 
@@ -45,6 +49,11 @@ Read the analysis guidance at
 `src/reference/ess-docs/conformance/powerfx-topic-local.md` and apply every heuristic in it to the
 expressions you gathered. Use its precision bar (>=80% confidence), reachability scoring, and severity
 mapping to decide which candidates are real findings and how serious each is.
+
+Then check `Global.*` reference integrity: read
+`src/reference/ess-docs/conformance/dangling-globals.md` and follow it — run `scripts/scan_globals.py`
+for the agent and topic, and turn each reported dangling reference into a finding using the same precision
+bar and severity mapping. If the script cannot run, skip this check and continue.
 
 This step is **internal reasoning**. Its rule IDs (e.g. `BTPF-001`), reachability tags
 (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -181,7 +181,7 @@ run, so the report is consistent session to session and `/update` can act on a f
 review scope is passed as `--solution` — the topic stem today (scope-neutral: a wider ISV/solution review
 would pass a different scope with no other change).
 
-1. Write this run's consolidated findings to a temp JSON file (`{"issues": [...]}`), each in the
+1. Assemble this run's consolidated findings as JSON (`{"issues": [...]}`), each in the
    finding-contract shape: `id` (a stable kebab-case behavior-describing slug), `title`, `severity`,
    `reachability`, `root_cause`, `concrete_fix`, `verification` (`static` for all current lenses;
    `needs-runtime-test` only for a finding that can only be confirmed by running the bot), and `files[]`
@@ -192,17 +192,26 @@ would pass a different scope with no other change).
    finding you recognize, so it is matched as the same finding rather than a new one.
 2. Reconcile prior findings. For each prior finding **not** re-detected this run — especially any the
    catalog marks `evidence_stale` (its files changed) — read the current topic: if its node/expression is
-   now gone or corrected, add it (at minimum its `id`) to a temp `--resolve` file. Also add a finding here
+   now gone or corrected, add it (at minimum its `id`) to a `--resolve` file under `.local\tmp\` (see step 3
+   for the workspace-internal staging rule). Also add a finding here
    if the **maker dismisses it** — set `"resolution": "not-a-bug"` when they judge it a false positive, or
    `"wont-fix"` when they acknowledge it but decline, and set `"resolved_by": "maker"`; the defaults are
    `"resolution": "fixed"` and `"resolved_by": "review-skill"`. A finding merely being absent this run is
    **not** resolution. A dismissed finding stays resolved until its code changes and it is re-detected, which
    reopens it.
-3. Run from the `solutions/ess-maker-skills/` directory:
+3. Run from the `solutions/ess-maker-skills/` directory. **Pipe the findings JSON to the script on stdin
+   with `--current -`.** Do not pass a temp-file path — a mis-pathed temp file (a Unix `/tmp/...` path on
+   Windows) or shell heredoc is a known failure. If you must stage the JSON in a file first, write it
+   **inside the workspace** under `.local\tmp\` (gitignored) — **never** `$env:TEMP`, `C:\temp`, or `/tmp`,
+   which are outside the workspace and trigger sensitive-file prompts. In PowerShell:
 
    ```
-   python scripts/merge_findings.py --solution {topic-stem} --current {tempCurrent.json} [--resolve {tempResolved.json}]
+   New-Item -ItemType Directory -Force .local\tmp | Out-Null
+   Set-Content -Path .local\tmp\findings.json -Value $json -Encoding utf8
+   Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -
    ```
+
+   To record resolutions, add `--resolve .local\tmp\resolved.json` (a workspace-internal path).
 
    The script writes `.local/review-findings/{topic-stem}-catalog.json` (and appends any resolutions to the
    shared `.local/review-findings/resolved-issue-ledger.jsonl`), reusing stable ids, keeping the higher
@@ -304,11 +313,12 @@ Dispatch **one subagent for the whole module** (not one per topic, and not one p
       output — do not re-run the detectors.
    2. Consolidate (Step 7).
    3. **Persist this topic's catalog — the required last action of the iteration, before moving to the next
-      topic.** Write this topic's consolidated findings to a temp JSON and run, from
-      `solutions/ess-maker-skills/`:
+      topic.** Pipe this topic's consolidated findings to the script on stdin, from
+      `solutions/ess-maker-skills/` (see Step 8 for the exact stdin form and the `.local\tmp\`
+      workspace-internal staging rule — never `$env:TEMP` / `/tmp`):
 
       ```
-      python scripts/merge_findings.py --solution {topic-stem} --current {tempCurrent.json}
+      Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -
       ```
 
       This write is **mandatory and per-topic**: do it once for each topic as you finish it. Do **not**

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -293,8 +293,10 @@ Dispatch **one subagent for the whole module** (not one per topic, and not one p
       drill-down read from it, and skipping the write silently loses the topic's results. Writing as you go also
       keeps findings from accumulating in context, so a long module does not degrade the review.
 
-The subagent returns only a compact per-topic summary (counts + finding ids); the per-topic catalogs on disk
-are the source the roll-up is built from. (If a module is very large and the loop risks losing focus late,
+The subagent returns a compact per-topic summary — per topic: the High/Medium/Low counts and, for each
+finding, its severity, plain-language issue type, and id. That summary (already in your context) is what the
+roll-up is **tabulated from**; the per-topic catalogs on disk are the durable record and the drill-down
+source, **not** re-read to aggregate. (If a module is very large and the loop risks losing focus late,
 split it into batches of topics across a few subagents — but read the shared docs once within each batch.)
 
 ### S-3: Verify every topic persisted
@@ -303,15 +305,18 @@ Before presenting, confirm the loop actually wrote a valid catalog for **each** 
 topic stem, check that `.local/review-findings/{topic-stem}-catalog.json` exists and parses (has an
 `issues` array). A missing or unparseable catalog means that topic's persist was skipped or its findings
 were rejected — **re-run the per-topic engine for that one topic** (Steps 2–8, persisting via
-`merge_findings.py`), then re-check. Do this only for the missing/invalid topics, not the whole module. Build
-the roll-up only once every in-scope topic has a valid catalog.
+`merge_findings.py`), then re-check. Do this only for the missing/invalid topics, not the whole module.
+Present the roll-up (S-4) only once every in-scope topic has a valid catalog.
 
 ### S-4: Present the roll-up
 
 Show a scope-level summary, then a per-topic table and an issue-type rollup — **not** each topic's full
-findings table. Follow the same exact-template discipline as Step 9 (including the **Speak the maker's
-language** rule — plain words, step display names, no internal vocabulary): use the verbatim lines below, do
-not improvise the verdict, add prose between sections, or narrate the analysis (including todo-list activity).
+findings table. **Tabulate it directly from the per-topic summaries the loop returned into your context**
+(counts + per-finding severity/issue-type/id) — do **not** re-read the catalogs to aggregate, and do **not**
+author a script or write a summary JSON to compute it; the roll-up is a presented table, not a persisted
+artifact. Follow the same exact-template discipline as Step 9 (including the **Speak the maker's language**
+rule — plain words, step display names, no internal vocabulary): use the verbatim lines below, do not
+improvise the verdict, add prose between sections, or narrate the analysis (including todo-list activity).
 
 If **no topic** in the scope has an active finding:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -189,203 +189,24 @@ today; scope-neutral for a wider review later).
 
 ## Step 9: Present the report
 
-Follow this format exactly. Do **not** add prose between sections, narrate what you checked, or explain the
-process. Use plain words per the **Speak the maker's language** rule; locate each finding by the
-**step/action it lives in** (its display name), never a node id or line number.
-
-### 9a — No findings
-
-If the active set is empty, show only this and stop — no table, no disclaimer, nothing to caveat:
-
-**Message:**
-
-I looked over `{TopicName}` and didn't spot anything to flag — you're good to publish.
-
-**End message.**
-
-### 9b — Verdict line
-
-Otherwise show one verdict line, keyed to the highest severity present:
-
-- Any High → `⚠️ **{TopicName}** — I spotted some things that could cause problems; worth a look before you publish.`
-- Any Medium (no High) → `**{TopicName}** — a few things that might be worth a look before you publish.`
-- Only Low → `**{TopicName}** — looks good; a couple of minor things to double-check before publishing.`
-
-Directly under it, this framing line **verbatim**:
-
-> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to your
-> scenario; use your judgment.
-
-### 9c — Findings table
-
-Then this table, one row per finding, sorted High → Medium → Low. Put any "no user impact today" items under
-a short **Minor / cleanup** heading below the main rows.
-
-| # | Severity | Where (step) | Potential issue | Suggested fix |
-|---|----------|--------------|-----------------|---------------|
-| 1 | Medium | "{step name/label}" | {what might be wrong — hedged} | {suggested fix} |
-
-The table carries each finding — do not restate rows in prose. Add one short line under the table **only**
-when a fix needs a Power Fx snippet or nuance the cell can't hold.
-
-### 9d — Close
-
-End with this **verbatim**:
-
-> Advisory — you can publish as-is. To fix one, type `/update` and name its step; re-run `/review` after
-> edits to re-check.
-
-### Issue detail view (when the maker asks about one issue)
-
-When the maker asks to see or fix a **specific issue** — "more details on X", "explain this one", "how do I
-fix it" — present that finding in this structured shape, **not flowing prose**. Pull the finding from its
-catalog (read the cited `files[].lines` if you need the exact expression to reference — a targeted read, not
-a re-analysis). One block per issue — a bold header line (`{plain-language title}` · {High/Medium/Low} ·
-`{topic-stem}.mcs.yml:{line}` "{step display name}"), then:
-
-- **Proposed fix:** {concise prose; technical language allowed — name the expression/property and the change}
-- **Why fix it this way:** {one or two plain sentences}
-
-This is the one place the maker's own code and `file:line` appear. Still keep the review system's vocabulary
-out (no rule IDs, reachability tags, "lens").
+Present the maker-facing report exactly per
+[`report-format.md`](src/reference/ess-docs/conformance/report-format.md): the no-findings message (9a),
+verdict line (9b), findings table (9c), and close (9d); and, when the maker asks about a **specific issue**,
+the **Issue detail view**. Follow those templates verbatim and apply the **Speak the maker's language** rule.
 
 ### Subagent mode
 
-**If invoked as a subagent by a parent flow** (not directly by the maker): skip 9a–9d and instead return the
-**structured** findings — rule IDs, severity, reachability, and sites from the analysis guidance — so the
-parent can consume them programmatically. Do not prompt the maker directly.
+**If invoked as a subagent by a parent flow** (not directly by the maker): skip the maker-facing report and
+instead return the **structured** findings — rule IDs, severity, reachability, and sites from the analysis
+guidance — so the parent can consume them programmatically. Do not prompt the maker directly.
 
 ## Scoped review (a whole module)
 
-Reached from Step 1 when the maker asked to review a module rather than one topic. The scope is a **module
-id** — a filename prefix shared by a backend's topics (`servicenow-hrsd`, `servicenow-itsm`, `workday`).
-
-**Resolve the in-scope set once, by prefix, and use that exact set for everything.** The in-scope topics are
-`{agent.folder}/topics/{module-id}*.mcs.yml` — a **prefix** match (the same `startswith` the detectors'
-`--module` uses), never a substring match. List them and let **N = that count**; both the review loop and the
-S-4 "N topics" figure must come from this one enumerated set, so the reported count always equals what was
-actually reviewed. A broad or non-canonical term can resolve to more than one backend — e.g. `servicenow`
-spans `servicenow-hrsd` **and** `servicenow-itsm`, and does **not** include the differently-prefixed
-`ess-hr-servicenow-*` persona-bundle copies. If the maker's term is ambiguous or matches zero topics, confirm
-the resolved module id and the exact topic list with them before starting.
-
-Run the analysis silently (the no-chatter rule still applies); the maker sees only the roll-up in S-4.
-
-### S-1: Run the detectors once across the scope
-
-From `solutions/ess-maker-skills/`, run each detector **once** with `--module` (not per topic):
-
-```
-python scripts/scan_globals.py  --agent {agent-slug} --module {module-id}
-python scripts/scan_bindings.py --agent {agent-slug} --module {module-id}
-python scripts/scan_config.py   --agent {agent-slug} --module {module-id}
-```
-
-Each reports findings for every in-scope topic at once (globals availability is still resolved agent-wide;
-`--module` only filters which topics are reported). Their output is authoritative, as in Steps 3/4/6c.
-
-### S-2: Review each topic through the engine (per-topic loop)
-
-Dispatch **one subagent for the whole module** (not one per topic, and not one per lens). That subagent:
-
-1. Reads the shared reference material **once** — the module's ISV reference doc (in full — do not distill
-   it) and the conformance guidance (`powerfx-topic-local.md`, `isv-conformance.md`,
-   `isv-integration-pattern.md`). A module maps to a single ISV, so its topics share one ISV doc; reading it
-   once here is what avoids re-reading it per topic.
-2. **Loops each in-scope topic**, giving each its own full attention (per-topic focus is deliberate —
-   scanning many topics at once for one lens skims and misses per-topic detail like a single hardcoded
-   value). For **each** topic, in order, run the per-topic engine and finish with the mandatory persist:
-   1. Read the topic and apply all six lenses (Steps 2–6c), using this topic's slice of the S-1 detector
-      output — do not re-run the detectors.
-   2. Consolidate (Step 7).
-   3. **Persist this topic's catalog — the required last action of the iteration, before moving to the next
-      topic.** Pipe this topic's consolidated findings to the script on stdin, from
-      `solutions/ess-maker-skills/` (see Step 8 for the exact stdin form and the `.local\tmp\`
-      workspace-internal staging rule — never `$env:TEMP` / `/tmp`):
-
-      ```
-      Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -
-      ```
-
-      This write is **mandatory and per-topic**: do it once for each topic as you finish it. Do **not**
-      defer persistence to the end of the loop, do **not** collect all topics and write them together, and
-      do **not** author a helper script to batch-write. `merge_findings.py` is the **only** sanctioned way to
-      write a catalog: it validates each finding against the contract (`id`, `title`, `severity`,
-      `reachability`, `root_cause`, `concrete_fix`, and a non-empty `files[]`) and **exits non-zero without
-      writing** if any is malformed. If it exits non-zero, the finding shape is wrong — correct the field names
-      and re-run for this topic; never hand-write a catalog or improvise a scanner to work around it. The
-      `{topic-stem}-catalog.json` on disk is the only durable record of this topic's findings — the roll-up and
-      drill-down read from it, and skipping the write silently loses the topic's results. Writing as you go also
-      keeps findings from accumulating in context, so a long module does not degrade the review.
-
-The subagent returns a compact per-topic summary — per topic: the High/Medium/Low counts and, for each
-finding, its severity, plain-language issue type, and id. That summary (already in your context) is what the
-roll-up is **tabulated from**; the per-topic catalogs on disk are the durable record and the drill-down
-source, **not** re-read to aggregate. (If a module is very large and the loop risks losing focus late,
-split it into batches of topics across a few subagents — but read the shared docs once within each batch.)
-
-### S-3: Verify every topic persisted
-
-Before presenting, confirm the loop actually wrote a valid catalog for **each** in-scope topic. For every
-topic stem, check that `.local/review-findings/{topic-stem}-catalog.json` exists and parses (has an
-`issues` array). A missing or unparseable catalog means that topic's persist was skipped or its findings
-were rejected — **re-run the per-topic engine for that one topic** (Steps 2–8, persisting via
-`merge_findings.py`), then re-check. Do this only for the missing/invalid topics, not the whole module.
-Present the roll-up (S-4) only once every in-scope topic has a valid catalog.
-
-### S-4: Present the roll-up
-
-Show a scope-level summary, then a per-topic table and an issue-type rollup — **not** each topic's full
-findings table. **Tabulate it directly from the per-topic summaries the loop returned into your context**
-(counts + per-finding severity/issue-type/id) — do **not** re-read the catalogs to aggregate, and do **not**
-author a script or write a summary JSON to compute it; the roll-up is a presented table, not a persisted
-artifact. Follow the same exact-template discipline as Step 9 (including the **Speak the maker's language**
-rule — plain words, step display names, no internal vocabulary): use the verbatim lines below, do not
-improvise the verdict, add prose between sections, or narrate the analysis (including todo-list activity).
-
-If **no topic** in the scope has an active finding:
-
-**Message:**
-
-I reviewed all {N} `{module-id}` topics and didn't spot anything to flag — you're good to publish.
-
-**End message.**
-
-Otherwise, one verdict line keyed to the highest severity anywhere in the scope (verbatim):
-
-- Any High → `⚠️ **Review — {module-id}** ({N} topics) — some things across these topics could cause problems; worth a look before you publish.`
-- Any Medium (no High) → `**Review — {module-id}** ({N} topics) — a few things across these topics might be worth a look before you publish.`
-- Only Low → `**Review — {module-id}** ({N} topics) — looks good; a few minor things to double-check before publishing.`
-
-Directly under it, this framing line **verbatim**:
-
-> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to your
-> scenario; use your judgment.
-
-Then the **per-topic table** — topics with findings first, worst severity first; omit clean topics but note
-the count below:
-
-| Topic | High | Medium | Low |
-|-------|------|--------|-----|
-| {topic-stem} | {n} | {n} | {n} |
-
-`{k} other topics were clean.`
-
-Then the **issue-type rollup** — the same active findings grouped by their plain-language issue type, so the
-maker sees which problems recur across the scope. Order by severity, then count:
-
-| Issue | Topics affected | Severity |
-|-------|-----------------|----------|
-| {plain-language issue type} | {count} | {High/Medium/Low} |
-
-Close with this **verbatim**:
-
-> To see a topic's details, ask to review it by name (e.g. `review {topic-stem}`) — its findings are saved.
-> To fix one, type `/update` and name the topic and step. Re-run to re-check.
-
-**Drill-down:** if the maker asks to see one topic, render that topic's Step-9c table from its
-`{topic-stem}-catalog.json` (active set). If they ask about a **specific issue**, use the **Issue detail
-view** (Step 9) — no re-analysis, only a targeted read of the cited line to quote the current expression.
+If Step 1 resolved to a **module scope** (all topics for a backend), follow
+[`scoped-review.md`](src/reference/ess-docs/conformance/scoped-review.md) instead of running Steps 2–9
+once: it resolves the in-scope set by prefix, runs the detectors once with `--module`, loops the per-topic
+engine (Steps 2–8) persisting each catalog, verifies persistence, and presents the scoped roll-up (per
+`report-format.md`). The per-topic engine (Steps 2–8) and the finding contract are unchanged.
 
 ## References
 
@@ -398,3 +219,5 @@ Guidance docs under `src/reference/ess-docs/conformance/` (read the one a step c
 - [`ux-contract.md`](src/reference/ess-docs/conformance/ux-contract.md) — adaptive-card UX contract (Step 4).
 - [`isv-conformance.md`](src/reference/ess-docs/conformance/isv-conformance.md) — ISV field/schema conformance (Step 6).
 - [`isv-integration-pattern.md`](src/reference/ess-docs/conformance/isv-integration-pattern.md) — shared-orchestrator pattern (Step 6b).
+- [`report-format.md`](src/reference/ess-docs/conformance/report-format.md) — maker-facing output templates: single-topic report (Step 9), issue detail view, scoped roll-up.
+- [`scoped-review.md`](src/reference/ess-docs/conformance/scoped-review.md) — the module-scope sub-workflow (S-1–S-4).

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -8,10 +8,13 @@ returns an **advisory** report — findings the maker should consider before pub
 
 ## Rules
 
-- Do NOT modify the topic. This skill only reads and reports; the review output is advisory prose and is
-  not written to disk.
+- Do NOT modify the topic. This skill only reads, reports, and writes its findings catalog/ledger under
+  `.local/`; it never edits the topic.
 - Operate on the authored `.mcs.yml` in the maker's agent folder (`{agent.folder}/topics/`), i.e. the
   topic **before publish**. Do not require the published `samples/` copy.
+- **Run the analysis silently.** Steps 3–8 are internal: run the detectors, read the reference docs, and
+  persist the catalog **without narrating them**. Do not tell the maker what tools you are calling or what
+  files you are reading. The only thing the maker sees is the final report in Step 9.
 - **TRACK PROGRESS**: use the todo list tool to track the steps below so the maker can see where you are.
 
 ## What this checks
@@ -190,55 +193,57 @@ would pass a different scope with no other change).
    "previously flagged, the code has since changed — worth confirming." If the script cannot run, present
    this run's consolidated findings and say the cross-run catalog was unavailable.
 
-## Step 9: Present the advisory report (customer-facing)
+## Step 9: Present the report
 
-Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
-no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
-(**High / Medium / Low**). Locate each finding by the **step/action it lives in** (its name/label), not a
+Follow this format exactly. Do **not** add prose between sections, narrate what you checked, or explain the
+process. Use plain words for severity (**High / Medium / Low**); never show internal terms (rule IDs,
+"lens", reachability tags, file jargon). Locate each finding by the **step/action it lives in**, never a
 line number.
 
-Frame every finding as a **potential** issue, not a confirmed bug. These come from common-pattern
-heuristics and can be false positives — hedge accordingly ("this might…", "you may want to check…",
-"this could…"), never "this is broken" or "you must fix". Use the highest-severity finding for the
-verdict:
+### 9a — No findings
 
-- No findings -> `I looked over this topic's logic and didn't spot anything to flag.`
-- Only Low / no-impact -> `This topic looks good — a couple of minor things you might want to double-check before publishing.`
-- Any Medium -> `I spotted a few things that might be worth a look before you publish this topic.`
-- Any High -> `I spotted some things that could cause problems — you may want to review these before publishing.`
+If the active set is empty, show only this and stop — no table, no disclaimer, nothing to caveat:
 
-Directly under the verdict, include this framing line:
+**Message:**
 
-> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to
-> your scenario; use your judgment.
+I looked over `{TopicName}` and didn't spot anything to flag — you're good to publish.
 
-Then a plain findings table. Locate each finding by the **step/action it lives in** (its name/label),
-not a line number — that is how you (or `/update`) will find and fix it:
+**End message.**
 
-> **Review — `{TopicName}`** — {verdict}
->
-> | # | Severity | Where (step) | Potential issue | Suggested fix |
-> |---|----------|--------------|-----------------|---------------|
-> | 1 | Medium | "Redirect to Workday Get Common Execution" | The flow call may not handle a failure, so an error could show the user nothing | Consider adding a branch that handles the failure case and shows an error message |
+### 9b — Verdict line
 
-The table carries each finding — do **not** restate its rows in prose below. Order rows High -> Medium ->
-Low, and group any "no user impact today" items under a short **Minor / cleanup** heading so the customer
-sees the most likely issues first. Add a short explanation under the table **only** for a finding whose
-suggested fix needs a Power Fx snippet or a nuance the table cell can't hold; keep it hedged and refer to
-the site by its **step name/label**. If every finding is self-explanatory from the table, add nothing.
+Otherwise show one verdict line, keyed to the highest severity present:
 
-## Step 10: Close
+- Any High → `⚠️ **{TopicName}** — I spotted some things that could cause problems; worth a look before you publish.`
+- Any Medium (no High) → `**{TopicName}** — a few things that might be worth a look before you publish.`
+- Only Low → `**{TopicName}** — looks good; a couple of minor things to double-check before publishing.`
 
-End advisory, never blocking:
+Directly under it, this framing line **verbatim**:
 
-> This is advisory — you can publish as-is. Consider addressing the higher-severity items first, then
-> re-run `/review` after edits to re-check.
+> These are potential issues flagged from common patterns — not confirmed bugs. Some may not apply to your
+> scenario; use your judgment.
 
-Each finding names the exact step and a suggested fix, so `/update` can apply it directly — point the
-customer there for any finding they want fixed ("type `/update` and mention the step, e.g. the one in
-row 2").
+### 9c — Findings table
 
-**If invoked as a subagent by a parent flow** (not directly by the customer): skip the plain-language
-translation and instead return the **structured** findings — rule IDs, severity, reachability, and sites
-from the analysis guidance — so the parent can consume them programmatically. Do not prompt the customer
-directly in that case.
+Then this table, one row per finding, sorted High → Medium → Low. Put any "no user impact today" items under
+a short **Minor / cleanup** heading below the main rows.
+
+| # | Severity | Where (step) | Potential issue | Suggested fix |
+|---|----------|--------------|-----------------|---------------|
+| 1 | Medium | "{step name/label}" | {what might be wrong — hedged} | {suggested fix} |
+
+The table carries each finding — do not restate rows in prose. Add one short line under the table **only**
+when a fix needs a Power Fx snippet or nuance the cell can't hold.
+
+### 9d — Close
+
+End with this **verbatim**:
+
+> Advisory — you can publish as-is. To fix one, type `/update` and name its step; re-run `/review` after
+> edits to re-check.
+
+### Subagent mode
+
+**If invoked as a subagent by a parent flow** (not directly by the maker): skip 9a–9d and instead return the
+**structured** findings — rule IDs, severity, reachability, and sites from the analysis guidance — so the
+parent can consume them programmatically. Do not prompt the maker directly.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -123,7 +123,9 @@ render blank at runtime**. Turn each reported field into a finding, applying the
 reachability scoring from the shared [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md)
 (this check uses the `BTCF` finding-ID prefix). The detector covers ServiceNow scenarios only (Workday's
 config declares only a top-level key); if it reports nothing, or the topic is not ServiceNow, this check
-contributes no findings. If the script cannot run, say so rather than silently skipping.
+contributes no findings. If the script cannot run, say so rather than silently skipping. **Fix** for a
+reported field: remove it from the topic's parse schema, or add it to the scenario config's
+`OutputFieldMapping` if the integration should return it.
 
 Steps 3–6c are **internal reasoning**, and every lens reports findings in the one shared shape defined by
 [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md) — precision bar, severity
@@ -189,8 +191,12 @@ the site by its **step name/label**. If every finding is self-explanatory from t
 
 End advisory, never blocking:
 
-> This is advisory — you can publish as-is. Consider addressing the higher-severity items first (use
-> `/update` to edit the topic), then re-run `/review` after edits to re-check.
+> This is advisory — you can publish as-is. Consider addressing the higher-severity items first, then
+> re-run `/review` after edits to re-check.
+
+Each finding names the exact step and a suggested fix, so `/update` can apply it directly — point the
+customer there for any finding they want fixed ("type `/update` and mention the step, e.g. the one in
+row 2").
 
 **If invoked as a subagent by a parent flow** (not directly by the customer): skip the plain-language
 translation and instead return the **structured** findings — rule IDs, severity, reachability, and sites

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -131,7 +131,7 @@ Steps 3–6c are **internal reasoning**, and every lens reports findings in the 
 [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md) — precision bar, severity
 via reachability, finding-ID prefixes, and the structured output format. Their rule IDs (e.g. `BTPF-001`),
 reachability tags (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** —
-they are NOT shown to the customer (see Step 8). Carry each finding's node locators (`id` / `displayName` /
+they are NOT shown to the customer (see Step 9). Carry each finding's node locators (`id` / `displayName` /
 `kind`) and `Fix targets` through internally so the consolidation and customer-facing steps can name the
 step and a fixer can act.
 
@@ -150,7 +150,47 @@ fix target). Within a group:
 
 Carry the consolidated locators, rule IDs, and `Fix targets` to Step 8.
 
-## Step 8: Present the advisory report (customer-facing)
+## Step 8: Persist and reconcile across runs
+
+The lenses are agentic, so coverage varies run to run — **a finding missing from this run is not evidence it
+was fixed.** Persist this run into the findings catalog and let the script reconcile it against the prior
+run, so the report is consistent session to session and `/update` can act on a finding precisely. The
+review scope is passed as `--solution` — the topic stem today (scope-neutral: a wider ISV/solution review
+would pass a different scope with no other change).
+
+1. Write this run's consolidated findings to a temp JSON file (`{"issues": [...]}`), each in the
+   finding-contract shape: `id` (a stable kebab-case behavior-describing slug), `title`, `severity`,
+   `reachability`, `root_cause`, `concrete_fix`, `verification` (`static` for all current lenses;
+   `needs-runtime-test` only for a finding that can only be confirmed by running the bot), and `files[]`
+   (`path` relative to `solutions/ess-maker-skills/` — the topic file, plus the config or other topic a
+   finding depends on, so its evidence hash is complete).
+   The **`id` is the cross-run identity** — first read the prior catalog
+   (`python scripts/merge_findings.py --solution {topic-stem} --show`) and **reuse the exact prior `id`** for a
+   finding you recognize, so it is matched as the same finding rather than a new one.
+2. Reconcile prior findings. For each prior finding **not** re-detected this run — especially any the
+   catalog marks `evidence_stale` (its files changed) — read the current topic: if its node/expression is
+   now gone or corrected, add it (at minimum its `id`) to a temp `--resolve` file. Also add a finding here
+   if the **maker dismisses it** — set `"resolution": "not-a-bug"` when they judge it a false positive, or
+   `"wont-fix"` when they acknowledge it but decline, and set `"resolved_by": "maker"`; the defaults are
+   `"resolution": "fixed"` and `"resolved_by": "review-skill"`. A finding merely being absent this run is
+   **not** resolution. A dismissed finding stays resolved until its code changes and it is re-detected, which
+   reopens it.
+3. Run from the `solutions/ess-maker-skills/` directory:
+
+   ```
+   python scripts/merge_findings.py --solution {topic-stem} --current {tempCurrent.json} [--resolve {tempResolved.json}]
+   ```
+
+   The script writes `.local/review-findings/{topic-stem}-catalog.json` (and appends any resolutions to the
+   shared `.local/review-findings/resolved-issue-ledger.jsonl`), reusing stable ids, keeping the higher
+   severity on a re-found finding, computing each finding's `evidence_hashes`, and setting `status`
+   (`active` / `resolved`) and `evidence_stale`. Its output is **authoritative** on the cross-run set.
+4. Present (Step 9) the **active** set from the merged catalog. A finding not re-detected this run whose
+   files are unchanged still appears (previously flagged, code unchanged). Flag `evidence_stale` findings as
+   "previously flagged, the code has since changed — worth confirming." If the script cannot run, present
+   this run's consolidated findings and say the cross-run catalog was unavailable.
+
+## Step 9: Present the advisory report (customer-facing)
 
 Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
 no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
@@ -187,7 +227,7 @@ sees the most likely issues first. Add a short explanation under the table **onl
 suggested fix needs a Power Fx snippet or a nuance the table cell can't hold; keep it hedged and refer to
 the site by its **step name/label**. If every finding is self-explanatory from the table, add nothing.
 
-## Step 9: Close
+## Step 10: Close
 
 End advisory, never blocking:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -21,9 +21,11 @@ This skill analyzes:
 - the topic's **Power Fx expression logic** (guidance:
   `src/reference/ess-docs/conformance/powerfx-topic-local.md`) — decidable from the authored topic file;
 - **`Global.*` reference integrity** across the agent (guidance:
-  `src/reference/ess-docs/conformance/dangling-globals.md`) — references that resolve to no variable.
+  `src/reference/ess-docs/conformance/dangling-globals.md`) — references that resolve to no variable;
+- **adaptive-card UX contract** (guidance: `src/reference/ess-docs/conformance/ux-contract.md`) — card
+  data bindings that resolve to nothing, and empty/error/confirmation-state gaps.
 
-Other checks (adaptive-card UX, cross-component error-code coverage) are not part of this skill; if the
+Other checks (cross-component error-code coverage) are not part of this skill; if the
 maker asks about those, say they are not covered rather than guessing.
 
 ## Step 1: Identify the topic to review
@@ -62,19 +64,34 @@ for some records": if the detector reports it, it will **always** read blank. Re
 applying the precision bar and reachability scoring to set severity. If the script genuinely cannot be
 run, say so in the report rather than silently skipping.
 
-## Step 4: Analyze Power Fx expression logic (internal reasoning)
+## Step 4: Check adaptive-card UX contract
+
+If the topic contains an adaptive card, run the binding detector from the
+`solutions/ess-maker-skills/` directory:
+
+```
+python scripts/scan_bindings.py --agent {agent-slug} --topic {topic-stem}
+```
+
+Its output is **authoritative** on whether a card's `Topic.*` reference resolves: every reference it
+reports **will always render blank at runtime**. Then read
+`src/reference/ess-docs/conformance/ux-contract.md` and assess the card's empty/error/confirmation states
+(Part 2). Turn each into a finding with the shared precision bar and severity mapping. If the script
+cannot run, say so rather than silently skipping.
+
+## Step 5: Analyze Power Fx expression logic (internal reasoning)
 
 Read the analysis guidance at
 `src/reference/ess-docs/conformance/powerfx-topic-local.md` and apply every heuristic in it to the
 expressions you gathered. Use its precision bar (>=80% confidence), reachability scoring, and severity
 mapping to decide which candidates are real findings and how serious each is.
 
-Steps 3–4 are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
+Steps 3–5 are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
 (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
-shown to the customer (see Step 5). Carry each finding's node locators (`id` / `displayName` / `kind`)
+shown to the customer (see Step 6). Carry each finding's node locators (`id` / `displayName` / `kind`)
 and `Fix targets` through internally so the customer-facing step can name the step and a fixer can act.
 
-## Step 5: Present the advisory report (customer-facing)
+## Step 6: Present the advisory report (customer-facing)
 
 Present findings in **plain language**. Do NOT expose internal terminology to the customer — no "lens",
 no rule IDs, no reachability tag names, no file-format jargon. Translate severity to plain words
@@ -113,7 +130,7 @@ customer's own content, not internal terminology). Refer to each site by its **s
 locatable. Order High -> Medium -> Low. Group any "no user impact today" items under a short
 **Minor / cleanup** heading so the customer prioritizes the most likely issues first.
 
-## Step 6: Close
+## Step 7: Close
 
 End advisory, never blocking:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -119,15 +119,19 @@ python scripts/scan_config.py --agent {agent-slug} --topic {topic-stem}
 
 Its output is **authoritative** on whether a parsed response field is returned by the scenario's template
 config: every field it reports is one the topic parses but the config never produces, so it **will always
-render blank at runtime**. Turn each reported field into a finding, applying the shared precision bar and
-reachability scoring for severity. The detector covers ServiceNow scenarios only (Workday's config declares
-only a top-level key); if it reports nothing, or the topic is not ServiceNow, this check contributes no
-findings. If the script cannot run, say so rather than silently skipping.
+render blank at runtime**. Turn each reported field into a finding, applying the precision bar and
+reachability scoring from the shared [`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md)
+(this check uses the `BTCF` finding-ID prefix). The detector covers ServiceNow scenarios only (Workday's
+config declares only a top-level key); if it reports nothing, or the topic is not ServiceNow, this check
+contributes no findings. If the script cannot run, say so rather than silently skipping.
 
-Steps 3–6c are **internal reasoning**. Their rule IDs (e.g. `BTPF-001`), reachability tags
-(`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** — they are NOT
-shown to the customer (see Step 7). Carry each finding's node locators (`id` / `displayName` / `kind`)
-and `Fix targets` through internally so the customer-facing step can name the step and a fixer can act.
+Steps 3–6c are **internal reasoning**, and every lens reports findings in the one shared shape defined by
+[`finding-contract.md`](src/reference/ess-docs/conformance/finding-contract.md) — precision bar, severity
+via reachability, finding-ID prefixes, and the structured output format. Their rule IDs (e.g. `BTPF-001`),
+reachability tags (`REACHABLE_NORMAL_UI`, etc.), and the word "lens" are working vocabulary **for you** —
+they are NOT shown to the customer (see Step 7). Carry each finding's node locators (`id` / `displayName` /
+`kind`) and `Fix targets` through internally so the customer-facing step can name the step and a fixer can
+act.
 
 ## Step 7: Present the advisory report (customer-facing)
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -297,12 +297,26 @@ Dispatch **one subagent for the whole module** (not one per topic, and not one p
    it) and the conformance guidance (`powerfx-topic-local.md`, `isv-conformance.md`,
    `isv-integration-pattern.md`). A module maps to a single ISV, so its topics share one ISV doc; reading it
    once here is what avoids re-reading it per topic.
-2. **Loops each in-scope topic, running the per-topic engine (Steps 2–8) on it** — reading the topic, all
-   six lenses (using this topic's slice of the S-1 detector output, not re-running the detectors),
-   consolidating (Step 7), and persisting its catalog (Step 8) — before moving to the next topic. Give each
-   topic its own full attention; per-topic focus is deliberate, because scanning many topics at once for one
-   lens skims and misses per-topic detail (e.g. a single hardcoded value). Persisting each catalog as it goes
-   keeps findings from accumulating in context, so a long module does not degrade the review.
+2. **Loops each in-scope topic**, giving each its own full attention (per-topic focus is deliberate —
+   scanning many topics at once for one lens skims and misses per-topic detail like a single hardcoded
+   value). For **each** topic, in order, run the per-topic engine and finish with the mandatory persist:
+   1. Read the topic and apply all six lenses (Steps 2–6c), using this topic's slice of the S-1 detector
+      output — do not re-run the detectors.
+   2. Consolidate (Step 7).
+   3. **Persist this topic's catalog — the required last action of the iteration, before moving to the next
+      topic.** Write this topic's consolidated findings to a temp JSON and run, from
+      `solutions/ess-maker-skills/`:
+
+      ```
+      python scripts/merge_findings.py --solution {topic-stem} --current {tempCurrent.json}
+      ```
+
+      This write is **mandatory and per-topic**: do it once for each topic as you finish it. Do **not**
+      defer persistence to the end of the loop, do **not** collect all topics and write them together, and
+      do **not** author a helper script to batch-write. The `{topic-stem}-catalog.json` on disk is the only
+      durable record of this topic's findings — the roll-up and drill-down read from it, and skipping the
+      write silently loses the topic's results. Writing as you go also keeps findings from accumulating in
+      context, so a long module does not degrade the review.
 
 The subagent returns only a compact per-topic summary (counts + finding ids); the per-topic catalogs on disk
 are the source the roll-up is built from. (If a module is very large and the loop risks losing focus late,

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -186,10 +186,7 @@ would pass a different scope with no other change).
    `reachability`, `root_cause`, `concrete_fix`, `verification` (`static` for all current lenses;
    `needs-runtime-test` only for a finding that can only be confirmed by running the bot), and `files[]`
    (`path` relative to `solutions/ess-maker-skills/` — the topic file, plus the config or other topic a
-   finding depends on, so its evidence hash is complete). When a runtime heuristic **caps a would-be finding
-   to `unreachable`** so you surface **no** finding (see the reachability rubric in `finding-contract.md`),
-   add an internal-only breadcrumb to a sibling `suppressions` array — `{ "id", "site", "suppressed_by" }` —
-   so a 0-finding result stays auditable (evaluated-and-suppressed, not never-looked).
+   finding depends on, so its evidence hash is complete).
    The **`id` is the cross-run identity** — first read the prior catalog
    (`python scripts/merge_findings.py --solution {topic-stem} --show`) and **reuse the exact prior `id`** for a
    finding you recognize, so it is matched as the same finding rather than a new one.

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -222,20 +222,28 @@ today; scope-neutral for a wider review later).
    `id`). `files[].path` is relative to `solutions/ess-maker-skills/`.
 2. Reconcile: for any prior finding now gone or corrected (especially `evidence_stale` ones), or one the
    maker dismisses, add it to a `--resolve` file per finding-contract's *Recording a resolution*.
-3. Persist from `solutions/ess-maker-skills/`. **Pipe the findings on stdin with `--current -`** — do not
-   pass a temp-file path (a Unix `/tmp/...` path does not exist on Windows, and a shell heredoc is not
-   supported in PowerShell). Any staging file goes **inside the workspace** under `.local\tmp\` (gitignored)
-   — never `$env:TEMP`, `C:\temp`, or `/tmp`, which trigger sensitive-file prompts.
+3. Persist from `solutions/ess-maker-skills/`. **Put the findings in a file and pass its path — never inline
+   the run's JSON into a shell command.** Baking the findings into a `Set-Content`/here-string makes the
+   command text different every run, so it never matches a prior approval and re-prompts each time; a file the
+   script reads keeps the executed command **identical across runs** (so an allow grant sticks), with the
+   run-specific data in the file rather than the command. Stage the file **inside the workspace** under
+   `.local\tmp\` (gitignored) — never `$env:TEMP`, `C:\temp`, or `/tmp`, which trigger sensitive-file prompts.
+
+   - Write `.local\tmp\findings.json` (and, when reconciling, `.local\tmp\resolved.json`) with your
+     file-writing capability — not an inline shell here-string. Ensure `.local\tmp\` exists first (a stable
+     `New-Item -ItemType Directory -Force .local\tmp | Out-Null` is fine — its text never varies, so it is
+     approved once, not per run).
+   - Then run the **stable** command (identical every run — only the file content changes):
 
    ```
-   New-Item -ItemType Directory -Force .local\tmp | Out-Null
-   Set-Content -Path .local\tmp\findings.json -Value $json -Encoding utf8
-   Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -
+   python scripts/merge_findings.py --solution {topic-stem} --current .local\tmp\findings.json
    ```
 
-   Add `--resolve .local\tmp\resolved.json` to record resolutions. The script's catalog is **authoritative**
-   on the cross-run set. If it cannot run, present this run's findings and say the cross-run catalog was
-   unavailable.
+   Add `--resolve .local\tmp\resolved.json` to record resolutions. If your only way to write a file is the
+   shell, `Get-Content .local\tmp\findings.json -Raw | python scripts/merge_findings.py --solution {topic-stem} --current -`
+   also works — the point is the findings live in the file, not inlined in the command. The script's catalog
+   is **authoritative** on the cross-run set. If it cannot run, present this run's findings and say the
+   cross-run catalog was unavailable.
 4. Present (Step 9) the **active** set from the merged catalog — including findings not re-detected this run
    whose files are unchanged; flag `evidence_stale` ones as "previously flagged, code has since changed —
    worth confirming."

--- a/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
@@ -50,6 +50,14 @@ already clear. Common modifications:
 Show the user the relevant section of the current topic and propose the
 specific edit. Explain what will change and why.
 
+**Acting on a `/review` finding.** If the change comes from a `/review` finding, it already names the exact
+node (its step/label plus the action `id` / `kind`) and a suggested fix. Locate that action by its
+identity — not a line number — and apply the finding's fix. The canonical fix pattern for the flagging
+heuristic lives in that finding's conformance lens doc; map the finding's rule-ID prefix
+(`BTPF`/`BTDG`/`BTUX`/`BTIC`/`BTIP`/`BTCF`) to its doc via the prefix table in
+`src/reference/ess-docs/conformance/finding-contract.md`, and apply the **Fix** shown next to the matching
+heuristic. If the finding merged several rule IDs, apply the fix for each. Then continue from Step 3.
+
 ## Step 3: Checkpoint
 
 Run in the terminal:

--- a/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
@@ -50,13 +50,21 @@ already clear. Common modifications:
 Show the user the relevant section of the current topic and propose the
 specific edit. Explain what will change and why.
 
-**Acting on a `/review` finding.** If the change comes from a `/review` finding, it already names the exact
-node (its step/label plus the action `id` / `kind`) and a suggested fix. Locate that action by its
-identity — not a line number — and apply the finding's fix. The canonical fix pattern for the flagging
-heuristic lives in that finding's conformance lens doc; map the finding's rule-ID prefix
-(`BTPF`/`BTDG`/`BTUX`/`BTIC`/`BTIP`/`BTCF`) to its doc via the prefix table in
-`src/reference/ess-docs/conformance/finding-contract.md`, and apply the **Fix** shown next to the matching
-heuristic. If the finding merged several rule IDs, apply the fix for each. Then continue from Step 3.
+**Acting on a `/review` finding.** If the change comes from a `/review` finding, prefer the structured
+findings catalog `/review` writes at `.local/review-findings/{topic-stem}-catalog.json` — it survives
+across sessions and gives each finding a stable `id`, its `files[]`, and a `concrete_fix`. List it with
+`python scripts/merge_findings.py --solution {topic-stem} --show` from `solutions/ess-maker-skills/`. Act on
+the finding whose `id` (or step/label) the customer named; if the catalog is absent, fall back to the
+suggested fix in the visible `/review` report. Either way, locate the action by its **identity** (`kind` +
+node `id`, step name/label, any quoted expression) — **not** a line number — and apply the fix. Read the
+surrounding actions first: if the node's actual context makes a better fix obvious than the suggestion (for
+example, the flagged value turns out to be dead — written but never read — so removing it is cleaner than
+rewriting it), apply that and say why. If one finding covers several angles at the same node, address each.
+
+After a fix is applied and you have confirmed by re-reading the file that the flagged node is gone or
+corrected, tell the customer to re-run `/review` — its reconcile step sees the finding's file changed
+(evidence-stale), confirms the node is gone, and records it resolved in the shared ledger so it stops being
+carried forward. Then continue from Step 3.
 
 ## Step 3: Checkpoint
 

--- a/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
@@ -19,6 +19,7 @@ take effect. **NEVER stop after editing only the local file.**
 - ALWAYS push changes to Copilot Studio after editing.
 - NEVER modify system topics (`on-error`, `conversation-start`, etc.) without
   warning the user about potential side effects.
+- **PRESERVE THE AUTHORING INVARIANTS**: follow [`authoring-invariants.md`](src/reference/ess-docs/customization/authoring-invariants.md) — an edit MUST keep the shared-system-topic delegation, the standard parse → iterate → table rendering, and the shared error path intact.
 - **TRACK PROGRESS**: Use the todo list tool to track your progress.
 
 ## Step 1: Identify the Topic

--- a/tests/scripts/test_review_engine.py
+++ b/tests/scripts/test_review_engine.py
@@ -1,0 +1,167 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Regression tests for the /review conformance engine's correctness gates.
+
+These pin three defects surfaced by an external review of the /review skill:
+
+  * F-1 -- ``merge_findings._hashes_match`` must judge evidence staleness
+    independently of the current working directory. It regressed when the
+    security pass anchored ``evidence_hashes`` on the skill root but left the
+    match side re-hashing a cwd-relative path, so a finding read as "fresh"
+    from the repo root and "stale" from ``scripts/``.
+  * F-2 -- the ``scan_*`` detectors must not print a clean all-clear when a
+    topic could not be read: an unreadable topic is skipped, so the result
+    does not cover it. They must warn and say coverage is incomplete.
+  * F-4 -- ``validate_current_findings`` / ``validate_resolutions`` must reject
+    out-of-enum ``reachability`` / ``verification`` / ``resolution`` values
+    rather than silently coercing them (the ledger is append-only, so a
+    coerced dismissal would be misrecorded permanently).
+
+The detector tests spawn each script as a subprocess against a throwaway agent
+created under the gitignored ``workspace/agents/`` tree, mirroring how the
+skill invokes them.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+import merge_findings
+
+# scripts/ live directly under the maker-skills root; workspace/agents/ is a
+# sibling of scripts/ and is gitignored, so throwaway agents leave no git trace.
+_SKILL_ROOT = Path(merge_findings.__file__).resolve().parent.parent
+_SCRIPTS_DIR = _SKILL_ROOT / "scripts"
+_AGENTS_DIR = _SKILL_ROOT / "workspace" / "agents"
+
+# A real in-tree file, used as stable evidence for the staleness tests.
+_EVIDENCE_REL = "scripts/merge_findings.py"
+
+
+def _finding(**overrides) -> dict:
+    """A minimal finding that passes validate_current_findings, with overrides."""
+    finding = {
+        "id": "sample-finding",
+        "title": "Sample finding",
+        "severity": "MEDIUM",
+        "reachability": "REACHABLE_NORMAL_UI",
+        "root_cause": "Something is wrong.",
+        "concrete_fix": "Fix the thing.",
+        "files": [{"path": _EVIDENCE_REL}],
+    }
+    finding.update(overrides)
+    return finding
+
+
+# --------------------------------------------------------------------------- #
+# F-1 -- staleness is cwd-independent
+# --------------------------------------------------------------------------- #
+
+def test_hashes_match_is_cwd_independent(monkeypatch, tmp_path):
+    stored = merge_findings.evidence_hashes(_finding())
+    assert stored and stored[0]["sha256"], "evidence hash should be populated"
+
+    monkeypatch.chdir(_SKILL_ROOT)
+    assert merge_findings._hashes_match(stored) is True
+
+    # From an unrelated directory the verdict must not flip.
+    monkeypatch.chdir(tmp_path)
+    assert merge_findings._hashes_match(stored) is True
+
+    monkeypatch.chdir(_SCRIPTS_DIR)
+    assert merge_findings._hashes_match(stored) is True
+
+
+def test_hashes_match_rejects_null_and_escaping():
+    # A stored hash of None (file was unreadable at store time) is a mismatch,
+    # never "unchanged".
+    assert merge_findings._hashes_match([{"file": _EVIDENCE_REL, "sha256": None}]) is False
+    # An empty ledger of hashes is a mismatch, not a vacuous match.
+    assert merge_findings._hashes_match([]) is False
+    # A path that escapes the skill tree cannot be silently treated as fresh.
+    assert merge_findings._hashes_match([{"file": "../../etc/hosts", "sha256": "deadbeef"}]) is False
+
+
+# --------------------------------------------------------------------------- #
+# F-4 -- enum validation rejects, never coerces
+# --------------------------------------------------------------------------- #
+
+def test_valid_finding_passes():
+    assert merge_findings.validate_current_findings([_finding()]) == []
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"reachability": "confirmed"},          # not an enum value (the F-4 example bug)
+        {"verification": "runtime"},            # not static / needs-runtime-test
+        {"severity": "CRITICAL"},               # not HIGH / MEDIUM / LOW
+        {"files": [{"path": "../../secret"}]},  # escapes the workspace
+        {"files": []},                          # no path -> evidence_hashes empty
+    ],
+)
+def test_invalid_finding_is_rejected(override):
+    errors = merge_findings.validate_current_findings([_finding(**override)])
+    assert errors, f"expected a validation error for {override}"
+
+
+def test_resolution_validation():
+    assert merge_findings.validate_resolutions([{"id": "x", "resolution": "fixed"}]) == []
+    # An absent resolution is legitimate (defaults to "fixed"); a wrong one is not.
+    assert merge_findings.validate_resolutions([{"id": "x"}]) == []
+    assert merge_findings.validate_resolutions([{"id": "x", "resolution": "resolved"}])
+
+
+# --------------------------------------------------------------------------- #
+# F-2 -- an unreadable topic never yields a clean all-clear
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def temp_agent():
+    """Create a throwaway agent with one readable and one undecodable topic.
+
+    Lives under the gitignored workspace/agents/ tree so it never pollutes git
+    status; removed on teardown.
+    """
+    name = f"_pytest_{uuid.uuid4().hex}"
+    agent_dir = _AGENTS_DIR / name
+    topics = agent_dir / "topics"
+    topics.mkdir(parents=True)
+    (agent_dir / "variables").mkdir()
+
+    good = (
+        "kind: AdaptiveDialog\n"
+        "beginDialog:\n"
+        "  kind: OnRecognizedIntent\n"
+        "  actions: []\n"
+    )
+    (topics / "good.mcs.yml").write_text(good, encoding="utf-8", newline="\r\n")
+    # Bytes that decode cleanly as neither UTF-8 nor UTF-16 -> read is skipped.
+    (topics / "bad.mcs.yml").write_bytes(b"\xff\xfe\x00\x80\x81\xff")
+
+    try:
+        yield name
+    finally:
+        shutil.rmtree(agent_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize("script", ["scan_globals.py", "scan_bindings.py", "scan_config.py"])
+def test_detector_flags_incomplete_coverage_on_unreadable_topic(temp_agent, script):
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPTS_DIR / script), "--agent", temp_agent],
+        capture_output=True,
+        text=True,
+    )
+    combined = proc.stdout + proc.stderr
+    # The skill reads detector output; a non-zero exit could abort the flow, so
+    # the detector must stay exit 0 while disclosing the gap.
+    assert proc.returncode == 0, combined
+    assert "NOT analyzed" in combined, combined
+    assert "coverage is incomplete" in proc.stdout, combined

--- a/tests/scripts/test_review_engine.py
+++ b/tests/scripts/test_review_engine.py
@@ -18,6 +18,19 @@ These pin three defects surfaced by an external review of the /review skill:
     rather than silently coercing them (the ledger is append-only, so a
     coerced dismissal would be misrecorded permanently).
 
+It also pins two defects from a second review of the same skill:
+
+  * AB-1 -- a dismissed finding (``not-a-bug`` / ``wont-fix`` /
+    ``false-positive``) must stay ``suppressed`` when a deterministic detector
+    re-emits it, until its evidence changes -- it must not resurface as
+    ``active`` every run. Re-passing the same dismissal must be idempotent
+    (no append-only ledger bloat). A ``fixed`` finding still reopens on
+    re-detection (a regression).
+  * AB-2 -- ``scan_config`` must resolve a ServiceNow scenario passed inline,
+    via a Switch fan-out, or through a transitive delegation hop (so the
+    response-field check runs) and return no scenario for an unresolvable
+    runtime variable (so it is disclosed, never silently skipped as clean).
+
 The detector tests spawn each script as a subprocess against a throwaway agent
 created under the gitignored ``workspace/agents/`` tree, mirroring how the
 skill invokes them.
@@ -34,6 +47,7 @@ from pathlib import Path
 import pytest
 
 import merge_findings
+import scan_config
 
 # scripts/ live directly under the maker-skills root; workspace/agents/ is a
 # sibling of scripts/ and is gitignored, so throwaway agents leave no git trace.
@@ -165,3 +179,229 @@ def test_detector_flags_incomplete_coverage_on_unreadable_topic(temp_agent, scri
     assert proc.returncode == 0, combined
     assert "NOT analyzed" in combined, combined
     assert "coverage is incomplete" in proc.stdout, combined
+
+
+# --------------------------------------------------------------------------- #
+# AB-1 -- a dismissed finding stays suppressed on re-detect (no resurfacing)
+# --------------------------------------------------------------------------- #
+
+def _evidence_sha() -> str:
+    return merge_findings.evidence_hashes(_finding())[0]["sha256"]
+
+
+def _ledger_line(resolution: str, evidence_hash, solution: str = "demo") -> dict:
+    return {
+        "id": "sample-finding:r1",
+        "solution": solution,
+        "issue_id": "sample-finding",
+        "resolution": resolution,
+        "evidence_hash": evidence_hash,
+    }
+
+
+def test_dismissed_finding_suppressed_on_same_run_redetect():
+    resolutions = {"sample-finding": {"ref": "sample-finding:r1", "resolution": "not-a-bug"}}
+    merged = merge_findings.merge(
+        [], [_finding()], resolutions, "2026-07-13", ledger=[], solution="demo"
+    )
+    assert merged[0]["status"] == "suppressed"
+    assert merged[0]["resolution"] == "not-a-bug"
+
+
+def test_prior_dismissal_suppresses_only_while_evidence_unchanged():
+    same = [_ledger_line("not-a-bug", _evidence_sha())]
+    merged = merge_findings.merge([], [_finding()], {}, "d", ledger=same, solution="demo")
+    assert merged[0]["status"] == "suppressed"
+
+    changed = [_ledger_line("not-a-bug", "deadbeef")]
+    merged = merge_findings.merge([], [_finding()], {}, "d", ledger=changed, solution="demo")
+    assert merged[0]["status"] == "active"
+
+
+def test_fixed_finding_reopens_on_redetect():
+    fixed = [_ledger_line("fixed", _evidence_sha())]
+    merged = merge_findings.merge([], [_finding()], {}, "d", ledger=fixed, solution="demo")
+    assert merged[0]["status"] == "active"
+
+
+def test_dismissal_is_scoped_by_solution():
+    other = [_ledger_line("not-a-bug", _evidence_sha(), solution="OTHER")]
+    merged = merge_findings.merge([], [_finding()], {}, "d", ledger=other, solution="demo")
+    assert merged[0]["status"] == "active"
+
+
+def test_append_resolutions_is_idempotent(monkeypatch, tmp_path):
+    # ledger_path() is cwd-relative (.local/review-findings/), so chdir isolates it.
+    monkeypatch.chdir(tmp_path)
+    resolved = [{"id": "sample-finding", "resolution": "not-a-bug"}]
+    for _ in range(3):
+        ledger = merge_findings._read_jsonl(merge_findings.ledger_path())
+        merge_findings.append_resolutions(
+            resolved, [[_finding()]], "demo", "2026-07-13", ledger
+        )
+    final = merge_findings._read_jsonl(merge_findings.ledger_path())
+    matches = [e for e in final if e.get("issue_id") == "sample-finding"]
+    assert len(matches) == 1, final
+
+
+# --------------------------------------------------------------------------- #
+# AB-2 / AB-2b -- ServiceNow scenario resolution (inline, Switch, transitive)
+# --------------------------------------------------------------------------- #
+
+def test_resolve_scenarios_reads_inline_literal():
+    node = {"input": {"binding": {"ScenarioName": '="msdyn_ServiceNowHRSDGetCaseDetails"'}}}
+    assert scan_config._resolve_scenarios(node, None, {}, {}) == ["msdyn_ServiceNowHRSDGetCaseDetails"]
+
+
+def test_resolve_scenarios_empty_for_unresolvable_runtime_variable():
+    # A runtime variable with no backing Switch cannot be resolved statically, so
+    # it returns [] (the caller discloses it, never silently reports clean).
+    node = {"input": {"binding": {"ScenarioName": "=Topic.MappedScenario"}}}
+    assert scan_config._resolve_scenarios(node, None, {}, {}) == []
+    assert scan_config._resolve_scenarios({"input": {"binding": {}}}, None, {}, {}) == []
+
+
+def test_switch_scenarios_extracts_every_branch_literal():
+    topic = {
+        "actions": [
+            {
+                "kind": "SetVariable",
+                "variable": "Topic.MappedScenario",
+                "value": (
+                    '=Switch(Topic.user_selected_coe, '
+                    '"sn_hr_core_case_payroll", "msdyn_ServiceNowHRSDCreateCasePayroll", '
+                    '"msdyn_ServiceNowHRSDCreateCaseCore")'
+                ),
+            }
+        ]
+    }
+    lits = scan_config._switch_scenarios(topic, "MappedScenario")
+    assert "msdyn_ServiceNowHRSDCreateCasePayroll" in lits
+    assert "msdyn_ServiceNowHRSDCreateCaseCore" in lits
+
+
+def test_resolve_scenarios_expands_inline_switch_fanout():
+    topic = {
+        "actions": [
+            {
+                "kind": "SetVariable",
+                "variable": "Topic.MappedScenario",
+                "value": (
+                    '=Switch(x, "a", "msdyn_ServiceNowHRSDCreateCasePayroll", '
+                    '"msdyn_ServiceNowHRSDCreateCaseCore")'
+                ),
+            }
+        ]
+    }
+    node = {"input": {"binding": {"ScenarioName": "=Topic.MappedScenario"}}}
+    result = scan_config._resolve_scenarios(node, None, topic, {})
+    assert set(result) == {
+        "msdyn_ServiceNowHRSDCreateCasePayroll",
+        "msdyn_ServiceNowHRSDCreateCaseCore",
+    }
+
+
+def test_resolve_scenarios_follows_transitive_delegation(tmp_path):
+    # A component topic with no literal/inline scenario delegates to a system topic
+    # that declares one; resolution must follow that hop.
+    system = tmp_path / "system.mcs.yml"
+    system.write_text(
+        'kind: AdaptiveDialog\nScenarioName: "=\\"msdyn_ServiceNowHRSDGetUserCases\\""\n',
+        encoding="utf-8",
+        newline="\r\n",
+    )
+    component = tmp_path / "component.mcs.yml"
+    component.write_text(
+        "beginDialog:\n"
+        "  actions:\n"
+        "    - kind: BeginDialog\n"
+        "      dialog: ns.topic.ServiceNowHRSDSystemGetCasesList\n",
+        encoding="utf-8",
+        newline="\r\n",
+    )
+    component_map = {
+        "ServiceNowHRSDSystemGetCasesList": system,
+        "ServiceNowHRSDGetUserCases": component,
+    }
+    node = {"input": {"binding": {}}, "dialog": "ns.topic.ServiceNowHRSDGetUserCases"}
+    result = scan_config._resolve_scenarios(node, component, {}, component_map)
+    assert result == ["msdyn_ServiceNowHRSDGetUserCases"]
+
+
+def test_resolve_scenarios_depth_guard_terminates(tmp_path):
+    # A cyclic delegation must not recurse without end — the depth guard returns [].
+    a = tmp_path / "a.mcs.yml"
+    b = tmp_path / "b.mcs.yml"
+    a.write_text(
+        "actions:\n  - kind: BeginDialog\n    dialog: ns.topic.B\n",
+        encoding="utf-8", newline="\r\n",
+    )
+    b.write_text(
+        "actions:\n  - kind: BeginDialog\n    dialog: ns.topic.A\n",
+        encoding="utf-8", newline="\r\n",
+    )
+    component_map = {"A": a, "B": b}
+    node = {"input": {"binding": {}}, "dialog": "ns.topic.A"}
+    assert scan_config._resolve_scenarios(node, a, {}, component_map) == []
+
+
+# --------------------------------------------------------------------------- #
+# Tier-A critique fixes -- config-unloadable disclosure + producer union
+# --------------------------------------------------------------------------- #
+
+def _sn_topic(dialog_suffix: str, scenario_literal: str, out_var: str) -> dict:
+    """A topic that begins one ServiceNow dialog (inline scenario) binding out_var."""
+    return {
+        "actions": [
+            {
+                "kind": "BeginDialog",
+                "dialog": f"ns.topic.{dialog_suffix}",
+                "input": {"binding": {"ScenarioName": f'="{scenario_literal}"'}},
+                "output": {"binding": {"result": f"Topic.{out_var}"}},
+            }
+        ]
+    }
+
+
+def test_resolved_scenario_with_unloadable_config_is_disclosed(tmp_path):
+    # Scenario resolves, but its template config file does not exist -> the fields
+    # went unchecked, so the variable must be disclosed, never reported clean.
+    topic = _sn_topic("ServiceNowHRSDSystemGetCasesList", "msdyn_ServiceNowHRSDNoSuchScenario", "Data")
+    component_map = {"ServiceNowHRSDSystemGetCasesList": tmp_path / "unused.mcs.yml"}
+    v2p, unresolved = scan_config.resolve_response_vars(topic, component_map, tmp_path, set())
+    assert "Data" not in v2p
+    assert unresolved.get("Data") == "ServiceNowHRSDSystemGetCasesList"
+
+
+def test_producer_fields_union_across_multiple_dialogs(tmp_path):
+    # Two dialogs bind the same response var; the var's produced set is the UNION,
+    # so a field produced by either path is not spuriously flagged.
+    configs = tmp_path
+    (configs / "msdyn-servicenowhrsdscenarioa.json").write_text(
+        '{"OutputFieldMapping": [{"OutputName": "FieldA"}]}', encoding="utf-8", newline="\r\n"
+    )
+    (configs / "msdyn-servicenowhrsdscenariob.json").write_text(
+        '{"OutputFieldMapping": [{"OutputName": "FieldB"}]}', encoding="utf-8", newline="\r\n"
+    )
+    topic = {
+        "actions": [
+            {
+                "kind": "BeginDialog",
+                "dialog": "ns.topic.ServiceNowHRSDSystemA",
+                "input": {"binding": {"ScenarioName": '="msdyn_ServiceNowHRSDScenarioA"'}},
+                "output": {"binding": {"result": "Topic.Shared"}},
+            },
+            {
+                "kind": "BeginDialog",
+                "dialog": "ns.topic.ServiceNowHRSDSystemB",
+                "input": {"binding": {"ScenarioName": '="msdyn_ServiceNowHRSDScenarioB"'}},
+                "output": {"binding": {"result": "Topic.Shared"}},
+            },
+        ]
+    }
+    component_map = {
+        "ServiceNowHRSDSystemA": configs / "a.mcs.yml",
+        "ServiceNowHRSDSystemB": configs / "b.mcs.yml",
+    }
+    v2p, _ = scan_config.resolve_response_vars(topic, component_map, configs, set())
+    assert {"FieldA", "FieldB"} <= v2p["Shared"]


### PR DESCRIPTION
## Description

Adds `/review` — an advisory, non-blocking static-analysis skill that reviews maker-authored Copilot Studio topics (`.mcs.yml`) for conformance issues **before publish**. It reads and reports; it never modifies topics.

The skill runs six conformance checks over a topic (or a whole module):

- **Power Fx logic** (agentic) — open-ended reasoning over the topic's expressions, guided by heuristics rather than a fixed rule set; covers issues like hardcoded environment values, ungated `ParseValue`, and failure-branch gaps.
- **Dangling `Global.*`** (detector `scan_globals.py`) — reads with no matching definition.
- **Card/topic binding-mismatch** (detector `scan_bindings.py`) — UX contract.
- **ISV conformance** (agentic) — checks the topic's field/schema use against the backend's documented conventions and known pitfalls, guided by the ISV reference docs rather than a fixed checklist.
- **ISV integration-pattern** (agentic) — judgment on whether the topic follows the supported shared-orchestrator approach rather than a standalone-flow shortcut.
- **ServiceNow config/topic** (detector `scan_config.py`) — parsed-but-not-produced response fields (silent blanks).

Findings persist to a per-topic **catalog + resolution ledger** (`merge_findings.py`) with strict finding-contract validation, sha256 evidence-hash staleness, and a stdin handoff. Supports **single-topic and scoped (per-module)** review. Reference docs (ISV domain, runtime heuristics) are synced as needed.

When those reference docs are absent (e.g. an external maker without the checkout), the review **degrades gracefully**: it runs every check it can, scores reliability-finding severity from the topic's visible structure (delegation to the shared system topic) rather than the runtime docs, and reports **honest reduced coverage** — naming the one skipped check (backend-specific ISV field conformance) rather than implying a clean bill of health. The reliability invariants are also captured as forward authoring guidance in `authoring-invariants.md`, wired into `/create` and `/update`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Detectors validated on the real HR agent: 0 false positives whole-agent; planted positives (typo Global, mismatched card binding, `ResolutionNotes` silent-blank) each flagged; reverted clean.
- Agentic lenses validated on real Workday + ServiceNow topics (both ISV directions).
- `merge_findings.py` exercised via CLI: schema-valid write, malformed-finding rejection (exit 2), stdin / file / not-found paths, per-run behavior.
- Live `/review` runs in VS Code (single-topic and scoped) across multiple models.
- Graceful reduced-coverage validated live: ISV docs present → full review, silent about coverage; a backend's doc absent → that topic reports reduced coverage while other backends stay full; runtime docs absent → still full coverage (severity scored structurally).
- Reference-doc presence is resolved by a **direct filesystem check** (the synced dirs are gitignored, so an index-respecting search would false-negative and silently skip the check).

## Checklist

- [x] My code follows the existing style
- [x] I have added/updated tests where applicable
- [x] I have updated documentation as needed

## Static validation (samples/ only)

N/A — this PR does not touch `samples/`.
