### PR TITLE
feat(mtk): [Worker] | output pipeline (validate + generic writeback + report) + RULE-002 EndConversation→CancelAllDialogs

### DIFF
--- a/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/CUSTOMIZATION_DISCOVERY.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/CUSTOMIZATION_DISCOVERY.md
@@ -216,7 +216,7 @@ Notes:
 The Output stage consumes `context.pending_writes` in **WRITEBACK** mode only
 (`ExecutionMode.WRITEBACK`). The list is already coalesced (one entry per record)
 and no-op-guarded by the `WritebackPlan`, so each entry maps to a single
-`update(f"{entity_set}({record_id})", changes)`. When
+`client.update(entity_set, record_id, changes)`. When
 `context.preferred_solution` is set (ALM customers), the writes target that
 solution — verified live in `GatherALMCustomerInputStep` via `GetPreferredSolution`
 so a typo cannot silently redirect writeback. In READONLY mode the pending writes

--- a/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/DATAVERSE_CLIENT.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/02_ARCHITECTURE/DATAVERSE_CLIENT.md
@@ -320,6 +320,10 @@ Persist transformed components.
 
 Update Dataverse artifacts.
 
+Support caller-supplied per-request headers for Dataverse platform scoping (for
+example `MSCRM.SolutionUniqueName`) without interpreting those headers as
+migration business logic.
+
 ---
 
 ## Consumes

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
@@ -12,6 +12,20 @@ task (`TASK-XXX`) where applicable, per `IMPLEMENTATION_GUIDE.md`.
 
 ## [Unreleased]
 
+- **TASK-007 DONE — Output pipeline validation + generic Dataverse writeback +
+  report rendering.** Replaced the postprocessing pass-through with
+  `ValidateMigration`, `Writeback`, and `GenerateMigrationReport` steps. The
+  Writeback step consumes the already-coalesced/no-op-guarded
+  `context.pending_writes` list and maps each entry directly to
+  `DataverseClient.update(entity_set, record_id, changes)` in WRITEBACK mode only;
+  READONLY is skipped by `MigrationPipelineStep` mode-gating. When
+  `context.preferred_solution` is set, Writeback passes the generic
+  `MSCRM.SolutionUniqueName` per-request header into the Dataverse client, which
+  now supports optional update headers without embedding ESS-specific logic.
+  `GenerateMigrationReport` renders `migration_report.md` via
+  `Reporter(logger.session_manager).render(context)`, preserving the two-file
+  session bundle.
+
 - **TASK-017 DONE — Writeback plan (coalescing + meaningful-change guard).** Added
   `WritebackPlan` / `WritebackTarget`
   (`src/modules/transformation/models/writeback_plan.py`), the shared accumulator

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/CHANGELOG.md
@@ -12,6 +12,19 @@ task (`TASK-XXX`) where applicable, per `IMPLEMENTATION_GUIDE.md`.
 
 ## [Unreleased]
 
+- **TASK-011 DONE — RULE-002: Replace EndConversation node.** Added
+  `ReplaceEndConversationStep` (`src/modules/transformation/steps/`), registered in
+  `build_transformation_pipeline` after `ApplyDaCompatibilityStep`. It iterates
+  `context.customizations` (the discovered Topic-V2 topics) and, per topic, rewrites
+  every `kind: EndConversation` node to `kind: CancelAllDialogs` (End All Topics)
+  in the topic's `data` YAML — a node-anchored line substitution that preserves the
+  list-item prefix, indentation, node ids, and all other logic (no YAML round-trip,
+  so untouched topics stay byte-identical). Edits are staged on the `WritebackPlan`
+  (chaining-aware via `target_for`), so a topic with no EndConversation node
+  produces no write. `supported_modes=("READONLY","WRITEBACK")`. Added unit tests
+  (pure transform + step wiring + chaining) and a golden test
+  (`tests/golden/test_replace_end_conversation_golden.py`).
+
 - **TASK-007 DONE — Output pipeline validation + generic Dataverse writeback +
   report rendering.** Replaced the postprocessing pass-through with
   `ValidateMigration`, `Writeback`, and `GenerateMigrationReport` steps. The

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
@@ -129,7 +129,7 @@ Instead, it establishes the complete framework, wiring, and developer experience
 | [TASK-004](tasks/TASK-004-dataverse-client.md)           | Dataverse Client               | DONE   | —        |
 | [TASK-005](tasks/TASK-005-diagnostics-framework.md)      | Diagnostics Framework          | DONE   | —        |
 | [TASK-006](tasks/TASK-006-preprocessing-pipeline.md)     | Preprocessing: Agent Config + Customization Discovery | DONE | TASK-015, TASK-004 |
-| [TASK-007](tasks/TASK-007-postprocessing-pipeline.md)    | Postprocessing Pipeline        | TODO   | TASK-015, TASK-004, TASK-005, TASK-016, TASK-017 |
+| [TASK-007](tasks/TASK-007-postprocessing-pipeline.md)    | Postprocessing Pipeline        | DONE   | TASK-015, TASK-004, TASK-005, TASK-016, TASK-017 |
 | [TASK-008](tasks/TASK-008-authentication-token-provider.md) | Authentication Token Provider | DONE   | —        |
 | [TASK-009](tasks/TASK-009-end-to-end-framework-validation.md) | End-to-End Framework Validation | BLOCKED | TASK-003, TASK-006, TASK-007, TASK-016 |
 | [TASK-015](tasks/TASK-015-input-pipeline-auth-discovery.md) | Input Pipeline: Auth + Agent Discovery + Orchestrator Wiring | DONE | TASK-002, TASK-005, TASK-008 |

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/TASKS.md
@@ -160,7 +160,7 @@ The framework architecture should remain unchanged.
 
 | Task                                                                   | Title                                       | Status | Consumes |
 | ---------------------------------------------------------------------- | ------------------------------------------- | ------ | -------- |
