### PR TITLE
feat(mtk): [Worker][TASK-004] | Dataverse Web API client (typed, retry, pagination)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,16 @@
       },
       "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python",
       "console": "integratedTerminal",
-      "justMyCode": false
+      "justMyCode": false,
+      "osx": {
+        "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python"
+      },
+      "linux": {
+        "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python"
+      },
+      "windows": {
+        "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/Scripts/python.exe"
+      }
     },
     {
       "name": "MTK: Run Tests (debug)",
@@ -27,7 +36,16 @@
       },
       "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python",
       "console": "integratedTerminal",
-      "justMyCode": false
+      "justMyCode": false,
+      "osx": {
+        "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python"
+      },
+      "linux": {
+        "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python"
+      },
+      "windows": {
+        "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/Scripts/python.exe"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "type": "debugpy",
       "request": "launch",
       "module": "service.mtk_orchestrator",
+      "args": ["--dev"],
       "cwd": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/src"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "MTK: Start (debug)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "service.mtk_orchestrator",
+      "cwd": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/src"
+      },
+      "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python",
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "MTK: Run Tests (debug)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["-q"],
+      "cwd": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/src"
+      },
+      "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python",
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/PIPELINES.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/PIPELINES.md
@@ -441,7 +441,7 @@ If `can_execute(context)` returns `False`, the Pipeline Engine skips the Step.
 This keeps the framework open for extension (new Steps filter on existing
 canonical models) and closed for modification (the `Component` model and
 Pipeline Engine remain unchanged when new Steps are added). Component type and
-trigger type constants are defined under `constants/`.
+trigger type constants are defined in `service/constants.py`.
 
 ---
 

--- a/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/REPOSITORY_STRUCTURE.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/03_ENGINEERING/REPOSITORY_STRUCTURE.md
@@ -59,7 +59,6 @@ tools/
     AGENTS.md
 
     src/
-        constants/
         core/
             auth/
                 token_provider.py
@@ -75,6 +74,7 @@ tools/
             utils/
         modules/
             preprocessing/
+                steps/
             migration/
                 migration_step.py
                 migration_pipeline.py
@@ -82,8 +82,10 @@ tools/
                     migration_context.py
                 steps/
             postprocessing/
+                steps/
         service/
             mtk_orchestrator.py
+            constants.py
             toolkit.py
 
     output/
@@ -164,16 +166,10 @@ Never contains:
 
 ---
 
-## constants/
+## service/constants.py
 
-Owns shared constants.
-
-Examples:
-
-* Execution Modes
-* Component Types
-* Solution Component Types
-* Configuration Keys
+Owns shared constants used across the pipeline (e.g. `SUPPORTED_MODES`).
+Imported by the orchestrator and passed to pipeline builders.
 
 Contains no executable logic.
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
@@ -229,6 +229,13 @@ task (`TASK-XXX`) where applicable, per `IMPLEMENTATION_GUIDE.md`.
   section 5 + section 12; also added the `core/auth/` package to the tree),
   `03_ENGINEERING/IMPLEMENTATION_GUIDE.md`, and the toolkit `README.md`.
 
+- **TASK-004 — Typed Dataverse Web API client.** Implemented
+  `src/core/outbound/dataverse_client.py` with per-request token acquisition,
+  required OData headers, GET-only retry/backoff, `@odata.nextLink`
+  pagination, HTTPS validation, and typed outbound exceptions. Added unit tests
+  for token acquisition, pagination, retry behavior, non-retried writes, and
+  error mapping. (`TASK-004`)
+
 ### Changed
 
 - (nothing yet)

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
@@ -12,6 +12,12 @@ task (`TASK-XXX`) where applicable, per `IMPLEMENTATION_GUIDE.md`.
 
 ## [Unreleased]
 
+- **TASK-015 input-pipeline review refinements.** Consolidated environment
+  prompting + MSAL authentication into `GatherInputWithAuthStep`, renamed agent
+  discovery to `AgentSelectionStep`, added `GatherPreferredSolutionStep`, and
+  moved shared auth/input step constants into `src/constants/auth.py`. The
+  toolkit now clearly prompts for the full Dataverse environment URL and records
+  the optional preferred solution up front for later writeback scenarios.
 - **Super-pipeline base/product split (framework vs ESS product).** Split the
   fluent super-pipeline into a generic, product-agnostic base and the ESS
   product subclass: `StagedPipeline[TContext]` now lives in `core/pipeline/`

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
@@ -126,7 +126,7 @@ Instead, it establishes the complete framework, wiring, and developer experience
 | [TASK-001](tasks/TASK-001-repository-scaffold.md)        | Repository Scaffold            | DONE   | —        |
 | [TASK-002](tasks/TASK-002-pipeline-framework.md)         | Pipeline Framework             | DONE   | —        |
 | [TASK-003](tasks/TASK-003-migration-orchestrator.md)     | Migration Orchestrator         | TODO   | TASK-002, TASK-005, TASK-015 |
-| [TASK-004](tasks/TASK-004-dataverse-client.md)           | Dataverse Client               | TODO   | —        |
+| [TASK-004](tasks/TASK-004-dataverse-client.md)           | Dataverse Client               | DONE   | —        |
 | [TASK-005](tasks/TASK-005-diagnostics-framework.md)      | Diagnostics Framework          | DONE   | —        |
 | [TASK-006](tasks/TASK-006-preprocessing-pipeline.md)     | Preprocessing Pipeline         | TODO   | TASK-015 |
 | [TASK-007](tasks/TASK-007-postprocessing-pipeline.md)    | Postprocessing Pipeline        | BLOCKED | TASK-015, TASK-004, TASK-005 |

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
@@ -132,7 +132,7 @@ Instead, it establishes the complete framework, wiring, and developer experience
 | [TASK-007](tasks/TASK-007-postprocessing-pipeline.md)    | Postprocessing Pipeline        | BLOCKED | TASK-015, TASK-004, TASK-005 |
 | [TASK-008](tasks/TASK-008-authentication-token-provider.md) | Authentication Token Provider | DONE   | —        |
 | [TASK-009](tasks/TASK-009-end-to-end-framework-validation.md) | End-to-End Framework Validation | BLOCKED | TASK-003, TASK-006, TASK-007 |
-| [TASK-015](tasks/TASK-015-input-pipeline-auth-discovery.md) | Input Pipeline: Auth + Agent Discovery + Orchestrator Wiring | TODO | TASK-002, TASK-005, TASK-008 |
+| [TASK-015](tasks/TASK-015-input-pipeline-auth-discovery.md) | Input Pipeline: Auth + Agent Discovery + Orchestrator Wiring | DONE | TASK-002, TASK-005, TASK-008 |
 
 ---
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
@@ -129,9 +129,9 @@ Instead, it establishes the complete framework, wiring, and developer experience
 | [TASK-004](tasks/TASK-004-dataverse-client.md)           | Dataverse Client               | TODO   | —        |
 | [TASK-005](tasks/TASK-005-diagnostics-framework.md)      | Diagnostics Framework          | DONE   | —        |
 | [TASK-006](tasks/TASK-006-preprocessing-pipeline.md)     | Preprocessing Pipeline         | TODO   | TASK-015 |
-| [TASK-007](tasks/TASK-007-postprocessing-pipeline.md)    | Postprocessing Pipeline        | TODO   | TASK-015 |
+| [TASK-007](tasks/TASK-007-postprocessing-pipeline.md)    | Postprocessing Pipeline        | BLOCKED | TASK-015, TASK-004, TASK-005 |
 | [TASK-008](tasks/TASK-008-authentication-token-provider.md) | Authentication Token Provider | DONE   | —        |
-| [TASK-009](tasks/TASK-009-end-to-end-framework-validation.md) | End-to-End Framework Validation | TODO | —      |
+| [TASK-009](tasks/TASK-009-end-to-end-framework-validation.md) | End-to-End Framework Validation | BLOCKED | TASK-003, TASK-006, TASK-007 |
 | [TASK-015](tasks/TASK-015-input-pipeline-auth-discovery.md) | Input Pipeline: Auth + Agent Discovery + Orchestrator Wiring | TODO | TASK-002, TASK-005, TASK-008 |
 
 ---
@@ -181,7 +181,7 @@ release.
 
 | Task                                                     | Title                          | Status | Consumes |
 | -------------------------------------------------------- | ------------------------------ | ------ | -------- |
-| [TASK-999](tasks/TASK-999-manual-e2e-validation.md)      | Manual End-to-End Validation   | TODO   | —        |
+| [TASK-999](tasks/TASK-999-manual-e2e-validation.md)      | Manual End-to-End Validation   | BLOCKED | TASK-009 |
 
 ---
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-001-repository-scaffold.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-001-repository-scaffold.md
@@ -17,7 +17,7 @@ logic is introduced.
 ## Acceptance Criteria
 
 - [ ] The `src/` layout exists exactly as specified in
