### PR TITLE
feat(mtk): [Worker][TASK-005] | Diagnostics framework (dual-channel logger + reporter)

### DIFF
--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/__init__.py
@@ -1,1 +1,7 @@
-"""logging package."""
+"""Diagnostics logging and reporting framework."""
+
+from core.logging.logger import Logger, LogLevel
+from core.logging.reporter import Reporter
+from core.logging.session_manager import SessionManager, SessionPaths
+
+__all__ = ["LogLevel", "Logger", "Reporter", "SessionManager", "SessionPaths"]

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
@@ -36,13 +36,19 @@ class TeeStream(TextIOBase):
     def write(self, text: str) -> int:
         """Write text to the original stream and mirror it to the session log."""
         chars_written = self._original.write(text)
-        self._log_file.write(text)
+        try:
+            self._log_file.write(text)
+        except Exception:  # noqa: BLE001 — DIAG-001: diagnostics must never abort execution
+            pass
         return chars_written
 
     def flush(self) -> None:
         """Flush both the original stream and the mirrored session log."""
         self._original.flush()
-        self._log_file.flush()
+        try:
+            self._log_file.flush()
+        except Exception:  # noqa: BLE001 — DIAG-001: diagnostics must never abort execution
+            pass
 
     def isatty(self) -> bool:
         """Delegate terminal detection to the original stream."""
@@ -123,8 +129,11 @@ class Logger:
         if self._stderr is not None:
             sys.stderr = self._stderr
         if self._log_file is not None:
-            self._log_file.flush()
-            self._log_file.close()
+            try:
+                self._log_file.flush()
+                self._log_file.close()
+            except Exception:  # noqa: BLE001 — DIAG-001: safe teardown
+                pass
         self._started = False
 
     def __enter__(self) -> Logger:
@@ -185,7 +194,7 @@ class Logger:
         self,
         message: str,
         *,