-| [TASK-011](tasks/TASK-011-rule-002-replace-endconversation-node.md)    | Implement RULE-002 — Replace EndConversation Node | TODO | RULE-002, TASK-006, TASK-016, TASK-017 |
+| [TASK-011](tasks/TASK-011-rule-002-replace-endconversation-node.md)    | Implement RULE-002 — Replace EndConversation Node | DONE | RULE-002, TASK-006, TASK-016, TASK-017 |
 | [TASK-012](tasks/TASK-012-rule-003-handle-onactivity-topic.md)         | Implement RULE-003 — Handle OnActivity Topic | TODO  | RULE-003, TASK-006, TASK-016, TASK-017 |
 | [TASK-013](tasks/TASK-013-rule-004-handle-ongeneratedresponse-topic.md) | Implement RULE-004 — Handle OnGeneratedResponse Topic | TODO | RULE-004, TASK-006, TASK-016, TASK-017 |
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-007-postprocessing-pipeline.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-007-postprocessing-pipeline.md
@@ -4,7 +4,7 @@
 | ---------- | ------------------------- |
 | ID         | TASK-007                  |
 | Workstream | 0 — Repository Foundation |
-| Status     | TODO                      |
+| Status     | DONE                      |
 | Consumes   | TASK-015, TASK-004, TASK-005, TASK-016, TASK-017 |
 
 ## Description
@@ -23,7 +23,7 @@ the real steps:
    record) and **no-op-guarded** (only genuinely-changed fields) by the
    `WritebackPlan` (TASK-017), so each entry
    `{"entity_set", "record_id", "changes"}` maps to a single
-   `update(f"{entity_set}({record_id})", changes)` — no de-duplication needed here.
+   `client.update(entity_set, record_id, changes)` — no de-duplication needed here.
    When `context.preferred_solution` is set (ALM customers, verified in
    `GatherALMCustomerInputStep`), the writes target that solution via the
    `MSCRM.SolutionUniqueName` request header. **WRITEBACK mode only** —
@@ -51,18 +51,18 @@ correct is owned by TASK-009 (E2E, `--dev` WRITEBACK).
 
 ## Acceptance Criteria
 
-- [ ] `ValidateMigration` step verifies post-conditions on migrated components.
-- [ ] `Writeback` step applies `context.pending_writes` via DataverseClient —
+- [x] `ValidateMigration` step verifies post-conditions on migrated components.
+- [x] `Writeback` step applies `context.pending_writes` via DataverseClient —
   **WRITEBACK only**.
-- [ ] Writeback targets `context.preferred_solution` (when set) via the
+- [x] Writeback targets `context.preferred_solution` (when set) via the
   `MSCRM.SolutionUniqueName` header.