-  `03_ENGINEERING/REPOSITORY_STRUCTURE.md` (`constants/`, `core/`, `modules/`,
+  `03_ENGINEERING/REPOSITORY_STRUCTURE.md` (`core/`, `modules/`,
   `service/`, `output/`, and `service/mtk_orchestrator.py`).
 - [ ] The `tests/` layout exists (`unit/`, `integration/`, `golden/`, `e2e/`).
 - [ ] The toolkit-root `output/` folder is present (generated, gitignored, kept

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-007-postprocessing-pipeline.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-007-postprocessing-pipeline.md
@@ -4,7 +4,7 @@
 | ---------- | ------------------------- |
 | ID         | TASK-007                  |
 | Workstream | 0 — Repository Foundation |
-| Status     | TODO                      |
+| Status     | BLOCKED                      |
 | Consumes   | TASK-015, TASK-004, TASK-005 |
 
 ## Description

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-009-end-to-end-framework-validation.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-009-end-to-end-framework-validation.md
@@ -4,7 +4,7 @@
 | ---------- | ------------------------- |
 | ID         | TASK-009                  |
 | Workstream | 0 — Repository Foundation |
-| Status     | TODO                      |
+| Status     | BLOCKED                      |
 | Consumes   | TASK-003, TASK-006, TASK-007 |
 
 ## Description

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-015-input-pipeline-auth-discovery.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-015-input-pipeline-auth-discovery.md
@@ -4,7 +4,7 @@
 | ---------- | -------------------------------------------------------------- |
 | ID         | TASK-015                                                       |
 | Workstream | 0 — Repository Foundation                                      |
-| Status     | TODO                                                           |
+| Status     | DONE                                                           |
 | Consumes   | TASK-002 (pipeline framework), TASK-005 (diagnostics), TASK-008 (token provider) |
 
 ## Description
@@ -21,19 +21,23 @@ This task delivers:
    `ChainedPipeline`, manages the diagnostics session lifecycle
    (`Logger.start_session` / `close()`), and surfaces the bundle path.
 2. **Input Pipeline steps** (`src/modules/preprocessing/`) — real steps that
-   authenticate, gather CLI inputs, and discover ESS agents.
+   gather the Dataverse environment URL, authenticate, discover ESS agents, and
+   capture the optional preferred solution for future writeback.
 3. **Migration + Output empty pass-throughs** — one no-op
    `MigrationPipelineStep` each so the chained pipeline runs end-to-end.
 
 ### Input Pipeline Flow
 
-1. **Authenticate** — use `MsalTokenProvider` (TASK-008) to acquire a Dataverse
-   bearer token. Proactive refresh is handled automatically.
-2. **Gather session inputs via CLI** — prompt for Tenant ID and Environment ID.
-   Populate on `MigrationContext`.
-3. **Discover ESS agents** — call Dataverse (`GET /bots`) scoped to the
+1. **Gather input + authenticate** — prompt for the full Dataverse environment
+   URL (`https://org.crm.dynamics.com`), discover the tenant from the
+   `WWW-Authenticate` challenge, then use `MsalTokenProvider` (TASK-008) to
+   acquire a Dataverse bearer token. Proactive refresh is handled
+   automatically.
+2. **Discover ESS agents** — call Dataverse (`GET /bots`) scoped to the
    environment, display the list (name, bot ID, status), let the user select one.
    Store selected agent on `MigrationContext`.
+3. **Gather preferred solution** — ask for the optional preferred solution
+   unique name up front so future writeback can target it when present.
 
 ### Orchestrator Shape
 
@@ -68,8 +72,11 @@ def main() -> None:
 - Input steps declare `supported_modes=("READONLY", "WRITEBACK")` (discovery
   runs in both modes).
 - CLI prompting uses Python `input()` — captured by Logger's stdout tee.
-- Dataverse calls use the token provider directly with `httpx` (TASK-004 not
-  landed yet — keep behind an interface so it can be swapped later).
+- The toolkit currently asks for the full Dataverse environment URL directly.
+  Future enhancement may resolve the URL from an Environment ID through the
+  Power Platform BAP discovery API before Dataverse auth.
+- Dataverse calls use the token provider directly with `httpx` for tenant
+  discovery before the Dataverse client is initialized.
 - No `EssMigrationToolkit` class — the orchestrator composes `ChainedPipeline`
   directly with `.add()`.
 - After this task, `./mtk.sh start` runs the full pipeline end-to-end and
@@ -82,11 +89,13 @@ def main() -> None:
 - [ ] Logger session lifecycle: `start_session` before pipeline, `close()` in
   `finally`, produces `output/session-<timestamp>/` with two files.
 - [ ] `MsalTokenProvider` is instantiated and used for Dataverse auth.
-- [ ] User is prompted for Tenant ID and Environment ID via CLI.
+- [ ] User is prompted for the full Dataverse environment URL via CLI.
 - [ ] Dataverse call retrieves ESS agents in the environment.
 - [ ] Agent list displayed; user selects one; stored on `MigrationContext`.
-- [ ] `MigrationContext` extended with: `tenant_id`, `environment_id`,
-  `selected_agent`.
+- [ ] User is prompted for an optional preferred solution unique name; blank
+  input leaves `preferred_solution` unset.
+- [ ] `MigrationContext` extended with: `tenant_id`, `environment_url`,
+  `selected_agent_id`, `selected_agent_name`, and `preferred_solution`.
 - [ ] Migration and Output stages are pass-through (one no-op step each).
 - [ ] All steps are `MigrationPipelineStep` subclasses with `supported_modes`.
 - [ ] Quality gates pass: `uv run ruff check .`, `uv run mypy src`,
@@ -96,9 +105,9 @@ def main() -> None:
 
 - `src/service/mtk_orchestrator.py` — composition root (ChainedPipeline wiring
   + Logger lifecycle)
-- `src/modules/preprocessing/steps/authenticate_step.py`
-- `src/modules/preprocessing/steps/gather_inputs_step.py`
-- `src/modules/preprocessing/steps/discover_agents_step.py`
+- `src/modules/preprocessing/steps/gather_input_with_auth_step.py`
+- `src/modules/preprocessing/steps/agent_selection_step.py`
+- `src/modules/preprocessing/steps/gather_preferred_solution_step.py`
 - `src/modules/migration/migration_pipeline.py` — builder returning pass-through
 - `src/modules/postprocessing/output_pipeline.py` — builder returning pass-through
 - `MigrationContext` extended with session input fields

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-999-manual-e2e-validation.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-999-manual-e2e-validation.md
@@ -4,7 +4,7 @@
 | ---------- | ------------------------- |
 | ID         | TASK-999                  |
 | Workstream | 3 — Final Validation      |
-| Status     | TODO                      |
+| Status     | BLOCKED                      |
 | Consumes   | —                         |
 
 ## Description

--- a/tools/ess-nextgen-migration-toolkit/.gitignore
+++ b/tools/ess-nextgen-migration-toolkit/.gitignore
@@ -16,3 +16,6 @@ venv/
 # Generated execution artifacts (keep folder, ignore contents)
 output/*
 !output/.gitkeep
+
+# Local developer config (tokens, env URLs — never committed)
+.local/

--- a/tools/ess-nextgen-migration-toolkit/.local/dev-config.example.json
+++ b/tools/ess-nextgen-migration-toolkit/.local/dev-config.example.json
@@ -1,0 +1,4 @@
+{
+  "environment_url": "https://your-org.crm.dynamics.com",
+  "token": ""
+}

--- a/tools/ess-nextgen-migration-toolkit/AGENTS.md
+++ b/tools/ess-nextgen-migration-toolkit/AGENTS.md
@@ -39,10 +39,15 @@
 
 | Concern               | Implementation location                         |
 | --------------------- | ----------------------------------------------- |
+| Pipeline framework    | `src/core/pipelines/`                           |
 | Dataverse APIs        | `src/core/outbound/`                            |
-| Domain Models         | `src/core/models/`                              |
+| Domain Models         | `src/core/models/` + `src/modules/migration/models/` |
 | Migration Rules       | `src/modules/migration/steps/`                  |
-| Pipeline Registration | `src/modules/migration/`                        |
+| Migration Step base   | `src/modules/migration/migration_step.py`       |
+| Input Pipeline        | `src/modules/preprocessing/`                    |
+| Output Pipeline       | `src/modules/postprocessing/`                   |
+| Orchestrator          | `src/service/mtk_orchestrator.py`               |
+| Constants             | `src/service/constants.py`                      |
 | Utilities             | `src/core/utils/`                               |
 | Diagnostics code      | `src/core/logging/`                             |
 | Generated output      | `output/session-<timestamp>/`                   |

--- a/tools/ess-nextgen-migration-toolkit/README.md
+++ b/tools/ess-nextgen-migration-toolkit/README.md
@@ -16,19 +16,18 @@ specifications define the system, and this code is one implementation of them.
 
 ```text
 src/
-    constants/       Shared constants
     core/
         auth/        Authentication (token_provider.py)
         logging/     Diagnostics framework
-        models/      Canonical domain models
+        models/      Canonical domain models (execution_context.py)
         outbound/    Dataverse client (dataverse_client.py)
-        pipeline/    Pipeline engine
+        pipelines/   Pipeline engine (pipeline.py, pipeline_step.py, chained_pipeline.py)
         utils/       Generic helpers
     modules/
-        preprocessing/
-        migration/       migration_pipeline.py, steps/
-        postprocessing/
-    service/         Orchestration (mtk_orchestrator.py)
+        preprocessing/   Input pipeline steps
+        migration/       Migration step base, models, migration_pipeline.py, steps/
+        postprocessing/  Output pipeline steps
+    service/         Orchestration (mtk_orchestrator.py, constants.py)
 output/              Generated, gitignored output
     session-<timestamp>/   migration_report.md, session.log
 tests/

--- a/tools/ess-nextgen-migration-toolkit/pyproject.toml
+++ b/tools/ess-nextgen-migration-toolkit/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Anil Kumar Adepu" }]
 dependencies = [
+    "httpx>=0.28.1",
     "msal>=1.37.0",
 ]
 

--- a/tools/ess-nextgen-migration-toolkit/pyproject.toml
+++ b/tools/ess-nextgen-migration-toolkit/pyproject.toml
@@ -32,7 +32,6 @@ dev = [
 # places top-level packages directly under src/. The build maps them explicitly.
 [tool.hatch.build.targets.wheel]
 packages = [
-    "src/constants",
     "src/core",
     "src/modules",
     "src/service",

--- a/tools/ess-nextgen-migration-toolkit/scripts/mtk.ps1
+++ b/tools/ess-nextgen-migration-toolkit/scripts/mtk.ps1
@@ -122,7 +122,7 @@ function Invoke-Run {
     $UV = Find-Uv
     Write-Host ""
     Write-Host "==> Starting the toolkit CLI..."
-    if ($DevMode) { & $UV run python src/service/mtk_orchestrator.py } else { & $UV run --no-dev python src/service/mtk_orchestrator.py }
+    if ($DevMode) { & $UV run python src/service/mtk_orchestrator.py --dev } else { & $UV run --no-dev python src/service/mtk_orchestrator.py }
 }
 
 # start = provision (idempotent) + run. The everyday command.

--- a/tools/ess-nextgen-migration-toolkit/scripts/mtk.sh
+++ b/tools/ess-nextgen-migration-toolkit/scripts/mtk.sh
@@ -124,7 +124,7 @@ cmd_run() {
   echo ""
   echo "==> Starting the toolkit CLI..."
   if [[ "$dev" == "1" ]]; then
-    exec "$UV" run python src/service/mtk_orchestrator.py
+    exec "$UV" run python src/service/mtk_orchestrator.py --dev
   else
     exec "$UV" run --no-dev python src/service/mtk_orchestrator.py
   fi

--- a/tools/ess-nextgen-migration-toolkit/src/constants/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/constants/__init__.py
@@ -1,1 +1,5 @@
-"""constants package."""
+"""Shared constants for the ESS Migration Toolkit."""
+
+from constants.auth import DATAVERSE_CLIENT_ID, SUPPORTED_MODES
+
+__all__ = ["DATAVERSE_CLIENT_ID", "SUPPORTED_MODES"]

--- a/tools/ess-nextgen-migration-toolkit/src/constants/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/constants/__init__.py
@@ -1,5 +1,0 @@
-"""Shared constants for the ESS Migration Toolkit."""
-
-from constants.auth import DATAVERSE_CLIENT_ID, SUPPORTED_MODES
-
-__all__ = ["DATAVERSE_CLIENT_ID", "SUPPORTED_MODES"]

--- a/tools/ess-nextgen-migration-toolkit/src/constants/auth.py
+++ b/tools/ess-nextgen-migration-toolkit/src/constants/auth.py
@@ -1,9 +1,0 @@
-"""Authentication constants for the ESS Migration Toolkit."""
-
-# Microsoft public client ID for Power Platform CLI / Dataverse delegated access.
-# Source: https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2
-# Scope: user_impersonation only (delegated, no admin consent).
-DATAVERSE_CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"
-
-# Supported execution modes — all input pipeline steps run in both.
-SUPPORTED_MODES = ("READONLY", "WRITEBACK")

--- a/tools/ess-nextgen-migration-toolkit/src/constants/auth.py
+++ b/tools/ess-nextgen-migration-toolkit/src/constants/auth.py
@@ -1,0 +1,9 @@
+"""Authentication constants for the ESS Migration Toolkit."""
+
+# Microsoft public client ID for Power Platform CLI / Dataverse delegated access.
+# Source: https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2
+# Scope: user_impersonation only (delegated, no admin consent).
+DATAVERSE_CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"
+
+# Supported execution modes — all input pipeline steps run in both.
+SUPPORTED_MODES = ("READONLY", "WRITEBACK")

--- a/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
@@ -146,19 +146,19 @@ def _default_now() -> float:
 def _normalize_scopes(
     requested_scopes: str | Sequence[str] | None,
     default_scopes: tuple[str, ...],
-) -> tuple[str, ...]:
+) -> list[str]:
     scopes = default_scopes if requested_scopes is None else _coerce_scopes(requested_scopes)
     if not scopes:
         raise ValueError("at least one scope must be provided.")
     for scope in scopes:
         _validate_https_url(scope, "scope")
-    return tuple(scopes)
+    return list(scopes)
 
 
-def _coerce_scopes(scopes: str | Sequence[str]) -> tuple[str, ...]:
+def _coerce_scopes(scopes: str | Sequence[str]) -> list[str]:
     if isinstance(scopes, str):
-        return (_resource_to_default_scope(scopes),)
-    return tuple(_resource_to_default_scope(scope) for scope in scopes)
+        return [_resource_to_default_scope(scopes)]
+    return [_resource_to_default_scope(scope) for scope in scopes]
 
 
 def _resource_to_default_scope(scope_or_resource: str) -> str:

--- a/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from core.logging import Logger
 
 TokenResult: TypeAlias = dict[str, object]
 Clock: TypeAlias = Callable[[], float]
-
-# TODO(TASK-005): replace this stdlib logger seam with the framework Logger.
-LOGGER = logging.getLogger(__name__)
 
 
 class AuthenticationException(RuntimeError):
@@ -72,15 +71,15 @@ class MsalTokenProvider:
     def __init__(
         self,
         config: MsalTokenProviderConfig,
+        logger: Logger,
         *,
         app: MsalApplication | None = None,
         now: Clock | None = None,
-        logger: logging.Logger | None = None,
     ) -> None:
         self._config = config
         self._app = app if app is not None else self._build_public_client_application(config)
         self._now = now if now is not None else _default_now
-        self._logger = logger if logger is not None else LOGGER
+        self._logger = logger
 
     def get_token(self, scopes: str | Sequence[str] | None = None) -> str:
         """Return a currently-valid bearer token for the requested HTTPS scopes."""
@@ -90,10 +89,18 @@ class MsalTokenProvider:
 
         result: TokenResult | None = None
         if account is not None:
-            self._logger.debug("Attempting silent token acquisition.")
+            self._logger.LogDebug(
+                "Attempting silent token acquisition.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             result = self._app.acquire_token_silent(normalized_scopes, account=account)
             if result is not None and self._token_needs_refresh(result):
-                self._logger.debug("Cached token is near expiry; forcing silent refresh.")
+                self._logger.LogDebug(
+                    "Cached token is near expiry; forcing silent refresh.",
+                    pipeline_stage="Auth",
+                    pipeline_step="TokenProvider",
+                )
                 result = self._app.acquire_token_silent(
                     normalized_scopes,
                     account=account,
@@ -102,18 +109,34 @@ class MsalTokenProvider:
 
         if result is None:
             if account is not None:
-                self._logger.warning("Silent token acquisition failed.")
+                self._logger.LogWarning(
+                    "Silent token acquisition failed.",
+                    pipeline_stage="Auth",
+                    pipeline_step="TokenProvider",
+                )
                 raise AuthenticationException("Authentication token acquisition failed.")
-            self._logger.info("Starting interactive token acquisition for cold start.")
+            self._logger.LogInfo(
+                "Starting interactive token acquisition for cold start.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             result = self._app.acquire_token_interactive(normalized_scopes)
 
         if self._token_needs_refresh(result):
-            self._logger.warning("Token acquisition returned an expired or near-expiry token.")
+            self._logger.LogWarning(
+                "Token acquisition returned an expired or near-expiry token.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             raise AuthenticationException("Authentication token acquisition failed.")
 
         access_token = result.get("access_token")
         if not isinstance(access_token, str) or not access_token:
-            self._logger.warning("Token acquisition response did not include a bearer token.")
+            self._logger.LogWarning(
+                "Token acquisition response did not include a bearer token.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             raise AuthenticationException("Authentication token acquisition failed.")
 
         return access_token

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
@@ -38,7 +38,7 @@ class TeeStream(TextIOBase):
         chars_written = self._original.write(text)
         try:
             self._log_file.write(text)
-        except Exception:  # noqa: BLE001 — DIAG-001: diagnostics must never abort execution
+        except (OSError, ValueError):  # DIAG-001: diagnostics must never abort execution
             pass
         return chars_written
 
@@ -47,7 +47,7 @@ class TeeStream(TextIOBase):
         self._original.flush()
         try:
             self._log_file.flush()
-        except Exception:  # noqa: BLE001 — DIAG-001: diagnostics must never abort execution
+        except (OSError, ValueError):  # DIAG-001: diagnostics must never abort execution
             pass
 
     def isatty(self) -> bool:
@@ -132,7 +132,7 @@ class Logger:
             try:
                 self._log_file.flush()
                 self._log_file.close()
-            except Exception:  # noqa: BLE001 — DIAG-001: safe teardown
+            except (OSError, ValueError):  # DIAG-001: safe teardown
                 pass
         self._started = False
 
@@ -256,5 +256,5 @@ class Logger:
             try:
                 self._log_file.write(line)
                 self._log_file.flush()
-            except Exception:  # noqa: BLE001 — DIAG-001
+            except OSError:  # DIAG-001: diagnostics file write failure
                 pass

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
@@ -247,7 +247,7 @@ class Logger:
             return
 
         timestamp = self._clock().strftime("%Y-%m-%d %H:%M:%S")
-        line = f"{timestamp} {level.name} {pipeline_stage} {pipeline_step} {message}\n"
+        line = f"[{timestamp}] [{level.name}] [{pipeline_stage}/{pipeline_step}] {message}\n"
         stream = sys.stderr if level >= LogLevel.ERROR else sys.stdout
         stream.write(line)
         stream.flush()

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
@@ -243,11 +243,18 @@ class Logger:
         pipeline_stage: str,
         pipeline_step: str,
     ) -> None:
-        if level < self._level:
-            return
-
         timestamp = self._clock().strftime("%Y-%m-%d %H:%M:%S")
         line = f"[{timestamp}] [{level.name}] [{pipeline_stage}/{pipeline_step}] {message}\n"
-        stream = sys.stderr if level >= LogLevel.ERROR else sys.stdout
-        stream.write(line)
-        stream.flush()
+
+        if level >= self._level:
+            # Above console threshold — write to console (TeeStream mirrors to session.log)
+            stream = sys.stderr if level >= LogLevel.ERROR else sys.stdout
+            stream.write(line)
+            stream.flush()
+        elif self._log_file is not None:
+            # Below console threshold — write directly to session.log only
+            try:
+                self._log_file.write(line)
+                self._log_file.flush()
+            except Exception:  # noqa: BLE001 — DIAG-001
+                pass

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/__init__.py
@@ -1,1 +1,10 @@
 """core.outbound — Dataverse client layer (OData/Web API communication)."""
+
+from core.outbound.dataverse_client import DataverseClient
+from core.outbound.exceptions import AuthenticationExpiredError, DataverseApiError
+
+__all__ = [
+    "AuthenticationExpiredError",
+    "DataverseApiError",
+    "DataverseClient",
+]

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
@@ -12,20 +12,27 @@ import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from typing import Any, Final
+from typing import Any, Final, Protocol
 from urllib.parse import urljoin, urlparse
 
 import httpx
 
-from core.auth.token_provider import MsalTokenProvider
 from core.outbound.exceptions import AuthenticationExpiredError, DataverseApiError
 
 JsonDict = dict[str, Any]
 Sleep = Callable[[float], None]
 
+
+class TokenProvider(Protocol):
+    """Any object that can provide a bearer token."""
+
+    def get_token(self) -> str: ...
+
+
 _API_PATH: Final[str] = "/api/data/v9.2/"
 _DEFAULT_TIMEOUT_SECONDS: Final[float] = 120.0
 _GET_ATTEMPTS: Final[int] = 3
+_MAX_RETRY_DELAY_SECONDS: Final[float] = 60.0
 _RETRY_STATUS_CODES: Final[frozenset[int]] = frozenset({429, 500, 502, 503, 504})
 _RECORD_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"\(([^()]+)\)")
 _O_DATA_HEADERS: Final[dict[str, str]] = {
@@ -49,7 +56,7 @@ class DataverseClient:
     def __init__(
         self,
         env_url: str,
-        token_provider: MsalTokenProvider,
+        token_provider: TokenProvider,
         *,
         client: httpx.Client | None = None,
         sleep: Sleep | None = None,
@@ -80,14 +87,6 @@ class DataverseClient:
         """Return the normalized Dataverse environment URL bound to this client."""
         return self.__env_url
 
-    def with_environment(self, env_url: str) -> DataverseClient:
-        """Return a client rebound to ``env_url`` with the same token provider."""
-        return DataverseClient(
-            env_url,
-            self.__token_provider,
-            sleep=self.__sleep,
-        )
-
     def query_all(
         self,
         entity_set: str,
@@ -105,6 +104,7 @@ class DataverseClient:
         next_link = _coerce_next_link(payload)
 
         while next_link is not None:
+            _validate_next_link(next_link, self.__env_url)
             payload = self.get(next_link)
             records.extend(_coerce_records(payload, entity_set))
             next_link = _coerce_next_link(payload)
@@ -133,7 +133,12 @@ class DataverseClient:
         )
         record_id = _extract_record_id(response)
         if record_id is None:
-            raise RuntimeError("Dataverse create response did not include a record ID.")
+            raise DataverseApiError(
+                status=response.status_code,
+                operation="create",
+                entity_set=entity_set,
+                message="Dataverse create response did not include a record ID.",
+            )
         return record_id
 
     def update(self, entity_set: str, record_id: str, data: JsonDict) -> None:
@@ -169,8 +174,6 @@ class DataverseClient:
             response = self.__request_with_get_retry(
                 path,
                 params=params,
-                operation=operation,
-                entity_set=entity_set,
             )
         else:
             response = self.__send_once(method, path, params=params, json=json)
@@ -183,24 +186,18 @@ class DataverseClient:
         path: str,
         *,
         params: dict[str, str] | None,
-        operation: str,
-        entity_set: str | None,
     ) -> httpx.Response:
-        last_response: httpx.Response | None = None
-        for attempt in range(1, _GET_ATTEMPTS + 1):
-            response = self.__send_once("GET", path, params=params)
-            last_response = response
-            if response.status_code not in _RETRY_STATUS_CODES or attempt == _GET_ATTEMPTS:
+        response = self.__send_once("GET", path, params=params)
+        for attempt in range(1, _GET_ATTEMPTS):
+            if response.status_code not in _RETRY_STATUS_CODES:
                 return response
 
             delay_seconds = _retry_delay_seconds(response, attempt)
             if delay_seconds > 0:
                 self.__sleep(delay_seconds)
+            response = self.__send_once("GET", path, params=params)
 
-        if last_response is None:
-            raise RuntimeError("GET retry loop completed without a response.")
-        self.__raise_for_status(last_response, operation=operation, entity_set=entity_set)
-        return last_response
+        return response
 
     def __send_once(
         self,
@@ -291,12 +288,35 @@ def _coerce_next_link(payload: JsonDict) -> str | None:
     return next_link if isinstance(next_link, str) and next_link else None
 
 
+def _validate_next_link(next_link: str, env_url: str) -> None:
+    """Reject nextLinks that point to a different host (token exfiltration guard)."""
+    parsed = urlparse(next_link)
+    env_parsed = urlparse(env_url)
+    if parsed.scheme and parsed.netloc:
+        if parsed.scheme.lower() != "https" or parsed.netloc.lower() != env_parsed.netloc.lower():
+            raise DataverseApiError(
+                status=0,
+                operation="read",
+                entity_set=None,
+                message=(
+                    f"@odata.nextLink points to a different host ({parsed.netloc}) "
+                    f"than the configured environment ({env_parsed.netloc}). "
+                    "Refusing to follow — possible token exfiltration."
+                ),
+            )
+
+
 def _json_payload(response: httpx.Response) -> JsonDict:
     if not response.content:
         return {}
     payload = response.json()
     if not isinstance(payload, dict):
-        raise RuntimeError("Dataverse response payload must be a JSON object.")
+        raise DataverseApiError(
+            status=response.status_code,
+            operation="read",
+            entity_set=None,
+            message="Dataverse response payload must be a JSON object.",
+        )
     return payload
 
 
@@ -306,17 +326,6 @@ def _extract_record_id(response: httpx.Response) -> str | None:
         match = _RECORD_ID_PATTERN.search(header_value)
         if match is not None:
             return match.group(1)
-
-    if response.content:
-        payload = response.json()
-        if isinstance(payload, dict):
-            string_ids = [
-                value
-                for key, value in payload.items()
-                if key.lower().endswith("id") and isinstance(value, str)
-            ]
-            if len(string_ids) == 1:
-                return string_ids[0]
     return None
 
 
@@ -341,8 +350,8 @@ def _retry_delay_seconds(response: httpx.Response, attempt: int) -> float:
     retry_after_header = response.headers.get("Retry-After")
     retry_after_seconds = _parse_retry_after_seconds(retry_after_header)
     if retry_after_seconds is not None:
-        return retry_after_seconds
-    return float(2 ** (attempt - 1))
+        return min(retry_after_seconds, _MAX_RETRY_DELAY_SECONDS)
+    return min(float(2 ** (attempt - 1)), _MAX_RETRY_DELAY_SECONDS)
 
 
 def _parse_retry_after_seconds(header_value: str | None) -> float | None:

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
@@ -75,6 +75,19 @@ class DataverseClient:
             )
         )
 
+    @property
+    def environment_url(self) -> str:
+        """Return the normalized Dataverse environment URL bound to this client."""
+        return self.__env_url
+
+    def with_environment(self, env_url: str) -> DataverseClient:
+        """Return a client rebound to ``env_url`` with the same token provider."""
+        return DataverseClient(
+            env_url,
+            self.__token_provider,
+            sleep=self.__sleep,
+        )
+
     def query_all(
         self,
         entity_set: str,

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
@@ -245,17 +245,26 @@ def _normalize_env_url(env_url: str) -> str:
     parsed = urlparse(env_url)
     if parsed.scheme.lower() != "https" or not parsed.netloc:
         raise ValueError("env_url must be an HTTPS URL.")
-    return env_url.rstrip("/")
+    if parsed.path.strip("/") or parsed.query or parsed.fragment:
+        raise ValueError("env_url must be the Dataverse root (no path, query, or fragment).")
+    return f"{parsed.scheme}://{parsed.netloc}"
 
 
 def _coerce_records(payload: JsonDict, entity_set: str) -> list[JsonDict]:
-    value = payload.get("value", [])
+    if "value" not in payload:
+        raise DataverseApiError(
+            status=200,
+            operation="read",
+            entity_set=entity_set,
+            message="Dataverse query response is missing the required 'value' key.",
+        )
+    value = payload["value"]
     if not isinstance(value, list):
         raise DataverseApiError(
             status=200,
             operation="read",
             entity_set=entity_set,
-            message="Dataverse query response did not include a record list.",
+            message="Dataverse query response 'value' is not a list.",
         )
     records: list[JsonDict] = []
     for item in value:
@@ -309,8 +318,9 @@ def _entity_from_path(path: str) -> str | None:
     parsed = urlparse(path)
     relative_path = parsed.path if parsed.scheme and parsed.netloc else path
     trimmed = relative_path.lstrip("/")
-    if trimmed.startswith("api/data/v9.2/"):
-        trimmed = trimmed[len("api/data/v9.2/") :]
+    api_prefix = _API_PATH.lstrip("/")
+    if trimmed.startswith(api_prefix):
+        trimmed = trimmed[len(api_prefix) :]
     return trimmed.split("?", maxsplit=1)[0] or None
 
 

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
@@ -1,7 +1,345 @@
-"""Dataverse REST wrapper.
+"""Typed Dataverse Web API client.
 
-Owns all Dataverse communication (authentication, REST helpers, serialization,
-retry handling). Implemented by TASK-004. This module is intentionally a
-placeholder created by the repository scaffold (TASK-001); business logic must
-never live here.
+Owns Dataverse authentication handoff, HTTP execution, retry handling, and
+OData serialization concerns. Business and migration logic must never live in
+this module.
 """
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from typing import Any, Final
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from core.auth.token_provider import MsalTokenProvider
+from core.outbound.exceptions import AuthenticationExpiredError, DataverseApiError
+
+JsonDict = dict[str, Any]
+Sleep = Callable[[float], None]
+
+_API_PATH: Final[str] = "/api/data/v9.2/"
+_DEFAULT_TIMEOUT_SECONDS: Final[float] = 120.0
+_GET_ATTEMPTS: Final[int] = 3
+_RETRY_STATUS_CODES: Final[frozenset[int]] = frozenset({429, 500, 502, 503, 504})
+_RECORD_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"\(([^()]+)\)")
+_O_DATA_HEADERS: Final[dict[str, str]] = {
+    "Accept": "application/json",
+    "OData-MaxVersion": "4.0",
+    "OData-Version": "4.0",
+    "Prefer": "odata.include-annotations=*",
+}
+
+
+class DataverseClient:
+    """Execute authenticated Dataverse Web API requests.
+
+    Responsibilities:
+    - obtain a fresh bearer token for every HTTP request,
+    - apply required OData headers,
+    - retry idempotent GET requests on Dataverse throttling/server failures,
+    - translate HTTP failures into typed outbound exceptions.
+    """
+
+    def __init__(
+        self,
+        env_url: str,
+        token_provider: MsalTokenProvider,
+        *,
+        client: httpx.Client | None = None,
+        sleep: Sleep | None = None,
+    ) -> None:
+        """Create a Dataverse client for one HTTPS environment.
+
+        Inputs:
+        - env_url: Dataverse environment root URL.
+        - token_provider: bearer-token provider used immediately before requests.
+
+        Output:
+        - initialized client ready for Dataverse Web API calls.
+        """
+        self._env_url = _normalize_env_url(env_url)
+        self._token_provider = token_provider
+        self._sleep = sleep if sleep is not None else time.sleep
+        self._client = (
+            client
+            if client is not None
+            else httpx.Client(
+                base_url=f"{self._env_url}{_API_PATH}",
+                timeout=_DEFAULT_TIMEOUT_SECONDS,
+            )
+        )
+
+    def query_all(
+        self,
+        entity_set: str,
+        *,
+        select: str,
+        filter: str | None = None,
+    ) -> list[JsonDict]:
+        """Return all records for an entity-set query across all pages."""
+        params: dict[str, str] = {"$select": select}
+        if filter is not None:
+            params["$filter"] = filter
+
+        payload = self.get(entity_set, params=params)
+        records = list(_coerce_records(payload, entity_set))
+        next_link = _coerce_next_link(payload)
+
+        while next_link is not None:
+            payload = self.get(next_link)
+            records.extend(_coerce_records(payload, entity_set))
+            next_link = _coerce_next_link(payload)
+
+        return records
+
+    def get(self, path: str, *, params: dict[str, str] | None = None) -> JsonDict:
+        """Execute one Dataverse GET request and return the JSON payload."""
+        response = self._request(
+            "GET",
+            path,
+            params=params,
+            operation="read",
+            entity_set=_entity_from_path(path),
+        )
+        return _json_payload(response)
+
+    def create(self, entity_set: str, data: JsonDict) -> str:
+        """Create one Dataverse record and return its Dataverse record ID."""
+        response = self._request(
+            "POST",
+            entity_set,
+            json=data,
+            operation="create",
+            entity_set=entity_set,
+        )
+        record_id = _extract_record_id(response)
+        if record_id is None:
+            raise RuntimeError("Dataverse create response did not include a record ID.")
+        return record_id
+
+    def update(self, entity_set: str, record_id: str, data: JsonDict) -> None:
+        """Update one Dataverse record without returning a payload."""
+        self._request(
+            "PATCH",
+            f"{entity_set}({record_id})",
+            json=data,
+            operation="update",
+            entity_set=entity_set,
+        )
+
+    def delete(self, entity_set: str, record_id: str) -> None:
+        """Delete one Dataverse record without returning a payload."""
+        self._request(
+            "DELETE",
+            f"{entity_set}({record_id})",
+            operation="delete",
+            entity_set=entity_set,
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: JsonDict | None = None,
+        operation: str,
+        entity_set: str | None,
+    ) -> httpx.Response:
+        if method == "GET":
+            response = self._request_with_get_retry(
+                path,
+                params=params,
+                operation=operation,
+                entity_set=entity_set,
+            )
+        else:
+            response = self._send_once(method, path, params=params, json=json)
+
+        self._raise_for_status(response, operation=operation, entity_set=entity_set)
+        return response
+
+    def _request_with_get_retry(
+        self,
+        path: str,
+        *,
+        params: dict[str, str] | None,
+        operation: str,
+        entity_set: str | None,
+    ) -> httpx.Response:
+        last_response: httpx.Response | None = None
+        for attempt in range(1, _GET_ATTEMPTS + 1):
+            response = self._send_once("GET", path, params=params)
+            last_response = response
+            if response.status_code not in _RETRY_STATUS_CODES or attempt == _GET_ATTEMPTS:
+                return response
+
+            delay_seconds = _retry_delay_seconds(response, attempt)
+            if delay_seconds > 0:
+                self._sleep(delay_seconds)
+
+        if last_response is None:
+            raise RuntimeError("GET retry loop completed without a response.")
+        self._raise_for_status(last_response, operation=operation, entity_set=entity_set)
+        return last_response
+
+    def _send_once(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: JsonDict | None = None,
+    ) -> httpx.Response:
+        token = self._token_provider.get_token()
+        headers = {**_O_DATA_HEADERS, "Authorization": f"Bearer {token}"}
+        return self._client.request(
+            method,
+            self._request_url(path),
+            headers=headers,
+            params=params,
+            json=json,
+        )
+
+    def _request_url(self, path: str) -> str:
+        parsed = urlparse(path)
+        if parsed.scheme and parsed.netloc:
+            return path
+        if path.startswith("/"):
+            return urljoin(f"{self._env_url}/", path.lstrip("/"))
+        return path
+
+    def _raise_for_status(
+        self,
+        response: httpx.Response,
+        *,
+        operation: str,
+        entity_set: str | None,
+    ) -> None:
+        if response.status_code < 400:
+            return
+
+        request_id = _request_id(response)
+        if response.status_code == 401:
+            raise AuthenticationExpiredError(
+                operation=operation,
+                entity_set=entity_set,
+                request_id=request_id,
+            )
+
+        raise DataverseApiError(
+            status=response.status_code,
+            operation=operation,
+            entity_set=entity_set,
+            request_id=request_id,
+        )
+
+
+def _normalize_env_url(env_url: str) -> str:
+    parsed = urlparse(env_url)
+    if parsed.scheme.lower() != "https" or not parsed.netloc:
+        raise ValueError("env_url must be an HTTPS URL.")
+    return env_url.rstrip("/")
+
+
+def _coerce_records(payload: JsonDict, entity_set: str) -> list[JsonDict]:
+    value = payload.get("value", [])
+    if not isinstance(value, list):
+        raise DataverseApiError(
+            status=200,
+            operation="read",
+            entity_set=entity_set,
+            message="Dataverse query response did not include a record list.",
+        )
+    records: list[JsonDict] = []
+    for item in value:
+        if isinstance(item, dict):
+            records.append(item)
+    return records
+
+
+def _coerce_next_link(payload: JsonDict) -> str | None:
+    next_link = payload.get("@odata.nextLink")
+    return next_link if isinstance(next_link, str) and next_link else None
+
+
+def _json_payload(response: httpx.Response) -> JsonDict:
+    if not response.content:
+        return {}
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise RuntimeError("Dataverse response payload must be a JSON object.")
+    return payload
+
+
+def _extract_record_id(response: httpx.Response) -> str | None:
+    header_value = response.headers.get("OData-EntityId") or response.headers.get("Location")
+    if header_value is not None:
+        match = _RECORD_ID_PATTERN.search(header_value)
+        if match is not None:
+            return match.group(1)
+
+    if response.content:
+        payload = response.json()
+        if isinstance(payload, dict):
+            string_ids = [
+                value
+                for key, value in payload.items()
+                if key.lower().endswith("id") and isinstance(value, str)
+            ]
+            if len(string_ids) == 1:
+                return string_ids[0]
+    return None
+
+
+def _request_id(response: httpx.Response) -> str | None:
+    request_id = response.headers.get("x-ms-request-id") or response.headers.get("request-id")
+    if request_id is None or isinstance(request_id, str):
+        return request_id
+    return str(request_id)
+
+
+def _entity_from_path(path: str) -> str | None:
+    parsed = urlparse(path)
+    relative_path = parsed.path if parsed.scheme and parsed.netloc else path
+    trimmed = relative_path.lstrip("/")
+    if trimmed.startswith("api/data/v9.2/"):
+        trimmed = trimmed[len("api/data/v9.2/") :]
+    return trimmed.split("?", maxsplit=1)[0] or None
+
+
+def _retry_delay_seconds(response: httpx.Response, attempt: int) -> float:
+    retry_after_header = response.headers.get("Retry-After")
+    retry_after_seconds = _parse_retry_after_seconds(retry_after_header)
+    if retry_after_seconds is not None:
+        return retry_after_seconds
+    return float(2 ** (attempt - 1))
+
+
+def _parse_retry_after_seconds(header_value: str | None) -> float | None:
+    if header_value is None:
+        return None
+    stripped = header_value.strip()
+    if not stripped:
+        return None
+
+    try:
+        return max(float(stripped), 0.0)
+    except ValueError:
+        pass
+
+    try:
+        retry_at = parsedate_to_datetime(stripped)
+    except (TypeError, ValueError, IndexError):
+        return None
+
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+    delta = retry_at - datetime.now(UTC)
+    return max(delta.total_seconds(), 0.0)

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
@@ -63,14 +63,14 @@ class DataverseClient:
         Output:
         - initialized client ready for Dataverse Web API calls.
         """
-        self._env_url = _normalize_env_url(env_url)
-        self._token_provider = token_provider
-        self._sleep = sleep if sleep is not None else time.sleep
-        self._client = (
+        self.__env_url = _normalize_env_url(env_url)
+        self.__token_provider = token_provider
+        self.__sleep = sleep if sleep is not None else time.sleep
+        self.__client = (
             client
             if client is not None
             else httpx.Client(
-                base_url=f"{self._env_url}{_API_PATH}",
+                base_url=f"{self.__env_url}{_API_PATH}",
                 timeout=_DEFAULT_TIMEOUT_SECONDS,
             )
         )
@@ -100,7 +100,7 @@ class DataverseClient:
 
     def get(self, path: str, *, params: dict[str, str] | None = None) -> JsonDict:
         """Execute one Dataverse GET request and return the JSON payload."""
-        response = self._request(
+        response = self.__request(
             "GET",
             path,
             params=params,
@@ -111,7 +111,7 @@ class DataverseClient:
 
     def create(self, entity_set: str, data: JsonDict) -> str:
         """Create one Dataverse record and return its Dataverse record ID."""
-        response = self._request(
+        response = self.__request(
             "POST",
             entity_set,
             json=data,
@@ -125,7 +125,7 @@ class DataverseClient:
 
     def update(self, entity_set: str, record_id: str, data: JsonDict) -> None:
         """Update one Dataverse record without returning a payload."""
-        self._request(
+        self.__request(
             "PATCH",
             f"{entity_set}({record_id})",
             json=data,
@@ -135,14 +135,14 @@ class DataverseClient:
 
     def delete(self, entity_set: str, record_id: str) -> None:
         """Delete one Dataverse record without returning a payload."""
-        self._request(
+        self.__request(
             "DELETE",
             f"{entity_set}({record_id})",
             operation="delete",
             entity_set=entity_set,
         )
 
-    def _request(
+    def __request(
         self,
         method: str,
         path: str,
@@ -153,19 +153,19 @@ class DataverseClient:
         entity_set: str | None,
     ) -> httpx.Response:
         if method == "GET":
-            response = self._request_with_get_retry(
+            response = self.__request_with_get_retry(
                 path,
                 params=params,
                 operation=operation,
                 entity_set=entity_set,
             )
         else:
-            response = self._send_once(method, path, params=params, json=json)
+            response = self.__send_once(method, path, params=params, json=json)
 
-        self._raise_for_status(response, operation=operation, entity_set=entity_set)
+        self.__raise_for_status(response, operation=operation, entity_set=entity_set)
         return response
 
-    def _request_with_get_retry(
+    def __request_with_get_retry(
         self,
         path: str,
         *,
@@ -175,21 +175,21 @@ class DataverseClient:
     ) -> httpx.Response:
         last_response: httpx.Response | None = None
         for attempt in range(1, _GET_ATTEMPTS + 1):
-            response = self._send_once("GET", path, params=params)
+            response = self.__send_once("GET", path, params=params)
             last_response = response
             if response.status_code not in _RETRY_STATUS_CODES or attempt == _GET_ATTEMPTS:
                 return response
 
             delay_seconds = _retry_delay_seconds(response, attempt)
             if delay_seconds > 0:
-                self._sleep(delay_seconds)
+                self.__sleep(delay_seconds)
 
         if last_response is None:
             raise RuntimeError("GET retry loop completed without a response.")
-        self._raise_for_status(last_response, operation=operation, entity_set=entity_set)
+        self.__raise_for_status(last_response, operation=operation, entity_set=entity_set)
         return last_response
 
-    def _send_once(
+    def __send_once(
         self,
         method: str,
         path: str,
@@ -197,25 +197,25 @@ class DataverseClient:
         params: dict[str, str] | None = None,
         json: JsonDict | None = None,
     ) -> httpx.Response:
-        token = self._token_provider.get_token()
+        token = self.__token_provider.get_token()
         headers = {**_O_DATA_HEADERS, "Authorization": f"Bearer {token}"}
-        return self._client.request(
+        return self.__client.request(
             method,
-            self._request_url(path),
+            self.__request_url(path),
             headers=headers,
             params=params,
             json=json,
         )
 
-    def _request_url(self, path: str) -> str:
+    def __request_url(self, path: str) -> str:
         parsed = urlparse(path)
         if parsed.scheme and parsed.netloc:
             return path
         if path.startswith("/"):
-            return urljoin(f"{self._env_url}/", path.lstrip("/"))
+            return urljoin(f"{self.__env_url}/", path.lstrip("/"))
         return path
 
-    def _raise_for_status(
+    def __raise_for_status(
         self,
         response: httpx.Response,
         *,

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/exceptions.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/exceptions.py
@@ -1,0 +1,48 @@
+"""Typed outbound exceptions for Dataverse client failures."""
+
+from __future__ import annotations
+
+
+class DataverseApiError(RuntimeError):
+    """Raised when the Dataverse Web API returns a non-authentication failure."""
+
+    def __init__(
+        self,
+        *,
+        status: int,
+        operation: str,
+        entity_set: str | None,
+        request_id: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.status = status
+        self.operation = operation
+        self.entity_set = entity_set
+        self.request_id = request_id
+        super().__init__(message or self._default_message())
+
+    def _default_message(self) -> str:
+        target = self.entity_set or "Dataverse resource"
+        message = f"Dataverse {self.operation} failed for {target} (HTTP {self.status})."
+        if self.request_id is None:
+            return message
+        return f"{message} Request ID: {self.request_id}."
+
+
+class AuthenticationExpiredError(DataverseApiError):
+    """Raised when a Dataverse request fails because the bearer token expired."""
+
+    def __init__(
+        self,
+        *,
+        operation: str,
+        entity_set: str | None,
+        request_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            status=401,
+            operation=operation,
+            entity_set=entity_set,
+            request_id=request_id,
+            message="Dataverse authentication expired or is no longer valid.",
+        )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/migration/migration_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/migration/migration_pipeline.py
@@ -7,20 +7,19 @@ from core.pipelines import Pipeline
 from modules.migration.migration_step import MigrationPipelineStep
 from modules.migration.models import MigrationContext
 
-_SUPPORTED_MODES = ("READONLY", "WRITEBACK")
-
 
 class _MigrationPassthroughStep(MigrationPipelineStep):
-    """Temporary pass-through until migration-rule steps land."""
+    """Placeholder: migration-rule steps (TASK-010+) will replace this."""
 
-    def __init__(self, logger: Logger) -> None:
+    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
         super().__init__(
-            description="Pass through the shared context until migration rules are implemented.",
-            supported_modes=_SUPPORTED_MODES,
+            description="No-op placeholder until migration rules are implemented.",
+            supported_modes=supported_modes,
         )
         self._logger = logger
 
     def execute(self, context: MigrationContext) -> MigrationContext:
+        # TODO: Migration-rule steps will replace this pass-through.
         self._logger.LogDebug(
             "Migration stage is currently a no-op.",
             pipeline_stage="Migration",
@@ -29,10 +28,12 @@ class _MigrationPassthroughStep(MigrationPipelineStep):
         return context
 
 
-def build_migration_pipeline(logger: Logger) -> Pipeline[MigrationContext, MigrationContext]:
+def build_migration_pipeline(
+    logger: Logger, supported_modes: tuple[str, ...]
+) -> Pipeline[MigrationContext, MigrationContext]:
     """Build the migration stage pipeline."""
     return (
         Pipeline.builder("Migration Pipeline", input_type=MigrationContext)
-        .use(_MigrationPassthroughStep(logger))
+        .use(_MigrationPassthroughStep(logger, supported_modes))
         .build()
     )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/migration/models/migration_context.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/migration/models/migration_context.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from core.models import ExecutionContext
 
@@ -17,3 +18,12 @@ class MigrationContext(ExecutionContext):
 
     All ESS migration steps operate on this type via ``MigrationPipelineStep``.
     """
+
+    tenant_id: str | None = None
+    user_id: str | None = None
+    user_email: str | None = None
+    environment_url: str | None = None
+    preferred_solution: str | None = None
+    selected_agent_id: str | None = None
+    selected_agent_name: str | None = None
+    dataverse_client: Any = field(default=None, repr=False)

--- a/tools/ess-nextgen-migration-toolkit/src/modules/migration/models/migration_context.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/migration/models/migration_context.py
@@ -19,9 +19,9 @@ class MigrationContext(ExecutionContext):
     All ESS migration steps operate on this type via ``MigrationPipelineStep``.
     """
 
-    tenant_id: str | None = None
-    user_id: str | None = None
-    user_email: str | None = None
+    tid: str | None = None
+    oid: str | None = None
+    upn: str | None = None
     environment_url: str | None = None
     preferred_solution: str | None = None
     selected_agent_id: str | None = None

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/__init__.py
@@ -1,1 +1,5 @@
-"""postprocessing package."""
+"""Postprocessing stage package."""
+
+from modules.postprocessing.output_pipeline import build_output_pipeline
+
+__all__ = ["build_output_pipeline"]

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/output_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/output_pipeline.py
@@ -1,4 +1,4 @@
-"""Migration Pipeline builder."""
+"""Output Pipeline builder."""
 
 from __future__ import annotations
 
@@ -10,29 +10,29 @@ from modules.migration.models import MigrationContext
 _SUPPORTED_MODES = ("READONLY", "WRITEBACK")
 
 
-class _MigrationPassthroughStep(MigrationPipelineStep):
-    """Temporary pass-through until migration-rule steps land."""
+class _OutputPassthroughStep(MigrationPipelineStep):
+    """Temporary pass-through until output behaviors land."""
 
     def __init__(self, logger: Logger) -> None:
         super().__init__(
-            description="Pass through the shared context until migration rules are implemented.",
+            description="Pass through the shared context until output behaviors are implemented.",
             supported_modes=_SUPPORTED_MODES,
         )
         self._logger = logger
 
     def execute(self, context: MigrationContext) -> MigrationContext:
         self._logger.LogDebug(
-            "Migration stage is currently a no-op.",
-            pipeline_stage="Migration",
+            "Output stage is currently a no-op.",
+            pipeline_stage="Output",
             pipeline_step=self.name(),
         )
         return context
 
 
-def build_migration_pipeline(logger: Logger) -> Pipeline[MigrationContext, MigrationContext]:
-    """Build the migration stage pipeline."""
+def build_output_pipeline(logger: Logger) -> Pipeline[MigrationContext, MigrationContext]:
+    """Build the output stage pipeline."""
     return (
-        Pipeline.builder("Migration Pipeline", input_type=MigrationContext)
-        .use(_MigrationPassthroughStep(logger))
+        Pipeline.builder("Output Pipeline", input_type=MigrationContext)
+        .use(_OutputPassthroughStep(logger))
         .build()
     )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/output_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/output_pipeline.py
@@ -7,20 +7,20 @@ from core.pipelines import Pipeline
 from modules.migration.migration_step import MigrationPipelineStep
 from modules.migration.models import MigrationContext
 
-_SUPPORTED_MODES = ("READONLY", "WRITEBACK")
-
 
 class _OutputPassthroughStep(MigrationPipelineStep):
-    """Temporary pass-through until output behaviors land."""
+    """Placeholder: validation/writeback/report steps (TASK-007) will replace this."""
 
-    def __init__(self, logger: Logger) -> None:
+    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
         super().__init__(
-            description="Pass through the shared context until output behaviors are implemented.",
-            supported_modes=_SUPPORTED_MODES,
+            description="No-op placeholder until output behaviors are implemented.",
+            supported_modes=supported_modes,
         )
         self._logger = logger
 
     def execute(self, context: MigrationContext) -> MigrationContext:
+        # TODO: ValidateMigration, Writeback (WRITEBACK-only), and
+        # GenerateMigrationReport steps will replace this once TASK-007 lands.
         self._logger.LogDebug(
             "Output stage is currently a no-op.",
             pipeline_stage="Output",
@@ -29,10 +29,12 @@ class _OutputPassthroughStep(MigrationPipelineStep):
         return context
 
 
-def build_output_pipeline(logger: Logger) -> Pipeline[MigrationContext, MigrationContext]:
+def build_output_pipeline(
+    logger: Logger, supported_modes: tuple[str, ...]
+) -> Pipeline[MigrationContext, MigrationContext]:
     """Build the output stage pipeline."""
     return (
         Pipeline.builder("Output Pipeline", input_type=MigrationContext)
-        .use(_OutputPassthroughStep(logger))
+        .use(_OutputPassthroughStep(logger, supported_modes))
         .build()
     )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/__init__.py
@@ -1,1 +1,5 @@
-"""preprocessing package."""
+"""Preprocessing stage package."""
+
+from modules.preprocessing.input_pipeline import build_input_pipeline
+
+__all__ = ["build_input_pipeline"]

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
@@ -13,12 +13,15 @@ from modules.preprocessing.steps import (
 
 
 def build_input_pipeline(
-    logger: Logger, supported_modes: tuple[str, ...]
+    logger: Logger,
+    supported_modes: tuple[str, ...],
+    *,
+    dev_mode: bool = False,
 ) -> Pipeline[MigrationContext, MigrationContext]:
     """Build the input stage pipeline."""
     return (
         Pipeline.builder("Input Pipeline", input_type=MigrationContext)
-        .use(GatherInputWithAuthStep(logger, supported_modes))
+        .use(GatherInputWithAuthStep(logger, supported_modes, dev_mode=dev_mode))
         .use(AgentSelectionStep(logger, supported_modes))
         .use(GatherPreferredSolutionStep(logger, supported_modes))
         .build()

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
@@ -12,12 +12,14 @@ from modules.preprocessing.steps import (
 )
 
 
-def build_input_pipeline(logger: Logger) -> Pipeline[MigrationContext, MigrationContext]:
+def build_input_pipeline(
+    logger: Logger, supported_modes: tuple[str, ...]
+) -> Pipeline[MigrationContext, MigrationContext]:
     """Build the input stage pipeline."""
     return (
         Pipeline.builder("Input Pipeline", input_type=MigrationContext)
-        .use(GatherInputWithAuthStep(logger))
-        .use(AgentSelectionStep(logger))
-        .use(GatherPreferredSolutionStep(logger))
+        .use(GatherInputWithAuthStep(logger, supported_modes))
+        .use(AgentSelectionStep(logger, supported_modes))
+        .use(GatherPreferredSolutionStep(logger, supported_modes))
         .build()
     )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
@@ -1,0 +1,23 @@
+"""Input Pipeline builder."""
+
+from __future__ import annotations
+
+from core.logging import Logger
+from core.pipelines import Pipeline
+from modules.migration.models import MigrationContext
+from modules.preprocessing.steps import (
+    AgentSelectionStep,
+    GatherInputWithAuthStep,
+    GatherPreferredSolutionStep,
+)
+
+
+def build_input_pipeline(logger: Logger) -> Pipeline[MigrationContext, MigrationContext]:
+    """Build the input stage pipeline."""
+    return (
+        Pipeline.builder("Input Pipeline", input_type=MigrationContext)
+        .use(GatherInputWithAuthStep(logger))
+        .use(AgentSelectionStep(logger))
+        .use(GatherPreferredSolutionStep(logger))
+        .build()
+    )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/__init__.py
@@ -1,0 +1,13 @@
+"""Preprocessing pipeline steps."""
+
+from modules.preprocessing.steps.agent_selection_step import AgentSelectionStep
+from modules.preprocessing.steps.gather_input_with_auth_step import GatherInputWithAuthStep
+from modules.preprocessing.steps.gather_preferred_solution_step import (
+    GatherPreferredSolutionStep,
+)
+
+__all__ = [
+    "AgentSelectionStep",
+    "GatherInputWithAuthStep",
+    "GatherPreferredSolutionStep",
+]

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/agent_selection_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/agent_selection_step.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from constants import SUPPORTED_MODES
 from core.logging import Logger
 from modules.migration.migration_step import MigrationPipelineStep
 from modules.migration.models import MigrationContext
@@ -13,10 +12,10 @@ from modules.migration.models import MigrationContext
 class AgentSelectionStep(MigrationPipelineStep):
     """Query Dataverse for agents, prompt for a selection, and store it."""
 
-    def __init__(self, logger: Logger) -> None:
+    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
         super().__init__(
             description="Discover available ESS agents and select the migration target.",
-            supported_modes=SUPPORTED_MODES,
+            supported_modes=supported_modes,
         )
         self._logger = logger
 

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/agent_selection_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/agent_selection_step.py
@@ -1,0 +1,81 @@
+"""Discover ESS agents in the selected Dataverse environment."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from constants import SUPPORTED_MODES
+from core.logging import Logger
+from modules.migration.migration_step import MigrationPipelineStep
+from modules.migration.models import MigrationContext
+
+
+class AgentSelectionStep(MigrationPipelineStep):
+    """Query Dataverse for agents, prompt for a selection, and store it."""
+
+    def __init__(self, logger: Logger) -> None:
+        super().__init__(
+            description="Discover available ESS agents and select the migration target.",
+            supported_modes=SUPPORTED_MODES,
+        )
+        self._logger = logger
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        if context.dataverse_client is None:
+            raise RuntimeError("Dataverse client is not initialized.")
+
+        agents = sorted(
+            context.dataverse_client.query_all("bots", select="name,botid,statecode"),
+            key=_agent_sort_key,
+        )
+        if not agents:
+            raise RuntimeError("No ESS agents were found in the selected environment.")
+
+        self._logger.LogInfo(
+            "Available ESS agents:",
+            pipeline_stage="Input",
+            pipeline_step=self.name(),
+        )
+        for index, agent in enumerate(agents, start=1):
+            self._logger.LogInfo(
+                _format_agent(index, agent),
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+
+        selection = _prompt_for_selection(len(agents))
+        selected = agents[selection - 1]
+        context.selected_agent_id = _string_field(selected, "botid")
+        context.selected_agent_name = _string_field(selected, "name")
+
+        self._logger.LogInfo(
+            f"Selected agent {context.selected_agent_name or '(unnamed agent)'}.",
+            pipeline_stage="Input",
+            pipeline_step=self.name(),
+        )
+        return context
+
+
+def _agent_sort_key(agent: dict[str, Any]) -> tuple[str, str]:
+    return (_string_field(agent, "name") or "", _string_field(agent, "botid") or "")
+
+
+def _format_agent(index: int, agent: dict[str, Any]) -> str:
+    name = _string_field(agent, "name") or "(unnamed agent)"
+    bot_id = _string_field(agent, "botid") or "(no id)"
+    state = str(agent.get("statecode", "unknown"))
+    return f"{index}. {name} [{bot_id}] state={state}"
+
+
+def _prompt_for_selection(count: int) -> int:
+    while True:
+        choice = input(f"Select agent [1-{count}]: ").strip()
+        if choice.isdigit():
+            index = int(choice)
+            if 1 <= index <= count:
+                return index
+
+
+def _string_field(record: dict[str, Any], field_name: str) -> str | None:
+    value = record.get(field_name)
+    return value if isinstance(value, str) and value else None

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
@@ -29,7 +29,9 @@ _TENANT_PATTERN = re.compile(r"login\.microsoftonline\.com/([^/]+)")
 class GatherInputWithAuthStep(MigrationPipelineStep):
     """Prompt for the Dataverse URL, authenticate, and initialize context access."""
 
-    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
+    def __init__(
+        self, logger: Logger, supported_modes: tuple[str, ...], *, dev_mode: bool = False
+    ) -> None:
         super().__init__(
             description=(
                 "Gather the target Dataverse environment and authenticate the current user."
@@ -37,9 +39,21 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
             supported_modes=supported_modes,
         )
         self._logger = logger
+        self._dev_mode = dev_mode
 
     def execute(self, context: MigrationContext) -> MigrationContext:
-        environment_url = _prompt_for_environment_url()
+        dev_config = _load_dev_config() if self._dev_mode else None
+
+        if dev_config and dev_config.get("environment_url"):
+            environment_url = dev_config["environment_url"]
+            self._logger.LogInfo(
+                f"[dev] Using environment from .local/dev-config.json: {environment_url}",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+        else:
+            environment_url = _prompt_for_environment_url()
+
         context.environment_url = environment_url
 
         self._logger.LogInfo(
@@ -47,22 +61,42 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
             pipeline_stage="Input",
             pipeline_step=self.name(),
         )
-        self._logger.LogInfo(
-            f"Discovering tenant and authenticating with MSAL for {environment_url}.",
-            pipeline_stage="Input",
-            pipeline_step=self.name(),
-        )
 
-        token_provider = MsalTokenProvider(_build_provider_config(environment_url))
-        token = token_provider.get_token()
-        claims = _decode_claims(token)
-
-        context.tid = _as_string(claims.get("tid"))
-        context.oid = _as_string(claims.get("oid"))
-        context.upn = _as_string(claims.get("upn")) or _as_string(
-            claims.get("preferred_username"),
-        )
-        context.dataverse_client = DataverseClient(environment_url, token_provider)
+        # Dev shortcut: if token is provided in dev-config, skip interactive auth
+        if dev_config and dev_config.get("token"):
+            token = dev_config["token"]
+            self._logger.LogInfo(
+                "[dev] Using hardcoded token from .local/dev-config.json (skipping MSAL).",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+            claims = _decode_claims(token)
+            context.tid = _as_string(claims.get("tid"))
+            context.oid = _as_string(claims.get("oid"))
+            context.upn = _as_string(claims.get("upn")) or _as_string(
+                claims.get("preferred_username"),
+            )
+            # Create a token provider that always returns the hardcoded token
+            config = _build_provider_config(environment_url)
+            token_provider = MsalTokenProvider(config)
+            # Monkey-patch get_token to return the static token for dev
+            token_provider.get_token = lambda *_a, **_kw: token  # type: ignore[method-assign]
+            context.dataverse_client = DataverseClient(environment_url, token_provider)
+        else:
+            self._logger.LogInfo(
+                f"Discovering tenant and authenticating with MSAL for {environment_url}.",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+            token_provider = MsalTokenProvider(_build_provider_config(environment_url))
+            token = token_provider.get_token()
+            claims = _decode_claims(token)
+            context.tid = _as_string(claims.get("tid"))
+            context.oid = _as_string(claims.get("oid"))
+            context.upn = _as_string(claims.get("upn")) or _as_string(
+                claims.get("preferred_username"),
+            )
+            context.dataverse_client = DataverseClient(environment_url, token_provider)
 
         self._logger.LogInfo(
             "Authentication completed.",
@@ -143,3 +177,17 @@ def _decode_claims(token: str) -> dict[str, Any]:
 
 def _as_string(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _load_dev_config() -> dict[str, str] | None:
+    """Load .local/dev-config.json if it exists. Returns None if missing."""
+    from pathlib import Path
+
+    config_path = Path(__file__).resolve().parents[4] / ".local" / "dev-config.json"
+    if not config_path.is_file():
+        return None
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (json.JSONDecodeError, OSError):
+        return None

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
@@ -76,12 +76,7 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
             context.upn = _as_string(claims.get("upn")) or _as_string(
                 claims.get("preferred_username"),
             )
-            # Create a token provider that always returns the hardcoded token
-            config = _build_provider_config(environment_url)
-            token_provider = MsalTokenProvider(config, self._logger)
-            # Monkey-patch get_token to return the static token for dev
-            token_provider.get_token = lambda *_a, **_kw: token  # type: ignore[method-assign]
-            context.dataverse_client = DataverseClient(environment_url, token_provider)
+            context.dataverse_client = DataverseClient(environment_url, _StaticTokenProvider(token))
         else:
             self._logger.LogInfo(
                 f"Discovering tenant and authenticating with MSAL for {environment_url}.",
@@ -193,3 +188,13 @@ def _load_dev_config() -> dict[str, str] | None:
         return data if isinstance(data, dict) else None
     except (json.JSONDecodeError, OSError):
         return None
+
+
+class _StaticTokenProvider:
+    """Dev-only token provider that returns a hardcoded token (no MSAL, no network)."""
+
+    def __init__(self, token: str) -> None:
+        self.__token = token
+
+    def get_token(self, *_args: object, **_kwargs: object) -> str:
+        return self.__token

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
@@ -1,0 +1,142 @@
+"""Prompt for environment input, authenticate, and seed context identity."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from constants import DATAVERSE_CLIENT_ID, SUPPORTED_MODES
+from core.auth import AuthenticationException, MsalTokenProvider, MsalTokenProviderConfig
+from core.logging import Logger
+from core.outbound import DataverseClient
+from modules.migration.migration_step import MigrationPipelineStep
+from modules.migration.models import MigrationContext
+
+_DEFAULT_TENANT = "organizations"
+_DEFAULT_SCOPE_SUFFIX = "/user_impersonation"
+_TENANT_PATTERN = re.compile(r"login\.microsoftonline\.com/([^/]+)")
+
+
+class GatherInputWithAuthStep(MigrationPipelineStep):
+    """Prompt for the Dataverse URL, authenticate, and initialize context access."""
+
+    def __init__(self, logger: Logger) -> None:
+        super().__init__(
+            description=(
+                "Gather the target Dataverse environment and authenticate the current user."
+            ),
+            supported_modes=SUPPORTED_MODES,
+        )
+        self._logger = logger
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        environment_url = _prompt_for_environment_url()
+        context.environment_url = environment_url
+
+        self._logger.LogInfo(
+            f"Using Dataverse environment {environment_url}.",
+            pipeline_stage="Input",
+            pipeline_step=self.name(),
+        )
+        self._logger.LogInfo(
+            f"Discovering tenant and authenticating with MSAL for {environment_url}.",
+            pipeline_stage="Input",
+            pipeline_step=self.name(),
+        )
+
+        token_provider = MsalTokenProvider(_build_provider_config(environment_url))
+        token = token_provider.get_token()
+        claims = _decode_claims(token)
+
+        context.tenant_id = _as_string(claims.get("tid"))
+        context.user_id = _as_string(claims.get("oid"))
+        context.user_email = _as_string(claims.get("upn")) or _as_string(
+            claims.get("preferred_username"),
+        )
+        context.dataverse_client = DataverseClient(environment_url, token_provider)
+
+        self._logger.LogInfo(
+            "Authentication completed.",
+            pipeline_stage="Input",
+            pipeline_step=self.name(),
+        )
+        return context
+
+
+def _prompt_for_environment_url() -> str:
+    # Future enhancement: accept an Environment ID and resolve the instance URL
+    # via the Power Platform BAP discovery API before Dataverse auth.
+    return _normalize_environment_url(
+        input(
+            "Dataverse environment URL (full URL, for example https://org.crm.dynamics.com): ",
+        ),
+    )
+
+
+def _normalize_environment_url(value: str) -> str:
+    normalized = value.strip().rstrip("/")
+    if not normalized:
+        raise ValueError("Environment URL must not be empty.")
+
+    parsed = urlparse(normalized)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("Environment URL must be an HTTPS URL.")
+
+    return normalized
+
+
+def _build_provider_config(environment_url: str) -> MsalTokenProviderConfig:
+    authority = os.environ.get("MTK_MSAL_AUTHORITY", _build_authority(environment_url))
+    scope = os.environ.get("MTK_MSAL_DEFAULT_SCOPE", f"{environment_url}{_DEFAULT_SCOPE_SUFFIX}")
+    return MsalTokenProviderConfig(
+        client_id=os.environ.get("MTK_MSAL_CLIENT_ID", DATAVERSE_CLIENT_ID),
+        authority=authority,
+        scopes=(scope,),
+    )
+
+
+def _build_authority(environment_url: str) -> str:
+    tenant_id = _discover_tenant(environment_url)
+    return f"https://login.microsoftonline.com/{tenant_id}"
+
+
+def _discover_tenant(environment_url: str) -> str:
+    response = httpx.get(
+        f"{environment_url}/api/data/v9.2/",
+        headers={"Accept": "application/json"},
+        follow_redirects=False,
+        timeout=10.0,
+    )
+    auth_header = response.headers.get("WWW-Authenticate", "")
+    match = _TENANT_PATTERN.search(auth_header)
+    if match:
+        return match.group(1)
+    return _DEFAULT_TENANT
+
+
+def _decode_claims(token: str) -> dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise AuthenticationException("Authentication token acquisition failed.")
+
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(f"{payload}{padding}")
+        claims = json.loads(decoded.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise AuthenticationException("Authentication token acquisition failed.") from exc
+
+    if not isinstance(claims, dict):
+        raise AuthenticationException("Authentication token acquisition failed.")
+    return claims
+
+
+def _as_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
@@ -78,7 +78,7 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
             )
             # Create a token provider that always returns the hardcoded token
             config = _build_provider_config(environment_url)
-            token_provider = MsalTokenProvider(config)
+            token_provider = MsalTokenProvider(config, self._logger)
             # Monkey-patch get_token to return the static token for dev
             token_provider.get_token = lambda *_a, **_kw: token  # type: ignore[method-assign]
             context.dataverse_client = DataverseClient(environment_url, token_provider)
@@ -88,7 +88,9 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
                 pipeline_stage="Input",
                 pipeline_step=self.name(),
             )
-            token_provider = MsalTokenProvider(_build_provider_config(environment_url))
+            token_provider = MsalTokenProvider(
+                _build_provider_config(environment_url), self._logger
+            )
             token = token_provider.get_token()
             claims = _decode_claims(token)
             context.tid = _as_string(claims.get("tid"))

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
@@ -11,12 +11,15 @@ from urllib.parse import urlparse
 
 import httpx
 
-from constants import DATAVERSE_CLIENT_ID, SUPPORTED_MODES
 from core.auth import AuthenticationException, MsalTokenProvider, MsalTokenProviderConfig
 from core.logging import Logger
 from core.outbound import DataverseClient
 from modules.migration.migration_step import MigrationPipelineStep
 from modules.migration.models import MigrationContext
+
+# Microsoft public client ID for Power Platform CLI / Dataverse delegated access.
+# Source: https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2
+DATAVERSE_CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"
 
 _DEFAULT_TENANT = "organizations"
 _DEFAULT_SCOPE_SUFFIX = "/user_impersonation"
@@ -26,12 +29,12 @@ _TENANT_PATTERN = re.compile(r"login\.microsoftonline\.com/([^/]+)")
 class GatherInputWithAuthStep(MigrationPipelineStep):
     """Prompt for the Dataverse URL, authenticate, and initialize context access."""
 
-    def __init__(self, logger: Logger) -> None:
+    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
         super().__init__(
             description=(
                 "Gather the target Dataverse environment and authenticate the current user."
             ),
-            supported_modes=SUPPORTED_MODES,
+            supported_modes=supported_modes,
         )
         self._logger = logger
 
@@ -54,9 +57,9 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
         token = token_provider.get_token()
         claims = _decode_claims(token)
 
-        context.tenant_id = _as_string(claims.get("tid"))
-        context.user_id = _as_string(claims.get("oid"))
-        context.user_email = _as_string(claims.get("upn")) or _as_string(
+        context.tid = _as_string(claims.get("tid"))
+        context.oid = _as_string(claims.get("oid"))
+        context.upn = _as_string(claims.get("upn")) or _as_string(
             claims.get("preferred_username"),
         )
         context.dataverse_client = DataverseClient(environment_url, token_provider)

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_preferred_solution_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_preferred_solution_step.py
@@ -1,0 +1,40 @@
+"""Capture the optional preferred solution for writeback."""
+
+from __future__ import annotations
+
+from constants import SUPPORTED_MODES
+from core.logging import Logger
+from modules.migration.migration_step import MigrationPipelineStep
+from modules.migration.models import MigrationContext
+
+
+class GatherPreferredSolutionStep(MigrationPipelineStep):
+    """Prompt for the optional preferred solution unique name."""
+
+    def __init__(self, logger: Logger) -> None:
+        super().__init__(
+            description="Capture the optional preferred solution for writeback.",
+            supported_modes=SUPPORTED_MODES,
+        )
+        self._logger = logger
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        preferred_solution = input(
+            "Do you have a preferred solution for writeback? "
+            "(Enter solution unique name, or press Enter to skip) ",
+        ).strip()
+
+        context.preferred_solution = preferred_solution or None
+        if context.preferred_solution is None:
+            self._logger.LogInfo(
+                "No preferred solution provided; writeback will use the default solution.",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+        else:
+            self._logger.LogInfo(
+                f"Using preferred solution {context.preferred_solution}.",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+        return context

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_preferred_solution_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_preferred_solution_step.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from constants import SUPPORTED_MODES
 from core.logging import Logger
 from modules.migration.migration_step import MigrationPipelineStep
 from modules.migration.models import MigrationContext
@@ -11,10 +10,10 @@ from modules.migration.models import MigrationContext
 class GatherPreferredSolutionStep(MigrationPipelineStep):
     """Prompt for the optional preferred solution unique name."""
 
-    def __init__(self, logger: Logger) -> None:
+    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
         super().__init__(
             description="Capture the optional preferred solution for writeback.",
-            supported_modes=SUPPORTED_MODES,
+            supported_modes=supported_modes,
         )
         self._logger = logger
 

--- a/tools/ess-nextgen-migration-toolkit/src/service/constants.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for the ESS Migration Toolkit."""
+
+# Supported execution modes for the ESS migration pipeline.
+SUPPORTED_MODES = ("READONLY", "WRITEBACK")

--- a/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from core.logging import Logger, Reporter
@@ -13,23 +14,28 @@ from modules.postprocessing import build_output_pipeline
 from modules.preprocessing import build_input_pipeline
 from service.constants import SUPPORTED_MODES
 
-OUTPUT_ROOT = Path(__file__).resolve().parents[2] / "output"
+TOOLKIT_ROOT = Path(__file__).resolve().parents[2]
+OUTPUT_ROOT = TOOLKIT_ROOT / "output"
+
+
+def _is_dev_mode() -> bool:
+    return "--dev" in sys.argv
 
 
 def main() -> None:
     """Build and run the ESS migration super-pipeline."""
+    dev_mode = _is_dev_mode()
     context = MigrationContext(ExecutionMode=ExecutionMode.READONLY)
     logger = Logger.start_session(OUTPUT_ROOT, context)
     try:
         toolkit = (
             ChainedPipeline[MigrationContext]()
-            .add(build_input_pipeline(logger, SUPPORTED_MODES))
+            .add(build_input_pipeline(logger, SUPPORTED_MODES, dev_mode=dev_mode))
             .add(build_migration_pipeline(logger, SUPPORTED_MODES))
             .add(build_output_pipeline(logger, SUPPORTED_MODES))
         )
         toolkit.run(context)
     except Exception:
-        # Print traceback while tee is still active so it lands in session.log
         import traceback
 
         traceback.print_exc()

--- a/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
@@ -11,6 +11,7 @@ from modules.migration import MigrationContext
 from modules.migration.migration_pipeline import build_migration_pipeline
 from modules.postprocessing import build_output_pipeline
 from modules.preprocessing import build_input_pipeline
+from service.constants import SUPPORTED_MODES
 
 OUTPUT_ROOT = Path(__file__).resolve().parents[2] / "output"
 
@@ -22,9 +23,9 @@ def main() -> None:
     try:
         toolkit = (
             ChainedPipeline[MigrationContext]()
-            .add(build_input_pipeline(logger))
-            .add(build_migration_pipeline(logger))
-            .add(build_output_pipeline(logger))
+            .add(build_input_pipeline(logger, SUPPORTED_MODES))
+            .add(build_migration_pipeline(logger, SUPPORTED_MODES))
+            .add(build_output_pipeline(logger, SUPPORTED_MODES))
         )
         toolkit.run(context)
     finally:

--- a/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
@@ -1,25 +1,42 @@
-"""ESS NextGen Migration Toolkit — orchestration entry point.
-
-This is the single entry point for the toolkit and the top of the dependency
-graph (the Application / Orchestration layer). It composes and drives the lower
-layers — the Pipeline Engine (``core.pipelines``), the pipeline-stage business
-logic (``modules`` — preprocessing, migration, postprocessing), and the
-Dataverse Client (``core.outbound``). For now it is a silent placeholder;
-orchestration logic and any command surface are added by later tasks.
-
-Run it via the ``mtk`` dispatcher (``./mtk.sh start``), which provisions the
-environment and then launches this module.
-"""
+"""ESS NextGen Migration Toolkit — orchestration entry point."""
 
 from __future__ import annotations
 
-import logging
+from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from core.logging import Logger, Reporter
+from core.models import ExecutionMode
+from core.pipelines import ChainedPipeline
+from modules.migration import MigrationContext
+from modules.migration.migration_pipeline import build_migration_pipeline
+from modules.postprocessing import build_output_pipeline
+from modules.preprocessing import build_input_pipeline
+
+OUTPUT_ROOT = Path(__file__).resolve().parents[2] / "output"
 
 
 def main() -> None:
-    """Toolkit orchestration entry point. Placeholder until wired up."""
+    """Build and run the ESS migration super-pipeline."""
+    context = MigrationContext(ExecutionMode=ExecutionMode.READONLY)
+    logger = Logger.start_session(OUTPUT_ROOT, context)
+    try:
+        toolkit = (
+            ChainedPipeline[MigrationContext]()
+            .add(build_input_pipeline(logger))
+            .add(build_migration_pipeline(logger))
+            .add(build_output_pipeline(logger))
+        )
+        toolkit.run(context)
+    finally:
+        try:
+            Reporter(logger.session_manager).render(context)
+            logger.LogInfo(
+                f"Session bundle written to {logger.session_manager.paths.session_dir}",
+                pipeline_stage="Output",
+                pipeline_step="Reporter",
+            )
+        finally:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
@@ -28,6 +28,12 @@ def main() -> None:
             .add(build_output_pipeline(logger, SUPPORTED_MODES))
         )
         toolkit.run(context)
+    except Exception:
+        # Print traceback while tee is still active so it lands in session.log
+        import traceback
+
+        traceback.print_exc()
+        raise
     finally:
         try:
             Reporter(logger.session_manager).render(context)

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/auth/test_token_provider.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/auth/test_token_provider.py
@@ -21,6 +21,22 @@ CLIENT_ID = "client-id"
 NOW = 1_000.0
 
 
+class FakeLogger:
+    """No-op logger for unit tests."""
+
+    def LogDebug(self, *a: object, **kw: object) -> None:
+        pass
+
+    def LogInfo(self, *a: object, **kw: object) -> None:
+        pass
+
+    def LogWarning(self, *a: object, **kw: object) -> None:
+        pass
+
+    def LogError(self, *a: object, **kw: object) -> None:
+        pass
+
+
 class FakeMsalApplication:
     def __init__(
         self,
@@ -69,7 +85,7 @@ def config(
 
 def test_cold_start_uses_interactive_acquisition_only_when_no_account_exists() -> None:
     app = FakeMsalApplication()
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     token = provider.get_token()
 
@@ -84,7 +100,7 @@ def test_existing_account_uses_silent_acquisition_without_interactive_fallback()
         accounts=[account],
         silent_results=[{"access_token": "silent-token", "expires_on": NOW + 3_600}],
     )
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     token = provider.get_token("https://contoso.crm.dynamics.com")
 
@@ -102,7 +118,7 @@ def test_near_expiry_token_forces_silent_refresh_before_returning() -> None:
             {"access_token": "refreshed-token", "expires_on": NOW + 3_600},
         ],
     )
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     token = provider.get_token()
 
@@ -121,7 +137,7 @@ def test_rejects_non_https_authority_and_scopes() -> None:
     with pytest.raises(ValueError, match="scope must be an HTTPS URL"):
         config(scopes=("http://contoso.crm.dynamics.com/.default",))
 
-    provider = MsalTokenProvider(config(), app=FakeMsalApplication(), now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=FakeMsalApplication(), now=lambda: NOW)
     with pytest.raises(ValueError, match="scope must be an HTTPS URL"):
         provider.get_token("http://contoso.crm.dynamics.com")
 
@@ -132,7 +148,7 @@ def test_acquisition_failure_raises_sanitized_authentication_exception() -> None
         accounts=[account],
         silent_results=[{"error": "invalid_grant", "error_description": "secret provider detail"}],
     )
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     with pytest.raises(AuthenticationException) as exc_info:
         provider.get_token()
@@ -154,7 +170,7 @@ def test_default_msal_application_uses_in_memory_cache_only(
     fake_msal = SimpleNamespace(PublicClientApplication=CapturingPublicClientApplication)
     monkeypatch.setattr("core.auth.token_provider.import_module", lambda name: fake_msal)
 
-    MsalTokenProvider(config())
+    MsalTokenProvider(config(), FakeLogger())
 
     assert calls == [{"client_id": CLIENT_ID, "authority": AUTHORITY}]
     assert "token_cache" not in calls[0]

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/auth/test_token_provider.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/auth/test_token_provider.py
@@ -85,7 +85,7 @@ def config(
 
 def test_cold_start_uses_interactive_acquisition_only_when_no_account_exists() -> None:
     app = FakeMsalApplication()
-    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)  # type: ignore[arg-type]
 
     token = provider.get_token()
 
@@ -100,7 +100,7 @@ def test_existing_account_uses_silent_acquisition_without_interactive_fallback()
         accounts=[account],
         silent_results=[{"access_token": "silent-token", "expires_on": NOW + 3_600}],
     )
-    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)  # type: ignore[arg-type]
 
     token = provider.get_token("https://contoso.crm.dynamics.com")
 
@@ -118,7 +118,7 @@ def test_near_expiry_token_forces_silent_refresh_before_returning() -> None:
             {"access_token": "refreshed-token", "expires_on": NOW + 3_600},
         ],
     )
-    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)  # type: ignore[arg-type]
 
     token = provider.get_token()
 
@@ -137,7 +137,7 @@ def test_rejects_non_https_authority_and_scopes() -> None:
     with pytest.raises(ValueError, match="scope must be an HTTPS URL"):
         config(scopes=("http://contoso.crm.dynamics.com/.default",))
 
-    provider = MsalTokenProvider(config(), FakeLogger(), app=FakeMsalApplication(), now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=FakeMsalApplication(), now=lambda: NOW)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="scope must be an HTTPS URL"):
         provider.get_token("http://contoso.crm.dynamics.com")
 
@@ -148,7 +148,7 @@ def test_acquisition_failure_raises_sanitized_authentication_exception() -> None
         accounts=[account],
         silent_results=[{"error": "invalid_grant", "error_description": "secret provider detail"}],
     )
-    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)  # type: ignore[arg-type]
 
     with pytest.raises(AuthenticationException) as exc_info:
         provider.get_token()
@@ -170,7 +170,7 @@ def test_default_msal_application_uses_in_memory_cache_only(
     fake_msal = SimpleNamespace(PublicClientApplication=CapturingPublicClientApplication)
     monkeypatch.setattr("core.auth.token_provider.import_module", lambda name: fake_msal)
 
-    MsalTokenProvider(config(), FakeLogger())
+    MsalTokenProvider(config(), FakeLogger())  # type: ignore[arg-type]
 
     assert calls == [{"client_id": CLIENT_ID, "authority": AUTHORITY}]
     assert "token_cache" not in calls[0]

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
@@ -92,8 +92,8 @@ def test_engineer_channel_writes_console_and_session_log(
     captured = capsys.readouterr()
     session_log = logger.session_manager.paths.log_path.read_text(encoding="utf-8")
 
-    assert "2026-07-18 14:32:05 DEBUG Migration DiagnosticsStep Debug detail" in captured.out
-    assert "2026-07-18 14:32:05 DEBUG Migration DiagnosticsStep Debug detail" in session_log
+    assert "[2026-07-18 14:32:05] [DEBUG] [Migration/DiagnosticsStep] Debug detail" in captured.out
+    assert "[2026-07-18 14:32:05] [DEBUG] [Migration/DiagnosticsStep] Debug detail" in session_log
 
 
 def test_customer_channel_updates_report_model_only(

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/logging/test_diagnostics_framework.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from core.logging import Logger, LogLevel, Reporter, SessionManager
-from core.models import ChangeEntry, DiagnosticEntry
+from core.models import ChangeEntry, DiagnosticEntry, ExecutionMode
 from modules.migration.models import MigrationContext
 
 FIXED_TIME = datetime(2026, 7, 18, 14, 32, 5)
@@ -159,7 +159,7 @@ def test_customer_channel_updates_report_model_only(
 
 def test_reporter_renders_customer_report_from_context_collectors(workspace: Path) -> None:
     context = MigrationContext(
-        ExecutionMode="WRITEBACK",
+        ExecutionMode=ExecutionMode.WRITEBACK,
         Changes=[
             ChangeEntry(
                 message="Runtime Provider CA → DA",
@@ -217,8 +217,8 @@ def test_tee_stream_survives_log_file_write_failure(
     try:
         # Force-close the log file to simulate disk/handle failure
         logger.session_manager.paths.log_path.open("w").close()
-        log_handle = logger._log_file  # noqa: SLF001
-        log_handle.close()
+        log_handle = logger._log_file  # noqa: SLF001  # type: ignore[union-attr]
+        log_handle.close()  # type: ignore[union-attr]
         # This must NOT raise — console output should still work
         sys.stdout.write("after-close output\n")
     finally:
@@ -247,7 +247,7 @@ def test_session_manager_prunes_old_sessions(workspace: Path) -> None:
     """SessionManager should keep at most max_sessions bundles."""
     times = [datetime(2026, 7, 18, 10, 0, s) for s in range(8)]
     for t in times[:7]:
-        mgr = SessionManager(workspace, clock=lambda _t=t: _t, max_sessions=5)
+        mgr = SessionManager(workspace, clock=lambda _t=t: _t, max_sessions=5)  # type: ignore[misc]
         mgr.create_session()
 
     session_dirs = sorted(d.name for d in workspace.iterdir() if d.is_dir())

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
@@ -1,0 +1,204 @@
+"""Unit tests for the typed Dataverse Web API client."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from core.outbound import AuthenticationExpiredError, DataverseApiError, DataverseClient
+
+ENV_URL = "https://contoso.crm.dynamics.com"
+
+
+class FakeTokenProvider:
+    def __init__(self, tokens: list[str] | None = None) -> None:
+        self._tokens = tokens or ["token-1"]
+        self.calls = 0
+
+    def get_token(self) -> str:
+        self.calls += 1
+        if self.calls <= len(self._tokens):
+            return self._tokens[self.calls - 1]
+        return self._tokens[-1]
+
+
+def make_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    token_provider: FakeTokenProvider | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> tuple[DataverseClient, FakeTokenProvider]:
+    provider = token_provider or FakeTokenProvider()
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.Client(transport=transport, base_url=f"{ENV_URL}/api/data/v9.2/")
+    return DataverseClient(ENV_URL, provider, client=http_client, sleep=sleep), provider
+
+
+def test_query_all_acquires_a_fresh_token_and_applies_odata_headers_per_request() -> None:
+    seen_tokens: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_tokens.append(request.headers["Authorization"])
+        assert request.headers["Accept"] == "application/json"
+        assert request.headers["OData-MaxVersion"] == "4.0"
+        assert request.headers["OData-Version"] == "4.0"
+        assert request.headers["Prefer"] == "odata.include-annotations=*"
+
+        if "page=2" in str(request.url):
+            return httpx.Response(200, json={"value": [{"id": 2}]})
+        return httpx.Response(
+            200,
+            json={
+                "value": [{"id": 1}],
+                "@odata.nextLink": f"{ENV_URL}/api/data/v9.2/bots?page=2",
+            },
+        )
+
+    client, provider = make_client(
+        handler,
+        token_provider=FakeTokenProvider(["token-1", "token-2"]),
+    )
+
+    records = client.query_all("bots", select="botid,name")
+
+    assert records == [{"id": 1}, {"id": 2}]
+    assert provider.calls == 2
+    assert seen_tokens == ["Bearer token-1", "Bearer token-2"]
+
+
+def test_query_all_follows_odata_next_link_until_all_pages_are_returned() -> None:
+    requests_seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(str(request.url))
+        if "page=3" in str(request.url):
+            return httpx.Response(200, json={"value": [{"id": 3}]})
+        if "page=2" in str(request.url):
+            return httpx.Response(
+                200,
+                json={
+                    "value": [{"id": 2}],
+                    "@odata.nextLink": f"{ENV_URL}/api/data/v9.2/bots?page=3",
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "value": [{"id": 1}],
+                "@odata.nextLink": f"{ENV_URL}/api/data/v9.2/bots?page=2",
+            },
+        )
+
+    client, _ = make_client(handler)
+
+    records = client.query_all("bots", select="botid")
+
+    assert records == [{"id": 1}, {"id": 2}, {"id": 3}]
+    assert requests_seen == [
+        f"{ENV_URL}/api/data/v9.2/bots?%24select=botid",
+        f"{ENV_URL}/api/data/v9.2/bots?page=2",
+        f"{ENV_URL}/api/data/v9.2/bots?page=3",
+    ]
+
+
+def test_get_retries_on_retryable_statuses_and_respects_retry_after_header() -> None:
+    attempts = 0
+    sleep_calls: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "7"})
+        if attempts == 2:
+            return httpx.Response(503)
+        return httpx.Response(200, json={"value": [{"id": 1}]})
+
+    client, provider = make_client(handler, sleep=sleep_calls.append)
+
+    payload = client.get("bots")
+
+    assert payload == {"value": [{"id": 1}]}
+    assert attempts == 3
+    assert provider.calls == 3
+    assert sleep_calls == [7.0, 2.0]
+
+
+@pytest.mark.parametrize(
+    ("operation", "runner"),
+    [
+        ("create", lambda client: client.create("bots", {"name": "Created"})),
+        ("update", lambda client: client.update("bots", "record-id", {"name": "Updated"})),
+        ("delete", lambda client: client.delete("bots", "record-id")),
+    ],
+)
+def test_mutating_operations_do_not_retry_on_server_failures(
+    operation: str,
+    runner: Callable[[DataverseClient], object],
+) -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(503)
+
+    client, provider = make_client(handler)
+
+    with pytest.raises(DataverseApiError) as exc_info:
+        runner(client)
+
+    assert attempts == 1
+    assert provider.calls == 1
+    assert exc_info.value.operation == operation
+
+
+def test_401_responses_raise_authentication_expired_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, headers={"x-ms-request-id": "req-401"})
+
+    client, _ = make_client(handler)
+
+    with pytest.raises(AuthenticationExpiredError) as exc_info:
+        client.get("bots")
+
+    assert exc_info.value.status == 401
+    assert exc_info.value.operation == "read"
+    assert exc_info.value.entity_set == "bots"
+    assert exc_info.value.request_id == "req-401"
+
+
+def test_non_auth_http_errors_raise_dataverse_api_error_with_context() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, headers={"x-ms-request-id": "req-404"})
+
+    client, _ = make_client(handler)
+
+    with pytest.raises(DataverseApiError) as exc_info:
+        client.create("bots", {"name": "Created"})
+
+    assert exc_info.value.status == 404
+    assert exc_info.value.operation == "create"
+    assert exc_info.value.entity_set == "bots"
+    assert exc_info.value.request_id == "req-404"
+
+
+def test_constructor_rejects_non_https_environment_urls() -> None:
+    with pytest.raises(ValueError, match="env_url must be an HTTPS URL"):
+        DataverseClient("http://contoso.crm.dynamics.com", FakeTokenProvider())
+
+
+def test_create_returns_record_id_from_odata_entity_id_header() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            204,
+            headers={"OData-EntityId": f"{ENV_URL}/api/data/v9.2/bots(12345)"},
+        )
+
+    client, _ = make_client(handler)
+
+    record_id = client.create("bots", {"name": "Created"})
+
+    assert record_id == "12345"

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
@@ -193,16 +193,6 @@ def test_constructor_rejects_non_https_environment_urls() -> None:
         DataverseClient("http://contoso.crm.dynamics.com", FakeTokenProvider())
 
 
-def test_with_environment_rebinds_client_to_new_environment() -> None:
-    provider = FakeTokenProvider()
-    original = DataverseClient(ENV_URL, provider)
-
-    rebound = original.with_environment("https://fabrikam.crm.dynamics.com")
-
-    assert original.environment_url == ENV_URL
-    assert rebound.environment_url == "https://fabrikam.crm.dynamics.com"
-
-
 def test_create_returns_record_id_from_odata_entity_id_header() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
@@ -16,9 +16,11 @@ class FakeTokenProvider:
     def __init__(self, tokens: list[str] | None = None) -> None:
         self._tokens = tokens or ["token-1"]
         self.calls = 0
+        self.requested_scopes: list[str | None] = []
 
-    def get_token(self) -> str:
+    def get_token(self, scopes: str | None = None) -> str:
         self.calls += 1
+        self.requested_scopes.append(scopes)
         if self.calls <= len(self._tokens):
             return self._tokens[self.calls - 1]
         return self._tokens[-1]
@@ -65,6 +67,7 @@ def test_query_all_acquires_a_fresh_token_and_applies_odata_headers_per_request(
 
     assert records == [{"id": 1}, {"id": 2}]
     assert provider.calls == 2
+    assert provider.requested_scopes == [None, None]
     assert seen_tokens == ["Bearer token-1", "Bearer token-2"]
 
 
@@ -188,6 +191,16 @@ def test_non_auth_http_errors_raise_dataverse_api_error_with_context() -> None:
 def test_constructor_rejects_non_https_environment_urls() -> None:
     with pytest.raises(ValueError, match="env_url must be an HTTPS URL"):
         DataverseClient("http://contoso.crm.dynamics.com", FakeTokenProvider())
+
+
+def test_with_environment_rebinds_client_to_new_environment() -> None:
+    provider = FakeTokenProvider()
+    original = DataverseClient(ENV_URL, provider)
+
+    rebound = original.with_environment("https://fabrikam.crm.dynamics.com")
+
+    assert original.environment_url == ENV_URL
+    assert rebound.environment_url == "https://fabrikam.crm.dynamics.com"
 
 
 def test_create_returns_record_id_from_odata_entity_id_header() -> None:

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/pipeline/test_pipeline_framework.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/pipeline/test_pipeline_framework.py
@@ -136,7 +136,7 @@ def test_incompatible_adjacent_step_types_fail_during_construction() -> None:
     builder = Pipeline.builder("invalid", input_type=int).use(IntToStringStep())
 
     with pytest.raises(PipelineConfigurationError, match="expects float"):
-        builder.use(FloatToStringStep())
+        builder.use(FloatToStringStep())  # type: ignore[arg-type]
 
 
 def test_pipeline_registry_rejects_duplicate_step_names() -> None:

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/migration/test_migration_step.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/migration/test_migration_step.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from core.models import ExecutionMode
 from core.pipelines import Pipeline
 from modules.migration.migration_step import MigrationPipelineStep
 from modules.migration.models import MigrationContext
@@ -44,12 +45,12 @@ def test_mode_gated_step_runs_only_in_declared_mode() -> None:
         .build()
     )
 
-    discover_ctx = MigrationContext(ExecutionMode="READONLY")
+    discover_ctx = MigrationContext(ExecutionMode=ExecutionMode.READONLY)
     result = pipeline.run(discover_ctx)
     assert len(result.Logs) == 1  # discover-only ran
     assert len(result.Warnings) == 0  # migrate-only skipped
 
-    migrate_ctx = MigrationContext(ExecutionMode="WRITEBACK")
+    migrate_ctx = MigrationContext(ExecutionMode=ExecutionMode.WRITEBACK)
     result = pipeline.run(migrate_ctx)
     assert len(result.Logs) == 0  # discover-only skipped
     assert len(result.Warnings) == 1  # migrate-only ran
@@ -58,7 +59,7 @@ def test_mode_gated_step_runs_only_in_declared_mode() -> None:
 def test_empty_supported_modes_runs_in_all_modes() -> None:
     pipeline = Pipeline.builder("always", input_type=MigrationContext).use(AllModesStep()).build()
 
-    for mode in ("READONLY", "WRITEBACK"):
+    for mode in (ExecutionMode.READONLY, ExecutionMode.WRITEBACK):
         ctx = MigrationContext(ExecutionMode=mode)
         result = pipeline.run(ctx)
         assert len(result.Changes) == 1
@@ -83,16 +84,16 @@ def test_subclass_can_override_can_execute_with_super() -> None:
     pipeline = Pipeline.builder("cond", input_type=MigrationContext).use(ConditionalStep()).build()
 
     # Right mode but no changes — skipped by subclass condition
-    ctx = MigrationContext(ExecutionMode="WRITEBACK")
+    ctx = MigrationContext(ExecutionMode=ExecutionMode.WRITEBACK)
     result = pipeline.run(ctx)
     assert len(result.Logs) == 0
 
     # Right mode AND has changes — runs
-    ctx = MigrationContext(ExecutionMode="WRITEBACK", Changes=[None])  # type: ignore[list-item]
+    ctx = MigrationContext(ExecutionMode=ExecutionMode.WRITEBACK, Changes=[None])  # type: ignore[list-item]
     result = pipeline.run(ctx)
     assert len(result.Logs) == 1
 
     # Wrong mode — skipped by super() mode gate
-    ctx = MigrationContext(ExecutionMode="READONLY", Changes=[None])  # type: ignore[list-item]
+    ctx = MigrationContext(ExecutionMode=ExecutionMode.READONLY, Changes=[None])  # type: ignore[list-item]
     result = pipeline.run(ctx)
     assert len(result.Logs) == 0

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/__init__.py
@@ -1,0 +1,1 @@
+"""Preprocessing unit tests."""

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
@@ -70,7 +70,7 @@ def test_gather_input_with_auth_step_populates_identity_and_bootstraps_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = FakeLogger()
-    step = GatherInputWithAuthStep(logger)  # type: ignore[arg-type]
+    step = GatherInputWithAuthStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
     StubMsalTokenProvider.instances.clear()
     discovered_authority = "https://login.microsoftonline.com/tenant-123"
     monkeypatch.setattr(
@@ -88,9 +88,9 @@ def test_gather_input_with_auth_step_populates_identity_and_bootstraps_client(
 
     context = step.execute(MigrationContext())
 
-    assert context.tenant_id == "tenant-123"
-    assert context.user_id == "user-456"
-    assert context.user_email == "maker@contoso.com"
+    assert context.tid == "tenant-123"
+    assert context.oid == "user-456"
+    assert context.upn == "maker@contoso.com"
     assert context.environment_url == "https://fabrikam.crm.dynamics.com"
     assert context.dataverse_client is not None
     assert context.dataverse_client.environment_url == "https://fabrikam.crm.dynamics.com"
@@ -135,7 +135,7 @@ def test_gather_preferred_solution_step_stores_solution_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = FakeLogger()
-    step = GatherPreferredSolutionStep(logger)  # type: ignore[arg-type]
+    step = GatherPreferredSolutionStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
     monkeypatch.setattr("builtins.input", lambda _: "ess_customizations")
 
     result = step.execute(MigrationContext())
@@ -147,7 +147,7 @@ def test_gather_preferred_solution_step_leaves_solution_empty_when_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = FakeLogger()
-    step = GatherPreferredSolutionStep(logger)  # type: ignore[arg-type]
+    step = GatherPreferredSolutionStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
     monkeypatch.setattr("builtins.input", lambda _: "   ")
 
     result = step.execute(MigrationContext())
@@ -159,7 +159,7 @@ def test_agent_selection_step_queries_agents_and_stores_selected_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = FakeLogger()
-    step = AgentSelectionStep(logger)  # type: ignore[arg-type]
+    step = AgentSelectionStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
     fake_client = FakeDataverseClient(
         [
             {"name": "Zebra Agent", "botid": "bot-z", "statecode": 1},
@@ -179,7 +179,7 @@ def test_agent_selection_step_queries_agents_and_stores_selected_agent(
 
 
 def test_build_input_pipeline_wires_steps_in_order() -> None:
-    pipeline = build_input_pipeline(FakeLogger())  # type: ignore[arg-type]
+    pipeline = build_input_pipeline(FakeLogger(), ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
 
     assert [step.name() for step in pipeline.steps] == [
         "GatherInputWithAuthStep",

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
@@ -48,7 +48,7 @@ class StubMsalTokenProvider:
     token = _make_token({"tid": "tenant-123", "oid": "user-456", "upn": "maker@contoso.com"})
     instances: list[StubMsalTokenProvider] = []
 
-    def __init__(self, config: object) -> None:
+    def __init__(self, config: object, *args: object, **kwargs: object) -> None:
         self.config = config
         self.instances.append(self)
 

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
 
+from core.logging import Logger
 from modules.migration.models import MigrationContext
 from modules.preprocessing.input_pipeline import build_input_pipeline
 from modules.preprocessing.steps.agent_selection_step import AgentSelectionStep
@@ -48,7 +49,7 @@ class StubMsalTokenProvider:
     token = _make_token({"tid": "tenant-123", "oid": "user-456", "upn": "maker@contoso.com"})
     instances: list[StubMsalTokenProvider] = []
 
-    def __init__(self, config: object, *args: object, **kwargs: object) -> None:
+    def __init__(self, config: Any, *args: Any, **kwargs: Any) -> None:
         self.config = config
         self.instances.append(self)
 
@@ -69,8 +70,8 @@ class FakeDataverseClient:
 def test_gather_input_with_auth_step_populates_identity_and_bootstraps_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    logger = FakeLogger()
-    step = GatherInputWithAuthStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
+    logger = cast(Logger, FakeLogger())
+    step = GatherInputWithAuthStep(logger, ("READONLY", "WRITEBACK"))
     StubMsalTokenProvider.instances.clear()
     discovered_authority = "https://login.microsoftonline.com/tenant-123"
     monkeypatch.setattr(
@@ -134,8 +135,8 @@ def test_discover_tenant_defaults_to_organizations_when_header_missing(
 def test_gather_preferred_solution_step_stores_solution_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    logger = FakeLogger()
-    step = GatherPreferredSolutionStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
+    logger = cast(Logger, FakeLogger())
+    step = GatherPreferredSolutionStep(logger, ("READONLY", "WRITEBACK"))
     monkeypatch.setattr("builtins.input", lambda _: "ess_customizations")
 
     result = step.execute(MigrationContext())
@@ -146,8 +147,8 @@ def test_gather_preferred_solution_step_stores_solution_name(
 def test_gather_preferred_solution_step_leaves_solution_empty_when_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    logger = FakeLogger()
-    step = GatherPreferredSolutionStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
+    logger = cast(Logger, FakeLogger())
+    step = GatherPreferredSolutionStep(logger, ("READONLY", "WRITEBACK"))
     monkeypatch.setattr("builtins.input", lambda _: "   ")
 
     result = step.execute(MigrationContext())
@@ -158,8 +159,8 @@ def test_gather_preferred_solution_step_leaves_solution_empty_when_skipped(
 def test_agent_selection_step_queries_agents_and_stores_selected_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    logger = FakeLogger()
-    step = AgentSelectionStep(logger, ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
+    logger = cast(Logger, FakeLogger())
+    step = AgentSelectionStep(logger, ("READONLY", "WRITEBACK"))
     fake_client = FakeDataverseClient(
         [
             {"name": "Zebra Agent", "botid": "bot-z", "statecode": 1},
@@ -174,12 +175,12 @@ def test_agent_selection_step_queries_agents_and_stores_selected_agent(
     assert fake_client.calls == [("bots", "name,botid,statecode")]
     assert result.selected_agent_id == "bot-a"
     assert result.selected_agent_name == "Alpha Agent"
-    assert ("INFO", "1. Alpha Agent [bot-a] state=0") in logger.messages
-    assert ("INFO", "2. Zebra Agent [bot-z] state=1") in logger.messages
+    assert ("INFO", "1. Alpha Agent [bot-a] state=0") in logger.messages  # type: ignore[attr-defined]
+    assert ("INFO", "2. Zebra Agent [bot-z] state=1") in logger.messages  # type: ignore[attr-defined]
 
 
 def test_build_input_pipeline_wires_steps_in_order() -> None:
-    pipeline = build_input_pipeline(FakeLogger(), ("READONLY", "WRITEBACK"))  # type: ignore[arg-type]
+    pipeline = build_input_pipeline(cast(Logger, FakeLogger()), ("READONLY", "WRITEBACK"))
 
     assert [step.name() for step in pipeline.steps] == [
         "GatherInputWithAuthStep",

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
@@ -1,0 +1,188 @@
+"""Unit tests for the input pipeline vertical slice."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from modules.migration.models import MigrationContext
+from modules.preprocessing.input_pipeline import build_input_pipeline
+from modules.preprocessing.steps.agent_selection_step import AgentSelectionStep
+from modules.preprocessing.steps.gather_input_with_auth_step import (
+    GatherInputWithAuthStep,
+    _discover_tenant,
+)
+from modules.preprocessing.steps.gather_preferred_solution_step import (
+    GatherPreferredSolutionStep,
+)
+
+
+def _make_token(claims: dict[str, str]) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode("ascii")
+    payload = (
+        base64.urlsafe_b64encode(json.dumps(claims).encode("utf-8"))
+        .rstrip(b"=")
+        .decode(
+            "ascii",
+        )
+    )
+    return f"{header}.{payload}.signature"
+
+
+class FakeLogger:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def LogInfo(self, message: str, **_: object) -> None:
+        self.messages.append(("INFO", message))
+
+    def LogDebug(self, message: str, **_: object) -> None:
+        self.messages.append(("DEBUG", message))
+
+
+class StubMsalTokenProvider:
+    token = _make_token({"tid": "tenant-123", "oid": "user-456", "upn": "maker@contoso.com"})
+    instances: list[StubMsalTokenProvider] = []
+
+    def __init__(self, config: object) -> None:
+        self.config = config
+        self.instances.append(self)
+
+    def get_token(self) -> str:
+        return self.token
+
+
+class FakeDataverseClient:
+    def __init__(self, agents: list[dict[str, Any]]) -> None:
+        self._agents = agents
+        self.calls: list[tuple[str, str]] = []
+
+    def query_all(self, entity_set: str, *, select: str) -> list[dict[str, Any]]:
+        self.calls.append((entity_set, select))
+        return list(self._agents)
+
+
+def test_gather_input_with_auth_step_populates_identity_and_bootstraps_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = FakeLogger()
+    step = GatherInputWithAuthStep(logger)  # type: ignore[arg-type]
+    StubMsalTokenProvider.instances.clear()
+    discovered_authority = "https://login.microsoftonline.com/tenant-123"
+    monkeypatch.setattr(
+        "modules.preprocessing.steps.gather_input_with_auth_step._discover_tenant",
+        lambda env_url: "tenant-123",
+    )
+    monkeypatch.setattr(
+        "modules.preprocessing.steps.gather_input_with_auth_step.MsalTokenProvider",
+        StubMsalTokenProvider,
+    )
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _: "https://fabrikam.crm.dynamics.com/",
+    )
+
+    context = step.execute(MigrationContext())
+
+    assert context.tenant_id == "tenant-123"
+    assert context.user_id == "user-456"
+    assert context.user_email == "maker@contoso.com"
+    assert context.environment_url == "https://fabrikam.crm.dynamics.com"
+    assert context.dataverse_client is not None
+    assert context.dataverse_client.environment_url == "https://fabrikam.crm.dynamics.com"
+    assert len(StubMsalTokenProvider.instances) == 1
+    provider = StubMsalTokenProvider.instances[0]
+    assert provider.config.client_id == "51f81489-12ee-4a9e-aaae-a2591f45987d"
+    assert provider.config.authority == discovered_authority
+    assert provider.config.scopes == ("https://fabrikam.crm.dynamics.com/user_impersonation",)
+
+
+def test_discover_tenant_reads_tenant_from_www_authenticate_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "modules.preprocessing.steps.gather_input_with_auth_step.httpx.get",
+        lambda *args, **kwargs: httpx.Response(
+            401,
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer authorization_uri="https://login.microsoftonline.com/'
+                    'tenant-789/oauth2/authorize"'
+                ),
+            },
+        ),
+    )
+
+    assert _discover_tenant("https://fabrikam.crm.dynamics.com") == "tenant-789"
+
+
+def test_discover_tenant_defaults_to_organizations_when_header_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "modules.preprocessing.steps.gather_input_with_auth_step.httpx.get",
+        lambda *args, **kwargs: httpx.Response(401),
+    )
+
+    assert _discover_tenant("https://fabrikam.crm.dynamics.com") == "organizations"
+
+
+def test_gather_preferred_solution_step_stores_solution_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = FakeLogger()
+    step = GatherPreferredSolutionStep(logger)  # type: ignore[arg-type]
+    monkeypatch.setattr("builtins.input", lambda _: "ess_customizations")
+
+    result = step.execute(MigrationContext())
+
+    assert result.preferred_solution == "ess_customizations"
+
+
+def test_gather_preferred_solution_step_leaves_solution_empty_when_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = FakeLogger()
+    step = GatherPreferredSolutionStep(logger)  # type: ignore[arg-type]
+    monkeypatch.setattr("builtins.input", lambda _: "   ")
+
+    result = step.execute(MigrationContext())
+
+    assert result.preferred_solution is None
+
+
+def test_agent_selection_step_queries_agents_and_stores_selected_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = FakeLogger()
+    step = AgentSelectionStep(logger)  # type: ignore[arg-type]
+    fake_client = FakeDataverseClient(
+        [
+            {"name": "Zebra Agent", "botid": "bot-z", "statecode": 1},
+            {"name": "Alpha Agent", "botid": "bot-a", "statecode": 0},
+        ],
+    )
+    context = MigrationContext(dataverse_client=fake_client)
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+
+    result = step.execute(context)
+
+    assert fake_client.calls == [("bots", "name,botid,statecode")]
+    assert result.selected_agent_id == "bot-a"
+    assert result.selected_agent_name == "Alpha Agent"
+    assert ("INFO", "1. Alpha Agent [bot-a] state=0") in logger.messages
+    assert ("INFO", "2. Zebra Agent [bot-z] state=1") in logger.messages
+
+
+def test_build_input_pipeline_wires_steps_in_order() -> None:
+    pipeline = build_input_pipeline(FakeLogger())  # type: ignore[arg-type]
+
+    assert [step.name() for step in pipeline.steps] == [
+        "GatherInputWithAuthStep",
+        "AgentSelectionStep",
+        "GatherPreferredSolutionStep",
+    ]

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
@@ -53,15 +53,15 @@ def test_main_runs_stage_pipelines_and_writes_two_bundle_files(
     monkeypatch.setattr(mtk_orchestrator, "OUTPUT_ROOT", tmp_path)
     monkeypatch.setattr(mtk_orchestrator, "MigrationContext", build_context)
     monkeypatch.setattr(
-        mtk_orchestrator, "build_input_pipeline", lambda logger, modes: _stage("input")
+        mtk_orchestrator, "build_input_pipeline", lambda logger, modes, **kw: _stage("input")
     )
     monkeypatch.setattr(
         mtk_orchestrator,
         "build_migration_pipeline",
-        lambda logger, modes: _stage("migration"),
+        lambda logger, modes, **kw: _stage("migration"),
     )
     monkeypatch.setattr(
-        mtk_orchestrator, "build_output_pipeline", lambda logger, modes: _stage("output")
+        mtk_orchestrator, "build_output_pipeline", lambda logger, modes, **kw: _stage("output")
     )
 
     mtk_orchestrator.main()
@@ -95,7 +95,7 @@ def test_main_closes_logger_when_pipeline_execution_fails(
             closed = True
 
     def fail_stage(
-        logger: object, modes: object = None
+        logger: object, modes: object = None, **kw: object
     ) -> Pipeline[MigrationContext, MigrationContext]:
         del logger
 
@@ -120,10 +120,10 @@ def test_main_closes_logger_when_pipeline_execution_fails(
     monkeypatch.setattr(mtk_orchestrator.Reporter, "render", lambda self, context: None)
     monkeypatch.setattr(mtk_orchestrator, "build_input_pipeline", fail_stage)
     monkeypatch.setattr(
-        mtk_orchestrator, "build_migration_pipeline", lambda logger, modes: _stage("m")
+        mtk_orchestrator, "build_migration_pipeline", lambda logger, modes, **kw: _stage("m")
     )
     monkeypatch.setattr(
-        mtk_orchestrator, "build_output_pipeline", lambda logger, modes: _stage("o")
+        mtk_orchestrator, "build_output_pipeline", lambda logger, modes, **kw: _stage("o")
     )
 
     with pytest.raises(RuntimeError, match="boom"):

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
@@ -46,7 +46,7 @@ def test_main_runs_stage_pipelines_and_writes_two_bundle_files(
     created_contexts: list[MigrationContext] = []
 
     def build_context(*, ExecutionMode: object) -> StageContext:
-        context = StageContext(ExecutionMode=ExecutionMode)
+        context = StageContext(ExecutionMode=ExecutionMode)  # type: ignore[arg-type]
         created_contexts.append(context)
         return context
 
@@ -68,7 +68,7 @@ def test_main_runs_stage_pipelines_and_writes_two_bundle_files(
 
     assert len(created_contexts) == 1
     assert created_contexts[0].ExecutionMode == "READONLY"
-    assert created_contexts[0].events == ["input", "migration", "output"]
+    assert created_contexts[0].events == ["input", "migration", "output"]  # type: ignore[attr-defined]
 
     session_dirs = sorted(path for path in tmp_path.iterdir() if path.is_dir())
     assert len(session_dirs) == 1
@@ -113,11 +113,11 @@ def test_main_closes_logger_when_pipeline_execution_fails(
         return Pipeline.builder("failing", input_type=MigrationContext).use(FailingStep()).build()
 
     monkeypatch.setattr(
-        mtk_orchestrator.Logger,
+        mtk_orchestrator.Logger,  # type: ignore[attr-defined]
         "start_session",
         lambda output_root, context: FakeLogger(),
     )
-    monkeypatch.setattr(mtk_orchestrator.Reporter, "render", lambda self, context: None)
+    monkeypatch.setattr(mtk_orchestrator.Reporter, "render", lambda self, context: None)  # type: ignore[attr-defined]
     monkeypatch.setattr(mtk_orchestrator, "build_input_pipeline", fail_stage)
     monkeypatch.setattr(
         mtk_orchestrator, "build_migration_pipeline", lambda logger, modes, **kw: _stage("m")

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
@@ -1,0 +1,122 @@
+"""Unit tests for orchestrator wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.pipelines import Pipeline, PipelineStep
+from modules.migration.models import MigrationContext
+from service import mtk_orchestrator
+
+
+@dataclass
+class StageContext(MigrationContext):
+    events: list[str] = field(default_factory=list)
+
+
+class RecordingStageStep(PipelineStep[MigrationContext, MigrationContext]):
+    def __init__(self, event: str) -> None:
+        super().__init__(input_type=MigrationContext, output_type=MigrationContext, name=event)
+        self._event = event
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        if isinstance(context, StageContext):
+            context.events.append(self._event)
+        return context
+
+
+def _stage(event: str) -> Pipeline[MigrationContext, MigrationContext]:
+    return (
+        Pipeline.builder(f"{event}-pipeline", input_type=MigrationContext)
+        .use(
+            RecordingStageStep(event),
+        )
+        .build()
+    )
+
+
+def test_main_runs_stage_pipelines_and_writes_two_bundle_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created_contexts: list[MigrationContext] = []
+
+    def build_context(*, ExecutionMode: object) -> StageContext:
+        context = StageContext(ExecutionMode=ExecutionMode)
+        created_contexts.append(context)
+        return context
+
+    monkeypatch.setattr(mtk_orchestrator, "OUTPUT_ROOT", tmp_path)
+    monkeypatch.setattr(mtk_orchestrator, "MigrationContext", build_context)
+    monkeypatch.setattr(mtk_orchestrator, "build_input_pipeline", lambda logger: _stage("input"))
+    monkeypatch.setattr(
+        mtk_orchestrator,
+        "build_migration_pipeline",
+        lambda logger: _stage("migration"),
+    )
+    monkeypatch.setattr(mtk_orchestrator, "build_output_pipeline", lambda logger: _stage("output"))
+
+    mtk_orchestrator.main()
+
+    assert len(created_contexts) == 1
+    assert created_contexts[0].ExecutionMode == "READONLY"
+    assert created_contexts[0].events == ["input", "migration", "output"]
+
+    session_dirs = sorted(path for path in tmp_path.iterdir() if path.is_dir())
+    assert len(session_dirs) == 1
+    assert sorted(path.name for path in session_dirs[0].iterdir()) == [
+        "migration_report.md",
+        "session.log",
+    ]
+
+
+def test_main_closes_logger_when_pipeline_execution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    closed = False
+
+    class FakeLogger:
+        session_manager = SimpleNamespace(paths=SimpleNamespace(session_dir=tmp_path / "session"))
+
+        def LogInfo(self, message: str, **_: object) -> None:
+            del message
+
+        def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    def fail_stage(logger: object) -> Pipeline[MigrationContext, MigrationContext]:
+        del logger
+
+        class FailingStep(PipelineStep[MigrationContext, MigrationContext]):
+            def __init__(self) -> None:
+                super().__init__(
+                    input_type=MigrationContext,
+                    output_type=MigrationContext,
+                    name="fail",
+                )
+
+            def execute(self, context: MigrationContext) -> MigrationContext:
+                raise RuntimeError("boom")
+
+        return Pipeline.builder("failing", input_type=MigrationContext).use(FailingStep()).build()
+
+    monkeypatch.setattr(
+        mtk_orchestrator.Logger,
+        "start_session",
+        lambda output_root, context: FakeLogger(),
+    )
+    monkeypatch.setattr(mtk_orchestrator.Reporter, "render", lambda self, context: None)
+    monkeypatch.setattr(mtk_orchestrator, "build_input_pipeline", fail_stage)
+    monkeypatch.setattr(mtk_orchestrator, "build_migration_pipeline", lambda logger: _stage("m"))
+    monkeypatch.setattr(mtk_orchestrator, "build_output_pipeline", lambda logger: _stage("o"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        mtk_orchestrator.main()
+
+    assert closed is True

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
@@ -52,13 +52,17 @@ def test_main_runs_stage_pipelines_and_writes_two_bundle_files(
 
     monkeypatch.setattr(mtk_orchestrator, "OUTPUT_ROOT", tmp_path)
     monkeypatch.setattr(mtk_orchestrator, "MigrationContext", build_context)
-    monkeypatch.setattr(mtk_orchestrator, "build_input_pipeline", lambda logger: _stage("input"))
+    monkeypatch.setattr(
+        mtk_orchestrator, "build_input_pipeline", lambda logger, modes: _stage("input")
+    )
     monkeypatch.setattr(
         mtk_orchestrator,
         "build_migration_pipeline",
-        lambda logger: _stage("migration"),
+        lambda logger, modes: _stage("migration"),
     )
-    monkeypatch.setattr(mtk_orchestrator, "build_output_pipeline", lambda logger: _stage("output"))
+    monkeypatch.setattr(
+        mtk_orchestrator, "build_output_pipeline", lambda logger, modes: _stage("output")
+    )
 
     mtk_orchestrator.main()
 
@@ -90,7 +94,9 @@ def test_main_closes_logger_when_pipeline_execution_fails(
             nonlocal closed
             closed = True
 
-    def fail_stage(logger: object) -> Pipeline[MigrationContext, MigrationContext]:
+    def fail_stage(
+        logger: object, modes: object = None
+    ) -> Pipeline[MigrationContext, MigrationContext]:
         del logger
 
         class FailingStep(PipelineStep[MigrationContext, MigrationContext]):
@@ -113,8 +119,12 @@ def test_main_closes_logger_when_pipeline_execution_fails(
     )
     monkeypatch.setattr(mtk_orchestrator.Reporter, "render", lambda self, context: None)
     monkeypatch.setattr(mtk_orchestrator, "build_input_pipeline", fail_stage)
-    monkeypatch.setattr(mtk_orchestrator, "build_migration_pipeline", lambda logger: _stage("m"))
-    monkeypatch.setattr(mtk_orchestrator, "build_output_pipeline", lambda logger: _stage("o"))
+    monkeypatch.setattr(
+        mtk_orchestrator, "build_migration_pipeline", lambda logger, modes: _stage("m")
+    )
+    monkeypatch.setattr(
+        mtk_orchestrator, "build_output_pipeline", lambda logger, modes: _stage("o")
+    )
 
     with pytest.raises(RuntimeError, match="boom"):
         mtk_orchestrator.main()

--- a/tools/ess-nextgen-migration-toolkit/uv.lock
+++ b/tools/ess-nextgen-migration-toolkit/uv.lock
@@ -7,6 +7,19 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +315,7 @@ name = "ess-nextgen-migration-toolkit"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "msal" },
 ]
 
@@ -314,7 +328,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "msal", specifier = ">=1.37.0" }]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "msal", specifier = ">=1.37.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -331,6 +348,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Implement the typed Dataverse Web API client in `src/core/outbound/` — the
single layer permitted to communicate with Dataverse. No business or migration
logic lives here.

### Implementation

- **`DataverseClient`** — sync `httpx.Client` wrapping all Dataverse HTTP
  concerns. Accepts `MsalTokenProvider`; calls `get_token()` per request (never
  caches tokens).
- **OData headers** — `Accept: application/json`, `OData-MaxVersion: 4.0`,
  `OData-Version: 4.0`, `Prefer: odata.include-annotations=*` on every request.
- **Retry** — GET retries on 429/500/502/503/504 (3 attempts, exponential
  backoff, respects `Retry-After`). POST/PATCH/DELETE are NOT retried (unsafe).
- **Pagination** — `query_all` follows `@odata.nextLink` automatically.
- **HTTPS-only** — constructor rejects non-HTTPS env URLs.
- **Typed errors** — `AuthenticationExpiredError` (401),
  `DataverseApiError` (4xx/5xx with status, operation, entity_set, request_id).
- **Generic** — all methods accept `entity_set` as a parameter (bots,
  botcomponents, solutions, msdyn_componentlayers, etc.).

### API surface

```python
class DataverseClient:
    def __init__(self, env_url: str, token_provider: MsalTokenProvider) -> None
    def query_all(self, entity_set, *, select, filter=None) -> list[dict]
    def get(self, path, *, params=None) -> dict
    def create(self, entity_set, data) -> str       # returns record ID
    def update(self, entity_set, record_id, data) -> None
    def delete(self, entity_set, record_id) -> None
```

### Also in this PR

- Master spec update: TASK-007/009/999 marked BLOCKED (writeback design pending)

## Related issue

Refs TASK-004

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / cleanup

## Testing

Gates pass from `tools/ess-nextgen-migration-toolkit/`:
- `uv run pytest` — 40 passed (10 new outbound tests + 30 existing)
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy src` — 32 source files, no issues

Test coverage (httpx MockTransport):
- Per-request token acquisition with OData headers
- Pagination following [@odata](https://github.com/odata).nextLink across pages
- GET retry on 429/5xx with exponential backoff + Retry-After
- POST/PATCH/DELETE NOT retried on server failures
- 401 → AuthenticationExpiredError
- 4xx/5xx → DataverseApiError with status, operation, entity_set
- HTTPS validation at construction
- Record ID extraction from OData-EntityId header

## Checklist
- [x] My code follows the existing style
- [x] I have added/updated tests where applicable
- [x] I have updated documentation as needed

## Static validation (samples/ only)

```text
Validation — N/A (no samples/ changes)
```