### PR TITLE
Harden Workday setup: advisory topic review, scoped push, OOTB topics installer, Windows path & az rest fixes

### DIFF
--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -332,6 +332,34 @@ before continuing. Do NOT proceed to review and push until the subagent
 has returned. Do NOT invoke the validate subagent after entire test set
 delete operations or after deleting the last remaining case in a category.
 
+**Topic review invocation:** When the maker runs `/create` **directly**, at
+**step 6.5 of the topic create flow** (`src/skills/topics/create/SKILL.md`) —
+after the scan and before the dry run/push — invoke `runSubagent` (the VS Code
+Copilot Chat tool) pointing the subagent to read
+`src/skills/topics/review/SKILL.md` as its first action, scoped to the **single
+topic just created** (pass the agent slug from `.local/config.json` and the
+topic stem — the filename without `.mcs.yml`) and asking it to present the
+**maker-facing report**. Running this review is **mandatory** in the direct
+`/create` flow: wait for the subagent to return, then paste its full report
+verbatim into the chat. Do NOT proceed to the dry run or push until the review
+has returned and its report is shown. The findings themselves are **advisory**
+— they never block the push; when findings exist, pause and let the maker
+choose to fix now (via `/update`) or push anyway. If the subagent or its
+detector scripts cannot run, say the review was skipped and continue — a review
+failure never blocks the push.
+
+**Do NOT invoke this step-6.5 review when the create-topic skill is running as
+the Workday setup flow's P6.1 authoring delegation**
+(`src/skills/setup/workday/create-new-topic.md`). At P6.1 the tenant reference
+IDs are not wired yet (P6.2 does that), so a review there would false-flag
+unresolved placeholders — there is **no** topic review at S6.1/P6.1. The Workday
+setup flow performs its **one and only** topic review later, at its **step P6.5
+(checklist row S6.3)** — *after* the `TOPIC-TRIGGER-*` and `TOPIC-INTEGRATION-*`
+checkpoints (S6.1, S6.2) pass and the topic is fully wired. That review uses the
+same invocation (`runSubagent` → `src/skills/topics/review/SKILL.md`, single
+topic, maker-facing report, displayed verbatim) and is `advisory` (row S6.3
+completes once the report is shown — it never blocks setup).
+
 **When the user asks to modify, delete, rename, or otherwise change an agent
 component, ALWAYS load and follow the corresponding skill file.** The skill
 contains the full checkpoint→edit→scan→push pipeline. Do NOT improvise a

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -193,7 +193,7 @@ _REF_SUFFIX_ROLES = {
 #     SAML Identity Providers". This is NOT reachable via any public
 #     Workday API the kit talks to (the SOAP RaaS / Worker services
 #     don't expose tenant security configuration). Comparison of the
-#     two thumbprints is therefore an operator step.
+#     two certificates is therefore an operator step.
 #
 # WD-CONN-102 reads the Entra side automatically, surfaces the
 # current active-cert thumbprint and NotAfter date, and emits a
@@ -2723,7 +2723,8 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
         ``CERT_EXPIRY_WARN_DAYS`` days, OR its NotBefore is in the
         future (not yet valid).
       * MANUAL — active cert is healthy. The operator must compare
-        its thumbprint against the row in Workday's "Edit Tenant
+        its certificate (validity dates, or an externally-computed
+        SHA-1 thumbprint) against the row in Workday's "Edit Tenant
         Setup - Security -> SAML Identity Providers" because that
         is not reachable from any Workday API the kit talks to.
       * NOT_CONFIGURED — no federated Workday SAML enterprise app
@@ -3073,7 +3074,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
             priority=Priority.HIGH.value, status=Status.MANUAL.value,
             description=description,
             result=(
-                f"{intro}. Manual thumbprint comparison required "
+                f"{intro}. Manual certificate comparison required "
                 "against Workday — the Workday 'X509 Certificate' "
                 "field is not exposed via any Workday API the kit "
                 "talks to (the SOAP RaaS / Worker services don't "
@@ -3086,7 +3087,7 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
                 "Workday has on file for the same Service Provider ID. "
                 "ESS uses exactly one of the federated apps listed "
                 "above; identify it via Workday first, then verify "
-                "only that app's thumbprint.\n"
+                "only that app's certificate.\n"
                 "\n"
                 "Step 1 — Identify the active Entra app from inside "
                 "Workday:\n"
@@ -3104,15 +3105,28 @@ def _check_saml_certificate_health(runner) -> list[CheckResult]:
                 "listed above — the matching row is the active "
                 "Entra app.\n"
                 "\n"
-                "Step 2 — Compare the thumbprints:\n"
-                "  a. In Workday, in that same row, open the 'X509 "
-                "Certificate' value and view its details — Workday "
-                "displays the SHA-1 thumbprint in colon-separated "
-                "uppercase hex (matches the format shown above).\n"
-                "  b. Compare it byte-for-byte against the active "
-                "thumbprint listed for that app above. They MUST "
-                "match exactly.\n"
-                "  c. If they differ, end-user browser-based SAML "
+                "Step 2 — Compare the certificate. Workday does NOT "
+                "display a thumbprint anywhere; its 'X509 Certificate' "
+                "object shows only Name, Valid From, Valid To, and the "
+                "Base64 certificate body. Verify parity one of two "
+                "ways:\n"
+                "  a. Quick check (no tooling) — open the 'X509 "
+                "Certificate' value on that row and confirm its "
+                "'Valid From' / 'Valid To' match the Entra cert's "
+                "NotBefore / NotAfter shown above.\n"
+                "  b. Definitive check — copy the Base64 certificate "
+                "body from Workday, wrap it between "
+                "'-----BEGIN CERTIFICATE-----' and "
+                "'-----END CERTIFICATE-----' markers, save it as a "
+                "PEM file (e.g. workday.cer), then compute its SHA-1 "
+                "thumbprint and confirm it equals the active Entra "
+                "thumbprint above (ignore ':' separators and case):\n"
+                "       PowerShell: [System.Security.Cryptography."
+                "X509Certificates.X509Certificate2]::"
+                "new(\"$PWD\\workday.cer\").Thumbprint\n"
+                "       openssl:    openssl x509 -in workday.cer "
+                "-noout -fingerprint -sha1\n"
+                "  If they differ, end-user browser-based SAML "
                 "SSO into Workday is broken. The OAuth-routed "
                 "``new_sharedworkdaysoap_ff0df`` connection used by "
                 "the ``ESS HR Workday`` and ``WorkdayRESTExecution`` "

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -332,17 +332,18 @@ def _run_single_checkpoint(args):
     print("\nRunning checkpoint...\n")
     result = runner.run()
 
-    _print_prioritized_summary(result)
+    _print_prioritized_summary(result, verbose_manual=True)
     save_results(result, args.output)
 
     if not result.results:
         print(f"\nNOTE: checkpoint {target} produced no result rows (the owning "
               "check may have skipped it for this tenant state).")
 
-    # Open the HTML report only when explicitly NOT suppressed. Single-checkpoint
-    # runs are usually invoked by skills headlessly, so default to not opening.
-    if not args.no_open and result.results:
-        open_report_in_browser(args.output)
+    # Single-checkpoint mode never auto-opens the HTML report. Programmatic
+    # pass/fail rows AND MANUAL verification steps are both printed in full in
+    # the terminal above (see verbose_manual), so they surface directly in
+    # Copilot chat instead of a browser popup. results.json / report.html are
+    # still written to args.output for anyone who wants them.
 
     sys.exit(1 if result.failed > 0 else 0)
 
@@ -701,15 +702,17 @@ def main():
         ).strip().lower() in ("1", "on", "true", "yes"):
             print("[telemetry] disabled via --no-telemetry")
 
-    # Open HTML report in browser (skip with --no-open for CI / headless runs)
-    if not args.no_open:
+    # Open the HTML report only when the run includes a MANUAL check — those
+    # need the browser's rich remediation view. Runs with no manual items are
+    # fully covered by the compact chat table (skip with --no-open too).
+    if not args.no_open and result.manual > 0:
         open_report_in_browser(args.output)
 
     # Exit code
     sys.exit(1 if result.failed > 0 else 0)
 
 
-def _print_prioritized_summary(result):
+def _print_prioritized_summary(result, *, verbose_manual=False):
     """Print a triage-first summary that mirrors the HTML layout.
 
     Three sections, biggest signal first:
@@ -784,8 +787,11 @@ def _print_prioritized_summary(result):
                     print(f"          {cont}")
             print()
 
-    # Section 2 — NEEDS MANUAL VERIFICATION (one-liner per row;
-    # full prose is in report.html so the terminal stays scannable).
+    # Section 2 — NEEDS MANUAL VERIFICATION. In scope runs this stays a
+    # one-liner per row (the full prose lives in report.html so the terminal
+    # stays scannable). In single-checkpoint mode (verbose_manual) we print
+    # the full result + verification steps inline so the manual steps surface
+    # directly in Copilot chat — no HTML popup needed.
     if manual:
         print()
         print(f"  NEEDS MANUAL VERIFICATION ({len(manual)})")
@@ -793,10 +799,24 @@ def _print_prioritized_summary(result):
         for r in manual:
             tag = _status_tag(r.status)
             role_text = f" | {', '.join(r.roles)}" if r.roles else ""
-            print(f"  {tag} {r.checkpoint_id} [{r.priority}{role_text}]: "
-                  f"{r.description}")
-        print("  (Open report.html for the full result + verification "
-              "steps.)")
+            if verbose_manual:
+                print(f"  {tag} {r.checkpoint_id} [{r.priority}{role_text}]: "
+                      f"{r.result}")
+                if r.remediation:
+                    # Indent multi-line remediation under the arrow so the
+                    # verification steps stay grouped with their finding
+                    # (mirrors the ACTION REQUIRED section).
+                    lines = r.remediation.splitlines()
+                    print(f"       -> {lines[0]}")
+                    for cont in lines[1:]:
+                        print(f"          {cont}")
+                print()
+            else:
+                print(f"  {tag} {r.checkpoint_id} [{r.priority}{role_text}]: "
+                      f"{r.description}")
+        if not verbose_manual:
+            print("  (Open report.html for the full result + verification "
+                  "steps.)")
 
     # Section 3 — PASSED (count only; the operator doesn't need to
     # scroll past 200+ green rows to find what needs their attention).

--- a/solutions/ess-maker-skills/scripts/flightcheck/registry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/registry.py
@@ -391,7 +391,7 @@ _SPECS: list[CheckpointSpec] = [
     # (prereqs=()) — each is independently runnable via --checkpoint. Emitted
     # by checks/workday_tenant.run_workday_tenant_checks. WD-API-CLIENT and
     # WD-TENANT are already in OWNED_PREFIXES, so the drift test forces these
-    # entries to exist. S4.4 cert-thumbprint parity reuses WD-CONN-102.
+    # entries to exist. S4.4 cert parity reuses WD-CONN-102.
     CheckpointSpec(
         key="WD-API-CLIENT-001",
         category_fn=run_workday_tenant_checks,

--- a/solutions/ess-maker-skills/scripts/install_ootb_topics.py
+++ b/solutions/ess-maker-skills/scripts/install_ootb_topics.py
@@ -1,0 +1,337 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS Maker Kit - Optional OOTB Workday topics installer.
+
+Deterministically copies selected ready-made Workday sample topics from the
+vendored ``src/examples/ess-samples/Workday`` tree into the agent's working
+``topics/`` folder, ready for ``push.py`` to publish.
+
+WHY THIS SCRIPT EXISTS
+----------------------
+The optional installer (setup skill 5b) used to let the assistant hand-copy
+and name files from a prose playbook. Free-form name derivation produced
+mangled slugs such as ``w-or-kd-ay-ge-tu-se-rp-ro-fi-le.mcs.yml`` (letters
+chopped into 2-char groups). push.py builds a topic's Dataverse schema name
+and display name from its filename, so a mangled filename corrupts the
+topic's identity. This script removes the assistant from the naming loop:
+filenames follow the kit's topic convention (PascalCase, alphanumeric — see
+``src/skills/topics/create/SKILL.md``), which also yields clean schema names.
+
+TOPICS ONLY - NOT TEMPLATE CONFIGS
+----------------------------------
+A Workday topic (the adaptive-dialog conversation logic) calls a Workday
+"scenario template" (``msdyn_employeeselfservicetemplateconfigs``) to talk to
+Workday. Those scenario templates are *managed* components delivered by the
+Workday extension pack installed in setup skill 5 (their meta.json carries
+``"ismanaged": true``). They cannot be created per-agent — attempting to do
+so returns HTTP 400 (duplicate). The sample folders ship the template XML
+purely as reference. Therefore this installer copies **only** the topic YAML
+and relies on the extension pack for the scenario templates it references.
+
+SUBSTITUTIONS
+-------------
+Each sample ``topic.yaml`` is rewritten before being written out:
+  1. Schema prefix: sample cross-topic references
+     ``msdyn_copilotforemployeeselfservicehr.topic.X`` are re-pointed at the
+     target agent's own schema name (a no-op when they already match).
+  2. ``<TENANT_NAME>`` placeholder -> the configured Workday tenant.
+
+This module performs pure local file operations (no network / auth), so it is
+fully unit-testable. The caller runs ``push.py --only-from <manifest>``
+afterwards to publish exactly the topics written here.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# The fixed schema prefix used throughout the vendored HR sample topics.
+# Cross-topic dialog references look like "<SAMPLE_SCHEMA>.topic.<Name>".
+SAMPLE_SCHEMA = "msdyn_copilotforemployeeselfservicehr"
+
+# Category folder -> friendly key.
+CATEGORY_DIRS = {
+    "EmployeeScenarios": "employee",
+    "ManagerScenarios": "manager",
+}
+
+DEFAULT_MANIFEST = os.path.join(".local", "setup", "ootb-push-manifest.txt")
+
+
+def solution_root():
+    """Absolute path to the ess-maker-skills solution root (scripts/..)."""
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def samples_dir(root=None):
+    """Absolute path to the vendored Workday samples tree."""
+    root = root or solution_root()
+    return os.path.join(root, "src", "examples", "ess-samples", "Workday")
+
+
+def topic_basename(folder_name):
+    """Convert a sample folder name to a clean PascalCase topic base name.
+
+    Strips every non-alphanumeric character (hyphens, spaces), matching the
+    kit's topic naming convention. Examples:
+      WorkdayGetUserProfile           -> WorkdayGetUserProfile
+      WorkdayManagersdirect-CompanyCode -> WorkdayManagersdirectCompanyCode
+    """
+    return re.sub(r"[^0-9A-Za-z]", "", folder_name)
+
+
+def rewrite_topic(content, schema_name, tenant):
+    """Apply the two required substitutions to a sample topic's YAML text."""
+    out = content.replace(
+        SAMPLE_SCHEMA + ".topic.", schema_name + ".topic."
+    )
+    if tenant:
+        out = out.replace("<TENANT_NAME>", tenant)
+    return out
+
+
+def discover(root=None):
+    """Discover installable sample scenarios.
+
+    Returns a list of dicts sorted by (category, folder), each:
+      {category, folder, basename, topic_src}
+    Only folders that contain a ``topic.yaml`` are included.
+    """
+    base = samples_dir(root)
+    found = []
+    for dirname, category in sorted(CATEGORY_DIRS.items()):
+        cat_dir = os.path.join(base, dirname)
+        if not os.path.isdir(cat_dir):
+            continue
+        for folder in sorted(os.listdir(cat_dir)):
+            folder_path = os.path.join(cat_dir, folder)
+            topic_src = os.path.join(folder_path, "topic.yaml")
+            if not os.path.isfile(topic_src):
+                continue
+            found.append({
+                "category": category,
+                "folder": folder,
+                "basename": topic_basename(folder),
+                "topic_src": topic_src,
+            })
+    return found
+
+
+def _norm(name):
+    """Loose key for matching a user-supplied scenario name."""
+    return re.sub(r"[^0-9a-z]", "", name.lower())
+
+
+def select(scenarios, categories=None, names=None):
+    """Filter discovered scenarios by category and/or explicit name list.
+
+    categories: iterable of {'employee','manager'} (None = no category filter).
+    names: iterable of scenario identifiers matched loosely against both the
+           folder name and the PascalCase basename (None = no name filter).
+    When both are None, returns everything.
+    """
+    cats = set(categories) if categories else None
+    wanted = {_norm(n) for n in names} if names else None
+    out = []
+    for s in scenarios:
+        if cats is not None and s["category"] not in cats:
+            continue
+        if wanted is not None and not (
+            _norm(s["folder"]) in wanted or _norm(s["basename"]) in wanted
+        ):
+            continue
+        out.append(s)
+    return out
+
+
+def _already_installed(basename, agent_dir):
+    """True if a topic with this base name already exists (working/baseline)."""
+    fname = basename + ".mcs.yml"
+    return (
+        os.path.isfile(os.path.join(agent_dir, "topics", fname))
+        or os.path.isfile(os.path.join(agent_dir, ".baseline", "topics", fname))
+    )
+
+
+def plan(selected, agent_dir):
+    """Compute per-scenario actions without touching disk.
+
+    Returns a list of dicts: {folder, basename, dest_rel, status} where
+    status is 'write' (new topic) or 'skip-exists' (already installed).
+    """
+    actions = []
+    for s in selected:
+        basename = s["basename"]
+        dest_rel = "topics/" + basename + ".mcs.yml"
+        status = "skip-exists" if _already_installed(basename, agent_dir) \
+            else "write"
+        actions.append({
+            "folder": s["folder"],
+            "category": s["category"],
+            "basename": basename,
+            "topic_src": s["topic_src"],
+            "dest_rel": dest_rel,
+            "status": status,
+        })
+    return actions
+
+
+def install(selected, agent_dir, schema_name, tenant, dry_run=False):
+    """Write selected topics into the agent's working tree.
+
+    Returns {written: [rel...], skipped: [{basename, reason}...]}.
+    Skips scenarios whose target topic already exists (idempotent).
+    """
+    written = []
+    skipped = []
+    for action in plan(selected, agent_dir):
+        if action["status"] == "skip-exists":
+            skipped.append({
+                "basename": action["basename"],
+                "reason": "already installed",
+            })
+            continue
+
+        dest_rel = action["dest_rel"]
+        dest_abs = os.path.join(agent_dir, *dest_rel.split("/"))
+        if not dry_run:
+            with open(action["topic_src"], "r", encoding="utf-8") as f:
+                content = f.read()
+            content = rewrite_topic(content, schema_name, tenant)
+            os.makedirs(os.path.dirname(dest_abs), exist_ok=True)
+            with open(dest_abs, "w", encoding="utf-8", newline="") as f:
+                f.write(content)
+        written.append(dest_rel)
+    return {"written": written, "skipped": skipped}
+
+
+def write_manifest(manifest_path, rel_paths):
+    """Write a push scope manifest (one topic relative path per line)."""
+    os.makedirs(os.path.dirname(os.path.abspath(manifest_path)), exist_ok=True)
+    with open(manifest_path, "w", encoding="utf-8", newline="") as f:
+        f.write("# OOTB Workday topics to push (scoped). Generated file.\n")
+        for rel in rel_paths:
+            f.write(rel + "\n")
+
+
+def _resolve_config(args):
+    """Resolve (agent_dir, schema_name, tenant) from flags or config files."""
+    agent_dir = args.agent_dir
+    schema_name = args.schema_name
+    tenant = args.tenant
+
+    if not agent_dir or not schema_name:
+        # Lazy import so the pure functions stay import-safe under test.
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from auth import load_config
+        cfg = load_config()
+        agent_dir = agent_dir or cfg["agent"]["folder"]
+        schema_name = schema_name or cfg["agent"]["schemaName"]
+
+    if tenant is None:
+        wd_path = os.path.join(
+            ".local", "connect", "workday", "config.json")
+        if os.path.isfile(wd_path):
+            try:
+                with open(wd_path, "r", encoding="utf-8") as f:
+                    tenant = json.load(f).get("tenant")
+            except (OSError, json.JSONDecodeError):
+                tenant = None
+    return agent_dir, schema_name, tenant
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(
+        description="Install ready-made Workday sample topics (topics only).")
+    parser.add_argument("--list", action="store_true",
+                        help="List available scenarios and exit.")
+    parser.add_argument("--all", action="store_true",
+                        help="Install all employee + manager scenarios.")
+    parser.add_argument("--employee", action="store_true",
+                        help="Install all employee scenarios.")
+    parser.add_argument("--manager", action="store_true",
+                        help="Install all manager scenarios.")
+    parser.add_argument("--scenarios", default=None,
+                        help="Comma-separated scenario names to install.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be written without writing.")
+    parser.add_argument("--manifest-out", default=DEFAULT_MANIFEST,
+                        help="Where to write the push scope manifest.")
+    parser.add_argument("--agent-dir", default=None,
+                        help="Override agent folder (default: from config).")
+    parser.add_argument("--schema-name", default=None,
+                        help="Override agent schema name (default: from config).")
+    parser.add_argument("--tenant", default=None,
+                        help="Override Workday tenant (default: from config).")
+    parser.add_argument("--samples-root", default=None,
+                        help="Override the solution root that holds src/examples.")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit a machine-readable JSON summary to stdout.")
+    args = parser.parse_args(argv)
+
+    scenarios = discover(args.samples_root)
+
+    if args.list:
+        for s in scenarios:
+            print(f"  [{s['category']:8}] {s['folder']}  ->  "
+                  f"topics/{s['basename']}.mcs.yml")
+        print(f"\n{len(scenarios)} scenario(s) available. Select with "
+              f"--all, --employee, --manager, or --scenarios A,B,C.")
+        return 0
+
+    categories = []
+    if args.all or args.employee:
+        categories.append("employee")
+    if args.all or args.manager:
+        categories.append("manager")
+    names = [n.strip() for n in args.scenarios.split(",")] \
+        if args.scenarios else None
+
+    if not categories and not names:
+        parser.error("select scenarios with --all, --employee, --manager, "
+                     "or --scenarios A,B,C (use --list to see options).")
+
+    selected = select(scenarios, categories or None, names)
+    if not selected:
+        print("No matching scenarios. Use --list to see available names.")
+        return 1
+
+    agent_dir, schema_name, tenant = _resolve_config(args)
+    result = install(selected, agent_dir, schema_name, tenant,
+                     dry_run=args.dry_run)
+
+    if result["written"] and not args.dry_run:
+        write_manifest(args.manifest_out, result["written"])
+
+    if args.json:
+        print(json.dumps({
+            "written": result["written"],
+            "skipped": result["skipped"],
+            "manifest": (args.manifest_out
+                         if result["written"] and not args.dry_run else None),
+            "dryRun": args.dry_run,
+        }, indent=2))
+    else:
+        verb = "Would write" if args.dry_run else "Wrote"
+        print(f"\n{verb} {len(result['written'])} topic(s):")
+        for rel in result["written"]:
+            print(f"  + {rel}")
+        if result["skipped"]:
+            print(f"\nSkipped {len(result['skipped'])} "
+                  f"already-installed topic(s):")
+            for s in result["skipped"]:
+                print(f"  - {s['basename']} ({s['reason']})")
+        if result["written"] and not args.dry_run:
+            print(f"\nManifest: {args.manifest_out}")
+            print("Next: python scripts/push.py --only-from "
+                  f"{args.manifest_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/ess-maker-skills/scripts/push.py
+++ b/solutions/ess-maker-skills/scripts/push.py
@@ -17,6 +17,7 @@ Usage:
     python scripts/push.py --dry-run — Show what would be pushed without pushing
 """
 
+import fnmatch
 import json
 import os
 import subprocess
@@ -37,6 +38,7 @@ from auth import (
     update_record,
     create_record,
     delete_record,
+    dataverse_get,
     load_config,
     AuthExpiredError,
 )
@@ -78,6 +80,39 @@ def _call_with_refresh(auth, fn, *args, **kwargs):
         if len(new_args) >= 2:
             new_args[1] = auth.token
         return fn(*new_args, **kwargs)
+
+
+def _verify_bot_exists(auth, env_url, bot_id):
+    """Fail fast if the configured agent bot is missing from this environment.
+
+    A stale/mismatched ``botId`` (the agent was deleted and recreated, or the
+    config points at a different environment) otherwise makes EVERY component
+    create/update fail with Dataverse's misleading 404 ("bot ... Does Not
+    Exist"), which the friendly error layer renders as "Could not find agent
+    components / solution may not be deployed" — a dead end that sends users
+    chasing a solution-install problem that isn't real. Surface the true
+    cause once, up front, instead.
+
+    Exits the process with status 2 when the bot cannot be resolved (404).
+    Other errors propagate unchanged so genuine transient failures are not
+    masked as a stale-config problem.
+    """
+    try:
+        _call_with_refresh(auth, dataverse_get, env_url, auth.token,
+                           f"bots({bot_id})", {"$select": "botid"})
+    except Exception as exc:  # noqa: BLE001 — surface the real cause below
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            print(
+                f"ERROR: The configured agent (botId {bot_id}) does not exist "
+                f"in this environment ({env_url}).\n"
+                "This usually means the agent was deleted and recreated, or the "
+                "config points at a different environment.\n"
+                "Fix: re-run /setup (or update agent.botId in .local/config.json) "
+                "so it matches the current agent, then push again."
+            )
+            sys.exit(2)
+        raise
 
 
 def classify_path(filepath):
@@ -143,6 +178,60 @@ def compute_diff(baseline_files, working_files):
             deleted.append(path)
 
     return changed, new, deleted
+
+
+def _read_only_manifest(path):
+    """Read a push scope manifest: one relative path/glob per line.
+
+    Blank lines and lines starting with '#' are ignored. Backslashes are
+    normalized to forward slashes so entries match the forward-slash
+    relative paths compute_diff produces.
+    """
+    globs = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                globs.append(line.replace("\\", "/"))
+    return globs
+
+
+def parse_only_globs(argv):
+    """Collect --only GLOB / --only=GLOB (repeatable) and --only-from FILE.
+
+    Returns a list of glob patterns. An empty list means "no scoping" —
+    push behaves exactly as before and touches every changed file.
+    """
+    globs = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--only" and i + 1 < len(argv):
+            globs.append(argv[i + 1].replace("\\", "/"))
+            i += 2
+            continue
+        if arg.startswith("--only="):
+            globs.append(arg.split("=", 1)[1].replace("\\", "/"))
+            i += 1
+            continue
+        if arg == "--only-from" and i + 1 < len(argv):
+            globs.extend(_read_only_manifest(argv[i + 1]))
+            i += 2
+            continue
+        if arg.startswith("--only-from="):
+            globs.extend(_read_only_manifest(arg.split("=", 1)[1]))
+            i += 1
+            continue
+        i += 1
+    return globs
+
+
+def matches_only(filepath, only_globs):
+    """True if filepath matches any scope glob (or scoping is disabled)."""
+    if not only_globs:
+        return True
+    fn = filepath.replace("\\", "/")
+    return any(fnmatch.fnmatch(fn, g) for g in only_globs)
 
 
 def load_component_map(agent_dir):
@@ -220,10 +309,54 @@ def update_baseline(agent_dir):
                     dirs_exist_ok=True)
 
 
+def update_baseline_scoped(agent_dir, only_globs):
+    """Refresh ONLY the scoped subset of the baseline after a scoped push.
+
+    A scoped push (--only / --only-from) sends just the matching files to
+    Dataverse. If we then ran the full update_baseline(), every OTHER
+    changed/new file in the working tree would get copied into the baseline
+    too — silently marking files that were never pushed as "pushed", so the
+    next /push would not retry them. That is a correctness bug, so scoped
+    pushes must refresh the baseline for the scoped files only and leave all
+    other pending working-tree changes still pending.
+
+    For each working file matching a scope glob, copy it (exact bytes) into
+    the baseline. Template-config .xml files also drag in their .meta.json
+    companion. Baseline files that match a scope glob but no longer exist in
+    the working tree are removed (a scoped delete).
+    """
+    import shutil
+
+    baseline_dir = os.path.join(agent_dir, ".baseline")
+    working = collect_files(agent_dir)
+
+    scoped = {rel for rel in working if matches_only(rel, only_globs)}
+    for rel in list(scoped):
+        if rel.startswith("template-configs/") and rel.endswith(".xml"):
+            meta = rel[:-4] + ".meta.json"
+            if meta in working:
+                scoped.add(meta)
+
+    for rel in scoped:
+        src = os.path.join(agent_dir, *rel.split("/"))
+        dst = os.path.join(baseline_dir, *rel.split("/"))
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copy2(src, dst)
+
+    # Scoped deletions: drop baseline files matching the scope that are gone.
+    for rel in collect_files(baseline_dir):
+        if matches_only(rel, only_globs) and rel not in working:
+            try:
+                os.remove(os.path.join(baseline_dir, *rel.split("/")))
+            except OSError:
+                pass
+
+
 def main():
     dry_run = "--dry-run" in sys.argv
     auto_yes = "--yes" in sys.argv
     force_delete = "--force-delete" in sys.argv
+    only_globs = parse_only_globs(sys.argv[1:])
 
     config = load_config()
     agent_dir = config["agent"]["folder"]
@@ -257,14 +390,27 @@ def main():
     new = [f for f in new if is_pushable(f)]
     deleted = [f for f in deleted if is_pushable(f)]
 
+    # Optional scoping: --only / --only-from restrict the push (and the
+    # baseline refresh) to files matching the given globs. Applied AFTER the
+    # pushable filter so scope patterns match the same relative paths shown.
+    if only_globs:
+        changed = [f for f in changed if matches_only(f, only_globs)]
+        new = [f for f in new if matches_only(f, only_globs)]
+        deleted = [f for f in deleted if matches_only(f, only_globs)]
+
     if not changed and not new and not deleted:
-        print("Nothing to push. Working files match the baseline.")
+        if only_globs:
+            print("Nothing to push in the selected scope.")
+        else:
+            print("Nothing to push. Working files match the baseline.")
         return
 
     # Show summary
     print("\n" + "=" * 50)
     print("PUSH SUMMARY")
     print("=" * 50)
+    if only_globs:
+        print(f"\n(Scoped push — {len(only_globs)} filter(s) active)")
 
     if changed:
         print(f"\nModified ({len(changed)}):")
@@ -364,6 +510,10 @@ def main():
     auth = _AuthHolder(env_url)
     auth.acquire()
     print("Authenticated.\n")
+
+    # Pre-flight: verify the configured agent bot still exists in this
+    # environment (see _verify_bot_exists for why this matters).
+    _verify_bot_exists(auth, env_url, bot_id)
 
     # Telemetry: a push is the ADK "build" of an agent's components into
     # Copilot Studio. Best-effort; never affects the push.
@@ -1011,7 +1161,10 @@ def main():
         # Phase 4: refresh baseline. Directory copy isn't atomic; failure
         # here only causes the next diff to over-report (false changes).
         try:
-            update_baseline(agent_dir)
+            if only_globs:
+                update_baseline_scoped(agent_dir, only_globs)
+            else:
+                update_baseline(agent_dir)
         except OSError as exc:
             print(
                 "\nWARNING: baseline refresh failed; component map and"

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/remediation-guide.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/remediation-guide.md
@@ -178,11 +178,18 @@ the Workday API Client's Authorized Public Key setting (see table above).
 rotation before `NotAfter`; same steps as above, but stage the new cert in
 both systems first and only flip the active selection during a low-traffic
 window.
-**Fix (MANUAL — active cert is healthy on the Entra side):** Compare the
-thumbprint surfaced in the result against the `X509 Certificate` thumbprint
-on the matching `Service Provider ID` row in Workday. They must match
-byte-for-byte (colon-separated uppercase hex); if they differ, re-upload the
-active Entra `Certificate (Base64)` into Workday.
+**Fix (MANUAL — active cert is healthy on the Entra side):** Workday does
+not display a thumbprint — its `X509 Certificate` object exposes only `Name`,
+`Valid From`, `Valid To`, and the Base64 certificate body. On the matching
+`Service Provider ID` row in Workday, verify parity either by (a) confirming
+`Valid From` / `Valid To` match the Entra cert's `NotBefore` / `NotAfter`
+surfaced in the result, or (b) copying the Base64 certificate out of Workday
+into a PEM file and computing its SHA-1 to compare against the Entra
+thumbprint in the result — PowerShell
+`[System.Security.Cryptography.X509Certificates.X509Certificate2]::new("$PWD\workday.cer").Thumbprint`
+or `openssl x509 -in workday.cer -noout -fingerprint -sha1` (ignore `:`
+separators and case). If they differ, re-upload the active Entra
+`Certificate (Base64)` into Workday.
 **Verify:** Re-run `/flightcheck --scope workday`
 
 ### WD-FLOW-xxx: Flow disabled

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/validation-matrix.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/validation-matrix.md
@@ -109,7 +109,7 @@ admin API** the kit can reach, and self-verifying through a Workday connection
 would be circular, so both are **always `MANUAL`**: they read only
 `.local/connect/workday/config.json`, echo the captured values, and name the
 Workday screen to verify. Neither needs a client or a Dataverse endpoint. The
-signing-cert thumbprint parity (S4.4) reuses `WD-CONN-102` — it is **not** minted
+signing-cert parity (S4.4) reuses `WD-CONN-102` — it is **not** minted
 here. See the setup catalog below for the owning checklist rows (S4.1–S4.4).
 
 | ID | Check | Priority | Method | Doc Link |
@@ -165,6 +165,12 @@ no client, no config, no Dataverse endpoint, no cassette). When no custom topic
 exists yet, each family returns a single `NotConfigured` "nothing to verify yet"
 row (id `…-001`) so the wildcard always resolves. See the setup catalog below for
 the owning checklist rows (S6.1–S6.2).
+
+> **Advisory review (S6.3).** After both checkpoints pass, skill-6 runs an
+> advisory **topic review** over the finished topic (checklist row S6.3, `advisory`
+> gate). It is **not** a flightcheck checkpoint — it surfaces authoring findings
+> and never blocks; the row completes once the report is shown. See
+> `src/skills/topics/review/SKILL.md`.
 
 | ID | Check | Priority | Method | Doc Link |
 |----|-------|----------|--------|----------|
@@ -442,7 +448,7 @@ of those checkpoint IDs, owned by the master setup checklist
 | `WD-ENTRA-SCOPE-001` | mint | skill-3 | S3.2 | prog | `user_impersonation` exposed, `4e4707ca` pre-authorized, Graph perms granted |
 | `WD-ENTRA-CONSENT-001` | mint | skill-3 | S3.3 | prog → manual if blocked | Admin consent on the Graph delegated perms |
 | `WD-ASSIGN-001` | mint | skill-3 | S3.4 | prog | Enterprise-app user/group assignment (or confirmed not required) |
-| `WD-CONN-102` | reuse | skill-3, skill-4 | S3.1, S4.4 | manual/attest | SAML signing-certificate health / thumbprint parity (returns `MANUAL`) |
+| `WD-CONN-102` | reuse | skill-3, skill-4 | S3.1, S4.4 | manual/attest | SAML signing-certificate health / certificate parity (returns `MANUAL`) |
 | `WD-ENTRA-NAMEID-001` | mint | skill-3 | S3.5 | prog → manual if brittle | NameID claim mapping (`claimsMappingPolicy`) |
 | `WD-ENTRA-SIGNOPT-001` | mint | skill-3 | S3.6 | manual | "Sign SAML response and assertion" signing option (portal-only) |
 | `WD-CONN-010` | reuse | skill-3 | S3.7 | attest | Single-Entra-tenant federation alignment |

--- a/solutions/ess-maker-skills/src/reference/ess-docs/setup/role-gating.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/setup/role-gating.md
@@ -28,6 +28,7 @@ evidence** — a flightcheck pass alone never completes them.
 |------|---------------|-----------|
 | Power Platform Administrator | provision-power-platform-environment (skill-1) | programmatic |
 | Environment Maker | install-ess (skill-2), install-workday-extension-pack (skill-5), create-new-topic (skill-6) | programmatic |
+| Environment Maker | install-workday-ootb-topics (optional, between skill-5 and skill-6) | programmatic |
 | App / Cloud App Admin or App Owner | SSO gallery app + connector config (skill-3) | programmatic |
 | App Admin / Cloud App Admin / Priv Role Admin / Global Admin | admin consent (skill-3) | programmatic — attempt; escalate to **manual** if blocked |
 | Workday Administrator | configure-workday-tenant (skill-4) | attestation |

--- a/solutions/ess-maker-skills/src/skills/setup/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/setup/SKILL.md
@@ -58,7 +58,7 @@ ID, App ID URI) are safe to capture in chat — see
 
    **Message:**
 
-   Here's where your Workday setup stands:
+   Here's the checklist of steps:
 
    **1. Power Platform environment**
    - {m} Set up your Power Platform environment
@@ -95,19 +95,32 @@ ID, App ID URI) are safe to capture in chat — see
    **6. Your first custom Workday topic**
    - {m} Give your new topic its trigger phrases
    - {m} Wire your new topic to Workday
+   - {m} Review your new topic for issues
 
    Picking up at: {title of the first item whose state is not `done`}.
 
    **End message.**
 
-   Then walk the items in Step order (S1.1, S1.2, S2.1, S3.1 … S6.2 — these IDs are
+   Then walk the items in Step order (S1.1, S1.2, S2.1, S3.1 … S6.3 — these IDs are
    internal only), pick the first whose state is not `done`, and dispatch by that
    Step in **Dispatch** below. A skill's playbook may re-run its own idempotent
    foundation steps (role gate, resource creation) ahead of the resume item to
    rehydrate in-memory state — follow the playbook's stated build order rather than
    jumping straight into it.
 
-4. If **every** item is `done`, show the **All done** message and stop.
+   **One interstitial — the ready-made-topics offer.** This offer is gated on the
+   persistent `ootbTopics.state` flag, **not** on the transient resume point, so it
+   can never be silently skipped in the S5→S6 handoff or lost once S6 completes.
+   The **S6 dispatch block enforces it**: whenever S6 is about to run, the offer
+   fires first unless `ootbTopics.state` is already `"installed"` or `"declined"`.
+   You therefore do not need to special-case it here — resume normally and let the
+   S6 block (and the **All done** safety net) trigger it.
+
+4. If **every** item is `done`: first, if `ootbTopics.state` is unset, `"pending"`,
+   or `"in-progress"`, run the **Optional — Install ready-made Workday topics** offer
+   in **Dispatch** once (its handler persists `"installed"`/`"declined"`) — this
+   rescues a setup that reached S6 before the offer was ever shown. Then show the
+   **All done** message and stop.
 
 ---
 
@@ -193,7 +206,64 @@ idempotent/read-only — before the first incomplete row.
 
 When it returns, go back to **Start** to resume at the next unverified row.
 
-### S6.1 through S6.2 — Create a new Workday topic (skill-6)
+### Optional — Install ready-made Workday topics (after skill-5, before skill-6)
+
+This is an **optional, opt-in** offer, not a tracked checklist row. It is triggered
+by the **S6 offer gate** (and, as a safety net, by the **All done** path) whenever
+`ootbTopics.state` is unset — i.e. once every S5 row is `done` and the offer has not
+yet been answered. Keying the trigger off the persistent `ootbTopics.state` flag —
+not off the transient resume point — is what stops it being silently skipped in the
+S5→S6 handoff or lost forever once S6 completes.
+
+Read `ootbTopics.state` in `.local/connect/workday/config.json`:
+
+- `"installed"` or `"declined"` → skip this offer entirely and dispatch S6.
+- unset / `"pending"` / `"in-progress"` → present the offer below.
+
+**Message:**
+
+Before you build your own topic, I can add a set of ready-made Workday topics to
+your agent — things like checking a vacation balance, requesting time off, looking
+up contact information or government IDs, and manager lookups for direct reports.
+Would you like me to add some of these now?
+
+**End message.**
+
+Use the `vscode_askQuestions` tool:
+
+```json
+[
+  {
+    "header": "Ready-made Workday topics",
+    "question": "Would you like to add ready-made Workday topics to your agent now?",
+    "options": [
+      { "label": "Yes, show me what's available", "recommended": true },
+      { "label": "No, I'll build my own" }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+- **"Yes"** → read
+  `src/skills/setup/workday/install-workday-ootb-topics.md` and follow it. When it
+  returns, go back to **Start** (the offer state is now `installed`/`declined`, so
+  the router falls through to S6).
+- **"No"** → set `ootbTopics.state = "declined"` in
+  `.local/connect/workday/config.json` (round-trip merge — never drop other keys),
+  then dispatch S6.
+
+### S6.1 through S6.3 — Create a new Workday topic (skill-6)
+
+**Offer gate — authoritative, runs before this skill.** Before reading the skill-6
+playbook, read `ootbTopics.state` in `.local/connect/workday/config.json`. If it is
+unset, `"pending"`, or `"in-progress"`, run the **Optional — Install ready-made
+Workday topics** offer above **now**, and do not enter skill-6 until it is answered
+(its handler sets `ootbTopics.state` to `"installed"` or `"declined"`). If it is
+already `"installed"` or `"declined"`, skip the offer and continue. Keying this gate
+off the persistent `ootbTopics.state` — rather than off the transient "S6.1 is the
+next incomplete row" resume condition — is what guarantees the offer fires in the
+S5→S6 handoff even when S6 is dispatched in the same turn S5 finished.
 
 Read `src/skills/setup/workday/create-new-topic.md` and follow it. That playbook
 role-gates (Environment Maker, programmatically), then delegates the topic and
@@ -203,12 +273,15 @@ Template Config + Shared Flow pattern), wires the tenant-specific reference IDs
 API scope the tenant doesn't grant yet), verifies each new topic is a well-formed
 triggerable definition (`TOPIC-TRIGGER-*`) and that its integration wiring
 resolves with no unresolved tenant reference-ID placeholders
-(`TOPIC-INTEGRATION-*`), and auto-generates a matching evaluation set — updating
-rows **S6.1**–**S6.2** through the shared checklist-updater. Both checkpoints are
+(`TOPIC-INTEGRATION-*`), runs an advisory review over the finished topic, and
+auto-generates a matching evaluation set — updating rows **S6.1**–**S6.3**
+through the shared checklist-updater. Both checkpoints are
 `*` families that expand to one row **per new/custom topic**. S6.1 is a
 programmatic gate that completes on a checkpoint pass; S6.2 is `prog (+ SME for
 IDs)` — the checkpoint proves the placeholders were resolved, but the row also
 needs a Workday SME's attestation that the wired reference-ID values are correct.
+S6.3 is an `advisory` row — after S6.1 and S6.2 pass it reviews the finished
+topic and shows the findings; it has no checkpoint and never blocks.
 On resume it always re-runs P6.0 (role gate) first — read-only — before the first
 incomplete row.
 

--- a/solutions/ess-maker-skills/src/skills/setup/shared/checklist-updater.md
+++ b/solutions/ess-maker-skills/src/skills/setup/shared/checklist-updater.md
@@ -15,8 +15,9 @@ not narrate tool calls.
 - `NEW_STATE` — `"in-progress"` \| `"done"` \| `"blocked"`.
 - `CHECKPOINT_RESULT` — the flightcheck result for the row's checkpoint, one of
   `PASSED` \| `FAILED` \| `WARNING` \| `MANUAL` \| `null` (null = not run yet).
-- `GATE` — the row's gate type: `"prog"` \| `"manual"` \| `"attest"` (from the
-  master setup checklist row; also recorded in config per `config-schema.md`).
+- `GATE` — the row's gate type: `"prog"` \| `"manual"` \| `"attest"` \|
+  `"advisory"` (from the master setup checklist row; also recorded in config per
+  `config-schema.md`).
 - `ACK` — *(manual/attest rows only)* `true` once the user has explicitly
   acknowledged the step and any evidence has been captured; otherwise `false`.
 
@@ -55,6 +56,97 @@ HTML comment the tooling reads.
 
 ---
 
+## U.0 — Show the checkpoint result to the user (in chat)
+
+**Timing — render this the instant a checkpoint run returns, and for a
+manual/attest row *before* you ask the attestation question.** When a
+`python scripts/flightcheck/cli.py --checkpoint <ID>` run just produced
+`CHECKPOINT_RESULT`, surface that result to the user — the U.0 table **and** the
+U.0a manual steps — before touching any state and before any attestation, so every
+checkpoint run has a visible outcome. Single-checkpoint runs never open the HTML
+report, so this in-chat render is the only place the user sees the outcome; never
+ask a user to attest to manual steps they have not been shown. If you already
+rendered this checkpoint's result this pass (per a skill's post-checkpoint display
+convention), do not repeat it — proceed to U.1. The U.1–U.3 status update below
+runs afterwards (once any attestation is answered) and does **not** re-display the
+result.
+
+- Skip this step when `CHECKPOINT_RESULT` is `null` (the checkpoint was not run
+  this pass — e.g. the row is only being moved to `in-progress`), or when
+  `workspace/flightcheck/results.json` does not exist.
+
+Read `workspace/flightcheck/results.json` — the run that led here wrote it. It has:
+
+```json
+{ "results": [ { "checkpoint_id": "...", "description": "...", "status": "..." }, ... ] }
+```
+
+Render a GitHub-flavoured markdown table in chat, **one row per entry** in
+`results`, using `description` verbatim for **Check** and `status` verbatim for
+**Status**:
+
+```
+| Check | Status |
+| --- | --- |
+| <description> | <status> |
+```
+
+Rules:
+- **Never** include `checkpoint_id`, the Step ID, or any other internal
+  identifier — there is no ID column; `description` is the only label shown.
+- If a `description` or `status` contains a `|`, escape it as `\|`; collapse any
+  newline to a single space.
+- If `results` is empty, render **no** table.
+- This table is **in addition to** the row's own **Message** blocks and the
+  manual verification steps below (see U.0a) — it does not replace or alter them.
+- Draw the table yourself in chat. Do not mention `results.json`, file paths, or
+  the tools used to produce it.
+
+---
+
+## U.0a — Show the manual verification steps to the user (in chat)
+
+Do this right after the U.0 table, before touching any state. A
+`python scripts/flightcheck/cli.py --checkpoint <ID>` run **never opens the HTML
+report** — for `MANUAL` checks the verification steps must appear **in chat**, not
+in a browser popup. This routine is what puts them there.
+
+- Skip this step when `CHECKPOINT_RESULT` is `null`, or when
+  `workspace/flightcheck/results.json` does not exist.
+
+Each entry in `results.json` carries the full text of what the operator must do —
+not just `description`/`status` but also the finding and the how-to:
+
+```json
+{ "checkpoint_id": "...", "description": "...", "status": "Manual",
+  "result": "<the finding / what a human must verify>",
+  "remediation": "<the step-by-step verification, may span multiple lines>" }
+```
+
+For **every** entry in `results` whose `status` is `Manual` (also `Warning` or
+`NotConfigured`, when present), render a block in chat — one per entry, in the
+order they appear — using `description` as the heading, then `result`, then
+`remediation`:
+
+```
+**<description>**
+
+<result>
+
+<remediation>
+```
+
+Rules:
+- Copy `result` and `remediation` **verbatim** — keep the numbered/bulleted steps
+  and every line break. Do **not** summarise, shorten, re-order, or paraphrase the
+  steps; the operator follows them exactly.
+- Still **never** surface `checkpoint_id`, the Step ID, or the hidden comment.
+- Do **not** open, mention, or link `report.html` — the steps live in chat now.
+- If no entry has a `Manual`/`Warning`/`NotConfigured` status, render no block.
+- Do not mention `results.json`, file paths, or the tools used to produce it.
+
+---
+
 ## U.1 — Locate the item
 
 Read `.local/setup/workday/tasks.md` (render from the template first if absent).
@@ -83,8 +175,14 @@ Decide `Status` as follows:
 | `prog` | `CHECKPOINT_RESULT` = `WARNING` / `null` | `in-progress` |
 | `manual` / `attest` | `ACK` = `true` (user acknowledged **and** evidence captured) | `done` |
 | `manual` / `attest` | `ACK` = `false`, regardless of `CHECKPOINT_RESULT` | `in-progress` (or `blocked` if `FAILED`) |
+| `advisory` | the advisory step has been run and its report shown (or attempted and skipped) | `done` |
 
 Notes:
+- An `advisory` row is not backed by a flightcheck checkpoint (`CHECKPOINT_RESULT`
+  is `null`). It **never blocks** — it completes to `done` once its advisory
+  output has been presented to the user, regardless of what the output found. If
+  the advisory step can't run, note it and still complete the row (advisory rows
+  never hold up the setup).
 - A `CHECKPOINT_RESULT` of `MANUAL` means "the checkpoint reported what it could,
   but completion needs a human." It **never** maps to `done` on its own — it
   requires `ACK = true`.
@@ -93,7 +191,9 @@ Notes:
   objective signal).
 
 If the row is `manual`/`attest` and `ACK` is `false`, before leaving the row
-`in-progress` confirm the user actually saw the manual step:
+`in-progress` confirm the user actually saw the manual step. (Precondition: the
+manual verification steps — U.0a — for this row's checkpoint must already have been
+rendered in chat. If they were not, show them now, then ask.)
 
 ```json
 [
@@ -139,7 +239,7 @@ lost — the orchestrator resumes from the first non-`done` row in `setupStatus`
        "{STEP_ID}": {
          "state": "<resulting status>",
          "checkpoint": "<the item's checkpoint ID>",
-         "gate": "<prog|manual|attest>",
+         "gate": "<prog|manual|attest|advisory>",
          "verifiedBy": "<programmatic|attested|null>"
        }
      }

--- a/solutions/ess-maker-skills/src/skills/setup/shared/config-schema.md
+++ b/solutions/ess-maker-skills/src/skills/setup/shared/config-schema.md
@@ -66,7 +66,7 @@ later steps. Unknown/absent fields are treated as `null`.
 ### Per-skill status fields (owned by each skill via the checklist-updater)
 
 Each setup skill records its own checkpoint outcomes under a `setupStatus`
-object, keyed by **Step ID** (`S1.1` … `S6.2`) from the master setup checklist.
+object, keyed by **Step ID** (`S1.1` … `S6.3`) from the master setup checklist.
 This is the durable record the checklist-updater (`checklist-updater.md`) reads
 and writes; the rendered `.local/setup/workday/tasks.md` is the human-readable
 view of the same data.
@@ -81,11 +81,39 @@ view of the same data.
 ```
 
 - `state` ∈ `pending` \| `in-progress` \| `done` \| `blocked`.
-- `gate` ∈ `prog` \| `manual` \| `attest` (from the master checklist row).
-- `verifiedBy` ∈ `programmatic` \| `attested` \| `null`. A `manual`/`attest`
-  row is **never** set to `done` by a flightcheck pass alone — it needs an
-  explicit user acknowledgement plus captured evidence (see
-  `checklist-updater.md` and `permission-gate.md`).
+- `gate` ∈ `prog` \| `manual` \| `attest` \| `advisory` (from the master checklist row).
+- `verifiedBy` ∈ `programmatic` \| `attested` \| `reviewed` \| `null`. A
+  `manual`/`attest` row is **never** set to `done` by a flightcheck pass alone —
+  it needs an explicit user acknowledgement plus captured evidence (see
+  `checklist-updater.md` and `permission-gate.md`). An `advisory` row (no
+  checkpoint) completes with `verifiedBy: "reviewed"` once its report has been
+  shown; it never blocks.
+
+### Optional ready-made-topics state (owned by the OOTB-topics installer)
+
+The optional installer offered between skill-5 and skill-6
+(`install-workday-ootb-topics.md`) is **not** a tracked `setupStatus` row — it
+records its own state under a top-level `ootbTopics` object so the router never
+re-prompts once the user has installed or declined.
+
+```json
+{
+  "ootbTopics": {
+    "state": "installed",
+    "selected": ["msdyn_HRWorkdayHCMEmployeeGetVacationBalance"],
+    "installed": ["msdyn_HRWorkdayHCMEmployeeGetVacationBalance"]
+  }
+}
+```
+
+- `state` ∈ `pending` (unset — offer not yet answered) \| `in-progress`
+  (selection made, mid-install) \| `installed` \| `declined`.
+- `selected` — scenario names the user chose to add (may be mid-install).
+- `installed` — scenario names actually pushed to the environment.
+
+The router treats `installed` and `declined` as terminal (skip the offer);
+any other value (including unset) means "offer not yet resolved". Owned solely by
+the installer; other skills only read it.
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/setup/shared/connection-fields.md
+++ b/solutions/ess-maker-skills/src/skills/setup/shared/connection-fields.md
@@ -25,9 +25,12 @@ not rephrase or narrate tool calls.
 
 ---
 
-## C.1 — App ID URI (Entra resource URL)
+## C.1 — Application ID URI
 
-The App ID URI is the Entra resource the connector requests a token for.
+The Application ID URI identifies the Entra app registration itself
+(`api://{entraAppId}`). skill-3 exposes it for the SAML token audience and the
+connector's API pre-authorization. It is **not** the connection's "Microsoft
+Entra resource URL" — see the note below.
 
 - Expected form: `api://{entraAppId}` (the GUID, not the object ID).
 - If `APP_ID_URI` is missing, derive it from `entraAppId`:
@@ -45,6 +48,13 @@ The App ID URI is the Entra resource the connector requests a token for.
 ```
 
 Save as `appIdUri`.
+
+> **Not the connection resource URL.** The Copilot Studio Workday connection
+> asks for a **Microsoft Entra resource URL** — the Workday SAML identifier
+> `http://www.workday.com/{tenant}` (matching the Entra app's Identifier /
+> Entity ID and Workday's SAML Service Provider ID), **not** this `api://…` App
+> ID URI. skill-5 builds it from `tenant`; see P5.1 in
+> `install-workday-extension-pack.md`.
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/setup/workday/configure-workday-tenant.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/configure-workday-tenant.md
@@ -26,13 +26,22 @@ files you are reading. **Never** show internal variable names or IDs in chat.
 | S4.1 | `WD-API-CLIENT-001` — Workday API client registered (SAML ****** grant, functional areas, Include Workday Owned Scope = Yes) | attest |
 | S4.2 | `WD-TENANT-001` — Tenant Setup – Security + connection fields captured | attest |
 | S4.3 | `WD-TENANT-001` — authentication policy scoped to the OAuth client + activated | attest |
-| S4.4 | `WD-CONN-102` *(reuse)* — Workday X.509 signing-cert thumbprint matches the Entra one | manual/attest |
+| S4.4 | `WD-CONN-102` *(reuse)* — Workday X.509 signing cert matches the Entra one | manual/attest |
 
 Run any one with:
 
 ```
 python scripts/flightcheck/cli.py --checkpoint <ID>
 ```
+
+**After every checkpoint run, show its result in chat first.** As soon as a
+`--checkpoint` run returns, render the result to the user per
+[`shared/checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the
+compact result table and, for any `MANUAL` (or `Warning` / `NotConfigured`) row,
+its full verification steps — **before** you show any later **Message** or ask any
+attestation question. Single-checkpoint runs never open the HTML report, so this
+in-chat render is the only place the user sees the manual steps; never ask a user
+to attest to steps they have not been shown.
 
 Both `WD-API-CLIENT-001` and `WD-TENANT-001` are always `MANUAL` — they read only
 `.local/connect/workday/config.json` and echo the captured values. A `MANUAL`
@@ -86,7 +95,7 @@ Use the `vscode_askQuestions` tool:
 [
   {
     "header": "Workday administrator",
-    "question": "Have you provisioned a Workday administrator to perform these manual Workday configuration steps with you?",
+    "question": "Have you looped in a Workday admin to perform the Workday side of configuration?",
     "options": [
       { "label": "Yes, I have", "recommended": true },
       { "label": "No, I have not" }
@@ -134,7 +143,8 @@ Before I change any Workday security settings, I need to check the tenant's
 current SAML sign-on. In Workday, search for and open the **Edit Tenant Setup –
 Security** task and find the **SAML Setup** section. Tell me, for the currently
 enabled Identity Provider row: the **Issuer** (or IdP name), the **Service
-Provider ID**, and the **x509 Certificate** name/thumbprint in use. If there is
+Provider ID**, and the **x509 Certificate** name plus its **Valid From** /
+**Valid To** dates (Workday shows no thumbprint). If there is
 no active SAML IdP yet, just say **none**.
 
 **End message.**
@@ -162,10 +172,10 @@ Wait for the user's answer, then record it as the pre-gate evidence
 
 ---
 
-## P4.1 — Upload the X.509 signing certificate & confirm thumbprint parity *(completes S4.4)*
+## P4.1 — Upload the X.509 signing certificate & confirm certificate parity *(completes S4.4)*
 
 Create the Workday **X.509 Public Key** from the Entra signing certificate skill-3
-activated, then confirm the thumbprint matches — a mismatch means the wrong
+activated, then confirm the certificate matches — a mismatch means the wrong
 certificate was uploaded and SSO will fail.
 
 **Message:**
@@ -177,7 +187,7 @@ Workday, run the **Create x509 Public Key** task and paste that certificate. Typ
 
 **End message.**
 
-Wait for the user, then verify the thumbprint parity against the certificate
+Wait for the user, then verify the certificate parity against the certificate
 skill-3 activated in Entra.
 
 **Message:**
@@ -201,11 +211,20 @@ command **opens a browser window for a Graph sign-in** before it returns. That i
 expected — do **not** cancel or re-run it while it pauses; it is blocked on the
 sign-in, not hung, and continues once you complete it.
 
+**Show the `WD-CONN-102` result in chat first.** It always returns `MANUAL` for
+the Workday-side comparison, so render it per
+[`checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the result
+table **and** its full verification steps — **before** the certificate-parity
+question below. Never ask the user to attest to a comparison they have not been
+shown.
+
 **Message:**
 
-Does the certificate thumbprint you uploaded in Workday match the one shown for
-your Workday app in Entra (Single sign-on → SAML Signing Certificate →
-Thumbprint)?
+Workday doesn't display a certificate thumbprint, so we compare another way.
+Confirm you uploaded the exact **Certificate (Base64)** from your Workday app in
+Entra (Single sign-on → SAML Signing Certificate), and that the **Valid From** /
+**Valid To** dates shown on the Workday x509 Public Key match that Entra
+certificate's validity dates. Do they match?
 
 **End message.**
 
@@ -214,8 +233,8 @@ Use the `vscode_askQuestions` tool:
 ```json
 [
   {
-    "header": "Certificate thumbprint",
-    "question": "Do the Workday and Entra signing-certificate thumbprints match?",
+    "header": "Certificate parity",
+    "question": "Does the uploaded Workday certificate (and its Valid From / Valid To dates) match the Entra signing certificate?",
     "options": [
       { "label": "Yes, they match", "recommended": true },
       { "label": "No / not sure" }
@@ -300,7 +319,11 @@ python scripts/flightcheck/cli.py --checkpoint WD-API-CLIENT-001
 ```
 
 This echoes the captured `oauthClientId` / `tokenEndpoint` and restates the
-registration facts to confirm. Show the user the checkpoint's result, then:
+registration facts to confirm. `WD-API-CLIENT-001` always returns `MANUAL`, so
+render its result in chat per
+[`checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the result
+table **and** its full verification steps — **before** you ask the user to
+acknowledge the row. Then:
 
 - Confirm the row via [`checklist-updater.md`](../shared/checklist-updater.md)
   with `STEP_ID="S4.1"`, `GATE="attest"`, `CHECKPOINT_RESULT="MANUAL"`, `ACK=true`
@@ -346,7 +369,10 @@ python scripts/flightcheck/cli.py --checkpoint WD-TENANT-001
 
 This echoes the captured `tenant` / `restBaseUrl` / `soapBaseUrl` / `appIdUri` and
 restates the Tenant Setup – Security and authentication-policy facts to confirm.
-Show the user the result, then update **S4.3** via
+`WD-TENANT-001` always returns `MANUAL`, so render its result in chat per
+[`checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the result
+table **and** its full verification steps — **before** you ask the user to
+confirm. Then update **S4.3** via
 [`checklist-updater.md`](../shared/checklist-updater.md) with `STEP_ID="S4.3"`,
 `GATE="attest"`, `CHECKPOINT_RESULT="MANUAL"`, `ACK=true` once the user confirms
 the policy is scoped and activated.

--- a/solutions/ess-maker-skills/src/skills/setup/workday/create-new-topic.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/create-new-topic.md
@@ -6,8 +6,9 @@ values). This skill creates a new custom Workday scenario beyond the OOTB set
 (for example *Request Time Off*): it authors the topic and its template
 configuration with the **Template Config + Shared Flow** pattern, wires the
 tenant-specific reference IDs, verifies the result with two per-topic checkpoint
-families, and auto-generates a matching evaluation set. It owns master-checklist
-rows **S6.1** and **S6.2**.
+families, runs an advisory review over the finished topic, and auto-generates a
+matching evaluation set. It owns master-checklist rows **S6.1**, **S6.2**, and
+**S6.3**.
 
 Depends on skill 5 (the Workday extension pack must be installed and wired — its
 connections bound, the REST endpoint verified, the cloud flows on, and the
@@ -36,12 +37,27 @@ files you are reading. **Never** show internal variable names or IDs in chat.
 | S6.1 | `TOPIC-TRIGGER-*` — each new topic is a well-formed AdaptiveDialog with a trigger (and trigger phrases when intent-routed) | prog |
 | S6.2 | `TOPIC-INTEGRATION-*` — each new topic's integration wiring resolves (no unresolved tenant reference-ID placeholders) | prog (+ SME for ID values) |
 
+> **S6.3 is advisory — not a checkpoint.** After S6.1 and S6.2 pass, this skill
+> runs an advisory **topic review** over the finished topic (P6.5) and shows the
+> findings to the user. It has no flightcheck checkpoint and **never blocks** —
+> its row completes once the report has been shown. See
+> [`topics/review/SKILL.md`](../../topics/review/SKILL.md).
+
 Run either family with:
 
 ```
 python scripts/flightcheck/cli.py --checkpoint TOPIC-TRIGGER-*
 python scripts/flightcheck/cli.py --checkpoint TOPIC-INTEGRATION-*
 ```
+
+**After every checkpoint run, show its result in chat first.** As soon as a
+`--checkpoint` run returns, render the result to the user per
+[`shared/checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the
+compact result table and, for any `MANUAL` (or `Warning` / `NotConfigured`) row,
+its full verification steps — **before** you show any later **Message** or ask any
+attestation question. Single-checkpoint runs never open the HTML report, so this
+in-chat render is the only place the user sees the manual steps; never ask a user
+to attest to steps they have not been shown.
 
 Each family expands to **one row per new/custom topic** found under the extracted
 agent — a topic is "new" when it differs from the OOTB `.baseline/` snapshot the
@@ -78,8 +94,14 @@ topic-authoring work, with:
   ```
 
   ```
-  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/systemusers({USER_ID})/systemuserroles_association?%24select=name" --query "value[].name" -o json
+  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/systemusers%28{USER_ID}%29/systemuserroles_association?%24select=name" --query "value[].name" -o json
   ```
+
+  (Percent-encode the key-lookup parentheses — `%28`/`%29`, not `(`/`)` — and the
+  OData `$` — `%24select`. On Windows the `az` launcher is a `cmd.exe` batch
+  wrapper: a raw `)` closes a batch block and the call fails with
+  `... was unexpected at this time`, so the encoded form runs first-try on every
+  shell.)
 
   The role is held if the returned role names include **`Environment Maker`**, or
   a superseding role (**`System Customizer`** or **`System Administrator`**).
@@ -120,6 +142,13 @@ The create-topic skill will select the Workday sample pattern, write
 template-config record in Dataverse, scan, dry-run, and push. When it returns,
 the new topic exists locally and in the environment. Continue to P6.2 to wire and
 verify the tenant reference IDs.
+
+**Do NOT run any topic review during this P6.1 authoring delegation** — the
+create-topic skill's own review sub-step (its step 6.5) must not fire here. The
+tenant reference IDs are not wired yet (P6.2 does that), so a review now would
+false-flag the unresolved placeholders. There is **no** review at S6.1/P6.1; the
+one and only topic review runs later at **P6.5 (row S6.3)**, once the integration
+wiring is verified.
 
 ---
 
@@ -270,7 +299,54 @@ wiring is a benign pass — there is nothing to resolve.)
 
 ---
 
-## P6.5 — Auto-generate a matching evaluation set *(delegated to the evaluate skill)*
+## P6.5 — Review the finished topic *(completes S6.3)*
+
+Now that the topic is authored, wired, and its trigger and integration are
+verified, run an **advisory** review over it to surface any remaining authoring
+issues before the user relies on it. This never blocks — it shows findings and
+lets the user decide.
+
+**Message:**
+
+Your topic is set up and verified. Let me do a quick review of it and flag
+anything worth tidying up before you rely on it.
+
+**End message.**
+
+Set **S6.3** `in-progress` via
+[`checklist-updater.md`](../shared/checklist-updater.md) with `STEP_ID="S6.3"`,
+`GATE="advisory"`, `NEW_STATE="in-progress"`.
+
+Invoke the review by calling `runSubagent` (the VS Code Copilot Chat tool),
+pointing the subagent to read
+[`src/skills/topics/review/SKILL.md`](../../topics/review/SKILL.md) as its first
+action — do not run its detectors yourself. Tell it this is a **single-topic**
+review of the topic just created (pass the agent slug from `.local/config.json`
+and the topic stem — the filename without `.mcs.yml`), and ask it to present the
+**maker-facing report** (its Step 9). Wait for the subagent to return, then
+**paste its full report into chat verbatim** — the verdict line, the findings
+table, and the close. Do NOT summarize or re-word it.
+
+- **If the report lists findings**, pause and ask the user how to proceed:
+  - **Fix now** → run [`topics/update`](../../topics/update/SKILL.md) (`/update`)
+    on the topic to apply the fixes, then re-run this review before completing
+    S6.3.
+  - **Continue** → the findings are advisory; leave them for later.
+- **If the report is clean**, say so briefly.
+
+Once the report has been shown and the user has chosen how to proceed, complete
+**S6.3** via [`checklist-updater.md`](../shared/checklist-updater.md) with
+`STEP_ID="S6.3"`, `GATE="advisory"`, `NEW_STATE="done"` — the review is advisory,
+so showing the report completes the row regardless of findings. Then continue to
+P6.6.
+
+**If the review can't run** (the subagent or its detector scripts fail), tell the
+user the review was skipped, complete **S6.3** as `done` (advisory rows never
+block the setup), and continue to P6.6.
+
+---
+
+## P6.6 — Auto-generate a matching evaluation set *(delegated to the evaluate skill)*
 
 Every new topic should ship with coverage, so generate a matching evaluation set
 automatically — the user should not have to run a separate step.
@@ -296,7 +372,7 @@ sanitized golden test user, not generic placeholders.
 
 ## Done
 
-When S6.1 and S6.2 are both `done`, return control to the setup router
+When S6.1, S6.2, and S6.3 are all `done`, return control to the setup router
 (`SKILL.md`).
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/setup/workday/install-ess.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/install-ess.md
@@ -22,6 +22,15 @@ Run it with:
 python scripts/flightcheck/cli.py --checkpoint ESS-SOLN-001
 ```
 
+**After every checkpoint run, show its result in chat first.** As soon as a
+`--checkpoint` run returns, render the result to the user per
+[`shared/checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the
+compact result table and, for any `MANUAL` (or `Warning` / `NotConfigured`) row,
+its full verification steps — **before** you show any later **Message** or ask any
+attestation question. Single-checkpoint runs never open the HTML report, so this
+in-chat render is the only place the user sees the manual steps; never ask a user
+to attest to steps they have not been shown.
+
 The base agent installs a managed solution whose unique name starts with
 `msdyn_copilotforemployeeselfservice` (the base, IT, and HR editions all match).
 
@@ -44,8 +53,14 @@ install work, with:
   ```
 
   ```
-  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/systemusers({USER_ID})/systemuserroles_association?%24select=name" --query "value[].name" -o json
+  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/systemusers%28{USER_ID}%29/systemuserroles_association?%24select=name" --query "value[].name" -o json
   ```
+
+  (Percent-encode the key-lookup parentheses — `%28`/`%29`, not `(`/`)` — and the
+  OData `$` — `%24select`. On Windows the `az` launcher is a `cmd.exe` batch
+  wrapper: a raw `)` closes a batch block and the call fails with
+  `... was unexpected at this time`, so the encoded form runs first-try on every
+  shell.)
 
   The role is held if the returned role names include **`Environment Maker`**, or
   a superseding role (**`System Customizer`** or **`System Administrator`**).
@@ -76,7 +91,10 @@ in this environment.
 python scripts/flightcheck/cli.py --checkpoint ESS-SOLN-001
 ```
 
-- **`PASSED`** (the solution is already installed) → skip to **P2.2**.
+- **`PASSED`** (the solution is already installed) → this pre-check **is** the
+  verification (it runs the same `ESS-SOLN-001` gate), so skip straight to
+  **P2.3** and record the row on this pass — do **not** re-run the checkpoint in
+  P2.2.
 - Anything else → show the install instructions below.
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/setup/workday/install-workday-extension-pack.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/install-workday-extension-pack.md
@@ -41,6 +41,15 @@ Run any one with:
 python scripts/flightcheck/cli.py --checkpoint <ID>
 ```
 
+**After every checkpoint run, show its result in chat first.** As soon as a
+`--checkpoint` run returns, render the result to the user per
+[`shared/checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the
+compact result table and, for any `MANUAL` (or `Warning` / `NotConfigured`) row,
+its full verification steps — **before** you show any later **Message** or ask any
+attestation question. Single-checkpoint runs never open the HTML report, so this
+in-chat render is the only place the user sees the manual steps; never ask a user
+to attest to steps they have not been shown.
+
 `WD-CONN-AUTH-001` and `WD-NET-001` always report `MANUAL`: the first echoes the
 observed connection auth parameter set for the operator to confirm (the Power
 Platform admin API exposes no kit-verifiable fingerprint for the
@@ -79,8 +88,14 @@ extension-pack work, with:
   ```
 
   ```
-  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/systemusers({USER_ID})/systemuserroles_association?%24select=name" --query "value[].name" -o json
+  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/systemusers%28{USER_ID}%29/systemuserroles_association?%24select=name" --query "value[].name" -o json
   ```
+
+  (Percent-encode the key-lookup parentheses — `%28`/`%29`, not `(`/`)` — and the
+  OData `$` — `%24select`. On Windows the `az` launcher is a `cmd.exe` batch
+  wrapper: a raw `)` closes a batch block and the call fails with
+  `... was unexpected at this time`, so the encoded form runs first-try on every
+  shell.)
 
   The role is held if the returned role names include **`Environment Maker`**, or
   a superseding role (**`System Customizer`** or **`System Administrator`**).
@@ -117,11 +132,16 @@ python scripts/flightcheck/cli.py --checkpoint WD-PKG-001
   the connection values the user will paste into the extension pack's connection
   form, then show the install steps.
 
-  Read the captured values from `.local/connect/workday/config.json` (persisted by
-  skill-4): `appIdUri`, `tokenEndpoint`, `oauthClientId`, `soapBaseUrl`, and
-  `restBaseUrl`. Present them with their Copilot Studio form labels — never the
-  internal field names. If any is blank, it was not captured: go back to skill-4
-  (the Workday tenant configuration, P4.3) to capture it before installing.
+  Read the captured values from `.local/connect/workday/config.json`: `tenant`
+  (persisted by skill-3/4), and `tokenEndpoint`, `oauthClientId`, `soapBaseUrl`,
+  and `restBaseUrl` (persisted by skill-4). Build the **Microsoft Entra resource
+  URL** as `http://www.workday.com/{tenant}` — the Workday tenant short name (the
+  same one in the Workday tenant URL, e.g. `acme_dpt1`), **not** the Entra App ID
+  URI. Present each with its Copilot Studio form label — never the internal field
+  names. If `tenant` is blank, derive it from the Workday tenant URL (the
+  `{tenant}` segment of `soapBaseUrl` / `oauthTokenUrl`); if any other value is
+  blank, it was not captured — go back to skill-4 (the Workday tenant
+  configuration, P4.3) to capture it before installing.
 
   **Message:**
 
@@ -129,7 +149,8 @@ python scripts/flightcheck/cli.py --checkpoint WD-PKG-001
   setup. Keep them handy — you'll paste them into the connection form when the
   installer prompts you:
 
-  - **Microsoft Entra resource URL (Application ID URI):** {appIdUri}
+  - **Workday tenant name:** {tenant}
+  - **Microsoft Entra resource URL:** http://www.workday.com/{tenant}
   - **Workday OAuth token URL (Token Endpoint):** {tokenEndpoint}
   - **Client ID:** {oauthClientId}
   - **SOAP base URL:** {soapBaseUrl}
@@ -228,7 +249,8 @@ parameter set (and owner) for you to confirm — the simplified extension pack's
 Workday connection must use **Microsoft Entra ID Integrated** (Entra SSO), not
 Basic/ISU or a client-secret grant.
 
-Show the user the checkpoint's result, then ask them to confirm:
+You will already have rendered the checkpoint's result in chat (the
+post-checkpoint display, U.0a). Ask the user to confirm the auth type:
 
 **Message:**
 
@@ -465,7 +487,8 @@ verify corporate firewall rules (a local probe would only prove this machine's
 egress, not the managed-connector outbound path), so it echoes the Workday REST and
 SOAP hosts that InfoSec/IT must allowlist for the Power Platform managed connectors.
 
-Show the user the echoed endpoints, then ask them to confirm:
+You will already have rendered the echoed REST + SOAP hosts in chat (the
+post-checkpoint display, U.0a). Ask the user to confirm the allowlisting is in place:
 
 **Message:**
 

--- a/solutions/ess-maker-skills/src/skills/setup/workday/install-workday-ootb-topics.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/install-workday-ootb-topics.md
@@ -1,0 +1,314 @@
+<!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
+# Skill 5b (Optional) — Install Ready-Made Workday Topics
+
+Role: **Environment Maker**. This **optional** skill installs the ready-made
+Workday **topics** that ship with the kit (vacation balance, time-off requests,
+contact info, government IDs, manager cost-center lookups, and more) into the
+user's agent. It is offered by the setup router **after skill 5 (the Workday
+extension pack)** and **before skill 6 (your first custom topic)**.
+
+**Topics only — not template configs.** Each Workday topic (the conversation
+logic) calls a Workday *scenario template* (`msdyn_employeeselfservicetemplateconfigs`)
+to reach Workday. Those scenario templates are **managed** components delivered by
+the Workday extension pack in skill 5 — they already exist in the environment and
+**cannot** be created per-agent (attempting to create one returns HTTP 400). This
+installer therefore writes **only** the topic YAML and relies on the extension pack
+for the scenario templates each topic references by `scenarioName`. The sample
+folders ship the template XML purely as reference; it is never pushed.
+
+It is **opt-in** — the user can decline and go straight to skill 6. It does **not**
+own a numbered master-checklist row; it records its own state under `ootbTopics` in
+`.local/connect/workday/config.json` (see
+[`config-schema.md`](../shared/config-schema.md)) so a resumed setup never
+re-prompts once the user has installed or declined.
+
+Depends on skill 5 (the extension pack must be installed and its Workday +
+Dataverse connections bound — the shared flow these topics call is part of that
+pack) and, transitively, skills 1–4.
+
+This skill **reuses** existing machinery rather than re-implementing it:
+- a deterministic converter script, `scripts/install_ootb_topics.py`, that writes
+  the selected topics with correct **PascalCase** names and the required
+  substitutions (this replaces free-form hand-copying, which previously produced
+  mangled file names that corrupted the topics' identity);
+- the **scoped push** (`scripts/push.py --only-from ...`) so **only** the topics
+  this skill writes are published — nothing else in the working tree is swept in;
+  and
+- skill 6's two per-topic checkpoint families — `TOPIC-TRIGGER-*` and
+  `TOPIC-INTEGRATION-*` — to verify each freshly written topic before it is pushed.
+
+Every **Message** block is the exact text to show the user. Copy it verbatim. Do
+not rephrase, add commentary, or tell the user what tools you are calling or what
+files you are reading. **Never** show internal variable names, IDs, file paths, or
+checkpoint identifiers in chat.
+
+---
+
+## Source of the ready-made topics
+
+The scenarios live **inside the kit**, already vendored, at:
+
+- `src/examples/ess-samples/Workday/EmployeeScenarios/` — 11 employee scenarios.
+- `src/examples/ess-samples/Workday/ManagerScenarios/` — 5 manager scenarios.
+
+Each scenario is a folder containing a `topic.yaml` (the Copilot Studio topic) and
+one or more `msdyn_*.xml` files. **Only the `topic.yaml` is installed** — the
+`msdyn_*.xml` template configs are reference copies of managed components the
+extension pack already registered, so this skill never writes or pushes them.
+**Only** use this vendored copy — never the repo-root `samples/` tree, which is
+outside the kit workspace and not reachable from here.
+
+The `ExtendedScenarios/` folder (loose topic-only YAMLs with no template config) is
+**out of scope** for this installer.
+
+---
+
+## Idempotency & resume
+
+- On entry, read `ootbTopics.state` in `.local/connect/workday/config.json`. If it
+  is already `"installed"`, tell the user their ready-made topics are already in
+  place and return to the router. (The router only reads this file when the state
+  is unset / `"pending"` / `"in-progress"`, so normally you arrive here to do work.)
+- **Skip any scenario that is already present** in the agent — if a topic of the
+  same name already exists under `{agent.folder}/topics/` or in the pushed baseline,
+  do not overwrite it. Report it as "already installed" and move on.
+- Persist `ootbTopics` after each phase so an interrupted run resumes cleanly.
+
+---
+
+## O.0 — Role gate (Environment Maker)
+
+Apply the shared [`permission-gate.md`](../shared/permission-gate.md) before any
+authoring work, with:
+
+- `REQUIRED_ROLE` = `"Environment Maker"`
+- `GATE_MODE` = `"programmatic"`
+- `STEP_ID` = `"OOTB.0"` (evidence label only — this installer owns no S-row)
+- `ROLE_QUERY` = a Dataverse security-role membership check for the signed-in
+  user. Read `dataverseEndpoint` from `.local/config.json`; call it `{ENV_URL}`:
+
+  ```
+  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/WhoAmI" --query "UserId" -o tsv
+  ```
+
+  ```
+  az rest --method GET --resource "{ENV_URL}" --url "{ENV_URL}/api/data/v9.2/systemusers%28{USER_ID}%29/systemuserroles_association?%24select=name" --query "value[].name" -o json
+  ```
+
+  (Percent-encode the key-lookup parentheses — `%28`/`%29`, not `(`/`)` — and the
+  OData `$` — `%24select`. On Windows the `az` launcher is a `cmd.exe` batch
+  wrapper: a raw `)` closes a batch block and the call fails with
+  `... was unexpected at this time`, so the encoded form runs first-try on every
+  shell.)
+
+  The role is held if the returned names include **`Environment Maker`**,
+  **`System Customizer`**, or **`System Administrator`**. Treat an
+  `Insufficient privileges` / forbidden response as "role not held"; on an
+  unrelated error follow the gate's retry-then-attest fallback.
+
+If `GATE_RESULT` is `"stop"`, **halt** — leave `ootbTopics.state` unchanged
+(`"pending"`) so the offer can be made again later. Otherwise carry
+`GATE_EVIDENCE` forward and continue.
+
+---
+
+## O.1 — Present the catalog & let the user choose
+
+Read the two vendored scenario folders. For each scenario, derive a short,
+plain-language label from its `README.md` (or its topic's `modelDescription`) —
+never show folder names, file names, or scenario IDs.
+
+**Message:**
+
+Here are the ready-made Workday topics I can add to your agent. **For employees:**
+check a vacation balance, request time off, view job details, look up contact
+information, education, government IDs, dependents, emergency contacts, user
+profile, update a home address, and give peer feedback. **For managers:** look up a
+direct report's company code, cost center, job taxonomy, service anniversary, and
+time in position.
+
+Which would you like me to add?
+
+**End message.**
+
+Use the `vscode_askQuestions` tool:
+
+```json
+[
+  {
+    "header": "Ready-made Workday topics",
+    "question": "Which ready-made Workday topics should I add to your agent?",
+    "options": [
+      { "label": "All of them (employee + manager)", "recommended": true },
+      { "label": "Employee topics only" },
+      { "label": "Manager topics only" },
+      { "label": "Let me pick specific ones" }
+    ],
+    "allowFreeformInput": true
+  }
+]
+```
+
+- **"All of them"** → select all 16 scenarios.
+- **"Employee topics only"** → select the 11 employee scenarios.
+- **"Manager topics only"** → select the 5 manager scenarios.
+- **"Let me pick specific ones"** (or a freeform answer) → confirm the specific
+  scenarios the user named, matching their words to the plain-language labels.
+
+Record the selected scenario list. Set `ootbTopics.state = "in-progress"` and
+`ootbTopics.selected = [<scenario names>]` in `.local/connect/workday/config.json`
+(round-trip merge — never drop other keys).
+
+If the user declines all (empty selection), set `ootbTopics.state = "declined"` and
+return to the router.
+
+---
+
+## O.2 — Back up, then write the selected topics into the agent
+
+First save a restore point:
+
+```
+python scripts/checkpoint.py "pre-install-ootb-workday-topics"
+```
+
+Then run the converter script to write the selected topics. **Do not hand-copy or
+name files yourself** — the script derives correct PascalCase file names and applies
+both required substitutions (the agent's schema prefix and the Workday `<TENANT_NAME>`),
+reading `agent.folder` / `agent.schemaName` from `.local/config.json` and `tenant`
+from `.local/connect/workday/config.json`. It skips any topic already present in the
+agent (working files or baseline) and writes a push manifest listing exactly what it
+wrote.
+
+Map the user's O.1 choice to one flag:
+
+- **All of them** → `--all`
+- **Employee topics only** → `--employee`
+- **Manager topics only** → `--manager`
+- **Specific ones** → `--scenarios "Name1,Name2,..."` (use the scenario folder or
+  topic base names; run `--list` first to see the exact names)
+
+```
+python scripts/install_ootb_topics.py --list
+python scripts/install_ootb_topics.py <selection-flag> --json
+```
+
+The script prints the topics it wrote (and any it skipped as already installed) and
+the manifest path (`.local/setup/ootb-push-manifest.txt`). It installs **topics
+only** — it never writes template configs, because those managed scenario templates
+already came with the extension pack. Do not push yet — verification comes first.
+
+---
+
+## O.3 — Wire tenant reference IDs (skill-4 loop-back if scopes are missing)
+
+Most of these scenarios resolve the employee at runtime (via the user-context
+lookup skill 5 wired) and need no author-time values. A few need a
+tenant-specific reference ID (for example a **Time Off Type ID** from the Workday
+*Time Off Types* report). Where a scenario left a reference-ID placeholder, walk
+the user through obtaining the real value from their Workday tenant and substitute
+it into the topic before pushing. (The `<TENANT_NAME>` substitution is already done
+by the O.2 script; this step is only for other tenant-specific reference IDs.)
+
+**If a selected scenario needs a Workday API functional area the registered API
+client doesn't grant yet** (a REST/SOAP scope error), loop back to skill 4:
+
+**Message:**
+
+One of these topics needs a Workday permission your API client doesn't grant yet.
+We'll jump back to the Workday tenant setup to add the required functional area,
+then come back here to finish adding your topics.
+
+**End message.**
+
+Read [`configure-workday-tenant.md`](./configure-workday-tenant.md) and re-run its
+**P4.3** (Register the API client) to add the missing functional area(s) — keeping
+**Include Workday Owned Scope = Yes** — then return here and continue.
+
+---
+
+## O.4 — Scan & verify the written topics *(reuses skill 6's checkpoints)*
+
+Check the whole agent folder for errors with the diagnostics tool. Fix any error
+in a **newly written** file before continuing; mention (but don't block on)
+pre-existing errors in other files.
+
+Then verify the freshly written topics — because nothing has been pushed yet, they
+count as new against the current baseline, so skill 6's two families cover them:
+
+**Message:**
+
+Now I'll check each topic I added is set up correctly and fully wired to Workday.
+
+**End message.**
+
+```
+python scripts/flightcheck/cli.py --checkpoint TOPIC-TRIGGER-*
+python scripts/flightcheck/cli.py --checkpoint TOPIC-INTEGRATION-*
+```
+
+**After each run, show its result in chat first.** Render the result per
+[`shared/checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the
+compact result table and, for any `MANUAL` / `Warning` / `NotConfigured` row, its
+full verification steps — **before** you show any later **Message** or ask any
+question.
+
+- `TOPIC-TRIGGER-*` — each added topic is a well-formed triggerable definition.
+- `TOPIC-INTEGRATION-*` — each added topic's integration wiring resolves with no
+  leftover placeholder tokens.
+
+If **any** row `FAILED`, fix it (return to O.2 for a definition problem, or O.3 for
+a leftover reference-ID placeholder) and re-run the affected family until it
+passes. Do not push topics that still fail.
+
+---
+
+## O.5 — Dry run, then push (scoped)
+
+Preview the change set — **scoped to just the topics this skill wrote** via the
+manifest from O.2, so unrelated working-tree changes are never touched:
+
+```
+python scripts/push.py --only-from .local/setup/ootb-push-manifest.txt --dry-run
+```
+
+Show the user the diff summary (which topics will be added). Then:
+
+**Message:**
+
+I'm ready to add these topics to your live agent. Want me to go ahead?
+
+**End message.**
+
+On confirmation:
+
+```
+python scripts/push.py --only-from .local/setup/ootb-push-manifest.txt --yes
+```
+
+This creates **only** the topic records in the environment and refreshes just their
+baseline entries, so these ready-made topics become part of your agent's baseline
+(and won't later be mistaken for a custom topic you author in skill 6). The managed
+scenario templates they call are already present from the extension pack, so nothing
+else is pushed.
+
+**If the push fails**, show the error and offer to retry, or to revert with
+`python scripts/checkpoint.py --revert`.
+
+---
+
+## O.6 — Record state & return
+
+Set, in `.local/connect/workday/config.json` (round-trip merge):
+
+- `ootbTopics.state = "installed"`
+- `ootbTopics.installed = [<scenario names actually pushed>]`
+
+Then return control to the setup router (`SKILL.md`) to continue at skill 6.
+
+**Message:**
+
+Done — your ready-made Workday topics are live in your agent. You can try them in
+Copilot Studio, or keep going and build your own custom topic next.
+
+**End message.**

--- a/solutions/ess-maker-skills/src/skills/setup/workday/provision-power-platform-environment.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/provision-power-platform-environment.md
@@ -23,6 +23,15 @@ Run any of them with:
 python scripts/flightcheck/cli.py --checkpoint <ID>
 ```
 
+**After every checkpoint run, show its result in chat first.** As soon as a
+`--checkpoint` run returns, render the result to the user per
+[`shared/checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the
+compact result table and, for any `MANUAL` (or `Warning` / `NotConfigured`) row,
+its full verification steps — **before** you show any later **Message** or ask any
+attestation question. Single-checkpoint runs never open the HTML report, so this
+in-chat render is the only place the user sees the manual steps; never ask a user
+to attest to steps they have not been shown.
+
 ---
 
 ## P1.0 — Role gate (Power Platform Administrator)

--- a/solutions/ess-maker-skills/src/skills/setup/workday/provision-workday-entra-app.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/provision-workday-entra-app.md
@@ -39,6 +39,15 @@ Run any one with:
 python scripts/flightcheck/cli.py --checkpoint <ID>
 ```
 
+**After every checkpoint run, show its result in chat first.** As soon as a
+`--checkpoint` run returns, render the result to the user per
+[`shared/checklist-updater.md`](../shared/checklist-updater.md) §U.0–U.0a — the
+compact result table and, for any `MANUAL` (or `Warning` / `NotConfigured`) row,
+its full verification steps — **before** you show any later **Message** or ask any
+attestation question. Single-checkpoint runs never open the HTML report, so this
+in-chat render is the only place the user sees the manual steps; never ask a user
+to attest to steps they have not been shown.
+
 **Build order (row order now matches it).** Row **S3.1** — the SSO gallery app — is
 the foundation every other row configures, so it is built first and the rows are
 numbered in build order (S3.1 → S3.7). Each section below is titled by the checklist
@@ -298,7 +307,7 @@ python scripts/flightcheck/cli.py --checkpoint WD-CONN-102
 ```
 
 `WD-CONN-102` reports the Entra-side signing-certificate health. It returns
-`MANUAL` for the healthy state because Workday-side thumbprint parity is verified
+`MANUAL` for the healthy state because Workday-side certificate parity is verified
 later in skill-4 (row S4.4). Present the certificate/thumbprint result to the
 user, then update **S3.1** via [`checklist-updater.md`](../shared/checklist-updater.md)
 with `STEP_ID="S3.1"`, `GATE="manual"`,

--- a/solutions/ess-maker-skills/src/skills/setup/workday/tasks.md
+++ b/solutions/ess-maker-skills/src/skills/setup/workday/tasks.md
@@ -62,7 +62,7 @@ express; all items start `pending`.
 ### 3. Workday single sign-on (Entra)
 
 - [ ] **Create the Workday single sign-on app** — Set up the Entra SSO application for Workday in SAML mode, with the right sign-on URLs and an active signing certificate.
-  <!-- id: S3.1 | role: App/Cloud App Admin | skill: skill-3 | automatable: Yes | checkpoints: WD-CONN-102 | gate: prog instantiate (Graph); WD-CONN-102 healthy-state = MANUAL (Entra cert health auto-checked; Workday thumbprint parity deferred to S4.4) | status: pending -->
+  <!-- id: S3.1 | role: App/Cloud App Admin | skill: skill-3 | automatable: Yes | checkpoints: WD-CONN-102 | gate: prog instantiate (Graph); WD-CONN-102 healthy-state = MANUAL (Entra cert health auto-checked; Workday certificate parity deferred to S4.4) | status: pending -->
 - [ ] **Expose the Workday API permission** — Publish the sign-in scope, pre-authorize the Workday connector, and request the Microsoft Graph permissions the agent needs.
   <!-- id: S3.2 | role: App/Cloud App Admin or App Owner | skill: skill-3 | automatable: Yes | checkpoints: WD-ENTRA-SCOPE-001 | gate: prog | status: pending -->
 - [ ] **Grant admin consent** — Approve the requested Microsoft Graph permissions on behalf of your organization.
@@ -84,8 +84,8 @@ express; all items start `pending`.
   <!-- id: S4.2 | role: Workday Administrator | skill: skill-4 | automatable: No | checkpoints: WD-TENANT-001 | gate: attest | status: pending -->
 - [ ] **Activate the Workday authentication policy** — Scope Workday's authentication policy to the new OAuth client, allow SAML sign-in, and activate it.
   <!-- id: S4.3 | role: Workday Administrator | skill: skill-4 | automatable: No | checkpoints: WD-TENANT-001 | gate: attest | status: pending -->
-- [ ] **Match the signing certificate** — Confirm the Workday-side signing certificate thumbprint matches the one in Entra.
-  <!-- id: S4.4 | role: Workday Administrator | skill: skill-4 | automatable: No (Workday cert field not API-reachable) | checkpoints: WD-CONN-102 | gate: manual/attest (WD-CONN-102 returns MANUAL — operator compares thumbprints) | status: pending -->
+- [ ] **Match the signing certificate** — Confirm the Workday-side signing certificate matches the one in Entra (validity dates, or an externally-computed SHA-1 — Workday shows no thumbprint).
+  <!-- id: S4.4 | role: Workday Administrator | skill: skill-4 | automatable: No (Workday cert field not API-reachable) | checkpoints: WD-CONN-102 | gate: manual/attest (WD-CONN-102 returns MANUAL — operator compares certificate: dates / external SHA-1) | status: pending -->
 
 ### 5. Workday extension pack
 
@@ -112,6 +112,8 @@ express; all items start `pending`.
   <!-- id: S6.1 | role: Environment Maker (+ Workday SME) | skill: skill-6 | automatable: Yes | checkpoints: TOPIC-TRIGGER-* | gate: prog | status: pending -->
 - [ ] **Wire your new topic to Workday** — Connect the new topic to Workday using your tenant's reference IDs, with no placeholders left behind.
   <!-- id: S6.2 | role: Environment Maker (+ Workday SME) | skill: skill-6 | automatable: Yes | checkpoints: TOPIC-INTEGRATION-* | gate: prog (+ SME for IDs) | status: pending -->
+- [ ] **Review your new topic for issues** — Run a quick check over the finished topic and show you anything worth tidying up before you rely on it.
+  <!-- id: S6.3 | role: Environment Maker | skill: skill-6 | automatable: Yes | checkpoints: n/a | gate: advisory | status: pending -->
 
 > Items whose checkpoint is a `*` family (the cloud flows, and each new topic)
 > expand to one checkbox **per** emitted / created item at run time. An item backed

--- a/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
@@ -139,7 +139,7 @@ Show the generated YAML to the user for review. Highlight the key parts:
 - Action chain (what happens step by step)
 - Any placeholders that still need values (like workflow GUIDs)
 
-## Step 6: Checkpoint, Write, Scan, and Push
+## Step 6: Checkpoint, Write, Scan, Review, and Push
 
 This is the end-to-end delivery step. Do NOT stop after writing the file.
 The user should never have to leave VS Code or manually push changes.
@@ -223,7 +223,53 @@ not just the new file.
   do NOT block the push. Example: "I also found 3 pre-existing errors in other
   topics. You can fix those later with `/scan`."
 
-### 6.5 — Dry run
+### 6.5 — Review the topic
+
+Run an advisory review over the topic you just wrote, **before** the dry run and
+push. This surfaces authoring issues the maker should consider — dangling
+`Global.*` references, adaptive-card bindings that render blank, Power Fx logic
+problems, and integration-pattern gaps — while the topic is still easy to change.
+
+**When the maker runs `/create` directly, running this review is mandatory — do
+not skip it.** The review's *findings*, however, are advisory: present them and
+let the maker decide; never refuse to proceed or treat a finding as a hard
+failure. Do NOT continue to 6.6 until the review has run and its report is
+displayed.
+
+**Exception — invoked by the Workday setup flow.** When this skill is being run
+as the P6.1 authoring delegation of
+`src/skills/setup/workday/create-new-topic.md`, **do NOT run this review sub-step
+at all**. The tenant reference IDs aren't wired yet at that point, so a review
+now would false-flag unresolved placeholders; the setup flow runs its one and
+only topic review after the wiring is verified (its S6.3). Run this review
+normally only when `/create` is invoked directly by the maker.
+
+1. Invoke the review by calling `runSubagent` (the VS Code Copilot Chat tool) —
+   do not run its detectors yourself. Point the subagent to read
+   `src/skills/topics/review/SKILL.md` as its first action, and tell it this is a
+   **single-topic** review of the topic you just created — pass the agent slug
+   (from `.local/config.json`) and the topic stem (the filename without
+   `.mcs.yml`). Ask it to present the **maker-facing report** (its Step 9), not
+   structured findings.
+
+2. **Display the subagent's full report verbatim** in the chat — the verdict line,
+   the findings table, and the close. Do NOT summarize, compress, or re-word it.
+
+3. **If the report lists findings**, pause and ask the maker how to proceed:
+   - **Fix now** → run `/update` on the topic to apply the fixes (it reads the
+     review's findings catalog), then re-run this review before continuing.
+   - **Push anyway** → continue to 6.6 with the findings unaddressed (they are
+     advisory).
+
+   Do NOT continue to the dry run until the maker has chosen.
+
+4. **If the report is clean** (no findings), say so briefly and continue to 6.6.
+
+**If the review can't run** (the subagent or its detector scripts fail), tell the
+maker the review was skipped, then continue to 6.6 — a review failure never blocks
+the push.
+
+### 6.6 — Dry run
 
 Run in the terminal:
 
@@ -240,7 +286,7 @@ will be created, modified, or deleted in their environment. Example:
 > |--------|------|
 > | ➕ New | topics/SubmitITSupportTicket.mcs.yml |
 
-### 6.6 — Push
+### 6.7 — Push
 
 Ask the user: "Ready to push to your environment?"
 
@@ -260,7 +306,7 @@ local baseline and component map.
   - **Revert** — `python scripts/checkpoint.py --revert` to restore the
     backup from step 6.1
 
-### 6.7 — Verify and link
+### 6.8 — Verify and link
 
 After a successful push, show the user what was created:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -261,6 +261,11 @@ the **Issue detail view**. Follow those templates verbatim and apply the **Speak
 instead return the **structured** findings — rule IDs, severity, reachability, and sites from the analysis
 guidance — so the parent can consume them programmatically. Do not prompt the maker directly.
 
+**When the parent wants the report shown to the maker** (e.g. the `/create` flow's post-write review at its
+step 6.5): present the normal **maker-facing report** (Step 9) instead of structured findings, so the parent
+can display it verbatim. The parent signals which output it needs when it invokes you; default to the
+maker-facing report when it is unspecified but the review is scoped to a single just-authored topic.
+
 ## Scoped review (a whole module)
 
 If Step 1 resolved to a **module scope** (all topics for a backend), follow

--- a/tests/flightcheck/checks/test_workday_saml_certificate.py
+++ b/tests/flightcheck/checks/test_workday_saml_certificate.py
@@ -15,7 +15,8 @@ is fully automatable). It then emits one of:
   * WARNING — active cert expiring within CERT_EXPIRY_WARN_DAYS or
     NotBefore is still in the future.
   * MANUAL — active cert is healthy; operator must compare the
-    thumbprint against Workday's "Edit Tenant Setup - Security ->
+    certificate (validity dates, or an externally-computed SHA-1
+    thumbprint) against Workday's "Edit Tenant Setup - Security ->
     SAML Identity Providers" row because that is not exposed via any
     Workday API the kit talks to.
 
@@ -176,8 +177,9 @@ class TestHealthyCertManual:
 
         assert r.status == "Manual"
         assert r.priority == "High"
-        # Result text should surface the colon-hex thumbprint so the
-        # operator can compare it byte-for-byte against Workday's view.
+        # Result text should surface the colon-hex Entra thumbprint
+        # so the operator can compute the Workday cert's SHA-1 and
+        # compare against it (Workday itself shows no thumbprint).
         assert _expected_thumbprint_for("cert-healthy-1") in r.result
         # SAML entity ID (Workday "Service Provider ID" join key) is
         # what lets the operator pick the right Entra app.
@@ -187,7 +189,12 @@ class TestHealthyCertManual:
         assert "Service Provider ID" in r.remediation
         assert "Step 2" in r.remediation
         assert "X509 Certificate" in r.remediation
-        assert "match exactly" in r.remediation
+        # Workday exposes no thumbprint — the compare must be by
+        # validity dates or an externally-computed SHA-1, NOT by a
+        # thumbprint Workday supposedly displays.
+        assert "Valid From" in r.remediation
+        assert "SHA-1" in r.remediation
+        assert "does NOT" in r.remediation
 
 
 class TestSignVerifyCoalescing:

--- a/tests/scripts/test_install_ootb_topics.py
+++ b/tests/scripts/test_install_ootb_topics.py
@@ -1,0 +1,193 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for solutions/ess-maker-skills/scripts/install_ootb_topics.py.
+
+Pure-logic, no network (see tests/AGENTS.md — pure-logic helpers are exempt
+from the cassette rule). These pin the behaviour that fixes the two bugs that
+broke the optional OOTB Workday topics installer:
+
+  1. Filenames must be clean PascalCase (no mangled "w-or-kd-ay-*" slugs).
+  2. The installer must write TOPICS ONLY — never template-configs, which are
+     managed components delivered by the Workday extension pack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import install_ootb_topics as ioot
+
+
+# --- naming (mangling prevention) -----------------------------------------
+
+class TestTopicBasename:
+    def test_strips_hyphens_to_pascalcase(self):
+        assert ioot.topic_basename(
+            "WorkdayManagersdirect-CompanyCode"
+        ) == "WorkdayManagersdirectCompanyCode"
+
+    def test_pascalcase_preserved(self):
+        assert ioot.topic_basename(
+            "WorkdayGetUserProfile") == "WorkdayGetUserProfile"
+
+    def test_result_is_alphanumeric_only(self):
+        for name in ("Weird Name!", "a-b-c", "Manager_Direct.Code"):
+            out = ioot.topic_basename(name)
+            assert out.isalnum(), f"{name!r} -> {out!r} not alnum"
+            assert "-" not in out
+
+
+# --- substitutions ---------------------------------------------------------
+
+class TestRewriteTopic:
+    def test_schema_prefix_repointed_for_all_topic_refs(self):
+        content = (
+            "dialog: msdyn_copilotforemployeeselfservicehr.topic."
+            "WorkdaySystemGetCommonExecution\n"
+            "other: msdyn_copilotforemployeeselfservicehr.topic."
+            "GetReferenceData\n"
+        )
+        out = ioot.rewrite_topic(content, "msdyn_myagentschema", "tenantX")
+        assert "msdyn_myagentschema.topic.WorkdaySystemGetCommonExecution" in out
+        # The non-Workday-prefixed shared topic is repointed too.
+        assert "msdyn_myagentschema.topic.GetReferenceData" in out
+        assert "msdyn_copilotforemployeeselfservicehr.topic." not in out
+
+    def test_tenant_placeholder_replaced(self):
+        out = ioot.rewrite_topic("host: <TENANT_NAME>.workday.com",
+                                 "s", "microsoft_dpt6")
+        assert out == "host: microsoft_dpt6.workday.com"
+
+    def test_no_tenant_leaves_placeholder(self):
+        out = ioot.rewrite_topic("host: <TENANT_NAME>", "s", None)
+        assert out == "host: <TENANT_NAME>"
+
+    def test_noop_when_prefix_matches(self):
+        content = ("dialog: msdyn_copilotforemployeeselfservicehr.topic."
+                   "WorkdayManagerCheck\n")
+        out = ioot.rewrite_topic(
+            content, "msdyn_copilotforemployeeselfservicehr", "t")
+        assert out == content
+
+
+# --- discovery / selection against the vendored samples --------------------
+
+class TestDiscover:
+    def test_finds_employee_and_manager_scenarios(self):
+        found = ioot.discover()
+        cats = {s["category"] for s in found}
+        assert cats == {"employee", "manager"}
+        # Every discovered scenario yields an alphanumeric base name.
+        for s in found:
+            assert s["basename"].isalnum()
+
+    def test_known_scenario_present_with_clean_name(self):
+        found = ioot.discover()
+        by_folder = {s["folder"]: s for s in found}
+        assert "WorkdayManagersdirect-CompanyCode" in by_folder
+        assert (by_folder["WorkdayManagersdirect-CompanyCode"]["basename"]
+                == "WorkdayManagersdirectCompanyCode")
+
+
+class TestSelect:
+    def _sample(self):
+        return [
+            {"category": "employee", "folder": "WorkdayGetUserProfile",
+             "basename": "WorkdayGetUserProfile", "topic_src": "x"},
+            {"category": "manager", "folder": "WorkdayManagersdirect-CostCenter",
+             "basename": "WorkdayManagersdirectCostCenter", "topic_src": "y"},
+        ]
+
+    def test_by_category(self):
+        out = ioot.select(self._sample(), categories=["manager"])
+        assert [s["folder"] for s in out] == ["WorkdayManagersdirect-CostCenter"]
+
+    def test_by_name_matches_folder_or_basename_loosely(self):
+        out = ioot.select(self._sample(),
+                          names=["workdaymanagersdirectcostcenter"])
+        assert len(out) == 1
+        out2 = ioot.select(self._sample(),
+                           names=["WorkdayManagersdirect-CostCenter"])
+        assert len(out2) == 1
+
+    def test_no_filter_returns_all(self):
+        assert len(ioot.select(self._sample())) == 2
+
+
+# --- install (topics only, idempotent) -------------------------------------
+
+def _fake_samples(root: Path):
+    """Build a minimal samples tree so install tests stay hermetic."""
+    emp = (root / "src" / "examples" / "ess-samples" / "Workday"
+           / "EmployeeScenarios" / "WorkdayGetUserProfile")
+    emp.mkdir(parents=True)
+    (emp / "topic.yaml").write_text(
+        "kind: AdaptiveDialog\n"
+        "dialog: msdyn_copilotforemployeeselfservicehr.topic."
+        "WorkdaySystemGetCommonExecution\n"
+        "host: <TENANT_NAME>.workday.com\n"
+    )
+    # A stray template-config XML that must NOT be copied by the installer.
+    (emp / "msdyn_HRWorkdayHCMEmployeeGetUserProfile.xml").write_text(
+        '<scenario name="msdyn_HRWorkdayHCMEmployeeGetUserProfile"/>')
+    return root
+
+
+class TestInstall:
+    def test_writes_topic_only_with_substitutions(self, tmp_path: Path):
+        _fake_samples(tmp_path)
+        agent = tmp_path / "agent"
+        agent.mkdir()
+        selected = ioot.discover(str(tmp_path))
+        result = ioot.install(selected, str(agent),
+                              "msdyn_myschema", "acme_dpt")
+
+        assert result["written"] == [
+            "topics/WorkdayGetUserProfile.mcs.yml"]
+        written = (agent / "topics" / "WorkdayGetUserProfile.mcs.yml").read_text()
+        assert "msdyn_myschema.topic.WorkdaySystemGetCommonExecution" in written
+        assert "acme_dpt.workday.com" in written
+        # TOPICS ONLY: no template-configs directory is ever created.
+        assert not (agent / "template-configs").exists()
+
+    def test_idempotent_skips_existing(self, tmp_path: Path):
+        _fake_samples(tmp_path)
+        agent = tmp_path / "agent"
+        agent.mkdir()
+        selected = ioot.discover(str(tmp_path))
+        ioot.install(selected, str(agent), "s", "t")
+        again = ioot.install(selected, str(agent), "s", "t")
+        assert again["written"] == []
+        assert again["skipped"][0]["basename"] == "WorkdayGetUserProfile"
+
+    def test_skips_when_present_in_baseline(self, tmp_path: Path):
+        _fake_samples(tmp_path)
+        agent = tmp_path / "agent"
+        base = agent / ".baseline" / "topics"
+        base.mkdir(parents=True)
+        (base / "WorkdayGetUserProfile.mcs.yml").write_text("existing")
+        selected = ioot.discover(str(tmp_path))
+        result = ioot.install(selected, str(agent), "s", "t")
+        assert result["written"] == []
+
+    def test_dry_run_writes_nothing(self, tmp_path: Path):
+        _fake_samples(tmp_path)
+        agent = tmp_path / "agent"
+        agent.mkdir()
+        selected = ioot.discover(str(tmp_path))
+        result = ioot.install(selected, str(agent), "s", "t", dry_run=True)
+        assert result["written"] == ["topics/WorkdayGetUserProfile.mcs.yml"]
+        assert not (agent / "topics").exists()
+
+
+class TestWriteManifest:
+    def test_manifest_contents(self, tmp_path: Path):
+        manifest = tmp_path / "m.txt"
+        ioot.write_manifest(str(manifest),
+                            ["topics/A.mcs.yml", "topics/B.mcs.yml"])
+        lines = manifest.read_text().splitlines()
+        assert "topics/A.mcs.yml" in lines
+        assert "topics/B.mcs.yml" in lines
+        # First line is a comment header.
+        assert lines[0].startswith("#")

--- a/tests/scripts/test_push_scope.py
+++ b/tests/scripts/test_push_scope.py
@@ -1,0 +1,173 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the --only / --only-from scoping added to scripts/push.py.
+
+Pure-logic, no network. The most important guard here is
+``update_baseline_scoped``: a scoped push must refresh ONLY the pushed files'
+baseline entries. If it refreshed the whole baseline it would silently mark
+unpushed working-tree changes as "pushed", so the next /push would never
+retry them — a correctness bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import push
+
+
+class TestParseOnlyGlobs:
+    def test_repeated_only_flags(self):
+        argv = ["--only", "topics/A.mcs.yml", "--only", "topics/B.mcs.yml"]
+        assert push.parse_only_globs(argv) == [
+            "topics/A.mcs.yml", "topics/B.mcs.yml"]
+
+    def test_equals_form(self):
+        assert push.parse_only_globs(["--only=topics/*.mcs.yml"]) == [
+            "topics/*.mcs.yml"]
+
+    def test_backslashes_normalised(self):
+        assert push.parse_only_globs(["--only", "topics\\A.mcs.yml"]) == [
+            "topics/A.mcs.yml"]
+
+    def test_no_flags_is_empty(self):
+        assert push.parse_only_globs(["--dry-run", "--yes"]) == []
+
+    def test_only_from_file(self, tmp_path: Path):
+        manifest = tmp_path / "m.txt"
+        manifest.write_text(
+            "# a comment\n"
+            "topics/A.mcs.yml\n"
+            "\n"
+            "template-configs\\X.xml\n"
+        )
+        globs = push.parse_only_globs(["--only-from", str(manifest)])
+        assert globs == ["topics/A.mcs.yml", "template-configs/X.xml"]
+
+
+class TestMatchesOnly:
+    def test_empty_globs_matches_everything(self):
+        assert push.matches_only("anything/at/all.yml", []) is True
+
+    def test_exact_path(self):
+        assert push.matches_only("topics/A.mcs.yml", ["topics/A.mcs.yml"])
+        assert not push.matches_only("topics/B.mcs.yml", ["topics/A.mcs.yml"])
+
+    def test_wildcard(self):
+        assert push.matches_only("topics/A.mcs.yml", ["topics/*.mcs.yml"])
+        assert not push.matches_only(
+            "workflows/f/workflow.json", ["topics/*.mcs.yml"])
+
+    def test_backslash_path_normalised(self):
+        assert push.matches_only("topics\\A.mcs.yml", ["topics/A.mcs.yml"])
+
+
+class TestUpdateBaselineScoped:
+    def _agent(self, tmp_path: Path) -> Path:
+        agent = tmp_path / "agent"
+        (agent / "topics").mkdir(parents=True)
+        (agent / ".baseline" / "topics").mkdir(parents=True)
+        return agent
+
+    def test_only_scoped_file_is_refreshed(self, tmp_path: Path):
+        agent = self._agent(tmp_path)
+        # A: changed and IN scope -> baseline should update to new content.
+        (agent / "topics" / "A.mcs.yml").write_text("new-A")
+        (agent / ".baseline" / "topics" / "A.mcs.yml").write_text("old-A")
+        # B: new and OUT of scope -> baseline must NOT gain B.
+        (agent / "topics" / "B.mcs.yml").write_text("new-B")
+
+        push.update_baseline_scoped(str(agent), ["topics/A.mcs.yml"])
+
+        assert (agent / ".baseline" / "topics" / "A.mcs.yml").read_text() == "new-A"
+        assert not (agent / ".baseline" / "topics" / "B.mcs.yml").exists()
+
+    def test_template_config_drags_meta_companion(self, tmp_path: Path):
+        agent = self._agent(tmp_path)
+        (agent / "template-configs").mkdir()
+        (agent / "template-configs" / "X.xml").write_text("<x/>")
+        (agent / "template-configs" / "X.meta.json").write_text("{}")
+
+        push.update_baseline_scoped(str(agent), ["template-configs/X.xml"])
+
+        b = agent / ".baseline" / "template-configs"
+        assert (b / "X.xml").read_text() == "<x/>"
+        assert (b / "X.meta.json").read_text() == "{}"
+
+    def test_scoped_delete_removes_from_baseline(self, tmp_path: Path):
+        agent = self._agent(tmp_path)
+        # C exists only in baseline (deleted from working) and is in scope.
+        (agent / ".baseline" / "topics" / "C.mcs.yml").write_text("old-C")
+        # D exists only in baseline but is OUT of scope -> must remain.
+        (agent / ".baseline" / "topics" / "D.mcs.yml").write_text("old-D")
+
+        push.update_baseline_scoped(str(agent), ["topics/C.mcs.yml"])
+
+        assert not (agent / ".baseline" / "topics" / "C.mcs.yml").exists()
+        assert (agent / ".baseline" / "topics" / "D.mcs.yml").exists()
+
+
+class _FakeResp:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+class _FakeHTTPError(Exception):
+    """Mimics requests.HTTPError: carries a .response with a status_code."""
+
+    def __init__(self, status_code: int):
+        super().__init__(f"HTTP {status_code}")
+        self.response = _FakeResp(status_code)
+
+
+class _FakeAuth:
+    def __init__(self):
+        self.token = "tok"
+
+    def refresh(self):
+        self.token = "tok2"
+        return self.token
+
+
+class TestVerifyBotExists:
+    """Pre-flight guard: a stale botId must fail fast with the real cause,
+    not the misleading "solution may not be deployed" 404 the friendly error
+    layer would otherwise emit for every component."""
+
+    def test_missing_bot_exits_with_actionable_message(self, monkeypatch, capsys):
+        def boom(env_url, token, path, params=None):
+            raise _FakeHTTPError(404)
+
+        monkeypatch.setattr(push, "dataverse_get", boom)
+        with pytest.raises(SystemExit) as exc:
+            push._verify_bot_exists(
+                _FakeAuth(), "https://x.crm.dynamics.com", "bad-bot")
+        assert exc.value.code == 2
+        out = capsys.readouterr().out
+        assert "does not exist in this environment" in out
+        assert "/setup" in out
+        assert "bad-bot" in out
+
+    def test_existing_bot_passes_and_targets_right_path(self, monkeypatch):
+        seen = {}
+
+        def ok(env_url, token, path, params=None):
+            seen["path"] = path
+            return {"botid": "good-bot"}
+
+        monkeypatch.setattr(push, "dataverse_get", ok)
+        push._verify_bot_exists(
+            _FakeAuth(), "https://x.crm.dynamics.com", "good-bot")
+        assert seen["path"] == "bots(good-bot)"
+
+    def test_non_404_error_propagates(self, monkeypatch):
+        def boom(env_url, token, path, params=None):
+            raise _FakeHTTPError(500)
+
+        monkeypatch.setattr(push, "dataverse_get", boom)
+        with pytest.raises(_FakeHTTPError):
+            push._verify_bot_exists(
+                _FakeAuth(), "https://x.crm.dynamics.com", "any")

--- a/tests/setup/test_checklist_template.py
+++ b/tests/setup/test_checklist_template.py
@@ -41,13 +41,13 @@ _EXPECTED_STEPS = {
     "S3.1", "S3.2", "S3.3", "S3.4", "S3.5", "S3.6", "S3.7",
     "S4.1", "S4.2", "S4.3", "S4.4",
     "S5.1", "S5.2", "S5.3", "S5.4", "S5.5", "S5.6", "S5.7", "S5.8",
-    "S6.1", "S6.2",
+    "S6.1", "S6.2", "S6.3",
 }
 
 _METADATA_KEYS = {
     "id", "role", "skill", "automatable", "checkpoints", "gate", "status",
 }
-_VALID_GATES = {"prog", "manual", "attest"}
+_VALID_GATES = {"prog", "manual", "attest", "advisory"}
 _STEP_RE = re.compile(r"^S\d+\.\d+$")
 # Upper-case checkpoint tokens, optionally a "-*" family suffix.
 _CKPT_RE = re.compile(r"[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*(?:-\*)?")
@@ -119,6 +119,15 @@ class TestChecklistTemplate:
         failures = []
         for meta in _parse_items():
             step = meta["id"]
+            # Advisory rows (e.g. the S6.3 topic review) carry no flightcheck
+            # checkpoint — their cell is a literal "n/a" sentinel — so they are
+            # exempt from checkpoint-token resolution.
+            if re.match(r"[a-z]+", meta["gate"]).group(0) == "advisory":
+                assert meta["checkpoints"] == "n/a", (
+                    f"{step}: advisory row must seed checkpoints 'n/a', "
+                    f"got {meta['checkpoints']!r}"
+                )
+                continue
             checkpoint_cell = meta["checkpoints"]
             tokens = _CKPT_RE.findall(checkpoint_cell)
             assert tokens, f"{step}: no checkpoint token in {checkpoint_cell!r}"

--- a/tests/setup/test_setup_router.py
+++ b/tests/setup/test_setup_router.py
@@ -50,6 +50,10 @@ _SKILL6 = (
     _SOLUTION / "src" / "skills" / "setup" / "workday"
     / "create-new-topic.md"
 )
+_OOTB = (
+    _SOLUTION / "src" / "skills" / "setup" / "workday"
+    / "install-workday-ootb-topics.md"
+)
 
 # Backtick-quoted repo-relative markdown paths the router points at.
 _PATH_RE = re.compile(r"`(src/skills/[^`]+?\.md)`")
@@ -145,11 +149,62 @@ class TestSetupRouter:
         text = _ROUTER.read_text(encoding="utf-8")
         assert (
             "src/skills/setup/workday/create-new-topic.md" in text
-        ), "router must dispatch S6.1-S6.2 to the skill-6 create-new-topic playbook"
+        ), "router must dispatch S6.1-S6.3 to the skill-6 create-new-topic playbook"
         assert _SKILL6.is_file(), f"missing skill-6 playbook: {_SKILL6}"
         # skill-6 is the last skill: the not-available-yet stub must be gone.
         assert "not available yet" not in text, (
             "router must not carry a not-available-yet stub once skill-6 is wired"
+        )
+
+    def test_router_offers_optional_ootb_topics_between_skill5_and_skill6(self):
+        # The optional ready-made-topics installer is offered after skill-5 and
+        # before skill-6. It is an opt-in interstitial (not a tracked S-row),
+        # gated by ootbTopics.state so a resumed setup never re-prompts.
+        text = _ROUTER.read_text(encoding="utf-8")
+        assert (
+            "src/skills/setup/workday/install-workday-ootb-topics.md" in text
+        ), "router must offer the optional OOTB-topics installer playbook"
+        assert _OOTB.is_file(), f"missing OOTB installer playbook: {_OOTB}"
+        assert "ootbTopics" in text, (
+            "router must gate the optional offer on ootbTopics.state so it is "
+            "not re-prompted after install/decline"
+        )
+        # The offer must sit between the skill-5 and skill-6 dispatch blocks.
+        pack_idx = text.index("install-workday-extension-pack.md")
+        ootb_idx = text.index("install-workday-ootb-topics.md")
+        create_idx = text.index("create-new-topic.md")
+        assert pack_idx < ootb_idx < create_idx, (
+            "the OOTB-topics offer must appear after the skill-5 dispatch and "
+            "before the skill-6 dispatch"
+        )
+
+    def test_ootb_offer_gated_on_persistent_state_not_transient_resume(self):
+        # Regression: the offer used to be gated on the transient "first
+        # non-done row is S6.1" resume condition, so once S6 completed the
+        # offer was never shown again and was silently skipped in the S5->S6
+        # handoff. It must instead be anchored to the persistent
+        # ootbTopics.state flag in two places: (1) a gate at the S6 dispatch
+        # entry (runs before skill-6), and (2) an All-done safety net for a
+        # setup that reached S6 before the offer was ever shown.
+        text = _ROUTER.read_text(encoding="utf-8")
+
+        # (1) The S6 dispatch block gates on ootbTopics.state BEFORE it reads
+        # the skill-6 playbook.
+        s6_idx = text.index("### S6.1 through S6.3")
+        create_idx = text.index("create-new-topic.md")
+        s6_gate = text[s6_idx:create_idx]
+        assert "ootbTopics.state" in s6_gate, (
+            "the S6 dispatch block must run the OOTB offer gated on "
+            "ootbTopics.state BEFORE reading create-new-topic.md, so the offer "
+            "cannot be skipped in the S5->S6 handoff"
+        )
+
+        # (2) The All-done path rescues a setup that never saw the offer.
+        done_idx = text.index("If **every** item is `done`")
+        assert "ootbTopics" in text[done_idx:done_idx + 600], (
+            "the All-done path must run the OOTB offer as a safety net when "
+            "ootbTopics.state is unset, so a setup that reached S6 before the "
+            "offer was shown still gets it"
         )
 
     def test_router_renders_from_template(self):
@@ -192,8 +247,8 @@ class TestSetupRouter:
         titles = re.findall(
             r"^- \[[ xX]\]\s+\*\*(.+?)\*\*\s+\u2014", template, re.MULTILINE
         )
-        assert len(titles) == 24, (
-            f"expected 24 item titles in template, parsed {len(titles)}"
+        assert len(titles) == 25, (
+            f"expected 25 item titles in template, parsed {len(titles)}"
         )
         missing_titles = [t for t in titles if t not in router]
         assert not missing_titles, (


### PR DESCRIPTION
## Summary

A batch of reliability, correctness, and UX improvements to the ESS Maker Kit's
Workday setup flow, FlightCheck, and push tooling. The changes are logically
independent and could be split, but are shipped together here.

## What's included

### 1. Advisory topic review wired into setup and create flows
- New tracked checklist row **S6.3** (`advisory` gate) runs `/review` over the
  finished topic **after** `TOPIC-TRIGGER-*` and `TOPIC-INTEGRATION-*` pass and
  the topic is fully wired (setup step **P6.5**). It surfaces the report in chat
  verbatim and never blocks setup.
- Standalone `/create` gains the same review at **step 6.5**.
- Enforced by an always-loaded `runSubagent` directive in
  `.github/copilot-instructions.md`; the premature P6.1 authoring-time review is
  explicitly suppressed (IDs aren't wired yet, so it would false-flag).
- New `advisory` gate documented in `checklist-updater.md` / `config-schema.md`
  and guarded by `tests/setup/`.
- Files: `topics/create/SKILL.md`, `topics/review/SKILL.md`,
  `setup/workday/create-new-topic.md`, `setup/SKILL.md`, `setup/workday/tasks.md`,
  shared `checklist-updater.md` / `config-schema.md`, `validation-matrix.md`.

### 2. Surface MANUAL checkpoint results in chat (no browser popup)
- Single-checkpoint FlightCheck runs now print the full MANUAL verification steps
  inline instead of opening `report.html`; full runs auto-open the report only
  when a MANUAL row exists (`flightcheck/cli.py`).
- Setup playbooks now instruct "show the checkpoint result in chat first" per
  `checklist-updater.md` §U.0–U.0a before any attestation
  (`provision-power-platform-environment.md`, `provision-workday-entra-app.md`,
  `configure-workday-tenant.md`, `install-ess.md`).

### 3. `az rest` Windows encoding fix
- The Dataverse role-check URL used raw parentheses `systemusers({id})`, which
  breaks on Windows (the `az` launcher is a `cmd.exe` batch wrapper — a raw `)`
  fails with "was unexpected at this time"). Now percent-encoded
  `systemusers%28{id}%29` (with `%24select`) across all 4 playbooks that use it.

### 4. skill-2: remove redundant re-check
- When the ESS solution is already installed, the P2.1 pre-check pass now records
  the row directly instead of re-running the identical `ESS-SOLN-001` checkpoint
  in P2.2 (`install-ess.md`).

### 5. Optional OOTB Workday topics installer
- New deterministic `scripts/install_ootb_topics.py` copies vendored sample
  Workday topics (TOPICS ONLY — managed template-configs are excluded) with
  kit-convention filenames, removing the assistant from the file-naming loop
  (which produced mangled slugs). Offered between skill-5 and skill-6.
- Files: `install_ootb_topics.py`, `setup/workday/install-workday-ootb-topics.md`,
  `role-gating.md`, `setup/SKILL.md` router offer.

### 6. push.py: scoped push + stale-botId pre-flight
- `--only <glob>` (repeatable) / `--only-from <file>` scope a push and refresh
  only the matching baseline entries (`update_baseline_scoped`), so unscoped
  pending changes stay pending.
- New `_verify_bot_exists` pre-flight surfaces a stale/mismatched `botId` (404)
  with a clear message instead of the misleading "could not find agent
  components / solution not deployed".

### 7. Windows deep-path (MAX_PATH) robustness
- `windows_long_path()` helper + shorter extraction slugs (hash-suffixed) so
  checkpoint/baseline copies survive deep OneDrive-backed workspaces
  (`checkpoint.py`, `setup.py`; also fixes an `onexc`→`onerror` regression).

### 8. WD-CONN-102 SAML certificate: no-thumbprint comparison
- Workday's X509 Public Key object exposes no thumbprint, only Name / Valid From
  / Valid To / Base64 body. The MANUAL remediation now compares via validity
  dates or an externally-computed SHA-1 (PowerShell/openssl), and the skill-4
  wording/questions follow suit (`flightcheck/checks/workday.py`,
  `remediation-guide.md`, `configure-workday-tenant.md`,
  `test_workday_saml_certificate.py`).

### 9. Doc clarifications
- `connection-fields.md`: distinguish the Application ID URI (`api://{appId}`)
  from the connection's "Microsoft Entra resource URL"
  (`http://www.workday.com/{tenant}`).

## Testing
- `pytest tests/setup/` → green (structural guards updated for S6.3 + `advisory`
  gate + the new checklist row/count).
- Also run the touched suites:
  `pytest tests/setup tests/scripts/test_push_scope.py tests/scripts/test_install_ootb_topics.py tests/flightcheck/checks/test_workday_saml_certificate.py -q`