-- [ ] `Writeback` is auto-skipped in READONLY mode (mode-gating via
+- [x] `Writeback` is auto-skipped in READONLY mode (mode-gating via
   `MigrationPipelineStep.can_execute`).
-- [ ] `GenerateMigrationReport` renders `migration_report.md` via Reporter.
-- [ ] Output bundle contains exactly `migration_report.md` + `session.log`.
-- [ ] All steps are `MigrationPipelineStep` subclasses with `supported_modes`.
-- [ ] No transformation logic in this stage.
-- [ ] Quality gates pass.
+- [x] `GenerateMigrationReport` renders `migration_report.md` via Reporter.
+- [x] Output bundle contains exactly `migration_report.md` + `session.log`.
+- [x] All steps are `MigrationPipelineStep` subclasses with `supported_modes`.
+- [x] No transformation logic in this stage.
+- [x] Quality gates pass.
 
 ## Deliverables
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-011-rule-002-replace-endconversation-node.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-011-rule-002-replace-endconversation-node.md
@@ -4,7 +4,7 @@
 | ---------- | --------------------------------- |
 | ID         | TASK-011                          |
 | Workstream | 2 — Incremental Migration Rules   |
-| Status     | TODO                              |
+| Status     | DONE                              |
 | Consumes   | RULE-002, TASK-006, TASK-016, TASK-017 |
 
 ## Description
@@ -35,20 +35,20 @@ topic; the plan diffs vs the original so an unchanged topic yields no write.
 
 ## Acceptance Criteria
 
-- [ ] `ReplaceEndConversationStep` is a `MigrationPipelineStep` registered in the
+- [x] `ReplaceEndConversationStep` is a `MigrationPipelineStep` registered in the
   Transformation Pipeline (`build_transformation_pipeline`) after
   `ApplyDaCompatibilityStep`.
-- [ ] Every EndConversation node in a topic's `data` YAML is replaced with an End
+- [x] Every EndConversation node in a topic's `data` YAML is replaced with an End
   All Topics (CancelAllDialogs) node per RULE-002, preserving node connectivity
   and all other topic logic.
-- [ ] The transform is **idempotent** (re-running yields no further change) and a
+- [x] The transform is **idempotent** (re-running yields no further change) and a
   pure function unit-tested independently of the step.
-- [ ] Edits are staged via `context.writeback` — the step never appends to
+- [x] Edits are staged via `context.writeback` — the step never appends to
   `pending_writes`; unchanged topics produce no write.
-- [ ] `supported_modes=("READONLY", "WRITEBACK")` (READONLY previews via
+- [x] `supported_modes=("READONLY", "WRITEBACK")` (READONLY previews via
   `pending_writes`; WRITEBACK persists — the Output stage, TASK-007, applies them).
-- [ ] Unit Tests and Golden Tests (YAML before/after fixtures) pass.
-- [ ] The framework architecture is unchanged.
+- [x] Unit Tests and Golden Tests (YAML before/after fixtures) pass.
+- [x] The framework architecture is unchanged.
 
 ## Deliverables
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-012-rule-003-handle-onactivity-topic.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-012-rule-003-handle-onactivity-topic.md
@@ -16,18 +16,49 @@ targets from `context.customizations` and **stages** its edits on the
 `WritebackPlan` (TASK-017) — no Dataverse I/O, never appends to `pending_writes`.
 
 **Input.** Iterate `context.customizations`
-(`dict[str, CustomizationComponent]`, Topic V2 topics). A topic's definition is
-`component.data` (YAML); an OnActivity topic is identified from that YAML. Its
-record is `botcomponents({component_id})`.
+(`dict[str, CustomizationComponent]`, Topic V2 topics). The OnActivity trigger is
+identified from the topic's `data` YAML (`beginDialog.kind == "OnActivity"`), but
+the **title and disabled state are record fields, NOT in the `data` YAML** (see
+bring-up findings below). Its record is `botcomponents({component_id})`.
 
-**Staging (chaining- and no-op-safe).**
+**Staging (chaining- and no-op-safe).** Detect the trigger from `component.data`,
+then stage the record-field edits (title + disabled state) — NOT `data`:
 
 ```python
+if not is_on_activity_topic(component.data):
+    continue
 target = context.writeback.target(
-    "botcomponents", component.component_id, original={"data": component.data}
+    "botcomponents",
+    component.component_id,
+    original={"name": component.name, "statecode": ..., "statuscode": ...},
 )
-target.set("data", deprecate_on_activity_topic(target.get("data")))
+target.set("name", deprecate_title(target.get("name")))   # "[DEPRECATED] " once
+target.set("statecode", _INACTIVE_STATECODE)              # disable
+target.set("statuscode", _INACTIVE_STATUSCODE)
 ```
+
+### Bring-up findings (from RULE-002, TASK-011)
+
+- A topic's `data` YAML root is `kind: AdaptiveDialog` + `inputs` /
+  `modelDescription` / `beginDialog` / `inputType` / `outputType` **only** — it
+  does **not** contain the topic title or an enabled/disabled flag (verified
+  against the `ess-samples` topic YAMLs).
+- **Trigger type** = `beginDialog.kind` in `data` (e.g. `OnActivity`,
+  `OnGeneratedResponse`, `OnRecognizedIntent`). Detect from `data`; do not modify
+  `data` for this rule.
+- **Title** = the botcomponent `name` field (hydrated as
+  `CustomizationComponent.name`). Prefix `"[DEPRECATED] "` once (idempotent).
+- **Disable** = the botcomponent `statecode`/`statuscode` (standard Dataverse
+  Inactive is `statecode=1`, `statuscode=2`). **UNCONFIRMED** for Copilot topics —
+  isolate the values as module constants and confirm live under TASK-009
+  (`./mtk.sh run --dev` WRITEBACK), per the existing UNCONFIRMED-field pattern.
+  `CustomizationComponent` does not yet hydrate statecode/statuscode; either read
+  them from the layer's `msdyn_componentjson` attributes or extend hydration.
+- **Idempotency (MIG-005)**: skip when the topic is already Inactive AND `name`
+  already starts with `[DEPRECATED]`.
+- **Migration warning**: emit via the diagnostics warning collector the Reporter
+  renders (confirm the exact API used by existing steps, e.g. `logger.LogWarning`
+  vs a context collector).
 
 ## Acceptance Criteria
 

--- a/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-013-rule-004-handle-ongeneratedresponse-topic.md
+++ b/dev-specs/ess-nextgen-migration-toolkit/04_EXECUTION/tasks/TASK-013-rule-004-handle-ongeneratedresponse-topic.md
@@ -17,18 +17,38 @@ the `WritebackPlan` (TASK-017) — no Dataverse I/O, never appends to
 `pending_writes`.
 
 **Input.** Iterate `context.customizations`
-(`dict[str, CustomizationComponent]`, Topic V2 topics). A topic's definition is
-`component.data` (YAML); an OnGeneratedResponse topic is identified from that YAML.
-Its record is `botcomponents({component_id})`.
+(`dict[str, CustomizationComponent]`, Topic V2 topics). The OnGeneratedResponse
+trigger is identified from the topic's `data` YAML
+(`beginDialog.kind == "OnGeneratedResponse"`), but the **title and disabled state
+are record fields, NOT in the `data` YAML** (see bring-up findings below). Its
+record is `botcomponents({component_id})`.
 
-**Staging (chaining- and no-op-safe).**
+**Staging (chaining- and no-op-safe).** Detect the trigger from `component.data`,
+then stage the record-field edits (title + disabled state) — NOT `data`:
 
 ```python
+if not is_generated_response_topic(component.data):
+    continue
 target = context.writeback.target(
-    "botcomponents", component.component_id, original={"data": component.data}
+    "botcomponents",
+    component.component_id,
+    original={"name": component.name, "statecode": ..., "statuscode": ...},
 )
-target.set("data", deprecate_generated_response_topic(target.get("data")))
+target.set("name", deprecate_title(target.get("name")))   # "[DEPRECATED] " once
+target.set("statecode", _INACTIVE_STATECODE)              # disable
+target.set("statuscode", _INACTIVE_STATUSCODE)
 ```
+
+### Bring-up findings (from RULE-002, TASK-011)
+
+Identical mechanism to RULE-003 (TASK-012) — see its "Bring-up findings" section:
+the topic title/enabled state are the botcomponent `name` + `statecode`/`statuscode`
+record fields (not the `data` YAML); the trigger type is `beginDialog.kind` in
+`data`; the Inactive `statecode`/`statuscode` values are **UNCONFIRMED** and must
+be isolated as constants + confirmed live under TASK-009; idempotency (MIG-005)
+skips a topic already Inactive with a `[DEPRECATED]`-prefixed `name`. Consider a
+shared `_deprecate_topic` helper so RULE-003 and RULE-004 share the disable +
+title-prefix logic and differ only in the trigger they match.
 
 ## Acceptance Criteria
 

--- a/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/src/core/outbound/dataverse_client.py
@@ -174,7 +174,14 @@ class DataverseClient:
             )
         return record_id
 
-    def update(self, entity_set: str, record_id: str, data: JsonDict) -> None:
+    def update(
+        self,
+        entity_set: str,
+        record_id: str,
+        data: JsonDict,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         """Update one Dataverse record without returning a payload."""
         self.__request(
             "PATCH",
@@ -182,6 +189,7 @@ class DataverseClient:
             json=data,
             operation="update",
             entity_set=entity_set,
+            headers=headers,
         )
 
     def delete(self, entity_set: str, record_id: str) -> None:
@@ -202,14 +210,16 @@ class DataverseClient:
         json: JsonDict | None = None,
         operation: str,
         entity_set: str | None,
+        headers: dict[str, str] | None = None,
     ) -> httpx.Response:
         if method == "GET":
             response = self.__request_with_get_retry(
                 path,
                 params=params,
+                headers=headers,
             )
         else:
-            response = self.__send_once(method, path, params=params, json=json)
+            response = self.__send_once(method, path, params=params, json=json, headers=headers)
 
         self.__raise_for_status(response, operation=operation, entity_set=entity_set)
         return response
@@ -219,8 +229,9 @@ class DataverseClient:
         path: str,
         *,
         params: dict[str, str] | None,
+        headers: dict[str, str] | None,
     ) -> httpx.Response:
-        response = self.__send_once("GET", path, params=params)
+        response = self.__send_once("GET", path, params=params, headers=headers)
         for attempt in range(1, _GET_ATTEMPTS):
             if response.status_code not in _RETRY_STATUS_CODES:
                 return response
@@ -228,7 +239,7 @@ class DataverseClient:
             delay_seconds = _retry_delay_seconds(response, attempt)
             if delay_seconds > 0:
                 self.__sleep(delay_seconds)