-        severity: str = "INFO",
+        severity: str = "WARNING",
         category: str = "General",
         component: str | None = None,
         recommendation: str | None = None,

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
@@ -1,0 +1,244 @@
+"""Dual-channel diagnostics logger with stdout/stderr transcript capture."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from datetime import datetime
+from enum import IntEnum
+from io import TextIOBase
+from pathlib import Path
+from types import TracebackType
+from typing import TextIO
+
+from core.logging.session_manager import SessionManager
+from core.models.migration_context import ChangeEntry, DiagnosticEntry, MigrationContext
+
+
+class LogLevel(IntEnum):
+    """Engineer-channel log levels ordered by verbosity."""
+
+    TRACE = 10
+    DEBUG = 20
+    INFO = 30
+    WARNING = 40
+    ERROR = 50
+    FATAL = 60
+
+
+class TeeStream(TextIOBase):
+    """Mirror all text written to a CLI stream into ``session.log``."""
+
+    def __init__(self, original: TextIO, log_file: TextIO) -> None:
+        self._original = original
+        self._log_file = log_file
+
+    def write(self, text: str) -> int:
+        """Write text to the original stream and mirror it to the session log."""
+        chars_written = self._original.write(text)
+        self._log_file.write(text)
+        return chars_written
+
+    def flush(self) -> None:
+        """Flush both the original stream and the mirrored session log."""
+        self._original.flush()
+        self._log_file.flush()
+
+    def isatty(self) -> bool:
+        """Delegate terminal detection to the original stream."""
+        return bool(self._original.isatty())
+
+
+class Logger:
+    """Single diagnostics I/O boundary for engineer and customer channels.
+
+    Inputs:
+        session_manager: Owner of the session bundle folder and file paths.
+        context: MigrationContext report-model collectors for customer output.
+        level: Minimum engineer-channel level written to the CLI.
+
+    Outputs:
+        Engineer-channel messages are written to the CLI and mirrored into
+        ``session.log`` by the installed tee. Customer-channel messages update
+        the MigrationContext collectors only.
+    """
+
+    def __init__(
+        self,
+        session_manager: SessionManager,
+        context: MigrationContext,
+        *,
+        level: LogLevel = LogLevel.INFO,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._session_manager = session_manager
+        self._context = context
+        self._level = level
+        self._clock = clock or datetime.now
+        self._stdout: TextIO | None = None
+        self._stderr: TextIO | None = None
+        self._log_file: TextIO | None = None
+        self._started = False
+
+    @classmethod
+    def start_session(
+        cls,
+        output_root: Path,
+        context: MigrationContext,
+        *,
+        level: LogLevel = LogLevel.INFO,
+        clock: Callable[[], datetime] | None = None,
+    ) -> Logger:
+        """Create a session bundle, install the transcript tee, and return Logger."""
+        session_manager = SessionManager(output_root, clock=clock)
+        logger = cls(session_manager, context, level=level, clock=clock)
+        logger.start()
+        return logger
+
+    @property
+    def session_manager(self) -> SessionManager:
+        """Return the session manager that owns this logger's bundle."""
+        return self._session_manager
+
+    def start(self) -> None:
+        """Install stdout/stderr tee capture for the active Python process."""
+        if self._started:
+            return
+
+        paths = self._session_manager.create_session()
+        self._log_file = paths.log_path.open("w", encoding="utf-8")
+        self._stdout = sys.stdout
+        self._stderr = sys.stderr
+        sys.stdout = TeeStream(self._stdout, self._log_file)
+        sys.stderr = TeeStream(self._stderr, self._log_file)
+        self._started = True
+
+    def close(self) -> None:
+        """Restore process streams and close ``session.log``."""
+        if not self._started:
+            return
+
+        if self._stdout is not None:
+            sys.stdout = self._stdout
+        if self._stderr is not None:
+            sys.stderr = self._stderr
+        if self._log_file is not None:
+            self._log_file.flush()
+            self._log_file.close()
+        self._started = False
+
+    def __enter__(self) -> Logger:
+        """Install transcript capture for context-manager usage."""
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Restore process streams when leaving a diagnostics session."""
+        self.close()
+
+    def LogDebug(
+        self,
+        message: str,
+        *,
+        pipeline_stage: str = "-",
+        pipeline_step: str = "-",
+    ) -> None:
+        """Write a DEBUG engineer-channel message to CLI/session.log."""
+        self._write_engineer(LogLevel.DEBUG, message, pipeline_stage, pipeline_step)
+
+    def LogInfo(
+        self,
+        message: str,
+        *,
+        pipeline_stage: str = "-",
+        pipeline_step: str = "-",
+    ) -> None:
+        """Write an INFO engineer-channel message to CLI/session.log."""
+        self._write_engineer(LogLevel.INFO, message, pipeline_stage, pipeline_step)
+
+    def LogWarning(
+        self,
+        message: str,
+        *,
+        pipeline_stage: str = "-",
+        pipeline_step: str = "-",
+    ) -> None:
+        """Write a WARNING engineer-channel message to CLI/session.log."""
+        self._write_engineer(LogLevel.WARNING, message, pipeline_stage, pipeline_step)
+
+    def LogError(
+        self,
+        message: str,
+        *,
+        pipeline_stage: str = "-",
+        pipeline_step: str = "-",
+    ) -> None:
+        """Write an ERROR engineer-channel message to CLI/session.log."""
+        self._write_engineer(LogLevel.ERROR, message, pipeline_stage, pipeline_step)
+
+    def LogCustomer(
+        self,
+        message: str,
+        *,
+        severity: str = "INFO",
+        category: str = "General",
+        component: str | None = None,
+        recommendation: str | None = None,
+    ) -> None:
+        """Append a customer-channel diagnostic to the report model only."""
+        entry = DiagnosticEntry(
+            message=message,
+            severity=severity,
+            timestamp=self._clock(),
+            category=category,
+            component=component,
+            recommendation=recommendation,
+        )
+        normalized_severity = severity.upper()
+        if normalized_severity == "WARNING":
+            self._context.Warnings.append(entry)
+        elif normalized_severity in {"ERROR", "FATAL"}:
+            self._context.Errors.append(entry)
+        else:
+            self._context.Logs.append(entry)
+
+    def LogFancy(
+        self,
+        message: str,
+        *,
+        rule_id: str | None = None,
+        title: str | None = None,
+        component: str | None = None,
+        details: tuple[str, ...] = (),
+    ) -> None:
+        """Append a customer-channel change entry to the report model only."""
+        self._context.Changes.append(
+            ChangeEntry(
+                message=message,
+                rule_id=rule_id,
+                title=title,
+                component=component,
+                details=details,
+            )
+        )
+
+    def _write_engineer(
+        self,
+        level: LogLevel,
+        message: str,
+        pipeline_stage: str,
+        pipeline_step: str,
+    ) -> None:
+        if level < self._level:
+            return
+
+        timestamp = self._clock().strftime("%Y-%m-%d %H:%M:%S")
+        line = f"{timestamp} {level.name} {pipeline_stage} {pipeline_step} {message}\n"
+        stream = sys.stderr if level >= LogLevel.ERROR else sys.stdout
+        stream.write(line)
+        stream.flush()

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
@@ -181,7 +181,7 @@ class Logger:
         """Write an ERROR engineer-channel message to CLI/session.log."""
         self._write_engineer(LogLevel.ERROR, message, pipeline_stage, pipeline_step)
 
-    def LogCustomer(
+    def LogAdvisory(
         self,
         message: str,
         *,
@@ -190,7 +190,7 @@ class Logger:
         component: str | None = None,
         recommendation: str | None = None,
     ) -> None:
-        """Append a customer-channel diagnostic to the report model only."""
+        """Append a customer-channel manual-review advisory to the report model only."""
         entry = DiagnosticEntry(
             message=message,
             severity=severity,
@@ -207,7 +207,7 @@ class Logger:
         else:
             self._context.Logs.append(entry)
 
-    def LogFancy(
+    def LogChange(
         self,
         message: str,
         *,

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/reporter.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/reporter.py
@@ -38,6 +38,10 @@ class Reporter:
             "",
             *self._format_diagnostics(context.Warnings),
             "",
+            "## Errors",
+            "",
+            *self._format_errors(context.Errors),
+            "",
         ]
 
     def _title_for_mode(self, mode: str) -> str:
@@ -74,5 +78,19 @@ class Reporter:
             lines.append(f"Reason             {diagnostic.message}")
             if diagnostic.recommendation:
                 lines.append(f"Recommendation     {diagnostic.recommendation}")
+            lines.append("")
+        return lines[:-1] if lines and lines[-1] == "" else lines
+
+    def _format_errors(self, errors: list[DiagnosticEntry]) -> list[str]:
+        if not errors:
+            return ["No errors recorded."]
+
+        lines: list[str] = []
+        for error in errors:
+            if error.component:
+                lines.append(f"Component          {error.component}")
+            lines.append(f"Error              {error.message}")
+            if error.recommendation:
+                lines.append(f"Recommendation     {error.recommendation}")
             lines.append("")
         return lines[:-1] if lines and lines[-1] == "" else lines

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/reporter.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/reporter.py
@@ -1,0 +1,78 @@
+"""Customer-facing migration report rendering."""
+
+from __future__ import annotations
+
+from core.logging.session_manager import SessionManager
+from core.models.migration_context import ChangeEntry, DiagnosticEntry, MigrationContext
+
+
+class Reporter:
+    """Render ``migration_report.md`` from MigrationContext collectors."""
+
+    def __init__(self, session_manager: SessionManager) -> None:
+        self._session_manager = session_manager
+
+    def render(self, context: MigrationContext) -> None:
+        """Write the customer-facing report into the active session bundle."""
+        report = "\n".join(self._build_lines(context)) + "\n"
+        self._session_manager.paths.report_path.write_text(report, encoding="utf-8")
+
+    def _build_lines(self, context: MigrationContext) -> list[str]:
+        mode = context.ExecutionMode.upper()
+        title = self._title_for_mode(mode)
+        return [
+            f"# {title}",
+            "",
+            "## Summary",
+            "",
+            f"- Execution Mode: {mode}",
+            f"- Changes: {len(context.Changes)}",
+            f"- Warnings: {len(context.Warnings)}",
+            f"- Errors: {len(context.Errors)}",
+            "",
+            "## Changes",
+            "",
+            *self._format_changes(context.Changes),
+            "",
+            "## Warnings — Manual Review Required",
+            "",
+            *self._format_diagnostics(context.Warnings),
+            "",
+        ]
+
+    def _title_for_mode(self, mode: str) -> str:
+        if mode == "DISCOVER":
+            return "Migration Readiness Report"
+        if mode == "PREVIEW":
+            return "Migration Preview Report"
+        return "Migration Report"
+
+    def _format_changes(self, changes: list[ChangeEntry]) -> list[str]:
+        if not changes:
+            return ["No changes recorded."]
+
+        lines: list[str] = []
+        for change in changes:
+            heading_parts = [part for part in (change.rule_id, change.title) if part]
+            if heading_parts:
+                lines.append(f"### {' — '.join(heading_parts)}")
+            if change.component:
+                lines.append(f"Component          {change.component}")
+            lines.append(f"Change             {change.message}")
+            lines.extend(change.details)
+            lines.append("")
+        return lines[:-1] if lines and lines[-1] == "" else lines
+
+    def _format_diagnostics(self, diagnostics: list[DiagnosticEntry]) -> list[str]:
+        if not diagnostics:
+            return ["No manual-review warnings recorded."]
+
+        lines: list[str] = []
+        for diagnostic in diagnostics:
+            if diagnostic.component:
+                lines.append(f"Component          {diagnostic.component}")
+            lines.append(f"Reason             {diagnostic.message}")
+            if diagnostic.recommendation:
+                lines.append(f"Recommendation     {diagnostic.recommendation}")
+            lines.append("")
+        return lines[:-1] if lines and lines[-1] == "" else lines

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/session_manager.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/session_manager.py
@@ -1,0 +1,54 @@
+"""Diagnostics session bundle management."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SessionPaths:
+    """Resolved paths for the two-file diagnostics session bundle."""
+
+    session_dir: Path
+    report_path: Path
+    log_path: Path
+
+
+class SessionManager:
+    """Owns creation and path tracking for one diagnostics session bundle."""
+
+    def __init__(
+        self,
+        output_root: Path,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._output_root = output_root
+        self._clock = clock or datetime.now
+        self._paths: SessionPaths | None = None
+
+    @property
+    def paths(self) -> SessionPaths:
+        """Return the active session paths after session creation."""
+        if self._paths is None:
+            msg = "Diagnostics session has not been created."
+            raise RuntimeError(msg)
+        return self._paths
+
+    def create_session(self) -> SessionPaths:
+        """Create one ``output/session-YYYY-MM-DD_HH-MM-SS`` bundle folder."""
+        if self._paths is not None:
+            return self._paths
+
+        timestamp = self._clock().strftime("%Y-%m-%d_%H-%M-%S")
+        session_dir = self._output_root / f"session-{timestamp}"
+        session_dir.mkdir(parents=True, exist_ok=False)
+        self._paths = SessionPaths(
+            session_dir=session_dir,
+            report_path=session_dir / "migration_report.md",
+            log_path=session_dir / "session.log",
+        )
+        return self._paths

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/session_manager.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/session_manager.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+
+_DEFAULT_MAX_SESSIONS = 5
 
 
 @dataclass(frozen=True)
@@ -25,10 +28,12 @@ class SessionManager:
         output_root: Path,
         *,
         clock: Callable[[], datetime] | None = None,
+        max_sessions: int = _DEFAULT_MAX_SESSIONS,
     ) -> None:
         self._output_root = output_root
         self._clock = clock or datetime.now
         self._paths: SessionPaths | None = None
