### PR TITLE
refactor(mtk): [Human] | Dev mode, verbose session logs, framework Logger in token provider

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "type": "debugpy",
       "request": "launch",
       "module": "service.mtk_orchestrator",
+      "args": ["--dev"],
       "cwd": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/src"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "MTK: Start (debug)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "service.mtk_orchestrator",
+      "cwd": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/src"
+      },
+      "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python",
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "MTK: Run Tests (debug)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["-q"],
+      "cwd": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/src"
+      },
+      "python": "${workspaceFolder}/tools/ess-nextgen-migration-toolkit/.venv/bin/python",
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/tools/ess-nextgen-migration-toolkit/.gitignore
+++ b/tools/ess-nextgen-migration-toolkit/.gitignore
@@ -16,3 +16,6 @@ venv/
 # Generated execution artifacts (keep folder, ignore contents)
 output/*
 !output/.gitkeep
+
+# Local developer config (tokens, env URLs — never committed)
+.local/

--- a/tools/ess-nextgen-migration-toolkit/.local/dev-config.example.json
+++ b/tools/ess-nextgen-migration-toolkit/.local/dev-config.example.json
@@ -1,0 +1,4 @@
+{
+  "environment_url": "https://your-org.crm.dynamics.com",
+  "token": ""
+}

--- a/tools/ess-nextgen-migration-toolkit/scripts/mtk.ps1
+++ b/tools/ess-nextgen-migration-toolkit/scripts/mtk.ps1
@@ -122,7 +122,7 @@ function Invoke-Run {
     $UV = Find-Uv
     Write-Host ""
     Write-Host "==> Starting the toolkit CLI..."
-    if ($DevMode) { & $UV run python src/service/mtk_orchestrator.py } else { & $UV run --no-dev python src/service/mtk_orchestrator.py }
+    if ($DevMode) { & $UV run python src/service/mtk_orchestrator.py --dev } else { & $UV run --no-dev python src/service/mtk_orchestrator.py }
 }
 
 # start = provision (idempotent) + run. The everyday command.

--- a/tools/ess-nextgen-migration-toolkit/scripts/mtk.sh
+++ b/tools/ess-nextgen-migration-toolkit/scripts/mtk.sh
@@ -124,7 +124,7 @@ cmd_run() {
   echo ""
   echo "==> Starting the toolkit CLI..."
   if [[ "$dev" == "1" ]]; then
-    exec "$UV" run python src/service/mtk_orchestrator.py
+    exec "$UV" run python src/service/mtk_orchestrator.py --dev
   else
     exec "$UV" run --no-dev python src/service/mtk_orchestrator.py
   fi

--- a/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
@@ -146,19 +146,19 @@ def _default_now() -> float:
 def _normalize_scopes(
     requested_scopes: str | Sequence[str] | None,
     default_scopes: tuple[str, ...],
-) -> tuple[str, ...]:
+) -> list[str]:
     scopes = default_scopes if requested_scopes is None else _coerce_scopes(requested_scopes)
     if not scopes:
         raise ValueError("at least one scope must be provided.")
     for scope in scopes:
         _validate_https_url(scope, "scope")
-    return tuple(scopes)
+    return list(scopes)
 
 
-def _coerce_scopes(scopes: str | Sequence[str]) -> tuple[str, ...]:
+def _coerce_scopes(scopes: str | Sequence[str]) -> list[str]:
     if isinstance(scopes, str):
-        return (_resource_to_default_scope(scopes),)
-    return tuple(_resource_to_default_scope(scope) for scope in scopes)
+        return [_resource_to_default_scope(scopes)]
+    return [_resource_to_default_scope(scope) for scope in scopes]
 
 
 def _resource_to_default_scope(scope_or_resource: str) -> str:

--- a/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/auth/token_provider.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from core.logging import Logger
 
 TokenResult: TypeAlias = dict[str, object]
 Clock: TypeAlias = Callable[[], float]
-
-# TODO(TASK-005): replace this stdlib logger seam with the framework Logger.
-LOGGER = logging.getLogger(__name__)
 
 
 class AuthenticationException(RuntimeError):
@@ -72,15 +71,15 @@ class MsalTokenProvider:
     def __init__(
         self,
         config: MsalTokenProviderConfig,
+        logger: Logger,
         *,
         app: MsalApplication | None = None,
         now: Clock | None = None,
-        logger: logging.Logger | None = None,
     ) -> None:
         self._config = config
         self._app = app if app is not None else self._build_public_client_application(config)
         self._now = now if now is not None else _default_now
-        self._logger = logger if logger is not None else LOGGER
+        self._logger = logger
 
     def get_token(self, scopes: str | Sequence[str] | None = None) -> str:
         """Return a currently-valid bearer token for the requested HTTPS scopes."""
@@ -90,10 +89,18 @@ class MsalTokenProvider:
 
         result: TokenResult | None = None
         if account is not None:
-            self._logger.debug("Attempting silent token acquisition.")
+            self._logger.LogDebug(
+                "Attempting silent token acquisition.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             result = self._app.acquire_token_silent(normalized_scopes, account=account)
             if result is not None and self._token_needs_refresh(result):
-                self._logger.debug("Cached token is near expiry; forcing silent refresh.")
+                self._logger.LogDebug(
+                    "Cached token is near expiry; forcing silent refresh.",
+                    pipeline_stage="Auth",
+                    pipeline_step="TokenProvider",
+                )
                 result = self._app.acquire_token_silent(
                     normalized_scopes,
                     account=account,
@@ -102,18 +109,34 @@ class MsalTokenProvider:
 
         if result is None:
             if account is not None:
-                self._logger.warning("Silent token acquisition failed.")
+                self._logger.LogWarning(
+                    "Silent token acquisition failed.",
+                    pipeline_stage="Auth",
+                    pipeline_step="TokenProvider",
+                )
                 raise AuthenticationException("Authentication token acquisition failed.")
-            self._logger.info("Starting interactive token acquisition for cold start.")
+            self._logger.LogInfo(
+                "Starting interactive token acquisition for cold start.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             result = self._app.acquire_token_interactive(normalized_scopes)
 
         if self._token_needs_refresh(result):
-            self._logger.warning("Token acquisition returned an expired or near-expiry token.")
+            self._logger.LogWarning(
+                "Token acquisition returned an expired or near-expiry token.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             raise AuthenticationException("Authentication token acquisition failed.")
 
         access_token = result.get("access_token")
         if not isinstance(access_token, str) or not access_token:
-            self._logger.warning("Token acquisition response did not include a bearer token.")
+            self._logger.LogWarning(
+                "Token acquisition response did not include a bearer token.",
+                pipeline_stage="Auth",
+                pipeline_step="TokenProvider",
+            )
             raise AuthenticationException("Authentication token acquisition failed.")
 
         return access_token

--- a/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/logging/logger.py
@@ -243,11 +243,18 @@ class Logger:
         pipeline_stage: str,
         pipeline_step: str,
     ) -> None:
-        if level < self._level:
-            return
-
         timestamp = self._clock().strftime("%Y-%m-%d %H:%M:%S")
         line = f"[{timestamp}] [{level.name}] [{pipeline_stage}/{pipeline_step}] {message}\n"
-        stream = sys.stderr if level >= LogLevel.ERROR else sys.stdout
-        stream.write(line)
-        stream.flush()
+
+        if level >= self._level:
+            # Above console threshold — write to console (TeeStream mirrors to session.log)
+            stream = sys.stderr if level >= LogLevel.ERROR else sys.stdout
+            stream.write(line)
+            stream.flush()
+        elif self._log_file is not None:
+            # Below console threshold — write directly to session.log only
+            try:
+                self._log_file.write(line)
+                self._log_file.flush()
+            except Exception:  # noqa: BLE001 — DIAG-001
+                pass

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/input_pipeline.py
@@ -13,12 +13,15 @@ from modules.preprocessing.steps import (
 
 
 def build_input_pipeline(
-    logger: Logger, supported_modes: tuple[str, ...]
+    logger: Logger,
+    supported_modes: tuple[str, ...],
+    *,
+    dev_mode: bool = False,
 ) -> Pipeline[MigrationContext, MigrationContext]:
     """Build the input stage pipeline."""
     return (
         Pipeline.builder("Input Pipeline", input_type=MigrationContext)
-        .use(GatherInputWithAuthStep(logger, supported_modes))
+        .use(GatherInputWithAuthStep(logger, supported_modes, dev_mode=dev_mode))
         .use(AgentSelectionStep(logger, supported_modes))
         .use(GatherPreferredSolutionStep(logger, supported_modes))
         .build()

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
@@ -29,7 +29,9 @@ _TENANT_PATTERN = re.compile(r"login\.microsoftonline\.com/([^/]+)")
 class GatherInputWithAuthStep(MigrationPipelineStep):
     """Prompt for the Dataverse URL, authenticate, and initialize context access."""
 
-    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
+    def __init__(
+        self, logger: Logger, supported_modes: tuple[str, ...], *, dev_mode: bool = False
+    ) -> None:
         super().__init__(
             description=(
                 "Gather the target Dataverse environment and authenticate the current user."
@@ -37,9 +39,21 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
             supported_modes=supported_modes,
         )
         self._logger = logger
+        self._dev_mode = dev_mode
 
     def execute(self, context: MigrationContext) -> MigrationContext:
-        environment_url = _prompt_for_environment_url()
+        dev_config = _load_dev_config() if self._dev_mode else None
+
+        if dev_config and dev_config.get("environment_url"):
+            environment_url = dev_config["environment_url"]
+            self._logger.LogInfo(
+                f"[dev] Using environment from .local/dev-config.json: {environment_url}",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+        else:
+            environment_url = _prompt_for_environment_url()
+
         context.environment_url = environment_url
 
         self._logger.LogInfo(
@@ -47,22 +61,42 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
             pipeline_stage="Input",
             pipeline_step=self.name(),
         )
-        self._logger.LogInfo(
-            f"Discovering tenant and authenticating with MSAL for {environment_url}.",
-            pipeline_stage="Input",
-            pipeline_step=self.name(),
-        )
 
-        token_provider = MsalTokenProvider(_build_provider_config(environment_url))
-        token = token_provider.get_token()
-        claims = _decode_claims(token)
-
-        context.tid = _as_string(claims.get("tid"))
-        context.oid = _as_string(claims.get("oid"))
-        context.upn = _as_string(claims.get("upn")) or _as_string(
-            claims.get("preferred_username"),
-        )
-        context.dataverse_client = DataverseClient(environment_url, token_provider)
+        # Dev shortcut: if token is provided in dev-config, skip interactive auth
+        if dev_config and dev_config.get("token"):
+            token = dev_config["token"]
+            self._logger.LogInfo(
+                "[dev] Using hardcoded token from .local/dev-config.json (skipping MSAL).",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+            claims = _decode_claims(token)
+            context.tid = _as_string(claims.get("tid"))
+            context.oid = _as_string(claims.get("oid"))
+            context.upn = _as_string(claims.get("upn")) or _as_string(
+                claims.get("preferred_username"),
+            )
+            # Create a token provider that always returns the hardcoded token
+            config = _build_provider_config(environment_url)
+            token_provider = MsalTokenProvider(config)
+            # Monkey-patch get_token to return the static token for dev
+            token_provider.get_token = lambda *_a, **_kw: token  # type: ignore[method-assign]
+            context.dataverse_client = DataverseClient(environment_url, token_provider)
+        else:
+            self._logger.LogInfo(
+                f"Discovering tenant and authenticating with MSAL for {environment_url}.",
+                pipeline_stage="Input",
+                pipeline_step=self.name(),
+            )
+            token_provider = MsalTokenProvider(_build_provider_config(environment_url))
+            token = token_provider.get_token()
+            claims = _decode_claims(token)
+            context.tid = _as_string(claims.get("tid"))
+            context.oid = _as_string(claims.get("oid"))
+            context.upn = _as_string(claims.get("upn")) or _as_string(
+                claims.get("preferred_username"),
+            )
+            context.dataverse_client = DataverseClient(environment_url, token_provider)
 
         self._logger.LogInfo(
             "Authentication completed.",
@@ -143,3 +177,17 @@ def _decode_claims(token: str) -> dict[str, Any]:
 
 def _as_string(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _load_dev_config() -> dict[str, str] | None:
+    """Load .local/dev-config.json if it exists. Returns None if missing."""
+    from pathlib import Path
+
+    config_path = Path(__file__).resolve().parents[4] / ".local" / "dev-config.json"
+    if not config_path.is_file():
+        return None
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (json.JSONDecodeError, OSError):
+        return None

--- a/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/preprocessing/steps/gather_input_with_auth_step.py
@@ -78,7 +78,7 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
             )
             # Create a token provider that always returns the hardcoded token
             config = _build_provider_config(environment_url)
-            token_provider = MsalTokenProvider(config)
+            token_provider = MsalTokenProvider(config, self._logger)
             # Monkey-patch get_token to return the static token for dev
             token_provider.get_token = lambda *_a, **_kw: token  # type: ignore[method-assign]
             context.dataverse_client = DataverseClient(environment_url, token_provider)
@@ -88,7 +88,9 @@ class GatherInputWithAuthStep(MigrationPipelineStep):
                 pipeline_stage="Input",
                 pipeline_step=self.name(),
             )
-            token_provider = MsalTokenProvider(_build_provider_config(environment_url))
+            token_provider = MsalTokenProvider(
+                _build_provider_config(environment_url), self._logger
+            )
             token = token_provider.get_token()
             claims = _decode_claims(token)
             context.tid = _as_string(claims.get("tid"))

--- a/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from core.logging import Logger, Reporter
@@ -13,23 +14,28 @@ from modules.postprocessing import build_output_pipeline
 from modules.preprocessing import build_input_pipeline
 from service.constants import SUPPORTED_MODES
 
-OUTPUT_ROOT = Path(__file__).resolve().parents[2] / "output"
+TOOLKIT_ROOT = Path(__file__).resolve().parents[2]
+OUTPUT_ROOT = TOOLKIT_ROOT / "output"
+
+
+def _is_dev_mode() -> bool:
+    return "--dev" in sys.argv
 
 
 def main() -> None:
     """Build and run the ESS migration super-pipeline."""
+    dev_mode = _is_dev_mode()
     context = MigrationContext(ExecutionMode=ExecutionMode.READONLY)
     logger = Logger.start_session(OUTPUT_ROOT, context)
     try:
         toolkit = (
             ChainedPipeline[MigrationContext]()
-            .add(build_input_pipeline(logger, SUPPORTED_MODES))
+            .add(build_input_pipeline(logger, SUPPORTED_MODES, dev_mode=dev_mode))
             .add(build_migration_pipeline(logger, SUPPORTED_MODES))
             .add(build_output_pipeline(logger, SUPPORTED_MODES))
         )
         toolkit.run(context)
     except Exception:
-        # Print traceback while tee is still active so it lands in session.log
         import traceback
 
         traceback.print_exc()

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/auth/test_token_provider.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/auth/test_token_provider.py
@@ -21,6 +21,22 @@ CLIENT_ID = "client-id"
 NOW = 1_000.0
 
 
+class FakeLogger:
+    """No-op logger for unit tests."""
+
+    def LogDebug(self, *a: object, **kw: object) -> None:
+        pass
+
+    def LogInfo(self, *a: object, **kw: object) -> None:
+        pass
+
+    def LogWarning(self, *a: object, **kw: object) -> None:
+        pass
+
+    def LogError(self, *a: object, **kw: object) -> None:
+        pass
+
+
 class FakeMsalApplication:
     def __init__(
         self,
@@ -69,7 +85,7 @@ def config(
 
 def test_cold_start_uses_interactive_acquisition_only_when_no_account_exists() -> None:
     app = FakeMsalApplication()
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     token = provider.get_token()
 
@@ -84,7 +100,7 @@ def test_existing_account_uses_silent_acquisition_without_interactive_fallback()
         accounts=[account],
         silent_results=[{"access_token": "silent-token", "expires_on": NOW + 3_600}],
     )
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     token = provider.get_token("https://contoso.crm.dynamics.com")
 
@@ -102,7 +118,7 @@ def test_near_expiry_token_forces_silent_refresh_before_returning() -> None:
             {"access_token": "refreshed-token", "expires_on": NOW + 3_600},
         ],
     )
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     token = provider.get_token()
 
@@ -121,7 +137,7 @@ def test_rejects_non_https_authority_and_scopes() -> None:
     with pytest.raises(ValueError, match="scope must be an HTTPS URL"):
         config(scopes=("http://contoso.crm.dynamics.com/.default",))
 
-    provider = MsalTokenProvider(config(), app=FakeMsalApplication(), now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=FakeMsalApplication(), now=lambda: NOW)
     with pytest.raises(ValueError, match="scope must be an HTTPS URL"):
         provider.get_token("http://contoso.crm.dynamics.com")
 
@@ -132,7 +148,7 @@ def test_acquisition_failure_raises_sanitized_authentication_exception() -> None
         accounts=[account],
         silent_results=[{"error": "invalid_grant", "error_description": "secret provider detail"}],
     )
-    provider = MsalTokenProvider(config(), app=app, now=lambda: NOW)
+    provider = MsalTokenProvider(config(), FakeLogger(), app=app, now=lambda: NOW)
 
     with pytest.raises(AuthenticationException) as exc_info:
         provider.get_token()
@@ -154,7 +170,7 @@ def test_default_msal_application_uses_in_memory_cache_only(
     fake_msal = SimpleNamespace(PublicClientApplication=CapturingPublicClientApplication)
     monkeypatch.setattr("core.auth.token_provider.import_module", lambda name: fake_msal)
 
-    MsalTokenProvider(config())
+    MsalTokenProvider(config(), FakeLogger())
 
     assert calls == [{"client_id": CLIENT_ID, "authority": AUTHORITY}]
     assert "token_cache" not in calls[0]

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/preprocessing/test_input_pipeline.py
@@ -48,7 +48,7 @@ class StubMsalTokenProvider:
     token = _make_token({"tid": "tenant-123", "oid": "user-456", "upn": "maker@contoso.com"})
     instances: list[StubMsalTokenProvider] = []
 
-    def __init__(self, config: object) -> None:
+    def __init__(self, config: object, *args: object, **kwargs: object) -> None:
         self.config = config
         self.instances.append(self)
 

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
@@ -53,15 +53,15 @@ def test_main_runs_stage_pipelines_and_writes_two_bundle_files(
     monkeypatch.setattr(mtk_orchestrator, "OUTPUT_ROOT", tmp_path)
     monkeypatch.setattr(mtk_orchestrator, "MigrationContext", build_context)
     monkeypatch.setattr(
-        mtk_orchestrator, "build_input_pipeline", lambda logger, modes: _stage("input")
+        mtk_orchestrator, "build_input_pipeline", lambda logger, modes, **kw: _stage("input")
     )
     monkeypatch.setattr(
         mtk_orchestrator,
         "build_migration_pipeline",
-        lambda logger, modes: _stage("migration"),
+        lambda logger, modes, **kw: _stage("migration"),
     )
     monkeypatch.setattr(
-        mtk_orchestrator, "build_output_pipeline", lambda logger, modes: _stage("output")
+        mtk_orchestrator, "build_output_pipeline", lambda logger, modes, **kw: _stage("output")
     )
 
     mtk_orchestrator.main()
@@ -95,7 +95,7 @@ def test_main_closes_logger_when_pipeline_execution_fails(
             closed = True
 
     def fail_stage(
-        logger: object, modes: object = None
+        logger: object, modes: object = None, **kw: object
     ) -> Pipeline[MigrationContext, MigrationContext]:
         del logger
 
@@ -120,10 +120,10 @@ def test_main_closes_logger_when_pipeline_execution_fails(
     monkeypatch.setattr(mtk_orchestrator.Reporter, "render", lambda self, context: None)
     monkeypatch.setattr(mtk_orchestrator, "build_input_pipeline", fail_stage)
     monkeypatch.setattr(
-        mtk_orchestrator, "build_migration_pipeline", lambda logger, modes: _stage("m")
+        mtk_orchestrator, "build_migration_pipeline", lambda logger, modes, **kw: _stage("m")
     )
     monkeypatch.setattr(
-        mtk_orchestrator, "build_output_pipeline", lambda logger, modes: _stage("o")
+        mtk_orchestrator, "build_output_pipeline", lambda logger, modes, **kw: _stage("o")
     )
 
     with pytest.raises(RuntimeError, match="boom"):


### PR DESCRIPTION
## Description

Three improvements to the diagnostics and developer experience, applied on top
of the TASK-015 input pipeline work:

### 1. VS Code debugger support + auth scope fix (`9fa2b2c`)

- Added `.vscode/launch.json` with "MTK: Start (debug)" config — launches the
  orchestrator with `--dev` flag and breakpoints enabled.
- Fixed MSAL auth constants: client ID `51f81489...` (Power Platform CLI),
  scope `{env_url}/user_impersonation` (Dataverse delegated), tenant discovered
  from WWW-Authenticate challenge.
- `_normalize_scopes` now returns `list[str]` (what MSAL expects).

### 2. Dev mode with hardcoded config (`3d8d2a8`)

- `--dev` flag forwarded from `mtk.sh`/`mtk.ps1` to the orchestrator.
- In dev mode, reads `.local/dev-config.json` — if `token` is non-empty, skips
  MSAL interactive auth and uses the hardcoded token (paste from browser dev
  tools). If empty, falls through to interactive auth.
- `.local/` gitignored. Example config at `.local/dev-config.example.json`.

### 3. Verbose session logs (`8570ecb`)

- `session.log` now captures ALL log levels (DEBUG through FATAL) — verbose
  for ESS engineer debugging of customer issues.
- Console output still respects the level filter (INFO+ for user-friendly CLI).
- Below-threshold lines write directly to `session.log` only, above-threshold
  lines go through the TeeStream (no duplication).
- Log format updated: `[timestamp] [LEVEL] [Stage/Step] message`
- Token provider migrated from stdlib `logging` to the framework Logger
  (mandatory positional param — no fallback, no hidden state).

## Type of change
- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor / cleanup

## Testing

- `uv run pytest` — 50 passed
- `uv run ruff check .` — clean
- `uv run mypy src` — no issues

## Checklist
- [x] My code follows the existing style
- [x] I have added/updated tests where applicable
- [x] I have updated documentation as needed