-            response = self.__send_once("GET", path, params=params)
+            response = self.__send_once("GET", path, params=params, headers=headers)
 
         return response
 
@@ -239,13 +250,18 @@ class DataverseClient:
         *,
         params: dict[str, str] | None = None,
         json: JsonDict | None = None,
+        headers: dict[str, str] | None = None,
     ) -> httpx.Response:
         token = self.__token_provider.get_token()
-        headers = {**_O_DATA_HEADERS, "Authorization": f"Bearer {token}"}
+        request_headers = {
+            **_O_DATA_HEADERS,
+            **(headers or {}),
+            "Authorization": f"Bearer {token}",
+        }
         return self.__client.request(
             method,
             self.__request_url(path),
-            headers=headers,
+            headers=request_headers,
             params=params,
             json=json,
         )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/output_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/output_pipeline.py
@@ -4,37 +4,23 @@ from __future__ import annotations
 
 from core.logging import Logger
 from core.pipelines import Pipeline
-from modules.transformation.migration_step import MigrationPipelineStep
+from modules.postprocessing.steps import (
+    GenerateMigrationReportStep,
+    ValidateMigrationStep,
+    WritebackStep,
+)
 from modules.transformation.models import MigrationContext
-
-
-class _OutputPassthroughStep(MigrationPipelineStep):
-    """Placeholder: validation/writeback/report steps (TASK-007) will replace this."""
-
-    def __init__(self, logger: Logger, supported_modes: tuple[str, ...]) -> None:
-        super().__init__(
-            description="No-op placeholder until output behaviors are implemented.",
-            supported_modes=supported_modes,
-        )
-        self._logger = logger
-
-    def execute(self, context: MigrationContext) -> MigrationContext:
-        # TODO: ValidateMigration, Writeback (WRITEBACK-only), and
-        # GenerateMigrationReport steps will replace this once TASK-007 lands.
-        self._logger.LogDebug(
-            "Output stage is currently a no-op.",
-            pipeline_stage="Output",
-            pipeline_step=self.name(),
-        )
-        return context
 
 
 def build_output_pipeline(
     logger: Logger, supported_modes: tuple[str, ...]
 ) -> Pipeline[MigrationContext, MigrationContext]:
     """Build the output stage pipeline."""
+    del supported_modes
     return (
         Pipeline.builder("Output Pipeline", input_type=MigrationContext)
-        .use(_OutputPassthroughStep(logger, supported_modes))
+        .use(ValidateMigrationStep(logger))
+        .use(WritebackStep(logger))
+        .use(GenerateMigrationReportStep(logger))
         .build()
     )

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/__init__.py
@@ -1,0 +1,11 @@
+"""Output-stage pipeline steps."""
+
+from modules.postprocessing.steps.generate_report_step import GenerateMigrationReportStep
+from modules.postprocessing.steps.validate_migration_step import ValidateMigrationStep
+from modules.postprocessing.steps.writeback_step import WritebackStep
+
+__all__ = [
+    "GenerateMigrationReportStep",
+    "ValidateMigrationStep",
+    "WritebackStep",
+]

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/generate_report_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/generate_report_step.py
@@ -1,0 +1,31 @@
+"""Render the terminal customer-facing migration report."""
+
+from __future__ import annotations
+
+from core.logging import Logger
+from modules.transformation.migration_step import MigrationPipelineStep
+from modules.transformation.models import MigrationContext
+from service.reporter import Reporter
+
+_SUPPORTED_MODES = ("READONLY", "WRITEBACK")
+
+
+class GenerateMigrationReportStep(MigrationPipelineStep):
+    """Render ``migration_report.md`` from MigrationContext collectors."""
+
+    def __init__(self, logger: Logger) -> None:
+        super().__init__(
+            name="GenerateMigrationReport",
+            description="Render the customer-facing migration report.",
+            supported_modes=_SUPPORTED_MODES,
+        )
+        self._logger = logger
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        Reporter(self._logger.session_manager).render(context)
+        self._logger.LogInfo(
+            "Rendered migration_report.md.",
+            pipeline_stage="Output",
+            pipeline_step=self.name(),
+        )
+        return context

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/validate_migration_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/validate_migration_step.py
@@ -1,0 +1,53 @@
+"""Validate output-stage postconditions before writeback/reporting."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.logging import Logger
+from modules.transformation.migration_step import MigrationPipelineStep
+from modules.transformation.models import MigrationContext
+
+_SUPPORTED_MODES = ("READONLY", "WRITEBACK")
+
+
+class MigrationValidationError(ValueError):
+    """Raised when migrated output state fails postcondition validation."""
+
+
+class ValidateMigrationStep(MigrationPipelineStep):
+    """Verify pending writeback entries are well-formed before persistence."""
+
+    def __init__(self, logger: Logger) -> None:
+        super().__init__(
+            name="ValidateMigration",
+            description="Validate migrated output postconditions.",
+            supported_modes=_SUPPORTED_MODES,
+        )
+        self._logger = logger
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        pending_writes = context.pending_writes
+        for index, pending_write in enumerate(pending_writes):
+            _validate_pending_write(pending_write, index)
+
+        self._logger.LogInfo(
+            f"Validated {len(pending_writes)} pending write(s).",
+            pipeline_stage="Output",
+            pipeline_step=self.name(),
+        )
+        return context
+
+
+def _validate_pending_write(pending_write: dict[str, Any], index: int) -> None:
+    entity_set = pending_write.get("entity_set")
+    if not isinstance(entity_set, str) or not entity_set:
+        raise MigrationValidationError(f"Pending write #{index + 1} has no entity_set.")
+
+    record_id = pending_write.get("record_id")
+    if not isinstance(record_id, str) or not record_id:
+        raise MigrationValidationError(f"Pending write #{index + 1} has no record_id.")
+
+    changes = pending_write.get("changes")
+    if not isinstance(changes, dict) or not changes:
+        raise MigrationValidationError(f"Pending write #{index + 1} has no changes.")

--- a/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/writeback_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/postprocessing/steps/writeback_step.py
@@ -1,0 +1,64 @@
+"""Apply coalesced pending writes to Dataverse."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from core.logging import Logger
+from modules.transformation.migration_step import MigrationPipelineStep
+from modules.transformation.models import MigrationContext
+
+_SOLUTION_UNIQUE_NAME_HEADER = "MSCRM.SolutionUniqueName"
+
+
+class WritebackError(RuntimeError):
+    """Raised when output writeback cannot be executed."""
+
+
+class WritebackStep(MigrationPipelineStep):
+    """Persist ``context.pending_writes`` in WRITEBACK mode."""
+
+    def __init__(self, logger: Logger) -> None:
+        super().__init__(
+            name="Writeback",
+            description="Apply pending Dataverse writes.",
+            supported_modes=("WRITEBACK",),
+        )
+        self._logger = logger
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        pending_writes = context.pending_writes
+        if not pending_writes:
+            self._logger.LogInfo(
+                "No pending writes to apply.",
+                pipeline_stage="Output",
+                pipeline_step=self.name(),
+            )
+            return context
+
+        client = context.dataverse_client
+        if client is None:
+            raise WritebackError("Dataverse client is not initialized.")
+
+        solution_headers = _solution_headers(context.preferred_solution)
+        for pending_write in pending_writes:
+            entity_set = cast(str, pending_write["entity_set"])
+            record_id = cast(str, pending_write["record_id"])
+            changes = cast(dict[str, Any], pending_write["changes"])
+            if solution_headers is None:
+                client.update(entity_set, record_id, changes)
+            else:
+                client.update(entity_set, record_id, changes, headers=solution_headers)
+
+        self._logger.LogInfo(
+            f"Applied {len(pending_writes)} pending write(s) to Dataverse.",
+            pipeline_stage="Output",
+            pipeline_step=self.name(),
+        )
+        return context
+
+
+def _solution_headers(preferred_solution: str | None) -> dict[str, str] | None:
+    if not preferred_solution:
+        return None
+    return {_SOLUTION_UNIQUE_NAME_HEADER: preferred_solution}