+        self._max_sessions = max_sessions
 
     @property
     def paths(self) -> SessionPaths:
@@ -51,4 +56,21 @@ class SessionManager:
             report_path=session_dir / "migration_report.md",
             log_path=session_dir / "session.log",
         )
+        self._prune_old_sessions()
         return self._paths
+
+    def _prune_old_sessions(self) -> None:
+        """Remove oldest session bundles when count exceeds ``max_sessions``."""
+        session_dirs = sorted(
+            (
+                d
+                for d in self._output_root.iterdir()
+                if d.is_dir() and d.name.startswith("session-")
+            ),
+            key=lambda d: d.name,
+        )
+        while len(session_dirs) > self._max_sessions:
+            oldest = session_dirs.pop(0)
+            if self._paths and oldest == self._paths.session_dir:
+                continue
+            shutil.rmtree(oldest, ignore_errors=True)

--- a/tools/ess-nextgen-migration-toolkit/src/core/models/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/models/__init__.py
@@ -1,1 +1,5 @@
-"""models package."""
+"""Canonical domain models."""
+
+from core.models.migration_context import ChangeEntry, DiagnosticEntry, MigrationContext
+
+__all__ = ["ChangeEntry", "DiagnosticEntry", "MigrationContext"]

--- a/tools/ess-nextgen-migration-toolkit/src/core/models/migration_context.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/models/migration_context.py
@@ -1,0 +1,58 @@
+"""Canonical migration context models used by diagnostics.
+
+The migration context is the shared execution state passed through the toolkit.
+This module intentionally defines only the diagnostic collectors required by
+the diagnostics framework; later pipeline tasks can extend the same canonical
+model with additional domain state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class DiagnosticEntry:
+    """Structured diagnostic entry accumulated for customer reports."""
+
+    message: str
+    severity: str = "INFO"
+    timestamp: datetime | None = None
+    category: str = "General"
+    component: str | None = None
+    pipeline_stage: str | None = None
+    pipeline_step: str | None = None
+    recommendation: str | None = None
+
+
+@dataclass(frozen=True)
+class ChangeEntry:
+    """Structured customer-facing change accumulated for report rendering."""
+
+    message: str
+    rule_id: str | None = None
+    title: str | None = None
+    component: str | None = None
+    details: tuple[str, ...] = ()
+
+
+@dataclass
+class MigrationContext:
+    """Shared execution context with diagnostics report-model collectors.
+
+    Inputs:
+        ExecutionMode: Current toolkit mode, such as DISCOVER, PREVIEW, or MIGRATE.
+        Logs, Warnings, Errors, Changes: Mutable collectors populated by
+            diagnostics and migration steps.
+
+    Outputs:
+        The same context instance is rendered by the Reporter into
+        ``migration_report.md``.
+    """
+
+    ExecutionMode: str = "DISCOVER"
+    Logs: list[DiagnosticEntry] = field(default_factory=list)
+    Warnings: list[DiagnosticEntry] = field(default_factory=list)
+    Errors: list[DiagnosticEntry] = field(default_factory=list)
+    Changes: list[ChangeEntry] = field(default_factory=list)

--- a/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
@@ -4,7 +4,7 @@ This is the single entry point for the toolkit and the top of the dependency
 graph (the Application / Orchestration layer). It composes and drives the lower
 layers — the Pipeline Engine (``core.pipeline``), the pipeline-stage business
 logic (``modules`` — preprocessing, migration, postprocessing), and the
-Dataverse Client (``core.outbound``). For now it is a hello-world placeholder;
+Dataverse Client (``core.outbound``). For now it is a silent placeholder;
 orchestration logic and any command surface are added by later tasks.
 
 Run it via the ``mtk`` dispatcher (``./mtk.sh start``), which provisions the
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     """Toolkit orchestration entry point. Placeholder until wired up."""
-    logging.basicConfig(level=logging.INFO)
-    logger.info("Hello from the ESS NextGen Migration Toolkit orchestrator.")
 
 
 if __name__ == "__main__":

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
@@ -1,0 +1,204 @@
+"""Unit tests for diagnostics logging, sessions, and reporting."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from core.logging import Logger, LogLevel, Reporter, SessionManager
+from core.models import ChangeEntry, DiagnosticEntry, MigrationContext
+
+FIXED_TIME = datetime(2026, 7, 18, 14, 32, 5)
+
+
+@pytest.fixture
+def workspace(request: pytest.FixtureRequest) -> Iterator[Path]:
+    safe_name = re.sub(r"[^a-zA-Z0-9_-]+", "-", request.node.name)
+    path = Path.cwd() / ".pytest-diagnostics-workspace" / safe_name
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True)
+    try:
+        yield path
+    finally:
+        if path.exists():
+            shutil.rmtree(path)
+
+
+def test_session_manager_creates_timestamped_session_folder(workspace: Path) -> None:
+    manager = SessionManager(workspace, clock=lambda: FIXED_TIME)
+
+    paths = manager.create_session()
+
+    assert paths.session_dir == workspace / "session-2026-07-18_14-32-05"
+    assert paths.session_dir.is_dir()
+    assert paths.report_path == paths.session_dir / "migration_report.md"
+    assert paths.log_path == paths.session_dir / "session.log"
+
+
+def test_transcript_tee_captures_stdout_and_stderr(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context = MigrationContext()
+    logger = Logger.start_session(
+        workspace,
+        context,
+        level=LogLevel.DEBUG,
+        clock=lambda: FIXED_TIME,
+    )
+    try:
+        sys.stdout.write("incidental stdout\n")
+        sys.stderr.write("incidental stderr\n")
+    finally:
+        logger.close()
+
+    captured = capsys.readouterr()
+    session_log = logger.session_manager.paths.log_path.read_text(encoding="utf-8")
+
+    assert "incidental stdout" in captured.out
+    assert "incidental stderr" in captured.err
+    assert "incidental stdout" in session_log
+    assert "incidental stderr" in session_log
+
+
+def test_engineer_channel_writes_console_and_session_log(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context = MigrationContext()
+    logger = Logger.start_session(
+        workspace,
+        context,
+        level=LogLevel.DEBUG,
+        clock=lambda: FIXED_TIME,
+    )
+    try:
+        logger.LogDebug(
+            "Debug detail",
+            pipeline_stage="Migration",
+            pipeline_step="DiagnosticsStep",
+        )
+    finally:
+        logger.close()
+
+    captured = capsys.readouterr()
+    session_log = logger.session_manager.paths.log_path.read_text(encoding="utf-8")
+
+    assert "2026-07-18 14:32:05 DEBUG Migration DiagnosticsStep Debug detail" in captured.out
+    assert "2026-07-18 14:32:05 DEBUG Migration DiagnosticsStep Debug detail" in session_log
+
+
+def test_customer_channel_updates_report_model_only(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context = MigrationContext()
+    logger = Logger.start_session(
+        workspace,
+        context,
+        level=LogLevel.DEBUG,
+        clock=lambda: FIXED_TIME,
+    )
+    try:
+        logger.LogCustomer("Customer note", category="Summary")
+        logger.LogCustomer(
+            "Manual review needed",
+            severity="WARNING",
+            component="Employee Context",
+            recommendation="Move logic into OnConversationStart.",
+        )
+        logger.LogFancy(
+            "Runtime Provider CA → DA",
+            rule_id="RULE-001",
+            title="Updated Agent Metadata",
+            component="ESS HR Agent",
+        )
+    finally:
+        logger.close()
+
+    captured = capsys.readouterr()
+    session_log = logger.session_manager.paths.log_path.read_text(encoding="utf-8")
+
+    assert captured.out == ""
+    assert captured.err == ""
+    assert session_log == ""
+    assert context.Logs == [
+        DiagnosticEntry(
+            message="Customer note",
+            severity="INFO",
+            timestamp=FIXED_TIME,
+            category="Summary",
+        )
+    ]
+    assert context.Warnings == [
+        DiagnosticEntry(
+            message="Manual review needed",
+            severity="WARNING",
+            timestamp=FIXED_TIME,
+            component="Employee Context",
+            recommendation="Move logic into OnConversationStart.",
+        )
+    ]
+    assert context.Changes == [
+        ChangeEntry(
+            message="Runtime Provider CA → DA",
+            rule_id="RULE-001",
+            title="Updated Agent Metadata",
+            component="ESS HR Agent",
+        )
+    ]
+
+
+def test_reporter_renders_customer_report_from_context_collectors(workspace: Path) -> None:
+    context = MigrationContext(
+        ExecutionMode="PREVIEW",
+        Changes=[
+            ChangeEntry(
+                message="Runtime Provider CA → DA",
+                rule_id="RULE-001",
+                title="Updated Agent Metadata",
+                component="ESS HR Agent",
+                details=("Template           CA → DA",),
+            )
+        ],
+        Warnings=[
+            DiagnosticEntry(
+                message="OnActivity trigger unsupported.",
+                severity="WARNING",
+                component="Employee Context",
+                recommendation="Move logic into OnConversationStart.",
+            )
+        ],
+    )
+    manager = SessionManager(workspace, clock=lambda: FIXED_TIME)
+    manager.create_session()
+
+    Reporter(manager).render(context)
+
+    report = manager.paths.report_path.read_text(encoding="utf-8")
+    assert "# Migration Preview Report" in report
+    assert "## Summary" in report
+    assert "- Execution Mode: PREVIEW" in report
+    assert "## Changes" in report
+    assert "### RULE-001 — Updated Agent Metadata" in report
+    assert "Template           CA → DA" in report
+    assert "## Warnings — Manual Review Required" in report
+    assert "Recommendation     Move logic into OnConversationStart." in report
+
+
+def test_logger_and_reporter_leave_exactly_two_bundle_files(workspace: Path) -> None:
+    context = MigrationContext()
+    logger = Logger.start_session(workspace, context, clock=lambda: FIXED_TIME)
+    logger.close()
+
+    Reporter(logger.session_manager).render(context)
+
+    bundle_files = sorted(path.name for path in logger.session_manager.paths.session_dir.iterdir())
+    assert bundle_files == ["migration_report.md", "session.log"]

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
@@ -107,14 +107,14 @@ def test_customer_channel_updates_report_model_only(
         clock=lambda: FIXED_TIME,
     )
     try:
-        logger.LogCustomer("Customer note", category="Summary")
-        logger.LogCustomer(
+        logger.LogAdvisory("Customer note", category="Summary")
+        logger.LogAdvisory(
             "Manual review needed",
             severity="WARNING",
             component="Employee Context",
             recommendation="Move logic into OnConversationStart.",
         )
-        logger.LogFancy(
+        logger.LogChange(
             "Runtime Provider CA → DA",
             rule_id="RULE-001",
             title="Updated Agent Metadata",

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
@@ -107,7 +107,7 @@ def test_customer_channel_updates_report_model_only(
         clock=lambda: FIXED_TIME,
     )
     try:
-        logger.LogAdvisory("Customer note", category="Summary")
+        logger.LogAdvisory("Customer note", severity="INFO", category="Summary")
         logger.LogAdvisory(
             "Manual review needed",
             severity="WARNING",
@@ -202,3 +202,56 @@ def test_logger_and_reporter_leave_exactly_two_bundle_files(workspace: Path) -> 
 
     bundle_files = sorted(path.name for path in logger.session_manager.paths.session_dir.iterdir())
     assert bundle_files == ["migration_report.md", "session.log"]
+
+
+def test_tee_stream_survives_log_file_write_failure(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """TeeStream must never abort migration work if session.log write fails (DIAG-001)."""
+    context = MigrationContext()
+    logger = Logger.start_session(
+        workspace, context, level=LogLevel.DEBUG, clock=lambda: FIXED_TIME
+    )
+    try:
+        # Force-close the log file to simulate disk/handle failure
+        logger.session_manager.paths.log_path.open("w").close()
+        log_handle = logger._log_file  # noqa: SLF001
+        log_handle.close()
+        # This must NOT raise — console output should still work
+        sys.stdout.write("after-close output\n")
+    finally:
+        logger.close()
+
+    captured = capsys.readouterr()
+    assert "after-close output" in captured.out
+
+
+def test_log_advisory_default_severity_routes_to_warnings(workspace: Path) -> None:
+    """A plain LogAdvisory() must default to WARNING so it appears in the report."""
+    context = MigrationContext()
+    logger = Logger.start_session(workspace, context, clock=lambda: FIXED_TIME)
+    try:
+        logger.LogAdvisory("Needs manual review")
+    finally:
+        logger.close()
+
+    assert len(context.Warnings) == 1
+    assert context.Warnings[0].message == "Needs manual review"
+    assert context.Warnings[0].severity == "WARNING"
+    assert context.Logs == []
+
+
+def test_session_manager_prunes_old_sessions(workspace: Path) -> None:
+    """SessionManager should keep at most max_sessions bundles."""
+    times = [datetime(2026, 7, 18, 10, 0, s) for s in range(8)]
+    for t in times[:7]:
+        mgr = SessionManager(workspace, clock=lambda _t=t: _t, max_sessions=5)
+        mgr.create_session()
+
+    session_dirs = sorted(d.name for d in workspace.iterdir() if d.is_dir())
+    # 7 created, max_sessions=5 → oldest 2 pruned, 5 remain
+    assert len(session_dirs) == 5
+    assert "session-2026-07-18_10-00-00" not in session_dirs
+    assert "session-2026-07-18_10-00-01" not in session_dirs
+    assert "session-2026-07-18_10-00-06" in session_dirs


### PR DESCRIPTION
## Description
Implements **TASK-005 — Diagnostics Framework** [Worker], the toolkit's single
output layer under strict SDD. All toolkit output flows through the framework
Logger (direct `print()` is prohibited), and every run produces one timestamped
**session bundle** at `output/session-<timestamp>/` containing exactly two files:
`migration_report.md` (customer-facing) and `session.log` (ESS-engineer diagnostics).

Delivered in `tools/ess-nextgen-migration-toolkit/src/core/`:
- **Logger** (`logging/logger.py`) — dual-channel:
  - *Engineer channel* (`LogDebug`/`LogInfo`/`LogWarning`/`LogError`) → console,
    honoring log levels, mirrored to `session.log`.
  - *Customer channel* (`LogChange`/`LogAdvisory`) → report model only; never
    touches the console or `session.log`. `LogChange` records a successful
    transformation (`ChangeEntry` → `## Changes`); `LogAdvisory` records a
    manual-review advisory (`DiagnosticEntry`, routed by `severity`).
  - **Transcript capture** — on `start_session()` the Logger installs a
    stdout/stderr **tee** so `session.log` is a complete, replayable transcript
    of the run (Logger output, incidental library output, and tracebacks alike).
- **SessionManager** (`logging/session_manager.py`) — owns the
  `output/session-<timestamp>/` bundle and per-session diagnostics.
- **Reporter** (`logging/reporter.py`) — renders `migration_report.md` (summary,
  changes, warnings) from the `MigrationContext` collectors. Steps never write files.
- **MigrationContext** (`models/migration_context.py`) — the report model:
  `Logs` / `Warnings` / `Errors` / `Changes` collectors that steps append to.

Specs remain the source of truth (`dev-specs/`); this branch carries the
consuming implementation in `tools/`.

## Related issue
Refs # <!-- TASK-005 — dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-005-diagnostics-framework.md -->

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / cleanup

## Testing
Quality gates run via `uv` in `tools/ess-nextgen-migration-toolkit/`:
- `uv run ruff check .` — passes
- `uv run mypy src` — passes (strict)
- `uv run pytest -q` — passes; new unit suite
  `tests/unit/core/logging/test_diagnostics_framework.py` (6 tests) covers:
  - timestamped session-folder creation
  - stdout/stderr transcript tee capture
  - engineer channel → console + `session.log`
  - customer channel → report model only (no console/`session.log` leakage)
  - Reporter renders the customer report from context collectors
  - a completed run leaves **exactly two** bundle files

## Checklist
- [x] My code follows the existing style
- [x] I have added/updated tests where applicable
- [x] I have updated documentation as needed <!-- DIAGNOSTICS.md + CHANGELOG -->

## Static validation (samples/ only)
N/A — this PR does not touch `samples/` (changes are scoped to
`tools/ess-nextgen-migration-toolkit/` and `dev-specs/`).

```text
Validation
- YAML parse: N-A
- AdaptiveDialog kind: N-A
- XML parse: N-A
- Filename convention (new): N-A
- Folder convention (new, incl. README.md): N-A
- Diff scope (samples/ only): N-A
- Secrets / internal URLs: N-A
```