### PR TITLE
ci: pin ruff (version + rule set) and add pre-commit lint so an upstream ruff release can't fail every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install ruff
-      run: pip install ruff
+      # Pinned for reproducibility: an unpinned install silently upgrades and a
+      # Ruff release that broadens the default rule set would fail every PR. The
+      # rule set itself is pinned in pyproject.toml ([tool.ruff.lint] select).
+      run: pip install ruff==0.16.0
 
     - name: Discover Python source paths
       id: discover

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 !setup/
 !no-commit/
 !pyproject.toml
+!.pre-commit-config.yaml
 !requirements-dev.txt
 !dev-specs/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Repo-root pre-commit hooks. Lints the repo's Python sources under solutions/,
+# tests/, and tools/ with Ruff, mirroring the "Lint Python" job in
+# .github/workflows/ci.yml so contributors catch lint failures locally before
+# pushing — the same gate, one commit earlier.
+#
+# Ruff is pinned to the SAME version as CI (see .github/workflows/ci.yml) and
+# reads its rule set from pyproject.toml ([tool.ruff.lint] select), which is
+# pinned to Ruff's classic default (E4/E7/E9 + F). Pinning both the version and
+# the rule set keeps lint deterministic: a future Ruff release that broadens the
+# default rule set can't silently fail every PR (which is exactly what happened
+# and prompted this config).
+#
+# EXCLUDED: tools/ess-nextgen-migration-toolkit/ is intentionally NOT covered
+# here. That toolkit is fully self-governed — it has its OWN Ruff config, its own
+# uv-locked Ruff version, and its own .pre-commit-config.yaml (installed via
+# `mtk run --dev`) — and it deliberately avoids the external ruff-pre-commit
+# mirror to stay pinned to uv.lock (no version drift). Its nearest Ruff config
+# wins for config; excluding it here keeps the tool VERSION self-governed too.
+#
+# Enable locally with:
+#     pre-commit install
+# Run on demand:
+#     pre-commit run --all-files
+minimum_pre_commit_version: "3.5.0"
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
+    hooks:
+      - id: ruff-check
+        name: ruff check — solutions/, tests/, tools/ (excl. MTK toolkit)
+        args: [--output-format=github]
+        files: ^(solutions|tests|tools)/.*\.py$
+        exclude: ^tools/ess-nextgen-migration-toolkit/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,22 @@ test = [
     "PyYAML>=6.0,<7.0",
 ]
 
+# Ruff configuration for the repo-root Python sources (solutions/ess-maker-skills/
+# scripts + src/mcp, and tests/). The ESS NextGen Migration Toolkit under
+# tools/ess-nextgen-migration-toolkit/ has its OWN [tool.ruff] in its own
+# pyproject.toml and is unaffected (ruff uses the nearest config).
+#
+# The rule set is pinned to Ruff's classic default (pycodestyle E4/E7/E9 + Pyflakes
+# F) ON PURPOSE: an unpinned `pip install ruff` in CI once picked up a newer Ruff
+# whose broadened default rule set flagged 200+ pre-existing issues and failed
+# *every* PR. Selecting rules explicitly makes lint deterministic across Ruff
+# versions. Grow this list intentionally (with the fixes), never implicitly.
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/tests/captures/_workday_keygen.py
+++ b/tests/captures/_workday_keygen.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import os
 import stat
 import sys
-from pathlib import Path
 
 from _common import KIT_ROOT
 

--- a/tests/captures/record_flightcheck_island_gateway.py
+++ b/tests/captures/record_flightcheck_island_gateway.py
@@ -324,11 +324,11 @@ def main() -> None:
             t = inner.get("$kind") if isinstance(inner, dict) else "(no-component)"
             type_counts[t or "(no-kind)"] = type_counts.get(t or "(no-kind)", 0) + 1
         if envelope_counts:
-            print(f"    Components by envelope $kind:")
+            print("    Components by envelope $kind:")
             for k, n in sorted(envelope_counts.items(), key=lambda kv: -kv[1]):
                 print(f"      {n:>4}  {k}")
         if type_counts:
-            print(f"    Components by inner $kind (the actual type):")
+            print("    Components by inner $kind (the actual type):")
             for k, n in sorted(type_counts.items(), key=lambda kv: -kv[1]):
                 print(f"      {n:>4}  {k}")
 
@@ -368,7 +368,7 @@ def main() -> None:
             cassette_path.write_text(text, encoding="utf-8")
             print(f"  Total scrubs: {scrubbed_count}. Cassette updated.")
         else:
-            print(f"  No bot-name scrubs needed (or names not found in cassette text).")
+            print("  No bot-name scrubs needed (or names not found in cassette text).")
 
 
 if __name__ == "__main__":

--- a/tests/captures/record_flightcheck_pp_admin.py
+++ b/tests/captures/record_flightcheck_pp_admin.py
@@ -74,7 +74,7 @@ def main() -> None:
         if not env_id:
             print(f"ERROR: no BAP environment matched Dataverse host {target_host!r}.")
             sys.exit(1)
-        print(f"  Resolved env_id by instanceUrl match")
+        print("  Resolved env_id by instanceUrl match")
 
         # Each subsequent call is best-effort — if any individual endpoint
         # 404s or 5xx's we want to keep capturing the others rather than

--- a/tests/captures/record_flightcheck_workday.py
+++ b/tests/captures/record_flightcheck_workday.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 import os
 import re
 import sys
-from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
 
 from _common import announce, build_cassette, chdir_kit_root, confirm_or_exit

--- a/tests/captures/record_flightcheck_workday_runs.py
+++ b/tests/captures/record_flightcheck_workday_runs.py
@@ -42,7 +42,6 @@ remaining BotSchemaName values before committing.
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -50,7 +49,13 @@ from pathlib import Path
 _KIT_SCRIPTS = Path(__file__).resolve().parents[2] / "solutions" / "ess-maker-skills" / "scripts"
 sys.path.insert(0, str(_KIT_SCRIPTS))
 
-from _common import announce, build_cassette, chdir_kit_root, confirm_or_exit, get_dataverse_url
+from _common import (  # noqa: E402
+    announce,
+    build_cassette,
+    chdir_kit_root,
+    confirm_or_exit,
+    get_dataverse_url,
+)
 
 
 def main() -> None:

--- a/tests/captures/record_workday_rest_admin.py
+++ b/tests/captures/record_workday_rest_admin.py
@@ -230,7 +230,6 @@ def _acquire_token_jwt_bearer(
     token_url: str, client_id: str, client_secret: str, private_key_path: str
 ) -> str | None:
     """Build a signed JWT assertion and exchange it for a bearer token."""
-    import requests
 
     print("  Auth flow: JWT Bearer (RFC 7523)")
     try:
@@ -304,7 +303,6 @@ def _acquire_token_client_credentials(
     """POST to Workday's OAuth token endpoint with client_credentials grant.
     Most Workday tenants don't support this grant type for clients
     registered via 'Register API Client for Integrations'."""
-    import requests
 
     print("  Auth flow: client_credentials")
     creds = base64.b64encode(f"{client_id}:{client_secret}".encode("utf-8")).decode("ascii")
@@ -364,7 +362,6 @@ def _acquire_token_refresh_token(
     The refresh token is bootstrapped via the
     "Manage Refresh Tokens for Integrations" task in Workday.
     """
-    import requests
 
     print("  Auth flow: refresh_token (Workday Application Credentials pattern)")
     creds = base64.b64encode(f"{client_id}:{client_secret}".encode("utf-8")).decode("ascii")

--- a/tests/captures/record_workday_wql.py
+++ b/tests/captures/record_workday_wql.py
@@ -119,7 +119,6 @@ Output: tests/fixtures/cassettes/workday_wql_admin.yaml
 from __future__ import annotations
 
 import os
-import re
 import sys
 
 from _common import announce, build_cassette, chdir_kit_root, confirm_or_exit
@@ -131,7 +130,6 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from record_workday_rest_admin import (  # noqa: E402
     REQUIRED_ENV as REST_REQUIRED_ENV,
     _acquire_token,
-    _check_env as _check_rest_env,
     _rewrite_web_to_soap_host,
 )
 
@@ -293,7 +291,7 @@ def main() -> None:
             catalog_dump = local_dir / "workday_wql_catalog.txt"
             with catalog_dump.open("w", encoding="utf-8") as fh:
                 fh.write(f"# Workday WQL data source catalog ({len(all_sources)} sources)\n")
-                fh.write(f"# Format: alias\\tdescriptor\\tWID\n")
+                fh.write("# Format: alias\\tdescriptor\\tWID\n")
                 for row in sorted(all_sources, key=lambda r: r.get("alias") or ""):
                     fh.write(f"{row.get('alias')}\t{row.get('descriptor')}\t{row.get('id')}\n")
             print(f"    Full catalog dumped to {catalog_dump} (gitignored).")
@@ -478,7 +476,7 @@ def main() -> None:
                     print(f"      - {fi.get('alias')}  [{fi.get('descriptor')}]")
             if filter_required and not where_clause and not target.get("filter"):
                 print(f"    WARNING: filterIsRequired=true but no 'filter'/'where' set in target_aliases for {alias}.")
-                print(f"    Query will likely fail with 400 'Specify a data source filter'.")
+                print("    Query will likely fail with 400 'Specify a data source filter'.")
 
             # Step 3a-fields: fetch the field catalog for this data source
             # via the /fields sub-resource. The detail endpoint above does
@@ -530,8 +528,6 @@ def main() -> None:
 
             # Step 3b: build a query using the first 5 field aliases.
             picked = field_aliases[:5]
-            # Build the basic SELECT (no WHERE / no body params).
-            select_clause = f"SELECT {', '.join(picked)} FROM {alias} LIMIT 5"
 
             def run_query(label: str, query: str, body_extras: dict | None = None,
                           url_params: dict | None = None) -> int:
@@ -607,8 +603,8 @@ def main() -> None:
                 # multiple known-failing probes just bloats the cassette
                 # with HTTP 400 noise. The discovery output above is the
                 # whole point of capturing this source.
-                print(f"    SKIP query: filterIsRequired=true, see KNOWN LIMITATION in module docstring.")
-                print(f"    Discovery metadata above is sufficient for a future agent to complete.")
+                print("    SKIP query: filterIsRequired=true, see KNOWN LIMITATION in module docstring.")
+                print("    Discovery metadata above is sufficient for a future agent to complete.")
 
     print()
     print("Cassette written. Inspect tests/fixtures/cassettes/workday_wql_admin.yaml")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ can stay focused on the behavior they're verifying.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Iterator
 

--- a/tests/flightcheck/checks/test_graph_connector_kb.py
+++ b/tests/flightcheck/checks/test_graph_connector_kb.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import pytest
 import responses
 
 from tests.conftest import require_validated_mock

--- a/tests/flightcheck/checks/test_workday_extension.py
+++ b/tests/flightcheck/checks/test_workday_extension.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import pytest
 import responses
 
 from tests.conftest import require_validated_mock

--- a/tests/scripts/test_discover.py
+++ b/tests/scripts/test_discover.py
@@ -12,7 +12,6 @@ the function level — no external API calls are made.
 from __future__ import annotations
 
 import json
-from io import StringIO
 from unittest.mock import patch
 
 import pytest
@@ -247,7 +246,7 @@ class TestDiscoverListEnvironmentsMode:
         output = capsys.readouterr().out
         assert "SELECTED_ENV_JSON:" in output
 
-        json_line = [l for l in output.splitlines() if "SELECTED_ENV_JSON:" in l][0]
+        json_line = [line for line in output.splitlines() if "SELECTED_ENV_JSON:" in line][0]
         payload = json.loads(json_line.split("SELECTED_ENV_JSON:", 1)[1])
         assert payload["displayName"] == "Test Environment 1"
         assert payload["instanceUrl"] == "https://org001.crm.dynamics.com"

--- a/tests/scripts/test_restore_template_configs.py
+++ b/tests/scripts/test_restore_template_configs.py
@@ -17,7 +17,6 @@ Coverage focus:
 from __future__ import annotations
 
 import json
-from unittest.mock import call
 
 import pytest
 

--- a/tests/test_captures_redaction.py
+++ b/tests/test_captures_redaction.py
@@ -14,7 +14,6 @@ import re
 import sys
 from pathlib import Path
 
-import pytest
 
 
 # Make tests/captures importable so we can poke at its internals.

--- a/tests/test_validate_samples.py
+++ b/tests/test_validate_samples.py
@@ -12,7 +12,6 @@ import sys
 import textwrap
 from pathlib import Path
 
-import pytest
 
 # Make repo-root tools/ package importable for tests without altering pyproject.
 _REPO_ROOT = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Problem

The repo-wide **CI → "Lint Python"** job (`.github/workflows/ci.yml`) runs on every
PR to `main` and installed ruff via an **unpinned** `pip install ruff`. Ruff 0.16.0
broadened its default rule set, so the job silently picked it up and flagged ~265
pre-existing findings in code no PR had touched — turning **every open PR red**,
including docs-only ones. It was non-deterministic by construction: identical commits
passed before the ruff release and failed after.

## Fix

Make lint deterministic + reproducible, and shift it left.

1. **Pinned rule set** — `pyproject.toml` gets an explicit `[tool.ruff]` selecting
   ruff's classic default `["E4", "E7", "E9", "F"]` (`target-version = "py311"`) —
   exactly what the code is clean under. Rules no longer drift with the tool version.
2. **Pinned version** — `ci.yml` installs `ruff==0.16.0`.
3. **Pre-commit hook** — new repo-root `.pre-commit-config.yaml` runs ruff (pinned to
   `v0.16.0`) over `solutions/`, `tests/`, and `tools/`, mirroring the CI lint so
   contributors catch it before pushing. Enable with `pre-commit install`.
   (`.gitignore` allow-lists the config; the repo root uses an ignore-all-then-allow
   pattern.)
4. **Lint debt** — broadening the hook to `tests/` surfaced 26 pre-existing findings
   (unused imports, redundant `f`-string prefixes, an ambiguous variable name `l`, one
   dead local, one import-not-at-top); all fixed. No behavior change.

## Scope / safety

- The **ESS NextGen Migration Toolkit** (`tools/ess-nextgen-migration-toolkit/`) is
  **excluded** from the root hook and unaffected by the root ruff config: it has its
  own `[tool.ruff]`, its own uv-locked ruff (0.15.20), and its own pre-commit config.
  Ruff resolves the nearest config, so its stricter rules still apply to its own tree.
- The rule set is kept intentionally minimal to restore green **without** rewriting
  findings in another solution. Grow `select` deliberately, alongside the fixes —
  never via a silent ruff upgrade.
- **No dependency changes** — `requirements-dev.txt` / `uv.lock` / build config are out
  of scope for this PR.

## Verification

- CI-equivalent ruff run over `solutions/`, `tests/`, `tools/` (excl. toolkit) →
  **clean (exit 0)**.
- `pre-commit run ruff-check --all-files` installs the pinned ruff and **passes**.
- MTK toolkit gates still green; config isolation confirmed (toolkit files get their
  stricter `B`/`UP`/`I`/`T20` rules; the covered trees get `E4/E7/E9/F`).

## Files
- `.github/workflows/ci.yml` — pin `ruff==0.16.0`
- `pyproject.toml` — explicit `[tool.ruff]` rule set
- `.pre-commit-config.yaml` — new pinned, scoped ruff hook
- `.gitignore` — allow-list `.pre-commit-config.yaml`
- `tests/**` — 26 lint fixes to pass under the pinned rule set