--- a/tools/ess-nextgen-migration-toolkit/src/modules/transformation/steps/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/transformation/steps/__init__.py
@@ -1,5 +1,6 @@
 """Transformation pipeline steps."""
 
 from modules.transformation.steps.apply_da_compatibility_step import ApplyDaCompatibilityStep
+from modules.transformation.steps.replace_end_conversation_step import ReplaceEndConversationStep
 
-__all__ = ["ApplyDaCompatibilityStep"]
+__all__ = ["ApplyDaCompatibilityStep", "ReplaceEndConversationStep"]

--- a/tools/ess-nextgen-migration-toolkit/src/modules/transformation/steps/replace_end_conversation_step.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/transformation/steps/replace_end_conversation_step.py
@@ -1,0 +1,86 @@
+"""RULE-002 — Replace EndConversation nodes with CancelAllDialogs (End All Topics).
+
+Declarative Agents do not support the ``EndConversation`` node; ESS has validated
+that ``CancelAllDialogs`` (End All Topics) preserves the expected runtime
+behavior. This step rewrites every ``EndConversation`` node in each customized
+topic's ``data`` YAML, preserving node connectivity, ids, and all other logic.
+
+The rewrite is a node-anchored line substitution (not a YAML round-trip), so
+untouched regions are left byte-for-byte identical — a topic with no
+EndConversation node produces no write. Edits are staged on the ``WritebackPlan``
+(``context.writeback``); the step performs no Dataverse I/O.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from core.logging import Logger
+from modules.transformation.migration_step import MigrationPipelineStep
+from modules.transformation.models import MigrationContext
+
+_BOTCOMPONENTS_ENTITY = "botcomponents"
+_DATA_FIELD = "data"
+_CANCEL_ALL_DIALOGS_KIND = "CancelAllDialogs"
+# A topic node is a YAML line like ``    - kind: EndConversation`` (optionally
+# without the list-item dash for a nested kind). Match the whole line and rewrite
+# only the kind, preserving the list-item prefix + indentation so the node id and
+# every other line are untouched.
+_END_CONVERSATION_RE = re.compile(
+    r"(?m)^(?P<prefix>[ \t]*(?:-[ \t]*)?)kind:[ \t]*EndConversation[ \t]*$"
+)
+
+
+class ReplaceEndConversationStep(MigrationPipelineStep):
+    """Rewrite EndConversation nodes to CancelAllDialogs across customized topics."""
+
+    def __init__(self, logger: Logger) -> None:
+        super().__init__(
+            name="ReplaceEndConversation",
+            description="Replace EndConversation nodes with CancelAllDialogs (RULE-002).",
+            supported_modes=("READONLY", "WRITEBACK"),
+        )
+        self._logger = logger
+
+    def execute(self, context: MigrationContext) -> MigrationContext:
+        rewritten = 0
+        for component in context.customizations.values():
+            # Read the working value if an earlier rule already staged this topic
+            # (chaining), else the original topic data.
+            existing = context.writeback.target_for(_BOTCOMPONENTS_ENTITY, component.component_id)
+            current = existing.get(_DATA_FIELD) if existing is not None else component.data
+
+            replaced = replace_end_conversation(current)
+            if replaced == current:
+                continue  # no EndConversation node -> nothing to stage
+
+            target = context.writeback.target(
+                _BOTCOMPONENTS_ENTITY,
+                component.component_id,
+                original={_DATA_FIELD: component.data},
+            )
+            target.set(_DATA_FIELD, replaced)
+            rewritten += 1
+
+        self._logger.LogInfo(
+            f"RULE-002 replaced EndConversation nodes in {rewritten} topic(s).",
+            pipeline_stage="Transformation",
+            pipeline_step=self.name(),
+        )
+        return context
+
+
+def replace_end_conversation(data: Any) -> Any:
+    """Replace every ``EndConversation`` node kind with ``CancelAllDialogs``.
+
+    Node-anchored line rewrite that preserves the list-item prefix, indentation,
+    the node id, and all other topic logic. Idempotent, and returns the input
+    unchanged when there is no EndConversation node (no reserialization).
+    """
+    if not isinstance(data, str) or not data:
+        return data
+    replaced, count = _END_CONVERSATION_RE.subn(
+        lambda match: f"{match.group('prefix')}kind: {_CANCEL_ALL_DIALOGS_KIND}", data
+    )
+    return replaced if count else data

--- a/tools/ess-nextgen-migration-toolkit/src/modules/transformation/transformation_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/src/modules/transformation/transformation_pipeline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from core.logging import Logger
 from core.pipelines import Pipeline
 from modules.transformation.models import MigrationContext
-from modules.transformation.steps import ApplyDaCompatibilityStep
+from modules.transformation.steps import ApplyDaCompatibilityStep, ReplaceEndConversationStep
 
 
 def build_transformation_pipeline(
@@ -15,5 +15,6 @@ def build_transformation_pipeline(
     return (
         Pipeline.builder("Transformation Pipeline", input_type=MigrationContext)
         .use(ApplyDaCompatibilityStep(logger, supported_modes))
+        .use(ReplaceEndConversationStep(logger))
         .build()
     )

--- a/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/src/service/mtk_orchestrator.py
@@ -70,7 +70,7 @@ def main(argv: list[str] | None = None) -> None:
         raise
     finally:
         try:
-            Reporter(logger.session_manager).render(context)
+            _render_report_if_missing(logger, context)
         finally:
             logger.close()
 
@@ -86,6 +86,13 @@ def _log_summary(logger: Logger, context: MigrationContext) -> None:
         pipeline_stage="Orchestrator",
         pipeline_step="summary",
     )
+
+
+def _render_report_if_missing(logger: Logger, context: MigrationContext) -> None:
+    """Render a best-effort failure report if Output did not reach report generation."""
+    if logger.session_manager.paths.report_path.exists():
+        return
+    Reporter(logger.session_manager).render(context)
 
 
 if __name__ == "__main__":

--- a/tools/ess-nextgen-migration-toolkit/tests/golden/test_replace_end_conversation_golden.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/golden/test_replace_end_conversation_golden.py
@@ -1,0 +1,76 @@
+"""Golden test for RULE-002 — deterministic EndConversation -> CancelAllDialogs.
+
+Input topic (a realistic AdaptiveDialog) -> ReplaceEndConversationStep -> the
+output must exactly match the golden result: only the EndConversation node kind
+changes; every other line (ids, indentation, logic) is byte-for-byte preserved.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from core.logging import Logger
+from modules.transformation.models import CustomizationComponent, MigrationContext
+from modules.transformation.steps.replace_end_conversation_step import ReplaceEndConversationStep
+
+_INPUT_TOPIC = """\
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  intent:
+    triggerQueries:
+      - Where can I eat?
+  actions:
+    - kind: SendActivity
+      id: greet
+      activity: Here are the dining stations near you.
+
+    - kind: EndConversation
+      id: pYEcde
+
+inputType: {}
+outputType: {}
+"""
+
+_GOLDEN_TOPIC = """\
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  intent:
+    triggerQueries:
+      - Where can I eat?
+  actions:
+    - kind: SendActivity
+      id: greet
+      activity: Here are the dining stations near you.
+
+    - kind: CancelAllDialogs
+      id: pYEcde
+
+inputType: {}
+outputType: {}
+"""
+
+
+class _FakeLogger:
+    def LogInfo(self, *_: object, **__: object) -> None: ...
+    def LogWarning(self, *_: object, **__: object) -> None: ...
+    def LogDebug(self, *_: object, **__: object) -> None: ...
+
+
+def test_replace_end_conversation_golden() -> None:
+    context = MigrationContext(
+        customizations={
+            "topic-dining": CustomizationComponent(component_id="topic-dining", data=_INPUT_TOPIC)
+        }
+    )
+
+    result = ReplaceEndConversationStep(cast(Logger, _FakeLogger())).execute(context)
+
+    writes = result.pending_writes
+    assert len(writes) == 1
+    assert writes[0]["entity_set"] == "botcomponents"
+    assert writes[0]["record_id"] == "topic-dining"
+    assert writes[0]["changes"]["data"] == _GOLDEN_TOPIC

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/core/outbound/test_dataverse_client.py
@@ -263,3 +263,28 @@ def test_create_returns_record_id_from_odata_entity_id_header() -> None:
     record_id = client.create("bots", {"name": "Created"})
 
     assert record_id == "12345"
