### PR TITLE
Emit tenant_name on all ADK events + connect telemetry for single-checkpoint runs

### DIFF
--- a/setup/Install-EssAdk.Tests.ps1
+++ b/setup/Install-EssAdk.Tests.ps1
@@ -304,6 +304,15 @@ Test 'Install-EssAdk.ps1 records success on the normal path, not in finally' {
         throw "finally must not force a 'success' outcome (mislabels Ctrl+C)"
     }
 }
+Test 'Install-EssAdk.ps1 records success for a FlightCheck-only install before its early return' {
+    # Regression: the FlightCheck-only branch returns from inside the top-level
+    # try before the normal-path success emit, so it must emit its own success
+    # completion. Otherwise the finally net mislabels it 'cancelled' and the
+    # Installer Outcomes / by-Platform tiles never receive a real completion.
+    if ($src -notmatch "(?s)Python not found\..*?Complete-EssInstallTelemetry -Outcome 'success'\s*\r?\n[^}]*?return") {
+        throw "FlightCheck-only branch must emit a 'success' completion before its early return"
+    }
+}
 Test 'PS emitter uses a short send timeout and trips a circuit breaker on failure' {
     $emitterSrc = Get-Content $psEmitter -Raw
     if ($emitterSrc -notmatch 'TimeoutSec 3') { throw 'PS emitter should use a short (3s) send timeout' }

--- a/setup/Install-EssAdk.ps1
+++ b/setup/Install-EssAdk.ps1
@@ -1101,6 +1101,16 @@ if ($FlightCheckOnly) {
         Write-Warn2 "  cd $workspace"
         Write-Warn2 '  python scripts/flightcheck/cli.py --scope full'
     }
+    # Record the FlightCheck-only install as a success HERE, before the early
+    # return below. This branch returns from inside the top-level try well
+    # before the normal-path success emit at the end, so without this the run
+    # has no completion event and the finally net mislabels a successful
+    # FlightCheck-only install as 'cancelled' -- leaving the Installer Outcomes
+    # / by-Platform tiles (both Complete-fed) empty while Attempts (Start-fed)
+    # keeps climbing. Idempotent: the finally's 'cancelled' is a no-op once any
+    # outcome has been emitted. (The FlightCheck run's own pass/fail verdict is
+    # separate telemetry emitted by cli.py; this outcome is the install's.)
+    Complete-EssInstallTelemetry -Outcome 'success'
     # ``return`` (not ``exit 0``) so the script ends without terminating
     # the PowerShell host. When this installer is invoked via
     # ``iex (irm .../bootstrap-flightcheck.ps1)`` from an interactive

--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -218,6 +218,12 @@ def set_identity(
     )
     _IDENTITY["tenant_id"] = tenant_id or ""
     _IDENTITY["tenant_name"] = tenant_name or ""
+    # When a Graph-capable flow (FlightCheck) resolves the org display name,
+    # persist it so ADK events emitted later in a *different* process (which
+    # only has a Dataverse/BAP token and can't resolve it) can reuse it. The
+    # cache is keyed by tenant_id in flightcheck.telemetry.cache_tenant_name.
+    if tenant_name:
+        _fc.cache_tenant_name(_IDENTITY["tenant_id"], tenant_name)
     return dict(_IDENTITY)
 
 
@@ -368,6 +374,12 @@ def common_dimensions(
     """Build the dimensions present on every event (spec Common Dimensions)."""
     tid = _IDENTITY["tenant_id"] if tenant_id is None else tenant_id
     tname = _IDENTITY["tenant_name"] if tenant_name is None else tenant_name
+    # Fall back to the org display name a prior Graph-capable run (FlightCheck)
+    # cached for THIS tenant, so pure-ADK events (session/build/deploy/
+    # capability/api) — which can't resolve it live — still carry it. Keyed by
+    # tenant_id, so a name cached for another tenant is never reused here.
+    if not tname:
+        tname = _fc.get_cached_tenant_name(tid or "")
     return {
         "schema_version": SCHEMA_VERSION,
         "instance_id": (

--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -243,10 +243,25 @@ def authenticate(env_url):
         import adk_telemetry
 
         claims = result.get("id_token_claims", {}) or {}
+        tenant_id = claims.get("tid", "") or tenant
         adk_telemetry.maybe_print_notice()
         adk_telemetry.start_session(
-            tenant_id=claims.get("tid", "") or tenant,
+            tenant_id=tenant_id,
         )
+        # Best-effort: resolve the tenant's org display name via a SILENT-ONLY
+        # Graph token (never prompts) and record it so ADK telemetry carries
+        # tenant_name even when the maker never runs FlightCheck. The Dataverse
+        # sign-in above usually leaves a first-party (FOCI) refresh token that
+        # silently satisfies the read scope; set_identity caches the name for
+        # later ADK processes. Silent failure just leaves tenant_name empty.
+        try:
+            from flightcheck.graph_client import resolve_tenant_display_name_silent
+
+            _tname = resolve_tenant_display_name_silent(tenant_id)
+            if _tname:
+                adk_telemetry.set_identity(tenant_id=tenant_id, tenant_name=_tname)
+        except Exception:  # noqa: BLE001 — name resolution is best-effort
+            pass
     except Exception:  # noqa: BLE001 — telemetry must never break auth
         pass
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -339,11 +339,86 @@ def _run_single_checkpoint(args):
         print(f"\nNOTE: checkpoint {target} produced no result rows (the owning "
               "check may have skipped it for this tenant state).")
 
-    # Single-checkpoint mode never auto-opens the HTML report. Programmatic
-    # pass/fail rows AND MANUAL verification steps are both printed in full in
-    # the terminal above (see verbose_manual), so they surface directly in
-    # Copilot chat instead of a browser popup. results.json / report.html are
-    # still written to args.output for anyone who wants them.
+    # --- Emit anonymous outcome telemetry (best-effort; never affects exit) ---
+    # Single-checkpoint mode never auto-opens the HTML report; results.json /
+    # report.html are still written to args.output for anyone who wants them.
+    # Single-checkpoint runs are the "connect" invocation source: incremental
+    # FlightChecks that gate individual setup/connect steps (ADO 7587431).
+    # Without this, checkpoint runs were invisible to the Aria dashboards even
+    # though they exercise the same checks a full run does.
+    if not getattr(args, "no_telemetry", False):
+        # Explicit --invocation-source wins; otherwise checkpoint mode attributes
+        # the run to "connect" (vs "cli"/"adk"/"installer" for --scope runs).
+        _inv_source = getattr(args, "invocation_source", None) or "connect"
+        _tele_debug = os.environ.get(
+            "ESS_FLIGHTCHECK_TELEMETRY_DEBUG", ""
+        ).strip().lower() in ("1", "on", "true", "yes")
+        # Resolve the active agent from config (may be empty for Entra-only
+        # checkpoints run before /setup writes a full config).
+        _agents = config.get("agents", [])
+        if not _agents:
+            _agent_entry = config.get("agent", {})
+            if _agent_entry:
+                _agents = [_agent_entry]
+        _active = config.get("activeAgent", config.get("agent", {}).get("slug", ""))
+        _active_agent = next(
+            (a for a in _agents if a.get("slug") == _active),
+            _agents[0] if _agents else {},
+        )
+        # Best-effort tenant display name (OII; privacy-approved). Reuses the
+        # already-authenticated Graph client when one was needed; never re-auths.
+        tenant_name = ""
+        try:
+            if graph is not None:
+                tenant_name = (graph.get_organization() or {}).get("displayName", "") or ""
+        except Exception:  # noqa: BLE001 — telemetry name is best-effort
+            tenant_name = ""
+        try:
+            from flightcheck import telemetry
+
+            _tele = telemetry.emit_flightcheck_telemetry(
+                result,
+                tenant_id=tenant_id or "",
+                tenant_name=tenant_name,
+                agent_id=_active_agent.get("botId", ""),
+                scope=f"checkpoint:{target}",
+                agent_count=len(_agents),
+                invocation_source=_inv_source,
+            )
+            if _tele_debug:
+                print(
+                    f"[telemetry] env={_tele.get('env')} sent={_tele.get('sent')} "
+                    f"events={_tele.get('events')} status={_tele.get('status')} "
+                    f"reason={_tele.get('reason')}"
+                )
+        except Exception as _tele_err:  # never break the run
+            if _tele_debug:
+                print(f"[telemetry] skipped — {type(_tele_err).__name__}: {_tele_err}")
+
+        # Additive adk.* event family (spec Feature #7403772), mirroring the
+        # --scope emit so checkpoint runs also count toward the adk.* cubes.
+        try:
+            import adk_telemetry as _adk
+
+            _agent_id = _active_agent.get("botId", "")
+            if tenant_id or tenant_name:
+                _adk.set_identity(tenant_id=tenant_id or "", tenant_name=tenant_name)
+            _ridx = _adk.next_run_index(_agent_id)
+            _adk.emit_flightcheck_run(agent_id=_agent_id, run_index=_ridx)
+            _result_map = {
+                "READY": "pass",
+                "READY_WITH_WARNINGS": "partial",
+                "NOT_READY": "fail",
+            }
+            _adk.emit_flightcheck_result(
+                agent_id=_agent_id,
+                run_index=_ridx,
+                result=_result_map.get(result.overall, "fail"),
+                duration_ms=int(getattr(result, "duration_secs", 0) * 1000),
+            )
+            _adk.flush(timeout=3)
+        except Exception:  # noqa: BLE001 — adk telemetry must never break the run
+            pass
 
     sys.exit(1 if result.failed > 0 else 0)
 
@@ -396,9 +471,12 @@ def main():
         help="Don't emit anonymous FlightCheck outcome telemetry",
     )
     parser.add_argument(
-        "--invocation-source", default="cli",
-        choices=["adk", "installer", "cli"],
-        help="How FlightCheck was invoked (adk=slash-command, installer=standalone installer, cli=direct Python CLI)",
+        "--invocation-source", default=None,
+        choices=["adk", "installer", "cli", "connect"],
+        help="How FlightCheck was invoked (adk=slash-command, installer=standalone "
+             "installer, cli=direct Python CLI, connect=incremental single-checkpoint "
+             "run from a connect/setup skill). Default: cli for --scope runs, connect "
+             "for --checkpoint runs.",
     )
     args = parser.parse_args()
 
@@ -418,6 +496,12 @@ def main():
     # None on the parser so checkpoint-mode can detect an explicit --scope.)
     if args.scope is None:
         args.scope = "full"
+
+    # --invocation-source defaults to "cli" for scope-mode runs. (Default is
+    # None on the parser so checkpoint-mode can default it to "connect" instead
+    # while still honouring an explicit --invocation-source.)
+    if args.invocation_source is None:
+        args.invocation_source = "cli"
 
     # Load config
     config_path = os.path.join(".local", "config.json")

--- a/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
@@ -72,6 +72,84 @@ _SESSION = requests.Session()
 _SESSION.mount("https://", HTTPAdapter(max_retries=_RETRY))
 
 
+def _persist_token_cache(cache: "msal.SerializableTokenCache", cache_path: str) -> None:
+    """Write the MSAL cache back to disk with strict 0o600 permissions.
+
+    The cache holds MSAL refresh tokens; default umask (0o644) would expose
+    them to other users on shared dev VMs. No-op when nothing changed.
+    """
+    if not cache.has_state_changed:
+        return
+    os.makedirs(".local", exist_ok=True)
+    try:
+        os.chmod(".local", 0o700)
+    except OSError:
+        pass  # Windows ignores chmod for directories
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    fd = os.open(cache_path, flags, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(cache.serialize())
+
+
+# Minimal scope for a silent-only org-name lookup. Requesting just this one
+# read scope (rather than the full GRAPH_SCOPES set) maximizes the chance a
+# token already cached from a prior first-party (FOCI) sign-in — e.g. the
+# Dataverse login in auth.py — silently satisfies it with no prompt.
+_ORG_READ_SCOPE = ["https://graph.microsoft.com/Organization.Read.All"]
+
+
+def resolve_tenant_display_name_silent(tenant_id: str) -> str:
+    """Return the tenant's org displayName via a SILENT-ONLY Graph token.
+
+    Best-effort and strictly non-interactive: if the shared MSAL cache
+    (``.local/.token_cache.bin``) holds no token that silently satisfies
+    ``Organization.Read.All`` for this tenant, returns ``""`` instead of
+    prompting. Because the Graph CLI Tools app and the Power Platform CLI app
+    (auth.py) are first-party FOCI apps sharing that cache, a prior Dataverse
+    sign-in is usually enough for this to succeed with no second prompt.
+
+    Used by the ADK auth bootstrap so ``tenant_name`` is populated for ADK
+    telemetry even when the maker never runs FlightCheck. Returns ``""`` on any
+    error, missing account, non-200 response, or empty result.
+    """
+    if not tenant_id:
+        return ""
+    try:
+        authority = f"https://login.microsoftonline.com/{tenant_id}"
+        cache = msal.SerializableTokenCache()
+        cache_path = os.path.join(".local", ".token_cache.bin")
+        if os.path.exists(cache_path):
+            with open(cache_path, "r", encoding="utf-8") as f:
+                cache.deserialize(f.read())
+        app = msal.PublicClientApplication(
+            GRAPH_CLIENT_ID, authority=authority, token_cache=cache
+        )
+        accounts = app.get_accounts()
+        if not accounts:
+            return ""
+        result = app.acquire_token_silent(_ORG_READ_SCOPE, account=accounts[0])
+        if not result or "access_token" not in result:
+            return ""
+        # Persist any silently-refreshed token so later processes stay silent.
+        _persist_token_cache(cache, cache_path)
+        resp = _SESSION.get(
+            f"{GRAPH_BASE}/organization",
+            headers={
+                "Authorization": f"Bearer {result['access_token']}",
+                "Accept": "application/json",
+            },
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return ""
+        orgs = (resp.json() or {}).get("value", []) or []
+        return (orgs[0].get("displayName", "") if orgs else "") or ""
+    except Exception:  # noqa: BLE001 — name resolution is strictly best-effort
+        return ""
+
+
 class GraphClient:
     """Lightweight Microsoft Graph client with MSAL interactive auth."""
 
@@ -114,18 +192,7 @@ class GraphClient:
         # Persist cache with strict 0o600 permissions on POSIX. The cache
         # holds MSAL refresh tokens; default umask (0o644) would expose them
         # to other users on shared dev VMs.
-        if cache.has_state_changed:
-            os.makedirs(".local", exist_ok=True)
-            try:
-                os.chmod(".local", 0o700)
-            except OSError:
-                pass  # Windows ignores chmod for directories
-            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-            if hasattr(os, "O_BINARY"):
-                flags |= os.O_BINARY
-            fd = os.open(cache_path, flags, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(cache.serialize())
+        _persist_token_cache(cache, cache_path)
 
         self._token = result["access_token"]
         return self._token

--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -246,6 +246,59 @@ def get_instance_id(local_dir: str = ".local") -> str:
         return str(uuid.uuid4())
 
 
+# Persisted tenant display name ({tenant_id, tenant_name}) so ADK events that
+# run in a *later* process without a Microsoft Graph token (session start,
+# build, deploy, capability, api — see adk_telemetry.py) can still stamp the
+# org name. Only a Graph-capable flow (FlightCheck) can resolve it live; it
+# caches the result here and the pure-ADK paths read it back. The cache is
+# keyed by tenant_id so a name resolved for one tenant is never reused for a
+# different tenant (e.g. a maker who switches tenants between runs).
+_TENANT_NAME_FILE = ".tenant_name"
+
+
+def cache_tenant_name(
+    tenant_id: str, tenant_name: str, local_dir: str = ".local"
+) -> None:
+    """Persist the resolved org display name for reuse by later ADK events.
+
+    Best-effort: any IO error is swallowed (telemetry must never break a
+    flow). No-op when either value is empty — we only cache a real, resolved
+    ``(tenant_id, tenant_name)`` pair. ``tenant_name`` is OII (org display
+    name); it is written under the gitignored ``.local/`` dir on the maker's
+    own machine, mirroring how ``.instance_id`` is persisted.
+    """
+    if not tenant_id or not tenant_name:
+        return
+    path = os.path.join(local_dir, _TENANT_NAME_FILE)
+    try:
+        os.makedirs(local_dir, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"tenant_id": tenant_id, "tenant_name": tenant_name}, f)
+    except OSError:
+        pass
+
+
+def get_cached_tenant_name(tenant_id: str, local_dir: str = ".local") -> str:
+    """Return the cached org display name IFF it matches ``tenant_id``.
+
+    Returns ``""`` when there is no cache, the cache is unreadable/malformed,
+    or the cached tenant_id doesn't match the current one (so a name resolved
+    for a different tenant is never leaked onto this tenant's events).
+    """
+    if not tenant_id:
+        return ""
+    path = os.path.join(local_dir, _TENANT_NAME_FILE)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return ""
+    if not isinstance(data, dict) or data.get("tenant_id") != tenant_id:
+        return ""
+    name = data.get("tenant_name")
+    return name if isinstance(name, str) else ""
+
+
 def get_adk_version() -> str:
     """Best-effort ADK version string (System Metadata).
 

--- a/tests/flightcheck/test_cli_single_checkpoint.py
+++ b/tests/flightcheck/test_cli_single_checkpoint.py
@@ -35,12 +35,16 @@ def _args(
     checkpoint: str,
     tmp_path: Path,
     environment_url: str | None = None,
+    no_telemetry: bool = True,
+    invocation_source: str | None = None,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         checkpoint=checkpoint,
         environment_url=environment_url,
         environment_id=None,
         output=str(tmp_path / "out"),
+        no_telemetry=no_telemetry,
+        invocation_source=invocation_source,
     )
 
 
@@ -157,3 +161,89 @@ class TestHermeticRun:
         with pytest.raises(SystemExit) as exc:
             cli._run_single_checkpoint(_args("FAKE-001", tmp_path))
         assert exc.value.code == 1
+
+
+class TestCheckpointTelemetry:
+    """Single-checkpoint runs emit outcome telemetry attributed to the
+    ``connect`` invocation source with a ``checkpoint:<ID>`` scope (ADO
+    7587431). The emit is best-effort and never affects the exit code.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch: pytest.MonkeyPatch) -> dict:
+        """Stub both telemetry families and capture the kwargs passed to the
+        legacy ``emit_flightcheck_telemetry`` call. Returns a dict that is
+        populated with ``called`` / ``kwargs`` once the emit runs."""
+        from flightcheck import telemetry as _tele_mod
+        import adk_telemetry as _adk_mod
+
+        captured: dict = {"called": False, "kwargs": None}
+
+        def _fake_emit(run_result, **kwargs):  # noqa: ARG001
+            captured["called"] = True
+            captured["kwargs"] = kwargs
+            return {"sent": False, "events": 0, "status": None, "env": "dev", "reason": "test"}
+
+        monkeypatch.setattr(_tele_mod, "emit_flightcheck_telemetry", _fake_emit)
+        # Neutralise the adk.* family so no network / real identity is touched.
+        monkeypatch.setattr(_adk_mod, "set_identity", lambda *a, **k: None)
+        monkeypatch.setattr(_adk_mod, "next_run_index", lambda *a, **k: 1)
+        monkeypatch.setattr(_adk_mod, "emit_flightcheck_run", lambda *a, **k: None)
+        monkeypatch.setattr(_adk_mod, "emit_flightcheck_result", lambda *a, **k: None)
+        monkeypatch.setattr(_adk_mod, "flush", lambda *a, **k: None)
+        return captured
+
+    def test_emits_connect_source_and_checkpoint_scope(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _silence_output: None,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        TestHermeticRun._install_fake_plan(
+            monkeypatch, [_row("WD-ENTRA-CONSENT-001", Status.PASSED.value)]
+        )
+        captured = self._capture(monkeypatch)
+        # no_telemetry=False reaches the emit; invocation_source unset -> connect.
+        with pytest.raises(SystemExit) as exc:
+            cli._run_single_checkpoint(
+                _args("WD-ENTRA-CONSENT-001", tmp_path, no_telemetry=False)
+            )
+        assert exc.value.code == 0
+        assert captured["called"] is True
+        assert captured["kwargs"]["invocation_source"] == "connect"
+        assert captured["kwargs"]["scope"] == "checkpoint:WD-ENTRA-CONSENT-001"
+
+    def test_explicit_invocation_source_wins(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _silence_output: None,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        TestHermeticRun._install_fake_plan(
+            monkeypatch, [_row("FAKE-001", Status.PASSED.value)]
+        )
+        captured = self._capture(monkeypatch)
+        with pytest.raises(SystemExit):
+            cli._run_single_checkpoint(
+                _args("FAKE-001", tmp_path, no_telemetry=False, invocation_source="adk")
+            )
+        assert captured["kwargs"]["invocation_source"] == "adk"
+
+    def test_no_telemetry_flag_suppresses_emit(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _silence_output: None,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        TestHermeticRun._install_fake_plan(
+            monkeypatch, [_row("FAKE-001", Status.PASSED.value)]
+        )
+        captured = self._capture(monkeypatch)
+        with pytest.raises(SystemExit):
+            cli._run_single_checkpoint(
+                _args("FAKE-001", tmp_path, no_telemetry=True)
+            )
+        assert captured["called"] is False

--- a/tests/flightcheck/test_graph_client.py
+++ b/tests/flightcheck/test_graph_client.py
@@ -1,0 +1,108 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for flightcheck.graph_client.resolve_tenant_display_name_silent.
+
+The helper resolves the tenant's org displayName via a SILENT-ONLY Graph
+token so ADK telemetry can carry ``tenant_name`` even when the maker never
+runs FlightCheck. It must NEVER trigger an interactive sign-in: if the shared
+MSAL cache can't silently satisfy the read scope, it returns "" instead of
+prompting. These tests pin the silent-only contract and the best-effort
+degradation to "" on every failure mode.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flightcheck import graph_client
+
+
+@pytest.fixture(autouse=True)
+def _cwd(tmp_path, monkeypatch):
+    # Run in a scratch cwd so the real repo ./.local/.token_cache.bin is never
+    # read or written during the test.
+    monkeypatch.chdir(tmp_path)
+
+
+def _fake_app(*, accounts, silent_result):
+    app = MagicMock()
+    app.get_accounts.return_value = accounts
+    app.acquire_token_silent.return_value = silent_result
+    # Guardrail: interactive must never be reached in silent-only mode.
+    app.acquire_token_interactive.side_effect = AssertionError(
+        "silent-only resolver must not prompt interactively"
+    )
+    return app
+
+
+def _resp(status_code, payload=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = payload or {}
+    return r
+
+
+def test_empty_tenant_id_returns_empty():
+    assert graph_client.resolve_tenant_display_name_silent("") == ""
+
+
+def test_no_cached_account_returns_empty_without_prompt():
+    app = _fake_app(accounts=[], silent_result=None)
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+    app.acquire_token_silent.assert_not_called()
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_silent_token_unavailable_returns_empty_without_prompt():
+    app = _fake_app(accounts=[SimpleNamespace()], silent_result=None)
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_success_returns_display_name():
+    app = _fake_app(
+        accounts=[SimpleNamespace()], silent_result={"access_token": "tok"}
+    )
+    resp = _resp(200, {"value": [{"displayName": "Contoso Ltd"}]})
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
+         patch.object(graph_client._SESSION, "get", return_value=resp) as mock_get:
+        assert (
+            graph_client.resolve_tenant_display_name_silent("tenant-Z") == "Contoso Ltd"
+        )
+    # Requested only the minimal Organization.Read.All scope.
+    app.acquire_token_silent.assert_called_once_with(
+        graph_client._ORG_READ_SCOPE, account=app.get_accounts.return_value[0]
+    )
+    mock_get.assert_called_once()
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_non_200_response_returns_empty():
+    app = _fake_app(
+        accounts=[SimpleNamespace()], silent_result={"access_token": "tok"}
+    )
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
+         patch.object(graph_client._SESSION, "get", return_value=_resp(403)):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+
+
+def test_empty_org_list_returns_empty():
+    app = _fake_app(
+        accounts=[SimpleNamespace()], silent_result={"access_token": "tok"}
+    )
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
+         patch.object(graph_client._SESSION, "get", return_value=_resp(200, {"value": []})):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+
+
+def test_exception_is_swallowed_returns_empty():
+    with patch.object(
+        graph_client.msal, "PublicClientApplication", side_effect=RuntimeError("boom")
+    ):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -57,6 +57,20 @@ def _isolate(monkeypatch, tmp_path):
     monkeypatch.setattr(adk, "_SYNC", True)
     monkeypatch.setattr(adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""})
 
+    # Isolate the persisted tenant-name cache (.local/.tenant_name) to tmp so
+    # tests never read/write the repo's real .local dir. adk_telemetry calls
+    # these on _fc at runtime, so patching them here redirects the cache dir.
+    _cache_dir = str(tmp_path / ".local")
+    _real_cache, _real_get = _fc.cache_tenant_name, _fc.get_cached_tenant_name
+    monkeypatch.setattr(
+        _fc, "cache_tenant_name",
+        lambda tid, name, local_dir=_cache_dir: _real_cache(tid, name, local_dir=local_dir),
+    )
+    monkeypatch.setattr(
+        _fc, "get_cached_tenant_name",
+        lambda tid, local_dir=_cache_dir: _real_get(tid, local_dir=local_dir),
+    )
+
     for var in (
         "ESS_ADK_TELEMETRY",
         "ESS_ADK_TELEMETRY_SYNC",
@@ -98,9 +112,63 @@ def test_set_identity_stores_tenant_name(monkeypatch):
     # Flows into every event's common dimensions (OII; privacy-approved).
     dims = adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")
     assert dims["tenant_name"] == "Contoso"
-    # Defaults to "" when not provided.
+    # Once resolved, the name is cached per-tenant and reused by later ADK
+    # events that lack a Graph token to resolve it live (persist-and-reuse),
+    # even when set_identity is later called for the same tenant without it.
     adk.set_identity(tenant_id="tenant-Z")
-    assert adk.common_dimensions(adk.SURFACE_CLI)["tenant_name"] == ""
+    assert adk.common_dimensions(adk.SURFACE_CLI)["tenant_name"] == "Contoso"
+
+
+def test_tenant_name_empty_when_never_resolved(monkeypatch):
+    # No Graph-capable flow ever resolved a name for this tenant -> stays "".
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+    adk.set_identity(tenant_id="tenant-Z")
+    assert adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")["tenant_name"] == ""
+
+
+def test_tenant_name_cache_not_reused_across_tenants(monkeypatch):
+    # A name cached for tenant-Z must never be stamped on a different tenant's
+    # events (the cache is keyed by tenant_id). Simulates a maker who resolved
+    # tenant-Z via FlightCheck, then runs an ADK flow authenticated as tenant-Y.
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+    adk.set_identity(tenant_id="tenant-Z", tenant_name="Contoso")  # seeds cache
+    monkeypatch.setattr(
+        adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
+    )
+    adk.set_identity(tenant_id="tenant-Y")  # different tenant, no name available
+    dims = adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")
+    assert dims["tenant_id"] == "tenant-Y"
+    assert dims["tenant_name"] == ""
+
+
+def test_tenant_name_reused_by_later_process_without_identity(monkeypatch):
+    # An ADK emit path (e.g. setup.py -> emit_agent_create) that never calls
+    # set_identity should still pick up a name a prior FlightCheck run cached
+    # for the same tenant, via the common_dimensions fallback.
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+    adk.set_identity(tenant_id="tenant-Z", tenant_name="Contoso")  # FlightCheck run
+    # Later process: fresh identity, no set_identity call, but tenant_id known.
+    monkeypatch.setattr(
+        adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
+    )
+    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="tenant-Z")
+    assert dims["tenant_name"] == "Contoso"
+
+
+def test_cache_tenant_name_round_trip_and_guards(tmp_path):
+    d = str(tmp_path / "state")
+    # Round-trip for a matching tenant.
+    _fc.cache_tenant_name("tenant-Z", "Contoso", local_dir=d)
+    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=d) == "Contoso"
+    # Mismatched tenant never inherits the cached name.
+    assert _fc.get_cached_tenant_name("tenant-Y", local_dir=d) == ""
+    # Missing dir/file -> "".
+    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=str(tmp_path / "nope")) == ""
+    # Empty inputs are no-ops (nothing cached, nothing returned).
+    _fc.cache_tenant_name("", "Contoso", local_dir=d)
+    _fc.cache_tenant_name("tenant-W", "", local_dir=d)
+    assert _fc.get_cached_tenant_name("tenant-W", local_dir=d) == ""
+    assert _fc.get_cached_tenant_name("", local_dir=d) == ""
 
 
 def test_explicit_instance_id_overrides_persisted(monkeypatch):

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -164,6 +164,15 @@ def test_cache_tenant_name_round_trip_and_guards(tmp_path):
     assert _fc.get_cached_tenant_name("tenant-Y", local_dir=d) == ""
     # Missing dir/file -> "".
     assert _fc.get_cached_tenant_name("tenant-Z", local_dir=str(tmp_path / "nope")) == ""
+    # Malformed / non-dict cache content -> "" (defensive; never raises).
+    import os as _os
+    _os.makedirs(str(tmp_path / "bad"), exist_ok=True)
+    with open(str(tmp_path / "bad" / _fc._TENANT_NAME_FILE), "w", encoding="utf-8") as _f:
+        _f.write("not-json{{")
+    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=str(tmp_path / "bad")) == ""
+    with open(str(tmp_path / "bad" / _fc._TENANT_NAME_FILE), "w", encoding="utf-8") as _f:
+        _f.write("[1, 2, 3]")
+    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=str(tmp_path / "bad")) == ""
     # Empty inputs are no-ops (nothing cached, nothing returned).
     _fc.cache_tenant_name("", "Contoso", local_dir=d)
     _fc.cache_tenant_name("tenant-W", "", local_dir=d)


### PR DESCRIPTION
ADO: [7590589 — tenant_name on all charts](https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7590589) · [7587431 — connect telemetry for single-checkpoint runs](https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7587431)

## Summary

Two related telemetry improvements so **every** ADK/FlightCheck Aria tile can be filtered by tenant, and so **incremental single-checkpoint runs are no longer invisible**.

### 1. Emit `tenant_name` on all ADK events (persist-and-reuse cache)

- `flightcheck/telemetry.py`: `cache_tenant_name` / `get_cached_tenant_name` — best-effort, keyed by `tenant_id` (no cross-tenant leakage), stored in gitignored `.local/.tenant_name`.
- `adk_telemetry.py`: `set_identity` seeds the cache when a name is present; `common_dimensions` (the single choke point every `emit_*` routes through) falls back to the cache, so all ADK events carry `tenantName`.

### 2. Populate `tenant_name` at `/setup` (silent-only Graph lookup)

So the name is cached even when the maker never runs FlightCheck.

- `flightcheck/graph_client.py`: `resolve_tenant_display_name_silent(tenant_id)` — silent-only (**never** prompts), minimal `Organization.Read.All` scope, returns `""` on any failure. Factored the secure MSAL cache write into `_persist_token_cache`.
- `auth.py`: telemetry bootstrap (runs on every Dataverse sign-in incl. `/setup`) now best-effort resolves + caches the name after `start_session`. Double-wrapped so it never breaks auth.

### 3. Emit `connect` telemetry for single-checkpoint FlightCheck runs (ADO 7587431)

`cli.py --checkpoint <ID>` runs gate incremental setup/connect steps (e.g. `WD-ENTRA-CONSENT-001`) but previously emitted **no** telemetry, so they never appeared on the dashboards.

- Added a best-effort emit to `_run_single_checkpoint` mirroring the `--scope` emit (legacy `ESSMakerKit.FlightCheck.*` + `adk.*` families), gated by `--no-telemetry`, `scope=checkpoint:<ID>`. Never affects the exit code.
- Added `connect` to `--invocation-source` choices. Checkpoint-mode runs **default** to `connect` (scope runs stay `cli`), so none of the 30+ markdown call sites need editing.

No Aria cube change needed — the `invocationSource` / `tenantName` dimensions auto-enumerate new values.

### 4. Fix missing completion telemetry for FlightCheck-only Windows installs

`setup/Install-EssAdk.ps1`'s FlightCheck-only branch `return`s from inside the top-level `try` **before** the normal-path `success` completion, so a successful FlightCheck-only install never emitted an `Installer.Complete` `success` event — the `finally` net mislabeled it `cancelled` (or emitted nothing). Result: the **Installer Outcomes** and **by-Platform** tiles stayed empty while **Attempts** (Start-fed) kept incrementing.

- Emit `Complete-EssInstallTelemetry -Outcome 'success'` before the early `return` (idempotent; the `finally` `cancelled` becomes a no-op).
- Brings the Windows installer to parity with `install-ess-adk.sh`, which already records `success` explicitly before the FlightCheck-only exit.

## Testing

- New `tests/flightcheck/test_graph_client.py` (silent-only contract).
- New checkpoint-telemetry tests in `test_cli_single_checkpoint.py` (connect source + checkpoint scope, explicit source wins, `--no-telemetry` suppresses).
- New `Install-EssAdk.Tests.ps1` regression test (FlightCheck-only branch emits `success` before its early return); **43/43** installer source-assertion tests pass.
- **912 flightcheck + adk telemetry tests pass.**

## Notes

- Silent success for #2 depends on the tenant having consented to `Organization.Read.All` for the first-party Graph app; otherwise it stays empty until any interactive Graph flow runs (intended silent-only tradeoff).
- `tenant_name` is OII (privacy-approved); `tenant_id` is never persisted.