+
+
+def test_update_merges_per_request_headers_without_replacing_odata_headers() -> None:
+    seen_headers: list[httpx.Headers] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(request.headers)
+        return httpx.Response(204)
+
+    client, _ = make_client(handler)
+
+    client.update(
+        "bots",
+        "record-id",
+        {"name": "Updated"},
+        headers={"MSCRM.SolutionUniqueName": "contoso_preferred"},
+    )
+
+    assert len(seen_headers) == 1
+    assert seen_headers[0]["MSCRM.SolutionUniqueName"] == "contoso_preferred"
+    assert seen_headers[0]["Accept"] == "application/json"
+    assert seen_headers[0]["OData-MaxVersion"] == "4.0"
+    assert seen_headers[0]["OData-Version"] == "4.0"
+    assert seen_headers[0]["Prefer"] == "odata.include-annotations=*"
+    assert seen_headers[0]["Authorization"] == "Bearer token-1"

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/postprocessing/__init__.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/postprocessing/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for postprocessing output-stage modules."""

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/postprocessing/test_output_pipeline.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/postprocessing/test_output_pipeline.py
@@ -1,0 +1,183 @@
+"""Unit tests for the output/postprocessing pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from core.logging import Logger
+from core.pipelines import Pipeline
+from modules.postprocessing.output_pipeline import build_output_pipeline
+from modules.postprocessing.steps import (
+    GenerateMigrationReportStep,
+    ValidateMigrationStep,
+    WritebackStep,
+)
+from modules.postprocessing.steps.validate_migration_step import MigrationValidationError
+from modules.transformation.migration_step import MigrationPipelineStep
+from modules.transformation.models import ExecutionMode, MigrationContext
+
+FIXED_TIME = datetime(2026, 7, 18, 14, 32, 5)
+
+
+class FakeLogger:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+
+    def LogInfo(self, message: str, **_: object) -> None:
+        self.infos.append(message)
+
+
+class FakeDataverseClient:
+    def __init__(self) -> None:
+        self.update_calls: list[tuple[str, str, dict[str, Any], dict[str, str] | None]] = []
+
+    def update(
+        self,
+        entity_set: str,
+        record_id: str,
+        data: dict[str, Any],
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.update_calls.append((entity_set, record_id, data, headers))
+
+
+@dataclass
+class InvalidPendingWritesContext(MigrationContext):
+    @property
+    def pending_writes(self) -> list[dict[str, Any]]:
+        return [{"entity_set": "bots", "record_id": "", "changes": {}}]
+
+
+def test_output_pipeline_uses_validate_writeback_and_report_steps() -> None:
+    pipeline = build_output_pipeline(cast(Logger, FakeLogger()), ("READONLY", "WRITEBACK"))
+
+    assert [step.name() for step in pipeline.steps] == [
+        "ValidateMigration",
+        "Writeback",
+        "GenerateMigrationReport",
+    ]
+    assert all(isinstance(step, MigrationPipelineStep) for step in pipeline.steps)
+    assert [step.supported_modes() for step in pipeline.steps] == [
+        frozenset({"READONLY", "WRITEBACK"}),
+        frozenset({"WRITEBACK"}),
+        frozenset({"READONLY", "WRITEBACK"}),
+    ]
+
+
+def test_validate_migration_accepts_well_formed_pending_writes() -> None:
+    context = MigrationContext()
+    context.writeback.target("bots", "bot-1", original={"template": "default"}).set(
+        "template",
+        "gptagent-1.0.0",
+    )
+
+    result = ValidateMigrationStep(cast(Logger, FakeLogger())).execute(context)
+
+    assert result is context
+
+
+def test_validate_migration_rejects_malformed_pending_write() -> None:
+    step = ValidateMigrationStep(cast(Logger, FakeLogger()))
+
+    with pytest.raises(MigrationValidationError, match="record_id"):
+        step.execute(InvalidPendingWritesContext())
+
+
+def test_writeback_applies_each_pending_write_exactly_once() -> None:
+    client = FakeDataverseClient()
+    context = MigrationContext(mode=ExecutionMode.WRITEBACK, dataverse_client=client)
+    context.writeback.target("bots", "bot-1", original={"template": "default"}).set(
+        "template",
+        "gptagent-1.0.0",
+    )
+    context.writeback.target("botcomponents", "component-1", original={"data": "old"}).set(
+        "data",
+        "new",
+    )
+
+    result = WritebackStep(cast(Logger, FakeLogger())).execute(context)
+
+    assert result is context
+    assert client.update_calls == [
+        ("bots", "bot-1", {"template": "gptagent-1.0.0"}, None),
+        ("botcomponents", "component-1", {"data": "new"}, None),
+    ]
+
+
+def test_writeback_is_skipped_in_readonly_by_mode_gate() -> None:
+    client = FakeDataverseClient()
+    context = MigrationContext(mode=ExecutionMode.READONLY, dataverse_client=client)
+    context.writeback.target("bots", "bot-1", original={"template": "default"}).set(
+        "template",
+        "gptagent-1.0.0",
+    )
+    pipeline = (
+        Pipeline.builder("writeback-mode-gate", input_type=MigrationContext)
+        .use(WritebackStep(cast(Logger, FakeLogger())))
+        .build()
+    )
+
+    result = pipeline.run(context)
+
+    assert result is context
+    assert client.update_calls == []
+
+
+def test_writeback_targets_preferred_solution_header_when_set() -> None:
+    client = FakeDataverseClient()
+    context = MigrationContext(
+        mode=ExecutionMode.WRITEBACK,
+        dataverse_client=client,
+        preferred_solution="contoso_preferred",
+    )
+    context.writeback.target("bots", "bot-1", original={"template": "default"}).set(
+        "template",
+        "gptagent-1.0.0",
+    )
+
+    WritebackStep(cast(Logger, FakeLogger())).execute(context)
+
+    assert client.update_calls == [
+        (
+            "bots",
+            "bot-1",
+            {"template": "gptagent-1.0.0"},
+            {"MSCRM.SolutionUniqueName": "contoso_preferred"},
+        )
+    ]
+
+
+def test_writeback_no_ops_on_empty_pending_writes() -> None:
+    client = FakeDataverseClient()
+    context = MigrationContext(mode=ExecutionMode.WRITEBACK, dataverse_client=client)
+
+    result = WritebackStep(cast(Logger, FakeLogger())).execute(context)
+
+    assert result is context
+    assert client.update_calls == []
+
+
+def test_generate_migration_report_renders_two_file_bundle(tmp_path: Path) -> None:
+    context = MigrationContext(mode=ExecutionMode.READONLY)
+    logger = Logger.start_session(
+        tmp_path,
+        context,
+        report_filename="migration_report.md",
+        clock=lambda: FIXED_TIME,
+    )
+    try:
+        result = GenerateMigrationReportStep(logger).execute(context)
+    finally:
+        logger.close()
+
+    assert result is context
+    bundle_files = sorted(path.name for path in logger.session_manager.paths.session_dir.iterdir())
+    assert bundle_files == ["migration_report.md", "session.log"]
+    report = logger.session_manager.paths.report_path.read_text(encoding="utf-8")
+    assert "# Migration Readiness Report" in report

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/modules/transformation/test_replace_end_conversation_step.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/modules/transformation/test_replace_end_conversation_step.py
@@ -1,0 +1,114 @@
+"""Unit tests for RULE-002 — ReplaceEndConversationStep."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from core.logging import Logger
+from modules.transformation.models import CustomizationComponent, MigrationContext
+from modules.transformation.steps.replace_end_conversation_step import (
+    ReplaceEndConversationStep,
+    replace_end_conversation,
+)
+
+
+class FakeLogger:
+    def LogInfo(self, *_: object, **__: object) -> None: ...
+    def LogWarning(self, *_: object, **__: object) -> None: ...
+    def LogDebug(self, *_: object, **__: object) -> None: ...
+
+
+def _step() -> ReplaceEndConversationStep:
+    return ReplaceEndConversationStep(cast(Logger, FakeLogger()))
+
+
+def _topic(component_id: str, data: str) -> CustomizationComponent:
+    return CustomizationComponent(component_id=component_id, data=data)
+
+
+# --- pure transform ---
+
+
+def test_replace_end_conversation_rewrites_node_and_preserves_id_and_indent() -> None:
+    data = "      actions:\n        - kind: EndConversation\n          id: pYEcde\n"
+
+    replaced = replace_end_conversation(data)
+
+    assert replaced == ("      actions:\n        - kind: CancelAllDialogs\n          id: pYEcde\n")
+
+
+def test_replace_end_conversation_rewrites_every_node() -> None:
+    data = "    - kind: EndConversation\n      id: a\n    - kind: EndConversation\n      id: b\n"
+
+    replaced = replace_end_conversation(data)
+
+    assert "EndConversation" not in replaced
+    assert replaced.count("kind: CancelAllDialogs") == 2
+    # ids preserved
+    assert "id: a" in replaced and "id: b" in replaced
+
+
+def test_replace_end_conversation_is_idempotent_when_already_cancel_all_dialogs() -> None:
+    data = "    - kind: CancelAllDialogs\n      id: pYEcde\n"
+    assert replace_end_conversation(data) == data
+
+
+def test_replace_end_conversation_leaves_topic_without_node_unchanged() -> None:
+    data = "beginDialog:\n  kind: OnRecognizedIntent\n  actions:\n    - kind: SendActivity\n"
+    assert replace_end_conversation(data) is data or replace_end_conversation(data) == data
+
+
+def test_replace_end_conversation_does_not_match_substring_in_other_lines() -> None:
+    # A variable that merely mentions the word must not be rewritten.
+    data = '    value: ="EndConversation was requested"\n'
+    assert replace_end_conversation(data) == data
+
+
+# --- step wiring ---
+
+
+def test_step_stages_data_write_only_for_topics_with_end_conversation() -> None:
+    context = MigrationContext(
+        customizations={
+            "topic-1": _topic("topic-1", "actions:\n  - kind: EndConversation\n    id: x\n"),
+            "topic-2": _topic("topic-2", "actions:\n  - kind: SendActivity\n    id: y\n"),
+        }
+    )
+
+    result = _step().execute(context)
+
+    writes = {w["record_id"]: w for w in result.pending_writes}
+    # Only topic-1 (had EndConversation) produces a write; topic-2 is untouched.
+    assert set(writes) == {"topic-1"}
+    assert writes["topic-1"]["entity_set"] == "botcomponents"
+    assert "kind: CancelAllDialogs" in writes["topic-1"]["changes"]["data"]
+    assert "EndConversation" not in writes["topic-1"]["changes"]["data"]
+
+
+def test_step_no_writes_when_no_topic_has_end_conversation() -> None:
+    context = MigrationContext(
+        customizations={"topic-2": _topic("topic-2", "actions:\n  - kind: SendActivity\n")}
+    )
+
+    result = _step().execute(context)
+
+    assert result.pending_writes == []
+
+
+def test_step_chains_on_working_value_from_an_earlier_edit() -> None:
+    context = MigrationContext(
+        customizations={"topic-1": _topic("topic-1", "  - kind: EndConversation\n    id: x\n")}
+    )
+    # Simulate an earlier rule having already edited this topic's data.
+    context.writeback.target(
+        "botcomponents", "topic-1", original={"data": "  - kind: EndConversation\n    id: x\n"}
+    ).set("data", "  - kind: EndConversation\n    id: x\n# edited-by-earlier-rule\n")
+
+    result = _step().execute(context)
+
+    writes = {w["record_id"]: w for w in result.pending_writes}
+    data = writes["topic-1"]["changes"]["data"]
+    # RULE-002 composed on the earlier edit (comment retained) and replaced the node.
+    assert "# edited-by-earlier-rule" in data
+    assert "kind: CancelAllDialogs" in data
+    assert "EndConversation" not in data

--- a/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
+++ b/tools/ess-nextgen-migration-toolkit/tests/unit/service/test_mtk_orchestrator.py
@@ -88,6 +88,7 @@ def test_main_closes_logger_when_pipeline_execution_fails(
         session_manager = SimpleNamespace(
             paths=SimpleNamespace(
                 session_dir=tmp_path / "session",
+                report_path=tmp_path / "session" / "migration_report.md",
                 log_path=tmp_path / "session" / "session.log",
             )
         )


### PR DESCRIPTION
## Summary
Closes the migration write loop and lands the first topic transformation rule,
stacked on the customization-discovery + writeback-plan work.

- **TASK-007 — Output pipeline** (`modules/postprocessing/`): replaces the
  pass-through with `ValidateMigration → Writeback → GenerateMigrationReport`.
- **RULE-002 / TASK-011 — Replace EndConversation node** (`modules/transformation/steps/`):
  the first business rule operating on the discovered topics.

## TASK-007 — Output pipeline
- **`ValidateMigration`** — verifies each pending write is well-formed
  (`entity_set` / `record_id` / non-empty `changes`); runs in both modes.
- **`Writeback`** (generic) — applies the already-coalesced, no-op-guarded
  `context.pending_writes` via `DataverseClient.update(entity_set, record_id, changes)`;
  `supported_modes=("WRITEBACK",)` (auto-skipped in READONLY by the mode gate);
  when `context.preferred_solution` is set, scopes writes via the
  `MSCRM.SolutionUniqueName` request header.
- **`GenerateMigrationReport`** — renders `migration_report.md` via `Reporter`
  (no direct file writes, DIAG-005). Orchestrator `finally` now renders only if the
  report is missing (failure path), avoiding a double render.
- **`DataverseClient`** gains a generic, backward-compatible `update(..., *, headers=None)`
  threaded through the request path — no ESS specifics in `core/`.

## RULE-002 — Replace EndConversation (TASK-011)
- **`ReplaceEndConversationStep`** iterates `context.customizations` and rewrites every
  `kind: EndConversation` node to `kind: CancelAllDialogs` (End All Topics) in each topic's
  `data` YAML. Node-anchored line substitution preserves the list-item prefix, indentation,
  node ids, and all other logic (no YAML round-trip); a topic with no such node produces no
  write. Staged on the `WritebackPlan` (chaining-aware), `supported_modes=("READONLY","WRITEBACK")`.
- Registered after `ApplyDaCompatibilityStep` in `build_transformation_pipeline`.

## Testing
- `ruff check` / `ruff format --check` / `mypy` / **`pytest` → 103 passed**.
- New: postprocessing output-pipeline tests (writeback call assertions, READONLY mode-gate
  skip, preferred-solution header, empty no-op, report bundle); RULE-002 unit tests
  (pure transform + step wiring + chaining) and a golden test.

## Task state
- TASK-007 → **DONE**; TASK-011 → **DONE**.
- TASK-012/013 (RULE-003/004) specs **enriched** with bring-up findings but **not implemented**:
  a topic's title/enabled state are the botcomponent `name` + `statecode`/`statuscode`
  record fields (not the `data` YAML), and the Inactive `statecode`/`statuscode` values are
  **UNCONFIRMED** — deferred pending live confirmation (TASK-009).

## Base / stacking
Branched from `users/aniladepu/features/mtk/customization-discovery-and-core-generalization`.
Target that branch (or merge it first) — a PR against `main` would also include the
customization-discovery + writeback-plan commits.

## Reviewer notes
- The `DataverseClient` header extension is the only `core/` change — confirm it stays generic.
- Live field-name confirmation (`template`/`configuration`/`data`, and the writeback targets)
  remains owned by TASK-009 (`./mtk.sh run --dev` WRITEBACK).