### PR TITLE
Improve setup onboarding and validation

### DIFF
--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -425,43 +425,58 @@ The file `.local/config.json` stores the user's setup state and agent details:
 
 ```json
 {
+  "configVersion": 2,
   "setup": "complete",
-  "agent": {
-    "name": "Employee Self-Service HR",
-    "botId": "...",
-    "schemaName": "msdyn_copilotforemployeeselfservicehr",
-    "isManaged": true,
-    "slug": "employee-self-service-hr",
-    "folder": "workspace/agents/employee-self-service-hr"
+  "activeAgent": "da.esshr",
+  "common": {
+    "dataverseEndpoint": "https://org.crm.dynamics.com",
+    "environmentSku": "Sandbox"
   },
-  "activeAgent": "employee-self-service-hr",
-  "agents": [
-    {
-      "name": "Employee Self-Service HR",
-      "botId": "...",
-      "schemaName": "msdyn_copilotforemployeeselfservicehr",
-      "isManaged": true,
-      "slug": "employee-self-service-hr",
-      "folder": "workspace/agents/employee-self-service-hr"
-    },
-    {
-      "name": "Employee Self-Service IT",
-      "botId": "...",
-      "schemaName": "msdyn_copilotforemployeeselfserviceit",
-      "isManaged": true,
-      "slug": "employee-self-service-it",
-      "folder": "workspace/agents/employee-self-service-it"
+  "agents": {
+    "da": {
+      "esshr": {
+        "name": "Employee Self-Service HR",
+        "botId": "...",
+        "schemaName": "msdyn_copilotforemployeeselfservicedahr",
+        "isManaged": true,
+        "slug": "employee-self-service-hr",
+        "folder": "workspace/agents/employee-self-service-hr",
+        "extraction": {
+          "templateConfigsDiscovered": true,
+          "templateConfigCount": 42,
+          "workflowCount": 3,
+          "evaluationCount": 0
+        }
+      },
+      "essit": {
+        "name": "Employee Self-Service IT",
+        "botId": "...",
+        "schemaName": "msdyn_copilotforemployeeselfservicedait",
+        "isManaged": true,
+        "slug": "employee-self-service-it",
+        "folder": "workspace/agents/employee-self-service-it",
+        "extraction": {
+          "templateConfigsDiscovered": true,
+          "templateConfigCount": 37,
+          "workflowCount": 2,
+          "evaluationCount": 0
+        }
+      }
     }
-  ],
-  "dataverseEndpoint": "https://org.crm.dynamics.com",
-  "templateConfigsDiscovered": true,
-  "templateConfigCount": 42,
-  "workflowCount": 3
+  }
 }
 ```
 
-The `agent` field is a backward-compatible copy of whichever agent is active
-(pointed to by `activeAgent` slug). All discovered agents are in the `agents`
-array. When setup runs for a new agent, it's added to `agents` and set as
-active. Skills read `agent.*` for the current agent; FlightCheck scans all
-agents under `workspace/agents/` regardless of which is active.
+`common` stores environment-wide values once. `activeAgent` is a dotted path:
+split it at `.` and resolve the active section under `agents` (for example,
+`da.esshr` resolves to `agents.da.esshr`). Agent identity and extraction
+metadata belong only in that section. The supported sections are
+`da.esshr`, `da.essit`, `cea.esshr`, and `cea.essit`.
+
+Call the resolved object `ACTIVE_AGENT` while following skill instructions.
+When any skill says to read the active agent's folder, slug, schema, or bot ID,
+resolve the section through `activeAgent`; do not expect a top-level `agent`
+copy. Shared values such as the environment URL are under
+`common.dataverseEndpoint`. Python commands that call `auth.load_config()`
+receive a compatibility runtime view, but skill instructions reading the JSON
+directly must use the persisted v2 paths above.

--- a/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
@@ -16,18 +16,23 @@ MCP startup is still incomplete.
 
 If `.local/config.json` exists with `setup` set to `"complete"`, and the
 onboarding checklist has steps 1–4 checked but step 5 unchecked, resume
-onboarding at step 5, beginning with its manual opt-in question. Wait for an
-explicit user choice; never start FlightCheck automatically. Do not ask for
+at agent discovery before readiness. Read `common.dataverseEndpoint` from the
+config as ENV_URL, then persist it with:
+
+```
+python scripts/onboarding_state.py save-environment --url "{ENV_URL}"
+```
+
+Then read `src/skills/onboarding/step1b.md` and follow it. This rechecks which
+of the four supported ESS agents are installed and offers only missing agents
+before readiness. Do not start FlightCheck directly and do not ask for
 `RESET`.
 
 If `.local/config.json` exists with `setup` set to `"complete"` and the
-conditions above do not apply, show:
-
-> Your environment is already set up. Re-running setup will replace your local agent files.
-> Type `RESET` to confirm a full re-setup, or anything else to cancel.
-
-and wait. If the user types exactly `RESET`, run `scripts/checkpoint.py` to snapshot the
-current state first, then proceed with onboarding. Otherwise STOP and tell the user setup was cancelled.
+conditions above do not apply, use the same agent-discovery route described
+above. Re-running `/setup` is how the user installs another supported ESS agent
+or switches the active local agent. Existing agent entries and workspaces are
+preserved by `scripts/setup.py`.
 
 If `.local/config.json` does not exist, proceed with onboarding immediately.
 

--- a/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
@@ -16,8 +16,9 @@ MCP startup is still incomplete.
 
 If `.local/config.json` exists with `setup` set to `"complete"`, and the
 onboarding checklist has steps 1–4 checked but step 5 unchecked, resume
-onboarding immediately at step 5 so the optional readiness check is offered
-again. Do not ask for `RESET`.
+onboarding at step 5, beginning with its manual opt-in question. Wait for an
+explicit user choice; never start FlightCheck automatically. Do not ask for
+`RESET`.
 
 If `.local/config.json` exists with `setup` set to `"complete"` and the
 conditions above do not apply, show:

--- a/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/setup.prompt.md
@@ -5,8 +5,22 @@ description: "Type Enter to set up your ESS customization environment"
 
 # Setup
 
-**Idempotency check.** Read `.local/config.json`. If it exists AND
-`setup` is `"complete"`, show:
+**Idempotency check.** Read `.local/config.json` and
+`workspace/onboarding/tasks.md`.
+
+If `.local/config.json` exists with `setup` set to `"complete"`, and the
+onboarding checklist exists with step 4 unchecked, mark steps 1–3 checked and
+resume onboarding immediately. The checklist router will continue at step 4.
+Do not ask for `RESET`; the durable config proves extraction completed, but
+MCP startup is still incomplete.
+
+If `.local/config.json` exists with `setup` set to `"complete"`, and the
+onboarding checklist has steps 1–4 checked but step 5 unchecked, resume
+onboarding immediately at step 5 so the optional readiness check is offered
+again. Do not ask for `RESET`.
+
+If `.local/config.json` exists with `setup` set to `"complete"` and the
+conditions above do not apply, show:
 
 > Your environment is already set up. Re-running setup will replace your local agent files.
 > Type `RESET` to confirm a full re-setup, or anything else to cancel.

--- a/solutions/ess-maker-skills/.gitignore
+++ b/solutions/ess-maker-skills/.gitignore
@@ -13,6 +13,9 @@ workspace/**
 # from the scripts dir (e.g. `python adk_telemetry.py --selftest`). Never commit.
 scripts/.local/
 
+# Per-user Dataverse MCP endpoint written by /setup. Never commit tenant URLs.
+.vscode/mcp.json
+
 # ISV reference docs synced from an internal ESS reference source (never committed)
 src/reference/ess-docs/isv/
 

--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -52,7 +52,8 @@ LOCAL_STATE_DIR = ".local"
 # load_config() below. Bump this when the on-disk schema changes in a way
 # old consumers can't tolerate, AND update setup.py to migrate or rewrite
 # config.json on the next run.
-EXPECTED_CONFIG_VERSION = 1
+EXPECTED_CONFIG_VERSION = 2
+SUPPORTED_CONFIG_VERSIONS = {1, 2}
 
 HEADERS_BASE = {
     "Accept": "application/json",
@@ -600,25 +601,73 @@ def delete_record(env_url, token, entity_set, record_id):
     return True
 
 
-def load_config():
+def normalize_config(cfg):
+    """Return a backward-compatible runtime view of config schema v1 or v2."""
+    if cfg.get("configVersion") != 2:
+        return cfg
+
+    common = cfg.get("common") or {}
+    grouped_agents = cfg.get("agents") or {}
+    agents = []
+    agents_by_key = {}
+    if isinstance(grouped_agents, dict):
+        for experience, experience_agents in grouped_agents.items():
+            if not isinstance(experience_agents, dict):
+                continue
+            for agent_section, agent in experience_agents.items():
+                if not isinstance(agent, dict):
+                    continue
+                config_key = f"{experience}.{agent_section}"
+                normalized_agent = {
+                    **agent,
+                    "configKey": config_key,
+                    "experience": experience,
+                    "agentSection": agent_section,
+                }
+                agents.append(normalized_agent)
+                agents_by_key[config_key] = normalized_agent
+
+    active_key = cfg.get("activeAgent")
+    active_agent = agents_by_key.get(active_key)
+    if active_agent is None and agents:
+        active_agent = agents[0]
+        active_key = active_agent["configKey"]
+
+    runtime = {
+        **cfg,
+        **common,
+        "common": common,
+        "agentsByKey": agents_by_key,
+        "agents": agents,
+        "activeAgentKey": active_key,
+    }
+    if active_agent:
+        runtime["agent"] = active_agent
+        runtime["activeAgent"] = active_agent.get("slug", active_key)
+        extraction = active_agent.get("extraction") or {}
+        runtime.update(extraction)
+    return runtime
+
+
+def load_config(*, required=True):
     """Load .local/config.json. Returns the parsed dict or exits on error.
 
-    Gates on `configVersion`: if the on-disk version doesn't match
-    `EXPECTED_CONFIG_VERSION`, exits with a clear instruction to re-run
-    setup. This catches the case where a kit upgrade changed the schema
-    and a downstream script would otherwise KeyError on a missing field.
+    Gates on supported `configVersion` values and normalizes schema v2 into a
+    backward-compatible runtime view for existing command implementations.
     """
     config_path = os.path.join(LOCAL_STATE_DIR, "config.json")
     if not os.path.exists(config_path):
+        if not required:
+            return {}
         print(f"ERROR: {config_path} not found. Run /setup first.")
         sys.exit(1)
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = json.load(f)
     ver = cfg.get("configVersion", 0)
-    if ver != EXPECTED_CONFIG_VERSION:
+    if ver not in SUPPORTED_CONFIG_VERSIONS:
         print(
-            f"ERROR: {config_path} is schema v{ver}, expected "
-            f"v{EXPECTED_CONFIG_VERSION}. Run `/setup --refresh` to migrate."
+            f"ERROR: {config_path} is schema v{ver}; supported versions are "
+            f"{sorted(SUPPORTED_CONFIG_VERSIONS)}. Run `/setup` to migrate."
         )
         sys.exit(1)
-    return cfg
+    return normalize_config(cfg)

--- a/solutions/ess-maker-skills/scripts/checkpoint.py
+++ b/solutions/ess-maker-skills/scripts/checkpoint.py
@@ -21,16 +21,9 @@ import sys
 import time
 from datetime import datetime, timezone
 
+from auth import load_config
+
 EXCLUDE_DIRS = {".baseline", ".checkpoints"}
-
-
-def load_config():
-    config_path = os.path.join(".local", "config.json")
-    if not os.path.exists(config_path):
-        print("ERROR: .local/config.json not found. Run /setup first.")
-        sys.exit(1)
-    with open(config_path, "r", encoding="utf-8") as f:
-        return json.load(f)
 
 
 def get_agent_dir(config):

--- a/solutions/ess-maker-skills/scripts/discover.py
+++ b/solutions/ess-maker-skills/scripts/discover.py
@@ -27,15 +27,21 @@ import argparse
 import json
 import sys
 import os
+from pathlib import Path
 from xml.etree import ElementTree as ET
 
 # Add scripts/ to path so we can import auth
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from auth import authenticate, query_all
 from http_errors import APIError
+from install_ess_agent import (
+    build_installation_options,
+    load_installation_config,
+)
 
 
 GITHUB_COPILOT_MCP_CLIENT_ID = "aebc6443-996d-45c2-90f0-388ff96faa56"
+LOCAL_CONFIG_PATH = Path(".local") / "config.json"
 
 
 def discover_agents(env_url, token):
@@ -54,6 +60,105 @@ def discover_agents(env_url, token):
             "ismanaged": r.get("ismanaged", False),
         })
     return agents
+
+
+def build_ess_agent_inventory(agents, config):
+    """Classify discovered bots and return missing supported installations."""
+    options = build_installation_options(config)
+    options_by_schema = {
+        option["schemaName"].casefold(): option
+        for option in options
+    }
+    ess_agents = []
+    installed_keys = set()
+
+    for agent in agents:
+        schema_name = agent.get("schemaname")
+        if not isinstance(schema_name, str):
+            continue
+        option = options_by_schema.get(schema_name.casefold())
+        if not option:
+            continue
+        ess_agents.append({
+            **agent,
+            "installationKey": option["key"],
+            "configKey": option["configKey"],
+        })
+        installed_keys.add(option["key"])
+
+    return {
+        "agents": ess_agents,
+        "installedInstallationKeys": sorted(installed_keys),
+        "availableInstallations": [
+            option for option in options
+            if option["key"] not in installed_keys
+        ],
+    }
+
+
+def sync_installed_agents(
+    env_url,
+    inventory,
+    config_path=LOCAL_CONFIG_PATH,
+):
+    """Persist every detected supported ESS agent in config schema v2."""
+    path = Path(config_path)
+    existing = {}
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        if existing.get("configVersion") not in (None, 2):
+            return existing
+
+    config = existing if existing.get("configVersion") == 2 else {
+        "configVersion": 2,
+        "setup": "in-progress",
+        "common": {},
+        "agents": {},
+    }
+    config.setdefault("common", {})["dataverseEndpoint"] = env_url.rstrip("/")
+    grouped_agents = config.setdefault("agents", {})
+
+    detected_keys = set()
+    for agent in inventory["agents"]:
+        config_key = agent["configKey"]
+        experience, agent_section = config_key.split(".", 1)
+        detected_keys.add(config_key)
+        existing_agent = (
+            grouped_agents.get(experience, {}).get(agent_section, {})
+        )
+        extraction = existing_agent.get("extraction") or {
+            "status": "not-started"
+        }
+        grouped_agents.setdefault(experience, {})[agent_section] = {
+            **existing_agent,
+            "name": agent["name"],
+            "botId": agent["botid"],
+            "schemaName": agent["schemaname"],
+            "isManaged": agent["ismanaged"],
+            "installation": {"status": "installed"},
+            "extraction": extraction,
+        }
+
+    for experience, experience_agents in grouped_agents.items():
+        if not isinstance(experience_agents, dict):
+            continue
+        for agent_section, agent in experience_agents.items():
+            config_key = f"{experience}.{agent_section}"
+            if (
+                isinstance(agent, dict)
+                and config_key not in detected_keys
+                and agent.get("installation")
+            ):
+                agent["installation"]["status"] = "not-detected"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(
+        json.dumps(config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(tmp_path, path)
+    return config
 
 
 def check_mcp_config(env_url, token):
@@ -125,6 +230,11 @@ def main():
                         help="Check Dataverse MCP and GitHub Copilot enablement")
     parser.add_argument("--select", type=int, default=None,
                         help="Select agent by number and output JSON")
+    parser.add_argument(
+        "--sync-config",
+        action="store_true",
+        help="Persist detected supported agents in .local/config.json",
+    )
     args = parser.parse_args()
 
     # --- Environment listing mode ---
@@ -184,17 +294,28 @@ def main():
 
     print("Discovering agents...")
     try:
-        agents = discover_agents(env_url, token)
+        discovered_agents = discover_agents(env_url, token)
+        inventory = build_ess_agent_inventory(
+            discovered_agents,
+            load_installation_config(),
+        )
     except APIError as e:
         print(e.format_for_terminal())
         sys.exit(1)
-
-    if not agents:
-        print("No agents found in this environment.")
-        print("Make sure your ESS agent is installed in Copilot Studio.")
+    except (OSError, ValueError) as e:
+        print(f"ERROR: Could not load ESS installation catalog: {e}")
         sys.exit(1)
 
-    print(f"Found {len(agents)} agent(s):")
+    print(f"ESS_AGENT_DISCOVERY_JSON:{json.dumps(inventory)}")
+    if args.sync_config:
+        sync_installed_agents(env_url, inventory)
+    agents = inventory["agents"]
+
+    if not agents:
+        print("No supported ESS agents found in this environment.")
+        sys.exit(1)
+
+    print(f"Found {len(agents)} supported ESS agent(s):")
     print_agent_table(agents)
 
     if args.select is not None:

--- a/solutions/ess-maker-skills/scripts/discover.py
+++ b/solutions/ess-maker-skills/scripts/discover.py
@@ -27,11 +27,15 @@ import argparse
 import json
 import sys
 import os
+from xml.etree import ElementTree as ET
 
 # Add scripts/ to path so we can import auth
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from auth import authenticate, query_all
 from http_errors import APIError
+
+
+GITHUB_COPILOT_MCP_CLIENT_ID = "aebc6443-996d-45c2-90f0-388ff96faa56"
 
 
 def discover_agents(env_url, token):
@@ -50,6 +54,45 @@ def discover_agents(env_url, token):
             "ismanaged": r.get("ismanaged", False),
         })
     return agents
+
+
+def check_mcp_config(env_url, token):
+    """Return the GA Dataverse MCP and GitHub Copilot allow-list state."""
+    organizations = query_all(
+        env_url,
+        token,
+        entity_set="organizations",
+        select="orgdborgsettings",
+    )
+    org_settings = (
+        organizations[0].get("orgdborgsettings") if organizations else None
+    )
+    root = ET.fromstring(org_settings or "<OrgSettings />")
+    mcp_value = (root.findtext("IsMCPEnabled") or "").strip().lower()
+
+    # Dataverse MCP is enabled by default when IsMCPEnabled is omitted.
+    server_enabled = mcp_value != "false"
+
+    clients = query_all(
+        env_url,
+        token,
+        entity_set="allowedmcpclients",
+        select="applicationid,isenabled,statecode",
+        filter_expr=(
+            f"applicationid eq '{GITHUB_COPILOT_MCP_CLIENT_ID}'"
+        ),
+    )
+    client_enabled = any(
+        client.get("isenabled") is True
+        and client.get("statecode", 0) == 0
+        for client in clients
+    )
+
+    return {
+        "configured": server_enabled and client_enabled,
+        "serverEnabled": server_enabled,
+        "githubCopilotEnabled": client_enabled,
+    }
 
 
 def print_agent_table(agents):
@@ -78,6 +121,8 @@ def main():
                         help="Power Platform environment URL")
     parser.add_argument("--list-environments", action="store_true",
                         help="List all environments in the tenant (no URL needed)")
+    parser.add_argument("--check-mcp-config", action="store_true",
+                        help="Check Dataverse MCP and GitHub Copilot enablement")
     parser.add_argument("--select", type=int, default=None,
                         help="Select agent by number and output JSON")
     args = parser.parse_args()
@@ -123,6 +168,19 @@ def main():
     print("Authenticating to Dataverse...")
     token = authenticate(env_url)
     print("Authenticated.\n")
+
+    if args.check_mcp_config:
+        print("Checking Dataverse MCP configuration...")
+        try:
+            state = check_mcp_config(env_url, token)
+        except (APIError, ET.ParseError) as e:
+            if isinstance(e, APIError):
+                print(e.format_for_terminal())
+            else:
+                print("ERROR: Dataverse returned invalid environment settings.")
+            sys.exit(1)
+        print(f"MCP_CONFIG_JSON:{json.dumps(state)}")
+        return
 
     print("Discovering agents...")
     try:

--- a/solutions/ess-maker-skills/scripts/ess_connection_binding.py
+++ b/solutions/ess-maker-skills/scripts/ess_connection_binding.py
@@ -1,0 +1,367 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Validate and bind connections required by ESS agent installations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from auth import authenticate, discover_tenant, query_all, update_record
+from flightcheck.pp_admin_client import PPAdminClient, derive_environment_id
+from install_ess_agent import CONFIG_PATH, load_installation_config
+
+
+PREFLIGHT_MARKER = "ESS_CONNECTION_PREFLIGHT_JSON:"
+BINDING_MARKER = "ESS_CONNECTION_BINDING_JSON:"
+LOCAL_CONFIG_PATH = Path(".local") / "config.json"
+
+
+def _connector_api_name(value: str | None) -> str:
+    return (value or "").rstrip("/").rsplit("/", 1)[-1].casefold()
+
+
+def _connection_status(connection: dict) -> str:
+    statuses = (connection.get("properties") or {}).get("statuses") or []
+    if not statuses or not isinstance(statuses[0], dict):
+        return "Unknown"
+    return str(statuses[0].get("status") or "Unknown")
+
+
+def connection_option(connection: dict) -> dict:
+    properties = connection.get("properties") or {}
+    created_by = properties.get("createdBy") or {}
+    return {
+        "name": connection.get("name"),
+        "displayName": properties.get("displayName") or connection.get("name"),
+        "accountName": (
+            properties.get("accountName")
+            or created_by.get("userPrincipalName")
+            or created_by.get("displayName")
+        ),
+        "status": _connection_status(connection),
+    }
+
+
+def matching_connections(connections: list[dict], connector_api_name: str) -> list[dict]:
+    matches = []
+    expected = connector_api_name.casefold()
+    for connection in connections:
+        properties = connection.get("properties") or {}
+        if _connector_api_name(properties.get("apiId")) != expected:
+            continue
+        if _connection_status(connection).casefold() != "connected":
+            continue
+        if connection.get("name"):
+            matches.append(connection_option(connection))
+    return matches
+
+
+def build_preflight_result(
+    installation: dict,
+    connections: list[dict],
+    environment_id: str,
+) -> dict:
+    requirement = installation.get("requiredConnection")
+    if requirement is None:
+        return {
+            "required": False,
+            "status": "not-required",
+            "environmentId": environment_id,
+            "connections": [],
+        }
+
+    options = matching_connections(
+        connections,
+        requirement["connectorApiName"],
+    )
+    status = (
+        "missing" if not options
+        else "ready" if len(options) == 1
+        else "selection-required"
+    )
+    return {
+        "required": True,
+        "status": status,
+        "environmentId": environment_id,
+        "connectorApiName": requirement["connectorApiName"],
+        "displayName": requirement["displayName"],
+        "referenceLogicalName": requirement["referenceLogicalName"],
+        "creationGuidance": requirement["creationGuidance"],
+        "connections": options,
+        "selectedConnection": options[0] if len(options) == 1 else None,
+    }
+
+
+def _installation(config: dict, experience: str, vertical: str) -> dict:
+    return config["installations"][f"{experience}.{vertical}"]
+
+
+def _persist_setup_status(
+    env_url: str,
+    installation: dict,
+    binding_result: dict,
+    config_path: Path | None = None,
+) -> None:
+    config_path = config_path or LOCAL_CONFIG_PATH
+    config = {}
+    if config_path.exists():
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    if config.get("configVersion") not in (None, 2):
+        raise RuntimeError(
+            "Cannot persist ESS connection state to an unsupported config version."
+        )
+    config.setdefault("configVersion", 2)
+    config.setdefault("setup", "in-progress")
+    config.setdefault("common", {})["dataverseEndpoint"] = env_url.rstrip("/")
+    experience, section = installation["configKey"].split(".", 1)
+    agent = config.setdefault("agents", {}).setdefault(
+        experience, {}
+    ).setdefault(section, {})
+    agent["installation"] = {"status": "installed"}
+    agent.setdefault("extraction", {"status": "not-started"})
+    agent["setupStatus"] = {
+        **(agent.get("setupStatus") or {}),
+        "S1": {
+            "state": "done",
+            "checkpoint": "ESS-SOLN-001",
+            "verifiedBy": "programmatic",
+        },
+        "S2": {
+            "state": "done",
+            "checkpoint": "ESS-CONN-001",
+            "verifiedBy": "programmatic",
+            "connectionName": binding_result.get("connectionName"),
+            "referenceLogicalName": binding_result.get("referenceLogicalName"),
+            "notRequired": not binding_result["required"],
+        },
+    }
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = config_path.with_suffix(config_path.suffix + ".tmp")
+    temporary_path.write_text(
+        json.dumps(config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary_path, config_path)
+
+
+def inspect_connections(
+    env_url: str,
+    experience: str,
+    vertical: str,
+    *,
+    config_path: Path = CONFIG_PATH,
+    pp_admin_client_factory=PPAdminClient,
+) -> dict:
+    env_url = env_url.rstrip("/")
+    config = load_installation_config(config_path)
+    installation = _installation(config, experience, vertical)
+    if installation.get("requiredConnection") is None:
+        return build_preflight_result(installation, [], "")
+
+    tenant_id = discover_tenant(env_url)
+    client = pp_admin_client_factory(tenant_id)
+    client.authenticate(include_flow=False)
+    environment_id = derive_environment_id(env_url, "", client)
+    if not environment_id:
+        raise RuntimeError(
+            "Could not resolve the selected Dataverse URL to a Power Platform "
+            "environment ID."
+        )
+    return build_preflight_result(
+        installation,
+        client.get_connections(environment_id),
+        environment_id,
+    )
+
+
+def _assert_reference_in_solution(
+    env_url: str,
+    token: str,
+    reference_id: str,
+    solution_unique_name: str,
+) -> None:
+    components = query_all(
+        env_url,
+        token,
+        "solutioncomponents",
+        "objectid,_solutionid_value",
+        filter_expr=f"objectid eq {reference_id}",
+    )
+    solution_ids = {
+        component.get("_solutionid_value")
+        for component in components
+        if component.get("_solutionid_value")
+    }
+    if not solution_ids:
+        raise RuntimeError(
+            "The required connection reference is not registered in a solution."
+        )
+
+    id_filter = " or ".join(
+        f"solutionid eq {solution_id}" for solution_id in sorted(solution_ids)
+    )
+    escaped_name = solution_unique_name.replace("'", "''")
+    solutions = query_all(
+        env_url,
+        token,
+        "solutions",
+        "solutionid,uniquename",
+        filter_expr=f"({id_filter}) and uniquename eq '{escaped_name}'",
+    )
+    if not solutions:
+        raise RuntimeError(
+            f"The required connection reference does not belong to solution "
+            f"'{solution_unique_name}'."
+        )
+
+
+def bind_connection(
+    env_url: str,
+    experience: str,
+    vertical: str,
+    connection_name: str | None,
+    *,
+    config_path: Path = CONFIG_PATH,
+    pp_admin_client_factory=PPAdminClient,
+) -> dict:
+    env_url = env_url.rstrip("/")
+    config = load_installation_config(config_path)
+    installation = _installation(config, experience, vertical)
+    requirement = installation.get("requiredConnection")
+    if requirement is None:
+        result = {
+            "required": False,
+            "status": "not-required",
+            "connectionName": None,
+        }
+        _persist_setup_status(env_url, installation, result)
+        return result
+    if not connection_name:
+        raise ValueError("A connection name is required for this ESS agent.")
+
+    preflight = inspect_connections(
+        env_url,
+        experience,
+        vertical,
+        config_path=config_path,
+        pp_admin_client_factory=pp_admin_client_factory,
+    )
+    selected = next(
+        (
+            option for option in preflight["connections"]
+            if option["name"] == connection_name
+        ),
+        None,
+    )
+    if selected is None:
+        raise ValueError(
+            "The selected connection is not a connected instance of "
+            f"{requirement['connectorApiName']} in this environment."
+        )
+
+    token = authenticate(env_url)
+    escaped_logical_name = requirement["referenceLogicalName"].replace("'", "''")
+    references = query_all(
+        env_url,
+        token,
+        "connectionreferences",
+        "connectionreferenceid,connectionreferencelogicalname,connectorid,"
+        "connectionid,statuscode",
+        filter_expr=(
+            f"connectionreferencelogicalname eq '{escaped_logical_name}'"
+        ),
+    )
+    if len(references) != 1:
+        raise RuntimeError(
+            "Expected exactly one required connection reference after "
+            f"installation, found {len(references)}."
+        )
+
+    reference = references[0]
+    if _connector_api_name(reference.get("connectorid")) != (
+        requirement["connectorApiName"].casefold()
+    ):
+        raise RuntimeError(
+            "The installed connection reference uses an unexpected connector."
+        )
+    _assert_reference_in_solution(
+        env_url,
+        token,
+        reference["connectionreferenceid"],
+        installation["solution"]["parentUniqueName"],
+    )
+
+    if reference.get("connectionid") != connection_name:
+        update_record(
+            env_url,
+            token,
+            "connectionreferences",
+            reference["connectionreferenceid"],
+            {"connectionid": connection_name},
+        )
+
+    verified = query_all(
+        env_url,
+        token,
+        "connectionreferences",
+        "connectionreferenceid,connectionid",
+        filter_expr=(
+            f"connectionreferenceid eq {reference['connectionreferenceid']}"
+        ),
+    )
+    if len(verified) != 1 or verified[0].get("connectionid") != connection_name:
+        raise RuntimeError(
+            "Dataverse accepted the binding request but the connection "
+            "reference did not retain the selected connection."
+        )
+
+    result = {
+        "required": True,
+        "status": "bound",
+        "connectionName": connection_name,
+        "connectionDisplayName": selected["displayName"],
+        "connectionAccountName": selected["accountName"],
+        "referenceId": reference["connectionreferenceid"],
+        "referenceLogicalName": requirement["referenceLogicalName"],
+    }
+    _persist_setup_status(env_url, installation, result)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate and bind required ESS installation connections"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("inspect", "bind"):
+        command_parser = subparsers.add_parser(command)
+        command_parser.add_argument("--url", required=True)
+        command_parser.add_argument("--experience", required=True, choices=("da", "cea"))
+        command_parser.add_argument("--vertical", required=True, choices=("hr", "it"))
+        if command == "bind":
+            command_parser.add_argument("--connection-name")
+    args = parser.parse_args()
+
+    try:
+        if args.command == "inspect":
+            result = inspect_connections(args.url, args.experience, args.vertical)
+            print(f"{PREFLIGHT_MARKER}{json.dumps(result)}")
+        else:
+            result = bind_connection(
+                args.url,
+                args.experience,
+                args.vertical,
+                args.connection_name,
+            )
+            print(f"{BINDING_MARKER}{json.dumps(result)}")
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/infrastructure.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/infrastructure.py
@@ -405,7 +405,7 @@ def check_microsoft_service_reachability(runner: Any) -> list[CheckResult]:
                 description="Network connectivity to Dataverse",
                 result="Dataverse target skipped: no Dataverse environment URL configured.",
                 remediation=(
-                    "Set dataverseEndpoint in .local/config.json or pass "
+                    "Set common.dataverseEndpoint in .local/config.json or pass "
                     "--environment-url to include Dataverse in INFRA-001."
                 ),
                 doc_link=_DOC_LINK_INFRA_001,

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/publishing.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/publishing.py
@@ -34,21 +34,20 @@ def _studio_agent_url(runner) -> str | None:
     The publishing/QA checks are agent-scoped in spirit (the maker
     runs evaluations against a specific agent), but the result rows
     themselves are emitted once per checklist item — not per agent.
-    We pick the first configured agent so the deep link lands on a
-    real Studio surface rather than the generic homepage; if a tenant
-    runs multi-agent the operator can switch from the agent picker.
+    Prefer the active agent so the deep link matches the current workspace,
+    falling back to the first configured agent for legacy runtime shapes.
     """
     env_id = getattr(runner, "env_id", None)
     if not env_id:
         return None
     config = getattr(runner, "config", None) or {}
-    bot_id = None
+    bot_id = (config.get("agent") or {}).get("botId")
+    if bot_id:
+        return f"{STUDIO_BASE}/environments/{env_id}/bots/{bot_id}/overview"
     for agent in config.get("agents", []) or []:
         bot_id = agent.get("botId")
         if bot_id:
             break
-    if not bot_id:
-        bot_id = (config.get("agent") or {}).get("botId")
     if not bot_id:
         return None
     return f"{STUDIO_BASE}/environments/{env_id}/bots/{bot_id}/overview"

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/solution.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/solution.py
@@ -54,6 +54,9 @@ def _check_ess_solution_installed(runner) -> list[CheckResult]:
     """
     env_url = getattr(runner, "env_url", None)
     token = getattr(runner, "dv_token", None)
+    expected_unique_name = getattr(
+        runner, "expected_solution_unique_name", None
+    )
 
     if not env_url or not token:
         return [CheckResult(roles=[Role.ESS_MAKER.value],
@@ -72,16 +75,32 @@ def _check_ess_solution_installed(runner) -> list[CheckResult]:
             _ESS_SOLN_FILTER,
         )
 
+        if expected_unique_name:
+            expected_casefold = expected_unique_name.casefold()
+            solutions = [
+                solution
+                for solution in solutions
+                if str(solution.get("uniquename", "")).casefold()
+                == expected_casefold
+            ]
+
         if not solutions:
+            if expected_unique_name:
+                result = (
+                    f"The expected ESS solution '{expected_unique_name}' is "
+                    "not installed in this environment."
+                )
+            else:
+                result = (
+                    "No solution whose unique name starts with "
+                    f"'{_ESS_SOLUTION_PREFIX}' is installed in this "
+                    "environment. The base ESS agent is not present."
+                )
             return [CheckResult(roles=[Role.ESS_MAKER.value],
                 checkpoint_id="ESS-SOLN-001", category="Solution",
                 priority=Priority.CRITICAL.value, status=Status.FAILED.value,
                 description=_ESS_SOLN_DESCRIPTION,
-                result=(
-                    "No solution whose unique name starts with "
-                    f"'{_ESS_SOLUTION_PREFIX}' is installed in this "
-                    "environment. The base ESS agent is not present."
-                ),
+                result=result,
                 remediation=(
                     "Install the Employee Self Service agent from AppSource "
                     "into this environment (Microsoft 365 admin center / "

--- a/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/checks/workday.py
@@ -5076,7 +5076,12 @@ def _cache_test_employee_id(employee_id: str):
     try:
         with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
-        config["workdayTestEmployeeId"] = employee_id
+        if config.get("configVersion") == 2:
+            config.setdefault("common", {})[
+                "workdayTestEmployeeId"
+            ] = employee_id
+        else:
+            config["workdayTestEmployeeId"] = employee_id
         with open(config_path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=2)
     except (OSError, json.JSONDecodeError):

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -38,6 +38,7 @@ from pathlib import Path
 # Ensure scripts/ is on the path so we can import auth
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from auth import load_config, normalize_config
 from flightcheck.runner import (
     FlightCheckRunner,
     save_results,
@@ -357,8 +358,7 @@ def _list_targets(args):
         payload["error"] = ".local/config.json not found. Run /setup first."
         print(json.dumps(payload))
         return
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
+    config = load_config()
 
     env_url = args.environment_url or config.get("dataverseEndpoint", "")
     from auth import discover_tenant
@@ -643,8 +643,7 @@ def _run_single_checkpoint(args):
     config = {}
     config_path = os.path.join(".local", "config.json")
     if os.path.exists(config_path):
-        with open(config_path, "r", encoding="utf-8") as f:
-            config = json.load(f)
+        config = load_config()
     elif plan.requires_config and not (
         target == "ESS-SOLN-001" and args.environment_url
     ):
@@ -653,7 +652,7 @@ def _run_single_checkpoint(args):
 
     env_url = args.environment_url or config.get("dataverseEndpoint", "")
     if plan.requires_dataverse_endpoint and not env_url:
-        print("ERROR: No dataverseEndpoint in .local/config.json.")
+        print("ERROR: No common.dataverseEndpoint in .local/config.json.")
         sys.exit(1)
 
     # --- Banner ---
@@ -1009,12 +1008,12 @@ def main():
         sys.exit(1)
 
     with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
+        config = normalize_config(json.load(f))
 
     infra_only_scope = args.scope == "infrastructure"
     env_url = args.environment_url or config.get("dataverseEndpoint", "")
     if not env_url and not infra_only_scope:
-        print("ERROR: No dataverseEndpoint in .local/config.json.")
+        print("ERROR: No common.dataverseEndpoint in .local/config.json.")
         sys.exit(1)
 
     # --- Banner ---
@@ -1260,6 +1259,18 @@ def main():
 
     # Save results
     save_results(result, args.output)
+    print(
+        "FLIGHTCHECK_COMPLETE_JSON:"
+        + json.dumps({
+            "overall": result.overall,
+            "durationSeconds": result.duration_secs,
+            "total": result.total,
+            "passed": result.passed,
+            "failed": result.failed,
+            "warnings": result.warnings,
+        }),
+        flush=True,
+    )
 
     # Emit anonymous outcome telemetry (best-effort; never affects exit code).
     if not args.no_telemetry:

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -645,7 +645,9 @@ def _run_single_checkpoint(args):
     if os.path.exists(config_path):
         with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
-    elif plan.requires_config:
+    elif plan.requires_config and not (
+        target == "ESS-SOLN-001" and args.environment_url
+    ):
         print("ERROR: .local/config.json not found. Run /setup first.")
         sys.exit(1)
 
@@ -754,6 +756,7 @@ def _run_single_checkpoint(args):
     )
     runner.config = config
     runner.env_url = env_url
+    runner.expected_solution_unique_name = args.expected_solution
     runner.dv_token = dv_token
     runner.env_id = env_id
     runner.graph = graph
@@ -903,6 +906,11 @@ def main():
              "report only its result. Hydrates the checkpoint's declared "
              "prerequisites and initialises only the clients it needs. Mutually "
              "exclusive with --scope.",
+    )
+    parser.add_argument(
+        "--expected-solution",
+        help="For ESS-SOLN-001, require this exact solution unique name. "
+             "Ignored by other checkpoints.",
     )
     parser.add_argument(
         "--list-checkpoints", action="store_true",

--- a/solutions/ess-maker-skills/scripts/flightcheck/environment_picker.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/environment_picker.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse
 # Ensure scripts/ is on the path so we can import auth and flightcheck modules
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from auth import discover_tenant
+from auth import discover_tenant, normalize_config
 from flightcheck.pp_admin_client import PPAdminClient
 from list_environments import parse_raw_environments
 
@@ -131,11 +131,11 @@ def main():
         sys.exit(1)
 
     with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
+        config = normalize_config(json.load(f))
 
     env_url = config.get("dataverseEndpoint", "")
     if not env_url:
-        print("ERROR: No dataverseEndpoint in .local/config.json.")
+        print("ERROR: No common.dataverseEndpoint in .local/config.json.")
         sys.exit(1)
 
     # Discover tenant and authenticate to Power Platform

--- a/solutions/ess-maker-skills/scripts/flightcheck/powerplatform_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/powerplatform_client.py
@@ -4,8 +4,9 @@
 """
 ESS Maker Kit — Power Platform API (Licensing / Billing Policy) Client
 
-Provides authenticated read access to the Power Platform API billing-policy
-surface for FlightCheck PRE-005 (Pay-As-You-Go binding detection).
+Provides authenticated access to documented Power Platform API surfaces:
+billing-policy reads for FlightCheck and Marketplace application management
+for onboarding.
 
 This is a DIFFERENT host and audience from the BAP admin client in
 ``pp_admin_client.py``:
@@ -18,9 +19,8 @@ This is a DIFFERENT host and audience from the BAP admin client in
 Authentication reuses the same MSAL token cache as auth.py /
 graph_client.py / pp_admin_client.py (``.local/.token_cache.bin``).
 
-API contract tier: ``documented`` — see the "API tier registry" in
-``tests/fixtures/cassettes/INDEX.md``. Response shapes verified against
-the MS Learn references cited on each method.
+API contract tier: ``documented``. Response shapes are verified against the
+Microsoft Learn references cited on each method.
 """
 
 import os
@@ -58,7 +58,8 @@ PP_API_SCOPE = "https://api.powerplatform.com/.default"
 API_VERSION = "2024-10-01"
 
 # Module-level session with bounded retry-with-backoff for 429/5xx, mirroring
-# pp_admin_client.py. Read-only verbs only; FlightCheck never mutates state.
+# pp_admin_client.py. Only read-only verbs are retried; application installation
+# POSTs are issued once so a lost response cannot trigger duplicate requests.
 _RETRY = Retry(
     total=3,
     backoff_factor=1,
@@ -232,3 +233,86 @@ class PowerPlatformClient:
         resp.raise_for_status()
         data = resp.json()
         return data.get("currencyAllocations", []) or []
+
+    def list_environment_application_packages(
+        self,
+        environment_id: str,
+    ) -> list | dict:
+        """List Marketplace application packages available to an environment.
+
+        MS Learn (documented tier):
+        https://learn.microsoft.com/rest/api/power-platform/appmanagement/applications/get-environment-application-package
+        """
+        return self._get_all(
+            f"/appmanagement/environments/{environment_id}/applicationPackages",
+            params={"api-version": API_VERSION},
+        )
+
+    def install_application_package(
+        self,
+        environment_id: str,
+        unique_name: str,
+    ) -> dict:
+        """Start installing a Marketplace application package.
+
+        MS Learn (documented tier):
+        https://learn.microsoft.com/rest/api/power-platform/appmanagement/applications/install-application-package
+        """
+        url = (
+            f"{PP_API_BASE}/appmanagement/environments/{environment_id}"
+            f"/applicationPackages/{unique_name}/install"
+        )
+        resp = _SESSION.post(
+            url,
+            headers={**self.headers, "Content-Type": "application/json"},
+            params={"api-version": API_VERSION},
+            json={"payloadValue": ""},
+            timeout=60,
+        )
+        if resp.status_code in (401, 403):
+            return {
+                "_error": "insufficient_permissions",
+                "_status": resp.status_code,
+            }
+        if resp.status_code not in (200, 202):
+            resp.raise_for_status()
+
+        data = resp.json() if resp.content else {}
+        operation_id = (
+            data.get("lastOperation", {}).get("operationId")
+            if isinstance(data, dict)
+            else None
+        )
+        return {
+            **data,
+            "_async": resp.status_code == 202,
+            "_operationId": operation_id,
+        }
+
+    def get_application_package_install_status(
+        self,
+        environment_id: str,
+        operation_id: str,
+    ) -> dict:
+        """Get progress for a Marketplace application installation.
+
+        MS Learn (documented tier):
+        https://learn.microsoft.com/rest/api/power-platform/appmanagement/applications/get-application-package-install-status
+        """
+        url = (
+            f"{PP_API_BASE}/appmanagement/environments/{environment_id}"
+            f"/operations/{operation_id}"
+        )
+        resp = _SESSION.get(
+            url,
+            headers=self.headers,
+            params={"api-version": API_VERSION},
+            timeout=60,
+        )
+        if resp.status_code in (401, 403):
+            return {
+                "_error": "insufficient_permissions",
+                "_status": resp.status_code,
+            }
+        resp.raise_for_status()
+        return resp.json()

--- a/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/pp_admin_client.py
@@ -142,17 +142,16 @@ class PPAdminClient:
     def __init__(self, tenant_id: str):
         self.tenant_id = tenant_id
         self._token: str | None = None
+        self._flow_token: str | None = None
 
-    def authenticate(self) -> str:
+    def authenticate(self, *, include_flow: bool = True) -> str:
         """Acquire Power Platform access tokens.
 
-        Acquires BOTH the PowerApps audience token (used for BAP / BAP
-        admin / PowerApps connections / DLP) and the Flow audience
-        token (used for the Power Automate admin flow-listing
-        endpoint at api.flow.microsoft.com). The two endpoints live
-        on different hosts and require different audience tokens —
-        acquiring only the PowerApps token leaves the flow endpoints
-        returning AuthenticationFailed.
+        Acquires the PowerApps audience token used for BAP / BAP admin /
+        PowerApps connections / DLP. By default it also acquires the Flow
+        audience token used for Power Automate admin flow-listing. Callers
+        that only need BAP can pass ``include_flow=False`` to avoid requesting
+        an unrelated audience.
 
         Returns the PowerApps token for backwards compatibility.
         """
@@ -187,7 +186,11 @@ class PPAdminClient:
             return result["access_token"]
 
         pp_token = acquire(PP_SCOPE, "PowerApps/BAP")
-        flow_token = acquire(FLOW_SCOPE, "Power Automate (Flow)")
+        flow_token = (
+            acquire(FLOW_SCOPE, "Power Automate (Flow)")
+            if include_flow
+            else None
+        )
 
         if cache.has_state_changed:
             os.makedirs(".local", exist_ok=True)

--- a/solutions/ess-maker-skills/scripts/install_ess_agent.py
+++ b/solutions/ess-maker-skills/scripts/install_ess_agent.py
@@ -530,6 +530,7 @@ def install_agent(
     sleep=time.sleep,
     clock=time.monotonic,
     status_callback=lambda message: print(message, flush=True),
+    installation_state_callback=lambda _status: None,
 ) -> str:
     """Authenticate and install the selected ESS application through REST APIs."""
     env_url = env_url.rstrip("/")
@@ -569,9 +570,11 @@ def install_agent(
     unique_name = package.get("uniqueName") or application_unique_name
     state = package.get("state")
     if state in INSTALLED_STATES:
+        installation_state_callback("automatic-complete")
         return schema_name
 
     if state in IN_PROGRESS_STATES:
+        installation_state_callback("installing")
         operation_id = None
     else:
         result = client.install_application_package(
@@ -587,11 +590,13 @@ def install_agent(
         operation_id = result.get("_operationId")
         last_state = result.get("lastOperation", {}).get("state")
         if last_state in INSTALLED_STATES:
+            installation_state_callback("automatic-complete")
             return schema_name
         if last_state == "InstallFailed":
             raise RuntimeError(
                 _error_message(result.get("lastOperation", {}), "Installation failed.")
             )
+        installation_state_callback("installing")
 
     _wait_for_install(
         client,
@@ -604,6 +609,7 @@ def install_agent(
         clock=clock,
         status_callback=status_callback,
     )
+    installation_state_callback("automatic-complete")
     return schema_name
 
 
@@ -630,14 +636,35 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    from onboarding_state import save_installation
+
+    def persist_installation_state(status):
+        save_installation(
+            args.url,
+            args.experience,
+            args.vertical,
+            status,
+            args.connection_name,
+            api_started=True,
+        )
+
     try:
         schema_name = install_agent(
             args.url,
             args.experience,
             args.vertical,
             connection_name=args.connection_name,
+            installation_state_callback=persist_installation_state,
         )
     except InstallationTimeoutError as error:
+        save_installation(
+            args.url,
+            args.experience,
+            args.vertical,
+            "manual-required",
+            args.connection_name,
+            api_started=True,
+        )
         result = {
             "environmentUrl": args.url.rstrip("/"),
             "experience": args.experience,

--- a/solutions/ess-maker-skills/scripts/install_ess_agent.py
+++ b/solutions/ess-maker-skills/scripts/install_ess_agent.py
@@ -34,6 +34,10 @@ VERTICAL_PACKAGE = {
     "hr": "Employee Self-Service HR",
     "it": "Employee Self-Service IT",
 }
+VERTICAL_CONFIG_SECTION = {
+    "hr": "esshr",
+    "it": "essit",
+}
 
 
 def load_parent_schemas(catalog_path: Path = CATALOG_PATH) -> dict[tuple[str, str], str]:
@@ -141,6 +145,20 @@ def load_installation_config(
                 )
             display_orders.add(display_order)
 
+    experience_short_labels: set[str] = set()
+    for key, metadata in experiences.items():
+        short_label = metadata.get("shortLabel")
+        if not isinstance(short_label, str) or not short_label.strip():
+            raise ValueError(
+                f"experiences.{key} must define a non-empty shortLabel."
+            )
+        normalized_short_label = short_label.casefold()
+        if normalized_short_label in experience_short_labels:
+            raise ValueError(
+                f"experiences contains duplicate shortLabel '{short_label}'."
+            )
+        experience_short_labels.add(normalized_short_label)
+
     expected_keys = {
         f"{experience_key}.{vertical_key}"
         for experience_key in experiences
@@ -153,20 +171,37 @@ def load_installation_config(
         )
 
     application_names: set[str] = set()
+    config_keys: set[str] = set()
     catalog_schemas = load_parent_schemas(catalog_path)
     for installation_key, installation in installations.items():
         experience_key = installation.get("experienceKey")
         vertical_key = installation.get("verticalKey")
+        config_key = installation.get("configKey")
         expected_key = f"{experience_key}.{vertical_key}"
         if installation_key != expected_key:
             raise ValueError(
                 f"Installation key '{installation_key}' does not match its "
                 f"experienceKey and verticalKey ('{expected_key}')."
             )
+        expected_config_key = (
+            f"{experience_key}.{VERTICAL_CONFIG_SECTION[vertical_key]}"
+        )
+        if config_key != expected_config_key:
+            raise ValueError(
+                f"Installation '{installation_key}' must use configKey "
+                f"'{expected_config_key}'."
+            )
+        if config_key in config_keys:
+            raise ValueError(
+                f"Installation configKey '{config_key}' is assigned more "
+                "than once."
+            )
+        config_keys.add(config_key)
 
         application = installation.get("marketplaceApplication") or {}
         solution = installation.get("solution") or {}
         catalog_match = installation.get("catalogMatch") or {}
+        required_connection = installation.get("requiredConnection")
         unique_name = application.get("uniqueName")
         parent_unique_name = solution.get("parentUniqueName")
         if not unique_name or not parent_unique_name:
@@ -198,7 +233,87 @@ def load_installation_config(
                 f"schema '{catalog_schema}' in solution-catalog.md."
             )
 
+        if vertical_key == "hr":
+            if required_connection is not None:
+                raise ValueError(
+                    f"Installation '{installation_key}' must not require a "
+                    "parent connection."
+                )
+        else:
+            required_fields = (
+                "displayName",
+                "connectorApiName",
+                "referenceLogicalName",
+                "creationGuidance",
+            )
+            if not isinstance(required_connection, dict) or any(
+                not isinstance(required_connection.get(field), str)
+                or not required_connection[field].strip()
+                for field in required_fields
+            ):
+                raise ValueError(
+                    f"Installation '{installation_key}' must define complete "
+                    "requiredConnection metadata."
+                )
+            if required_connection["connectorApiName"] != "shared_alchemy":
+                raise ValueError(
+                    f"Installation '{installation_key}' must use the "
+                    "shared_alchemy connector."
+                )
+            expected_reference_prefix = parent_unique_name.casefold()
+            if not required_connection["referenceLogicalName"].casefold().startswith(
+                expected_reference_prefix
+            ):
+                raise ValueError(
+                    f"Installation '{installation_key}' connection reference "
+                    "does not match its parent solution."
+                )
+
     return config
+
+
+def build_installation_options(config: dict) -> list[dict]:
+    """Build the single ordered DA/CEA × HR/IT installation picker."""
+    experiences = config["experiences"]
+    verticals = config["verticals"]
+
+    options = []
+    for key, installation in config["installations"].items():
+        experience_key = installation["experienceKey"]
+        vertical_key = installation["verticalKey"]
+        experience = experiences[experience_key]
+        vertical = verticals[vertical_key]
+        options.append({
+            "key": key,
+            "configKey": installation["configKey"],
+            "experience": experience_key,
+            "vertical": vertical_key,
+            "label": (
+                f"{experience['shortLabel']} : {vertical['label']}"
+            ),
+            "description": (
+                f"{experience['description']} {vertical['description']}"
+            ),
+            "schemaName": installation["solution"]["parentUniqueName"],
+            "requiredConnection": installation.get("requiredConnection"),
+        })
+
+    return sorted(
+        options,
+        key=lambda option: (
+            experiences[option["experience"]]["displayOrder"],
+            verticals[option["vertical"]]["displayOrder"],
+        ),
+    )
+
+
+def find_installation_by_schema(config: dict, schema_name: str) -> dict | None:
+    """Return the configured installation whose solution schema matches."""
+    target = schema_name.casefold()
+    for option in build_installation_options(config):
+        if option["schemaName"].casefold() == target:
+            return option
+    return None
 
 
 INSTALLED_STATES = {"Installed", "TemplateInstalled"}
@@ -223,6 +338,57 @@ class InstallationTimeoutError(RuntimeError):
             f"{timeout_seconds // 60} minutes."
         )
 
+
+def _connector_api_name(value: str | None) -> str:
+    return (value or "").rstrip("/").rsplit("/", 1)[-1].casefold()
+
+
+def validate_required_connection(
+    installation: dict,
+    connections: list[dict],
+    selected_connection_name: str | None = None,
+) -> str | None:
+    """Hard-gate installation on its required connected connector instance."""
+    requirement = installation.get("requiredConnection")
+    if requirement is None:
+        return None
+
+    matches = []
+    expected_connector = requirement["connectorApiName"].casefold()
+    for connection in connections:
+        properties = connection.get("properties") or {}
+        statuses = properties.get("statuses") or []
+        status = (
+            statuses[0].get("status")
+            if statuses and isinstance(statuses[0], dict)
+            else None
+        )
+        if (
+            connection.get("name")
+            and _connector_api_name(properties.get("apiId")) == expected_connector
+            and str(status or "").casefold() == "connected"
+        ):
+            matches.append(connection["name"])
+
+    if not matches:
+        raise RuntimeError(
+            f"This ESS agent requires an active {requirement['displayName']} "
+            "connection. Create it in the selected environment before "
+            "installation."
+        )
+    if selected_connection_name:
+        if selected_connection_name not in matches:
+            raise RuntimeError(
+                "The selected required connection is not connected or does not "
+                f"use {requirement['connectorApiName']}."
+            )
+        return selected_connection_name
+    if len(matches) > 1:
+        raise RuntimeError(
+            "Multiple connected instances of the required connector exist. "
+            "Select one during connection preflight before installation."
+        )
+    return matches[0]
 
 def _find_package(packages: list[dict], schema_name: str) -> dict | None:
     """Find the entitled application whose unique name matches the catalog."""
@@ -354,6 +520,7 @@ def install_agent(
     experience: str,
     vertical: str,
     *,
+    connection_name: str | None = None,
     config_path: Path = CONFIG_PATH,
     catalog_path: Path = CATALOG_PATH,
     pp_admin_client_factory=PPAdminClient,
@@ -380,6 +547,12 @@ def install_agent(
         raise RuntimeError(
             "Could not resolve the selected environment's Power Platform ID."
         )
+
+    validate_required_connection(
+        installation,
+        pp_admin.get_connections(environment_id),
+        connection_name,
+    )
 
     client = powerplatform_client_factory(tenant_id)
     client.authenticate()
@@ -451,6 +624,10 @@ def main() -> None:
         choices=sorted(VERTICAL_PACKAGE),
         help="Agent vertical: hr or it",
     )
+    parser.add_argument(
+        "--connection-name",
+        help="Required connection selected by connection preflight",
+    )
     args = parser.parse_args()
 
     try:
@@ -458,6 +635,7 @@ def main() -> None:
             args.url,
             args.experience,
             args.vertical,
+            connection_name=args.connection_name,
         )
     except InstallationTimeoutError as error:
         result = {

--- a/solutions/ess-maker-skills/scripts/install_ess_agent.py
+++ b/solutions/ess-maker-skills/scripts/install_ess_agent.py
@@ -1,0 +1,318 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Install an Employee Self-Service app with the Power Platform API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import time
+
+from auth import discover_tenant
+from flightcheck.powerplatform_client import PowerPlatformClient
+from flightcheck.pp_admin_client import PPAdminClient
+
+
+CATALOG_PATH = (
+    Path(__file__).resolve().parents[1] / "src" / "reference"
+    / "solution-catalog.md"
+)
+
+EXPERIENCE_STATUS = {
+    "da": "Active (DA bundle)",
+    "cea": "Active (CEA bundle)",
+}
+
+VERTICAL_PACKAGE = {
+    "hr": "Employee Self-Service HR",
+    "it": "Employee Self-Service IT",
+}
+
+
+def load_parent_schemas(catalog_path: Path = CATALOG_PATH) -> dict[tuple[str, str], str]:
+    """Read DA/CEA and HR/IT parent schema mappings from the solution catalog."""
+    mappings: dict[tuple[str, str], str] = {}
+    in_parents = False
+
+    for line in catalog_path.read_text(encoding="utf-8").splitlines():
+        if line == "## Parents":
+            in_parents = True
+            continue
+        if in_parents and line.startswith("## "):
+            break
+        if not in_parents or not line.startswith("|"):
+            continue
+
+        columns = [column.strip() for column in line.strip("|").split("|")]
+        if len(columns) != 5 or not columns[0].isdigit():
+            continue
+
+        package = columns[1]
+        schema = columns[2].strip("`")
+        status = columns[3]
+
+        experience = next(
+            (
+                key for key, expected_status in EXPERIENCE_STATUS.items()
+                if status == expected_status
+            ),
+            None,
+        )
+        vertical = next(
+            (
+                key for key, expected_package in VERTICAL_PACKAGE.items()
+                if package == expected_package
+            ),
+            None,
+        )
+        if experience and vertical:
+            mappings[(experience, vertical)] = schema
+
+    expected = {
+        (experience, vertical)
+        for experience in EXPERIENCE_STATUS
+        for vertical in VERTICAL_PACKAGE
+    }
+    missing = expected - mappings.keys()
+    if missing:
+        missing_labels = ", ".join(
+            f"{experience.upper()}/{vertical.upper()}"
+            for experience, vertical in sorted(missing)
+        )
+        raise ValueError(
+            f"Solution catalog is missing parent schema mappings: {missing_labels}"
+        )
+
+    return mappings
+
+
+INSTALLED_STATES = {"Installed", "TemplateInstalled"}
+IN_PROGRESS_STATES = {
+    "InstallRequested",
+    "Installing",
+    "InstallScheduled",
+    "InstallRetrying",
+}
+FAILED_STATES = {"InstallFailed"}
+
+
+def _find_package(packages: list[dict], schema_name: str) -> dict | None:
+    """Find the entitled application whose unique name matches the catalog."""
+    target = schema_name.casefold()
+    for package in packages:
+        names = (
+            package.get("uniqueName"),
+            package.get("applicationName"),
+        )
+        if any(
+            isinstance(name, str) and name.casefold() == target
+            for name in names
+        ):
+            return package
+    return None
+
+
+def _error_message(response: dict, default: str) -> str:
+    """Return a concise API error without dumping the full response."""
+    error = (
+        response.get("error")
+        or response.get("errorDetails")
+        or response.get("lastError")
+        or {}
+    )
+    if isinstance(error, dict):
+        message = error.get("message") or error.get("errorName")
+        if message:
+            return str(message)
+    message = response.get("statusMessage")
+    return str(message) if message else default
+
+
+def _list_packages(client: PowerPlatformClient, environment_id: str) -> list[dict]:
+    packages = client.list_environment_application_packages(environment_id)
+    if isinstance(packages, dict) and packages.get("_error"):
+        raise RuntimeError(
+            "Your account cannot read Marketplace applications for this "
+            "environment. Use a Power Platform or Dynamics 365 administrator "
+            "account."
+        )
+    return packages
+
+
+def _wait_for_install(
+    client: PowerPlatformClient,
+    environment_id: str,
+    unique_name: str,
+    operation_id: str | None,
+    *,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    sleep,
+) -> None:
+    """Poll the operation endpoint, falling back to package state if needed."""
+    deadline = time.monotonic() + timeout_seconds
+
+    while time.monotonic() < deadline:
+        if operation_id:
+            status_response = client.get_application_package_install_status(
+                environment_id,
+                operation_id,
+            )
+            if status_response.get("_error"):
+                raise RuntimeError(
+                    "Your account cannot read application installation status."
+                )
+            status = status_response.get("status")
+            if status == "Succeeded":
+                return
+            if status in {"Failed", "Canceled"}:
+                raise RuntimeError(
+                    _error_message(
+                        status_response,
+                        f"Application installation ended with status {status}.",
+                    )
+                )
+        else:
+            package = _find_package(
+                _list_packages(client, environment_id),
+                unique_name,
+            )
+            if package:
+                state = package.get("state")
+                if state in INSTALLED_STATES:
+                    return
+                if state in FAILED_STATES:
+                    raise RuntimeError(
+                        _error_message(
+                            package,
+                            f"Application installation ended with state {state}.",
+                        )
+                    )
+
+        sleep(poll_interval_seconds)
+
+    raise RuntimeError(
+        f"Application installation did not finish within "
+        f"{timeout_seconds // 60} minutes."
+    )
+
+
+def install_agent(
+    env_url: str,
+    experience: str,
+    vertical: str,
+    *,
+    catalog_path: Path = CATALOG_PATH,
+    pp_admin_client_factory=PPAdminClient,
+    powerplatform_client_factory=PowerPlatformClient,
+    timeout_seconds: int = 1800,
+    poll_interval_seconds: int = 20,
+    sleep=time.sleep,
+) -> str:
+    """Authenticate and install the selected ESS application through REST APIs."""
+    env_url = env_url.rstrip("/")
+    schema_name = load_parent_schemas(catalog_path)[(experience, vertical)]
+    tenant_id = discover_tenant(env_url)
+
+    pp_admin = pp_admin_client_factory(tenant_id)
+    pp_admin.authenticate(include_flow=False)
+    environment_id = pp_admin.find_environment_id_by_dataverse_url(env_url)
+    if not environment_id:
+        raise RuntimeError(
+            "Could not resolve the selected environment's Power Platform ID."
+        )
+
+    client = powerplatform_client_factory(tenant_id)
+    client.authenticate()
+    package = _find_package(
+        _list_packages(client, environment_id),
+        schema_name,
+    )
+    if not package:
+        raise RuntimeError(
+            f"The Marketplace application '{schema_name}' is not available "
+            "for this tenant or environment."
+        )
+
+    unique_name = package.get("uniqueName") or schema_name
+    state = package.get("state")
+    if state in INSTALLED_STATES:
+        return schema_name
+
+    if state in IN_PROGRESS_STATES:
+        operation_id = None
+    else:
+        result = client.install_application_package(
+            environment_id,
+            unique_name,
+        )
+        if result.get("_error"):
+            raise RuntimeError(
+                "Your account cannot install Marketplace applications in this "
+                "environment. Use a Power Platform or Dynamics 365 "
+                "administrator account."
+            )
+        operation_id = result.get("_operationId")
+        last_state = result.get("lastOperation", {}).get("state")
+        if last_state in INSTALLED_STATES:
+            return schema_name
+        if last_state == "InstallFailed":
+            raise RuntimeError(
+                _error_message(result.get("lastOperation", {}), "Installation failed.")
+            )
+
+    _wait_for_install(
+        client,
+        environment_id,
+        unique_name,
+        operation_id,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        sleep=sleep,
+    )
+    return schema_name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Install an Employee Self-Service agent application"
+    )
+    parser.add_argument("--url", required=True, help="Dataverse environment URL")
+    parser.add_argument(
+        "--experience",
+        required=True,
+        choices=sorted(EXPERIENCE_STATUS),
+        help="Agent experience: da or cea",
+    )
+    parser.add_argument(
+        "--vertical",
+        required=True,
+        choices=sorted(VERTICAL_PACKAGE),
+        help="Agent vertical: hr or it",
+    )
+    args = parser.parse_args()
+
+    try:
+        schema_name = install_agent(
+            args.url,
+            args.experience,
+            args.vertical,
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    result = {
+        "environmentUrl": args.url.rstrip("/"),
+        "experience": args.experience,
+        "vertical": args.vertical,
+        "schemaName": schema_name,
+    }
+    print(f"INSTALLED_ESS_AGENT_JSON:{json.dumps(result)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/install_ess_agent.py
+++ b/solutions/ess-maker-skills/scripts/install_ess_agent.py
@@ -20,6 +20,10 @@ CATALOG_PATH = (
     Path(__file__).resolve().parents[1] / "src" / "reference"
     / "solution-catalog.md"
 )
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[1] / "src" / "reference"
+    / "ess-agent-installation" / "config.json"
+)
 
 EXPERIENCE_STATUS = {
     "da": "Active (DA bundle)",
@@ -89,6 +93,114 @@ def load_parent_schemas(catalog_path: Path = CATALOG_PATH) -> dict[tuple[str, st
     return mappings
 
 
+def load_installation_config(
+    config_path: Path = CONFIG_PATH,
+    catalog_path: Path = CATALOG_PATH,
+) -> dict:
+    """Load installation metadata and reject ambiguous or stale mappings."""
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    if config.get("schemaVersion") != 1:
+        raise ValueError("Unsupported ESS installation config schemaVersion.")
+
+    experiences = config.get("experiences")
+    verticals = config.get("verticals")
+    installations = config.get("installations")
+    if not all(isinstance(value, dict) for value in (
+        experiences,
+        verticals,
+        installations,
+    )):
+        raise ValueError(
+            "ESS installation config must define experiences, verticals, "
+            "and installations objects."
+        )
+
+    for dimension_name, dimension in (
+        ("experiences", experiences),
+        ("verticals", verticals),
+    ):
+        labels: set[str] = set()
+        display_orders: set[int] = set()
+        for key, metadata in dimension.items():
+            label = metadata.get("label")
+            display_order = metadata.get("displayOrder")
+            if not isinstance(label, str) or not label.strip():
+                raise ValueError(
+                    f"{dimension_name}.{key} must define a non-empty label."
+                )
+            normalized_label = label.casefold()
+            if normalized_label in labels:
+                raise ValueError(
+                    f"{dimension_name} contains duplicate label '{label}'."
+                )
+            labels.add(normalized_label)
+            if not isinstance(display_order, int) or display_order in display_orders:
+                raise ValueError(
+                    f"{dimension_name}.{key} must define a unique integer "
+                    "displayOrder."
+                )
+            display_orders.add(display_order)
+
+    expected_keys = {
+        f"{experience_key}.{vertical_key}"
+        for experience_key in experiences
+        for vertical_key in verticals
+    }
+    if set(installations) != expected_keys:
+        raise ValueError(
+            "ESS installation config must define exactly one entry for every "
+            "experience and vertical combination."
+        )
+
+    application_names: set[str] = set()
+    catalog_schemas = load_parent_schemas(catalog_path)
+    for installation_key, installation in installations.items():
+        experience_key = installation.get("experienceKey")
+        vertical_key = installation.get("verticalKey")
+        expected_key = f"{experience_key}.{vertical_key}"
+        if installation_key != expected_key:
+            raise ValueError(
+                f"Installation key '{installation_key}' does not match its "
+                f"experienceKey and verticalKey ('{expected_key}')."
+            )
+
+        application = installation.get("marketplaceApplication") or {}
+        solution = installation.get("solution") or {}
+        catalog_match = installation.get("catalogMatch") or {}
+        unique_name = application.get("uniqueName")
+        parent_unique_name = solution.get("parentUniqueName")
+        if not unique_name or not parent_unique_name:
+            raise ValueError(
+                f"Installation '{installation_key}' is missing an application "
+                "or parent solution unique name."
+            )
+        normalized_name = unique_name.casefold()
+        if normalized_name in application_names:
+            raise ValueError(
+                f"Marketplace application unique name '{unique_name}' is "
+                "assigned to more than one installation."
+            )
+        application_names.add(normalized_name)
+
+        if catalog_match != {
+            "parentPackage": VERTICAL_PACKAGE[vertical_key],
+            "status": EXPERIENCE_STATUS[experience_key],
+        }:
+            raise ValueError(
+                f"Installation '{installation_key}' has catalogMatch metadata "
+                "that does not match its experience and vertical."
+            )
+
+        catalog_schema = catalog_schemas[(experience_key, vertical_key)]
+        if unique_name != catalog_schema or parent_unique_name != catalog_schema:
+            raise ValueError(
+                f"Installation '{installation_key}' does not match the parent "
+                f"schema '{catalog_schema}' in solution-catalog.md."
+            )
+
+    return config
+
+
 INSTALLED_STATES = {"Installed", "TemplateInstalled"}
 IN_PROGRESS_STATES = {
     "InstallRequested",
@@ -97,6 +209,19 @@ IN_PROGRESS_STATES = {
     "InstallRetrying",
 }
 FAILED_STATES = {"InstallFailed"}
+DEFAULT_TIMEOUT_SECONDS = 10 * 60
+
+
+class InstallationTimeoutError(RuntimeError):
+    """Raised when Power Platform does not finish installation in time."""
+
+    def __init__(self, unique_name: str, timeout_seconds: int):
+        self.unique_name = unique_name
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            "Application installation did not finish within "
+            f"{timeout_seconds // 60} minutes."
+        )
 
 
 def _find_package(packages: list[dict], schema_name: str) -> dict | None:
@@ -151,11 +276,20 @@ def _wait_for_install(
     timeout_seconds: int,
     poll_interval_seconds: int,
     sleep,
+    clock,
+    status_callback,
 ) -> None:
     """Poll the operation endpoint, falling back to package state if needed."""
-    deadline = time.monotonic() + timeout_seconds
+    started_at = clock()
+    deadline = started_at + timeout_seconds
+    poll_number = 0
 
-    while time.monotonic() < deadline:
+    while True:
+        now = clock()
+        if now >= deadline:
+            break
+        poll_number += 1
+        observed_status = "Unknown"
         if operation_id:
             status_response = client.get_application_package_install_status(
                 environment_id,
@@ -166,6 +300,12 @@ def _wait_for_install(
                     "Your account cannot read application installation status."
                 )
             status = status_response.get("status")
+            observed_status = status or "InProgress"
+            status_callback(
+                "Installation status "
+                f"(poll {poll_number}, {int(now - started_at)}s elapsed): "
+                f"{observed_status}"
+            )
             if status == "Succeeded":
                 return
             if status in {"Failed", "Canceled"}:
@@ -182,6 +322,12 @@ def _wait_for_install(
             )
             if package:
                 state = package.get("state")
+                observed_status = state or "Unknown"
+                status_callback(
+                    "Installation status "
+                    f"(poll {poll_number}, {int(now - started_at)}s elapsed): "
+                    f"{observed_status}"
+                )
                 if state in INSTALLED_STATES:
                     return
                 if state in FAILED_STATES:
@@ -191,13 +337,16 @@ def _wait_for_install(
                             f"Application installation ended with state {state}.",
                         )
                     )
+            else:
+                status_callback(
+                    "Installation status "
+                    f"(poll {poll_number}, {int(now - started_at)}s elapsed): "
+                    f"{observed_status}"
+                )
 
         sleep(poll_interval_seconds)
 
-    raise RuntimeError(
-        f"Application installation did not finish within "
-        f"{timeout_seconds // 60} minutes."
-    )
+    raise InstallationTimeoutError(unique_name, timeout_seconds)
 
 
 def install_agent(
@@ -205,16 +354,23 @@ def install_agent(
     experience: str,
     vertical: str,
     *,
+    config_path: Path = CONFIG_PATH,
     catalog_path: Path = CATALOG_PATH,
     pp_admin_client_factory=PPAdminClient,
     powerplatform_client_factory=PowerPlatformClient,
-    timeout_seconds: int = 1800,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     poll_interval_seconds: int = 20,
     sleep=time.sleep,
+    clock=time.monotonic,
+    status_callback=lambda message: print(message, flush=True),
 ) -> str:
     """Authenticate and install the selected ESS application through REST APIs."""
     env_url = env_url.rstrip("/")
-    schema_name = load_parent_schemas(catalog_path)[(experience, vertical)]
+    config = load_installation_config(config_path, catalog_path)
+    installation_key = f"{experience}.{vertical}"
+    installation = config["installations"][installation_key]
+    schema_name = installation["solution"]["parentUniqueName"]
+    application_unique_name = installation["marketplaceApplication"]["uniqueName"]
     tenant_id = discover_tenant(env_url)
 
     pp_admin = pp_admin_client_factory(tenant_id)
@@ -229,15 +385,15 @@ def install_agent(
     client.authenticate()
     package = _find_package(
         _list_packages(client, environment_id),
-        schema_name,
+        application_unique_name,
     )
     if not package:
         raise RuntimeError(
-            f"The Marketplace application '{schema_name}' is not available "
+            f"The Marketplace application '{application_unique_name}' is not available "
             "for this tenant or environment."
         )
 
-    unique_name = package.get("uniqueName") or schema_name
+    unique_name = package.get("uniqueName") or application_unique_name
     state = package.get("state")
     if state in INSTALLED_STATES:
         return schema_name
@@ -272,6 +428,8 @@ def install_agent(
         timeout_seconds=timeout_seconds,
         poll_interval_seconds=poll_interval_seconds,
         sleep=sleep,
+        clock=clock,
+        status_callback=status_callback,
     )
     return schema_name
 
@@ -301,6 +459,21 @@ def main() -> None:
             args.experience,
             args.vertical,
         )
+    except InstallationTimeoutError as error:
+        result = {
+            "environmentUrl": args.url.rstrip("/"),
+            "experience": args.experience,
+            "vertical": args.vertical,
+            "schemaName": error.unique_name,
+            "timeoutMinutes": error.timeout_seconds // 60,
+        }
+        print(
+            "ESS_AGENT_INSTALLATION_TIMEOUT_JSON:"
+            f"{json.dumps(result)}",
+            flush=True,
+        )
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(2)
     except (OSError, RuntimeError, ValueError) as error:
         print(f"ERROR: {error}", file=sys.stderr)
         sys.exit(1)

--- a/solutions/ess-maker-skills/scripts/onboarding_state.py
+++ b/solutions/ess-maker-skills/scripts/onboarding_state.py
@@ -21,8 +21,6 @@ INSTALLATION_STATUSES = {
 }
 CONNECTION_STATUSES = {
     "not-required",
-    "missing",
-    "selected",
     "bound",
 }
 
@@ -78,6 +76,23 @@ def load_state(*, recover_from_mcp=True):
             f"Unsupported onboarding state version: {state.get('version')}"
         )
 
+    installation = state.get("installation") or {}
+    if (
+        installation.get("status") == "installing"
+        and installation.get("apiStarted") is not True
+    ):
+        state.pop("installation", None)
+        setup_status = state.get("setupStatus")
+        if isinstance(setup_status, dict):
+            setup_status.pop("S1", None)
+
+    connection = state.get("connection") or {}
+    if connection.get("status") in {"missing", "selected"}:
+        state.pop("connection", None)
+        setup_status = state.get("setupStatus")
+        if isinstance(setup_status, dict):
+            setup_status.pop("S2", None)
+
     if state.get("environmentUrl"):
         state["environmentUrl"] = _normalize_environment_url(
             state["environmentUrl"]
@@ -131,11 +146,31 @@ def save_agent(url, bot_id, name, schema_name, is_managed):
     return save_state(state)
 
 
-def save_installation(url, experience, vertical, status):
+def save_installation(
+    url,
+    experience,
+    vertical,
+    status,
+    connection_name=None,
+    *,
+    api_started=False,
+):
     if status not in INSTALLATION_STATUSES:
         raise ValueError(f"Unsupported installation status: {status}")
+    if status == "installing" and not api_started:
+        raise ValueError(
+            "Installing state can only be saved after the installation API "
+            "accepts the request or reports an in-progress package."
+        )
     state = load_state(recover_from_mcp=False)
     state["environmentUrl"] = _normalize_environment_url(url)
+    previous_installation = state.get("installation") or {}
+    if (
+        connection_name is None
+        and previous_installation.get("experience") == experience
+        and previous_installation.get("vertical") == vertical
+    ):
+        connection_name = previous_installation.get("connectionName")
     connection = state.get("connection") or {}
     if (
         connection.get("experience") != experience
@@ -150,6 +185,10 @@ def save_installation(url, experience, vertical, status):
         "vertical": vertical,
         "status": status,
     }
+    if api_started or previous_installation.get("apiStarted") is True:
+        state["installation"]["apiStarted"] = True
+    if connection_name:
+        state["installation"]["connectionName"] = connection_name
     state.setdefault("setupStatus", {})["S1"] = {
         "state": (
             "done" if status in {"automatic-complete", "verified"}
@@ -175,7 +214,7 @@ def save_connection(
 ):
     if status not in CONNECTION_STATUSES:
         raise ValueError(f"Unsupported connection status: {status}")
-    if status in {"selected", "bound"} and not connection_name:
+    if status == "bound" and not connection_name:
         raise ValueError(f"Connection name is required for status '{status}'")
     state = load_state(recover_from_mcp=False)
     state["environmentUrl"] = _normalize_environment_url(url)
@@ -186,15 +225,9 @@ def save_connection(
         "connectionName": connection_name,
     }
     state.setdefault("setupStatus", {})["S2"] = {
-        "state": (
-            "done" if status in {"not-required", "bound"}
-            else "blocked" if status == "missing"
-            else "in-progress"
-        ),
+        "state": "done",
         "checkpoint": "ESS-CONN-001",
-        "verifiedBy": (
-            "programmatic" if status in {"not-required", "bound"} else None
-        ),
+        "verifiedBy": "programmatic",
         "connectionName": connection_name,
         "notRequired": status == "not-required",
     }
@@ -246,6 +279,12 @@ def main():
     installation_parser.add_argument(
         "--status", required=True, choices=sorted(INSTALLATION_STATUSES)
     )
+    installation_parser.add_argument("--connection-name")
+    installation_parser.add_argument(
+        "--api-started",
+        action="store_true",
+        help="Confirm the Power Platform API accepted or is running installation",
+    )
 
     connection_parser = subparsers.add_parser(
         "save-connection", help="Save ESS connection preflight or binding state"
@@ -284,6 +323,8 @@ def main():
                 args.experience,
                 args.vertical,
                 args.status,
+                args.connection_name,
+                api_started=args.api_started,
             ))
         elif args.command == "save-connection":
             _print_state(save_connection(

--- a/solutions/ess-maker-skills/scripts/onboarding_state.py
+++ b/solutions/ess-maker-skills/scripts/onboarding_state.py
@@ -19,6 +19,12 @@ INSTALLATION_STATUSES = {
     "automatic-complete",
     "verified",
 }
+CONNECTION_STATUSES = {
+    "not-required",
+    "missing",
+    "selected",
+    "bound",
+}
 
 
 def _normalize_environment_url(url):
@@ -130,10 +136,67 @@ def save_installation(url, experience, vertical, status):
         raise ValueError(f"Unsupported installation status: {status}")
     state = load_state(recover_from_mcp=False)
     state["environmentUrl"] = _normalize_environment_url(url)
+    connection = state.get("connection") or {}
+    if (
+        connection.get("experience") != experience
+        or connection.get("vertical") != vertical
+    ):
+        state.pop("connection", None)
+        setup_status = state.get("setupStatus")
+        if isinstance(setup_status, dict):
+            setup_status.pop("S2", None)
     state["installation"] = {
         "experience": experience,
         "vertical": vertical,
         "status": status,
+    }
+    state.setdefault("setupStatus", {})["S1"] = {
+        "state": (
+            "done" if status in {"automatic-complete", "verified"}
+            else "in-progress" if status == "installing"
+            else "blocked"
+        ),
+        "checkpoint": "ESS-SOLN-001",
+        "verifiedBy": (
+            "programmatic"
+            if status in {"automatic-complete", "verified"}
+            else None
+        ),
+    }
+    return save_state(state)
+
+
+def save_connection(
+    url,
+    experience,
+    vertical,
+    status,
+    connection_name=None,
+):
+    if status not in CONNECTION_STATUSES:
+        raise ValueError(f"Unsupported connection status: {status}")
+    if status in {"selected", "bound"} and not connection_name:
+        raise ValueError(f"Connection name is required for status '{status}'")
+    state = load_state(recover_from_mcp=False)
+    state["environmentUrl"] = _normalize_environment_url(url)
+    state["connection"] = {
+        "experience": experience,
+        "vertical": vertical,
+        "status": status,
+        "connectionName": connection_name,
+    }
+    state.setdefault("setupStatus", {})["S2"] = {
+        "state": (
+            "done" if status in {"not-required", "bound"}
+            else "blocked" if status == "missing"
+            else "in-progress"
+        ),
+        "checkpoint": "ESS-CONN-001",
+        "verifiedBy": (
+            "programmatic" if status in {"not-required", "bound"} else None
+        ),
+        "connectionName": connection_name,
+        "notRequired": status == "not-required",
     }
     return save_state(state)
 
@@ -184,6 +247,21 @@ def main():
         "--status", required=True, choices=sorted(INSTALLATION_STATUSES)
     )
 
+    connection_parser = subparsers.add_parser(
+        "save-connection", help="Save ESS connection preflight or binding state"
+    )
+    connection_parser.add_argument("--url", required=True)
+    connection_parser.add_argument(
+        "--experience", required=True, choices=("da", "cea")
+    )
+    connection_parser.add_argument(
+        "--vertical", required=True, choices=("hr", "it")
+    )
+    connection_parser.add_argument(
+        "--status", required=True, choices=sorted(CONNECTION_STATUSES)
+    )
+    connection_parser.add_argument("--connection-name")
+
     subparsers.add_parser("clear", help="Clear partial onboarding state")
     args = parser.parse_args()
 
@@ -206,6 +284,14 @@ def main():
                 args.experience,
                 args.vertical,
                 args.status,
+            ))
+        elif args.command == "save-connection":
+            _print_state(save_connection(
+                args.url,
+                args.experience,
+                args.vertical,
+                args.status,
+                args.connection_name,
             ))
         else:
             clear_state()

--- a/solutions/ess-maker-skills/scripts/onboarding_state.py
+++ b/solutions/ess-maker-skills/scripts/onboarding_state.py
@@ -13,6 +13,12 @@ from urllib.parse import urlparse
 STATE_PATH = os.path.join(".local", "onboarding.json")
 MCP_CONFIG_PATH = os.path.join(".vscode", "mcp.json")
 STATE_VERSION = 1
+INSTALLATION_STATUSES = {
+    "installing",
+    "manual-required",
+    "automatic-complete",
+    "verified",
+}
 
 
 def _normalize_environment_url(url):
@@ -119,6 +125,19 @@ def save_agent(url, bot_id, name, schema_name, is_managed):
     return save_state(state)
 
 
+def save_installation(url, experience, vertical, status):
+    if status not in INSTALLATION_STATUSES:
+        raise ValueError(f"Unsupported installation status: {status}")
+    state = load_state(recover_from_mcp=False)
+    state["environmentUrl"] = _normalize_environment_url(url)
+    state["installation"] = {
+        "experience": experience,
+        "vertical": vertical,
+        "status": status,
+    }
+    return save_state(state)
+
+
 def clear_state():
     try:
         os.remove(STATE_PATH)
@@ -151,6 +170,20 @@ def main():
     agent_parser.add_argument("--schema", required=True)
     agent_parser.add_argument("--managed", action="store_true")
 
+    installation_parser = subparsers.add_parser(
+        "save-installation", help="Save ESS application installation progress"
+    )
+    installation_parser.add_argument("--url", required=True)
+    installation_parser.add_argument(
+        "--experience", required=True, choices=("da", "cea")
+    )
+    installation_parser.add_argument(
+        "--vertical", required=True, choices=("hr", "it")
+    )
+    installation_parser.add_argument(
+        "--status", required=True, choices=sorted(INSTALLATION_STATUSES)
+    )
+
     subparsers.add_parser("clear", help="Clear partial onboarding state")
     args = parser.parse_args()
 
@@ -166,6 +199,13 @@ def main():
                 args.name,
                 args.schema,
                 args.managed,
+            ))
+        elif args.command == "save-installation":
+            _print_state(save_installation(
+                args.url,
+                args.experience,
+                args.vertical,
+                args.status,
             ))
         else:
             clear_state()

--- a/solutions/ess-maker-skills/scripts/onboarding_state.py
+++ b/solutions/ess-maker-skills/scripts/onboarding_state.py
@@ -1,0 +1,179 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Persist partial /setup progress across Copilot conversations."""
+
+import argparse
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+
+STATE_PATH = os.path.join(".local", "onboarding.json")
+MCP_CONFIG_PATH = os.path.join(".vscode", "mcp.json")
+STATE_VERSION = 1
+
+
+def _normalize_environment_url(url):
+    normalized = url.rstrip("/")
+    parsed = urlparse(normalized)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("Environment URL must be a valid HTTPS URL.")
+    return normalized
+
+
+def _read_json(path):
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"Could not read {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object.")
+    return value
+
+
+def _environment_from_mcp_config():
+    config = _read_json(MCP_CONFIG_PATH)
+    if not config:
+        return None
+
+    servers = config.get("servers") or config.get("mcpServers") or {}
+    if not isinstance(servers, dict):
+        return None
+
+    for server in servers.values():
+        if not isinstance(server, dict):
+            continue
+        url = server.get("url")
+        if not isinstance(url, str):
+            continue
+        for suffix in ("/api/mcp", "/api/mcp_preview"):
+            if url.rstrip("/").endswith(suffix):
+                return _normalize_environment_url(
+                    url.rstrip("/")[:-len(suffix)]
+                )
+    return None
+
+
+def load_state(*, recover_from_mcp=True):
+    state = _read_json(STATE_PATH) or {}
+    if state and state.get("version") != STATE_VERSION:
+        raise ValueError(
+            f"Unsupported onboarding state version: {state.get('version')}"
+        )
+
+    if state.get("environmentUrl"):
+        state["environmentUrl"] = _normalize_environment_url(
+            state["environmentUrl"]
+        )
+    elif recover_from_mcp:
+        try:
+            recovered_url = _environment_from_mcp_config()
+        except ValueError as exc:
+            state["recoveryWarning"] = str(exc)
+        else:
+            if recovered_url:
+                state = {
+                    **state,
+                    "version": STATE_VERSION,
+                    "environmentUrl": recovered_url,
+                }
+    return state
+
+
+def save_state(state):
+    os.makedirs(os.path.dirname(STATE_PATH), exist_ok=True)
+    state = {**state, "version": STATE_VERSION}
+    tmp_path = STATE_PATH + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2)
+        handle.write("\n")
+        handle.flush()
+        try:
+            os.fsync(handle.fileno())
+        except OSError:
+            pass
+    os.replace(tmp_path, STATE_PATH)
+    return state
+
+
+def save_environment(url):
+    state = load_state(recover_from_mcp=False)
+    state["environmentUrl"] = _normalize_environment_url(url)
+    return save_state(state)
+
+
+def save_agent(url, bot_id, name, schema_name, is_managed):
+    state = load_state(recover_from_mcp=False)
+    state["environmentUrl"] = _normalize_environment_url(url)
+    state["agent"] = {
+        "botId": bot_id,
+        "name": name,
+        "schemaName": schema_name,
+        "isManaged": is_managed,
+    }
+    return save_state(state)
+
+
+def clear_state():
+    try:
+        os.remove(STATE_PATH)
+    except FileNotFoundError:
+        return
+
+
+def _print_state(state):
+    print(f"ONBOARDING_STATE_JSON:{json.dumps(state)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read or update partial ESS onboarding state"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("show", help="Show saved onboarding state")
+
+    environment_parser = subparsers.add_parser(
+        "save-environment", help="Save the selected environment"
+    )
+    environment_parser.add_argument("--url", required=True)
+
+    agent_parser = subparsers.add_parser(
+        "save-agent", help="Save the selected environment and agent"
+    )
+    agent_parser.add_argument("--url", required=True)
+    agent_parser.add_argument("--bot-id", required=True)
+    agent_parser.add_argument("--name", required=True)
+    agent_parser.add_argument("--schema", required=True)
+    agent_parser.add_argument("--managed", action="store_true")
+
+    subparsers.add_parser("clear", help="Clear partial onboarding state")
+    args = parser.parse_args()
+
+    try:
+        if args.command == "show":
+            _print_state(load_state())
+        elif args.command == "save-environment":
+            _print_state(save_environment(args.url))
+        elif args.command == "save-agent":
+            _print_state(save_agent(
+                args.url,
+                args.bot_id,
+                args.name,
+                args.schema,
+                args.managed,
+            ))
+        else:
+            clear_state()
+            print("ONBOARDING_STATE_CLEARED")
+    except (OSError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/ess-maker-skills/scripts/push.py
+++ b/solutions/ess-maker-skills/scripts/push.py
@@ -741,9 +741,14 @@ def _cache_environment_sku(sku):
         config_path = os.path.join(".local", "config.json")
         with open(config_path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        if data.get("environmentSku") == sku:
+        target = (
+            data.setdefault("common", {})
+            if data.get("configVersion") == 2
+            else data
+        )
+        if target.get("environmentSku") == sku:
             return
-        data["environmentSku"] = sku
+        target["environmentSku"] = sku
         _atomic_write_text(config_path, json.dumps(data, indent=2))
     except Exception:  # noqa: BLE001 — caching is best-effort only
         pass

--- a/solutions/ess-maker-skills/scripts/setup.py
+++ b/solutions/ess-maker-skills/scripts/setup.py
@@ -38,6 +38,10 @@ import sys
 from datetime import date
 
 from auth import EXPECTED_CONFIG_VERSION
+from install_ess_agent import (
+    find_installation_by_schema,
+    load_installation_config,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -495,11 +499,21 @@ def write_config(agent_info, slug, output_dir, template_configs_discovered,
     crash mid-write cannot leave a corrupted half-JSON file that bricks
     the kit (the file gates every subsequent kit operation).
 
-    Supports multiple agents: maintains an `agents` array with all discovered
-    agents, `activeAgent` pointing to the current slug, and a backward-compat
-    `agent` field that mirrors the active agent.
+    Supports multiple agents using nested stable sections such as
+    `agents.da.esshr`, with shared environment settings under `common`.
     """
     bot_id = agent_info["botId"]
+    installation = find_installation_by_schema(
+        load_installation_config(),
+        agent_info["schema"],
+    )
+    if installation is None:
+        raise ValueError(
+            f"Agent schema '{agent_info['schema']}' is not mapped in the "
+            "ESS installation configuration."
+        )
+    config_key = installation["configKey"]
+    experience_key, agent_section = config_key.split(".", 1)
     agent_entry = {
         "name": agent_info["name"],
         "botId": bot_id,
@@ -507,6 +521,16 @@ def write_config(agent_info, slug, output_dir, template_configs_discovered,
         "isManaged": agent_info["managed"],
         "slug": slug,
         "folder": output_dir.replace("\\", "/"),
+        "installation": {
+            "status": "installed",
+        },
+        "extraction": {
+            "status": "complete",
+            "templateConfigsDiscovered": template_configs_discovered,
+            "templateConfigCount": template_config_count,
+            "workflowCount": workflow_count,
+            "evaluationCount": evaluation_count,
+        },
     }
 
     # Load existing config to preserve other agents and connections
@@ -532,33 +556,72 @@ def write_config(agent_info, slug, output_dir, template_configs_discovered,
             f"updating to v{EXPECTED_CONFIG_VERSION}."
         )
 
-    # Build or update agents array
-    agents = existing.get("agents", [])
+    if existing.get("configVersion") == 2:
+        agents = existing.get("agents") or {}
+        common = existing.get("common") or {}
+    else:
+        agents = {}
+        common = {}
+        legacy_agents = existing.get("agents") or []
+        if not legacy_agents and isinstance(existing.get("agent"), dict):
+            legacy_agents = [existing["agent"]]
+        for legacy_agent in legacy_agents:
+            legacy_schema = legacy_agent.get("schemaName")
+            if not legacy_schema:
+                continue
+            legacy_installation = find_installation_by_schema(
+                load_installation_config(),
+                legacy_schema,
+            )
+            if legacy_installation:
+                legacy_key = legacy_installation["configKey"]
+                legacy_experience, legacy_section = legacy_key.split(".", 1)
+            else:
+                legacy_experience = "legacy"
+                legacy_section = legacy_agent.get("slug", "agent")
+            migrated_agent = dict(legacy_agent)
+            migrated_agent["installation"] = {"status": "installed"}
+            migrated_agent["extraction"] = {"status": "complete"}
+            if legacy_agent.get("slug") == existing.get("activeAgent"):
+                migrated_agent["extraction"].update({
+                    key: existing[key]
+                    for key in (
+                        "templateConfigsDiscovered",
+                        "templateConfigCount",
+                        "workflowCount",
+                        "evaluationCount",
+                    )
+                    if key in existing
+                })
+            agents.setdefault(legacy_experience, {})[
+                legacy_section
+            ] = migrated_agent
+        for key, value in existing.items():
+            if key not in {
+                "configVersion",
+                "setup",
+                "agent",
+                "activeAgent",
+                "agents",
+                "dataverseEndpoint",
+                "templateConfigsDiscovered",
+                "templateConfigCount",
+                "workflowCount",
+                "evaluationCount",
+            }:
+                common[key] = value
+        if existing.get("dataverseEndpoint"):
+            common["dataverseEndpoint"] = existing["dataverseEndpoint"]
 
-    # Remove existing entry for this slug if present (update case)
-    agents = [a for a in agents if a.get("slug") != slug]
-    agents.append(agent_entry)
-
-    # Sort by name for consistent ordering
-    agents.sort(key=lambda a: a.get("name", ""))
-
+    agents.setdefault(experience_key, {})[agent_section] = agent_entry
+    common["dataverseEndpoint"] = agent_info["url"]
     config = {
         "configVersion": EXPECTED_CONFIG_VERSION,  # gated by auth.load_config
         "setup": "complete",
-        "agent": agent_entry,             # backward compat: active agent
-        "activeAgent": slug,              # slug of the active agent
-        "agents": agents,                 # all discovered agents
-        "dataverseEndpoint": agent_info["url"],
-        "templateConfigsDiscovered": template_configs_discovered,
-        "templateConfigCount": template_config_count,
-        "workflowCount": workflow_count,
-        "evaluationCount": evaluation_count,
+        "activeAgent": config_key,
+        "common": common,
+        "agents": agents,
     }
-
-    # Preserve existing connections and other user-set fields
-    for key in ("connections", "workdayTestEmployeeId", "referenceSource", "environmentSku"):
-        if key in existing and key not in config:
-            config[key] = existing[key]
 
     os.makedirs(local_dir, exist_ok=True)
     tmp_path = config_path + ".tmp"

--- a/solutions/ess-maker-skills/src/reference/ess-agent-installation/config.json
+++ b/solutions/ess-maker-skills/src/reference/ess-agent-installation/config.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": 1,
+  "experiences": {
+    "da": {
+      "label": "ESS as DA (Recommended)",
+      "description": "Install the declarative agent experience.",
+      "displayOrder": 1,
+      "recommended": true
+    },
+    "cea": {
+      "label": "ESS as CEA",
+      "description": "Install the custom engine agent experience.",
+      "displayOrder": 2,
+      "recommended": false
+    }
+  },
+  "verticals": {
+    "hr": {
+      "label": "Employee Self-Service HR",
+      "description": "Install the Human Resources agent.",
+      "displayOrder": 1
+    },
+    "it": {
+      "label": "Employee Self-Service IT",
+      "description": "Install the Information Technology agent.",
+      "displayOrder": 2
+    }
+  },
+  "installations": {
+    "da.hr": {
+      "experienceKey": "da",
+      "verticalKey": "hr",
+      "marketplaceApplication": {
+        "uniqueName": "msdyn_CopilotForEmployeeSelfServiceDAHR"
+      },
+      "solution": {
+        "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceDAHR"
+      },
+      "catalogMatch": {
+        "parentPackage": "Employee Self-Service HR",
+        "status": "Active (DA bundle)"
+      }
+    },
+    "da.it": {
+      "experienceKey": "da",
+      "verticalKey": "it",
+      "marketplaceApplication": {
+        "uniqueName": "msdyn_CopilotForEmployeeSelfServiceDAIT"
+      },
+      "solution": {
+        "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceDAIT"
+      },
+      "catalogMatch": {
+        "parentPackage": "Employee Self-Service IT",
+        "status": "Active (DA bundle)"
+      }
+    },
+    "cea.hr": {
+      "experienceKey": "cea",
+      "verticalKey": "hr",
+      "marketplaceApplication": {
+        "uniqueName": "msdyn_CopilotForEmployeeSelfServiceHR"
+      },
+      "solution": {
+        "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceHR"
+      },
+      "catalogMatch": {
+        "parentPackage": "Employee Self-Service HR",
+        "status": "Active (CEA bundle)"
+      }
+    },
+    "cea.it": {
+      "experienceKey": "cea",
+      "verticalKey": "it",
+      "marketplaceApplication": {
+        "uniqueName": "msdyn_CopilotForEmployeeSelfServiceIT"
+      },
+      "solution": {
+        "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceIT"
+      },
+      "catalogMatch": {
+        "parentPackage": "Employee Self-Service IT",
+        "status": "Active (CEA bundle)"
+      }
+    }
+  }
+}

--- a/solutions/ess-maker-skills/src/reference/ess-agent-installation/config.json
+++ b/solutions/ess-maker-skills/src/reference/ess-agent-installation/config.json
@@ -2,12 +2,14 @@
   "schemaVersion": 1,
   "experiences": {
     "da": {
+      "shortLabel": "DA",
       "label": "ESS as DA (Recommended)",
       "description": "Install the declarative agent experience.",
       "displayOrder": 1,
       "recommended": true
     },
     "cea": {
+      "shortLabel": "CEA",
       "label": "ESS as CEA",
       "description": "Install the custom engine agent experience.",
       "displayOrder": 2,
@@ -28,6 +30,7 @@
   },
   "installations": {
     "da.hr": {
+      "configKey": "da.esshr",
       "experienceKey": "da",
       "verticalKey": "hr",
       "marketplaceApplication": {
@@ -36,12 +39,14 @@
       "solution": {
         "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceDAHR"
       },
+      "requiredConnection": null,
       "catalogMatch": {
         "parentPackage": "Employee Self-Service HR",
         "status": "Active (DA bundle)"
       }
     },
     "da.it": {
+      "configKey": "da.essit",
       "experienceKey": "da",
       "verticalKey": "it",
       "marketplaceApplication": {
@@ -50,12 +55,19 @@
       "solution": {
         "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceDAIT"
       },
+      "requiredConnection": {
+        "displayName": "Microsoft 365 Self-Help",
+        "connectorApiName": "shared_alchemy",
+        "referenceLogicalName": "msdyn_copilotforemployeeselfservicedait.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319",
+        "creationGuidance": "In make.powerapps.com, select the target environment, open Connections, choose New connection, search for Microsoft 365 Self-Help, and create the connection."
+      },
       "catalogMatch": {
         "parentPackage": "Employee Self-Service IT",
         "status": "Active (DA bundle)"
       }
     },
     "cea.hr": {
+      "configKey": "cea.esshr",
       "experienceKey": "cea",
       "verticalKey": "hr",
       "marketplaceApplication": {
@@ -64,12 +76,14 @@
       "solution": {
         "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceHR"
       },
+      "requiredConnection": null,
       "catalogMatch": {
         "parentPackage": "Employee Self-Service HR",
         "status": "Active (CEA bundle)"
       }
     },
     "cea.it": {
+      "configKey": "cea.essit",
       "experienceKey": "cea",
       "verticalKey": "it",
       "marketplaceApplication": {
@@ -77,6 +91,12 @@
       },
       "solution": {
         "parentUniqueName": "msdyn_CopilotForEmployeeSelfServiceIT"
+      },
+      "requiredConnection": {
+        "displayName": "Microsoft 365 Self-Help",
+        "connectorApiName": "shared_alchemy",
+        "referenceLogicalName": "msdyn_copilotforemployeeselfserviceit.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319",
+        "creationGuidance": "In make.powerapps.com, select the target environment, open Connections, choose New connection, search for Microsoft 365 Self-Help, and create the connection."
       },
       "catalogMatch": {
         "parentPackage": "Employee Self-Service IT",

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/powerfx-topic-local.md
@@ -11,7 +11,7 @@ the one `.mcs.yml` file, needing only the topic itself.
 
 ## How to run this lens
 
-You are invoked with the path to one authored topic (`{agent.folder}/topics/{Name}.mcs.yml`). Read the
+You are invoked with the path to one authored topic (`{ACTIVE_AGENT.folder}/topics/{Name}.mcs.yml`). Read the
 whole file. Walk every Power Fx expression (any value beginning with `=`, and expression bodies inside
 `AdaptiveCardPrompt.card` / `AdaptiveCardTemplate.cardContent`). Evaluate each against the heuristics
 below. This is a **judgment lens**, not a closed rule set — each heuristic is a starting question; the

--- a/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/conformance/scoped-review.md
@@ -11,7 +11,7 @@ The scope is a **module id** — a filename prefix shared by a backend's topics 
 `servicenow-itsm`, `workday`).
 
 **Resolve the in-scope set once, by prefix, and use that exact set for everything.** The in-scope topics are
-`{agent.folder}/topics/{module-id}*.mcs.yml` — a **prefix** match (the same `startswith` the detectors'
+`{ACTIVE_AGENT.folder}/topics/{module-id}*.mcs.yml` — a **prefix** match (the same `startswith` the detectors'
 `--module` uses), never a substring match. List them and let **N = that count**; both the review loop and the
 S-4 "N topics" figure must come from this one enumerated set, so the reported count always equals what was
 actually reviewed. A broad or non-canonical term can resolve to more than one backend — e.g. `servicenow`

--- a/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/permissions-required.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/flightcheck/permissions-required.md
@@ -66,11 +66,11 @@ WD-SEC-003 Personal Data write-permission runtime probe.
 1. **Environment variables** — if already set (e.g., from a CI pipeline)
 2. **`.vscode/mcp.json`** — base URL and tenant are read directly (they're
    not secrets). Username/password use `${input:...}` so they can't be read.
-3. **`.local/config.json`** → `connections.Workday` — tenant and base URL from
+3. **`.local/config.json`** → `common.connections.Workday` — tenant and base URL from
    the `/connect workday` setup
 4. **Interactive prompt** — if creds still missing, prompts for ISU username
    and password at runtime. **Never saved to disk.**
-5. **`.local/config.json`** → `workdayTestEmployeeId` — cached after first prompt
+5. **`.local/config.json`** → `common.workdayTestEmployeeId` — cached after first prompt
    so you only enter it once
 
 Environment variables needed (if not auto-resolved):

--- a/solutions/ess-maker-skills/src/reference/solution-catalog.md
+++ b/solutions/ess-maker-skills/src/reference/solution-catalog.md
@@ -22,6 +22,12 @@ reference names, and runtime sources from packaged workflow definitions.
 
 ## Parents
 
+> [!IMPORTANT]
+>
+> `scripts/install_ess_agent.py` resolves Marketplace applications from the
+> **Parent package**, **Parent schema name**, and **Status** values below.
+> Keep those values stable when editing this catalog.
+
 | # | Parent package | Parent schema name | Status | Parent connection reference (logical name — connector) |
 | --- | --- | --- | --- | --- |
 | 1 | Employee Self-Service HR | `msdyn_CopilotForEmployeeSelfServiceHR` | Active (CEA bundle) | _(none)_ |

--- a/solutions/ess-maker-skills/src/reference/solution-catalog.md
+++ b/solutions/ess-maker-skills/src/reference/solution-catalog.md
@@ -18,7 +18,8 @@ reference names, and runtime sources from packaged workflow definitions.
 
 - A **child** declares its parent via `applicationTargets[].targetApplicationUniqueName`. An **anchor** package declares its own schema name via `AnchorSolutionUniqueName` and has no `applicationTargets`; an anchor targeted by at least one child is listed below as a **parent**.
 - **Schema name** is the `msdyn_...` unique name (the key under `DeploymentSettings[]` for a child). It does not always equal `msdyn_` + the package name.
-- The **Connector** column shows the short connector name; every connector id has the constant prefix `/providers/Microsoft.PowerApps/apis/` (omitted for brevity).
+- The **Connector** column shows the friendly name displayed in Power Apps and
+  the packaged connection-reference logical name on separate lines.
 
 ## Parents
 
@@ -30,76 +31,76 @@ reference names, and runtime sources from packaged workflow definitions.
 > **Parent package**, **Parent schema name**, and **Status** values below.
 > Update both files together.
 
-| # | Parent package | Parent schema name | Status | Parent connection reference (logical name — connector) |
+| # | Parent package | Parent schema name | Status | Required connector |
 | --- | --- | --- | --- | --- |
 | 1 | Employee Self-Service HR | `msdyn_CopilotForEmployeeSelfServiceHR` | Active (CEA bundle) | _(none)_ |
-| 2 | Employee Self-Service IT | `msdyn_CopilotForEmployeeSelfServiceIT` | Active (CEA bundle) | `msdyn_copilotforemployeeselfserviceit.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319` — `shared_alchemy` |
+| 2 | Employee Self-Service IT | `msdyn_CopilotForEmployeeSelfServiceIT` | Active (CEA bundle) | Name: `Microsoft 365 Self-Help`<br>Logical name: `msdyn_copilotforemployeeselfserviceit.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319` |
 | 3 | Employee Self-Service HR | `msdyn_CopilotForEmployeeSelfServiceDAHR` | Active (DA bundle) | _(none)_ |
-| 4 | Employee Self-Service IT | `msdyn_CopilotForEmployeeSelfServiceDAIT` | Active (DA bundle) | `msdyn_copilotforemployeeselfservicedait.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319` — `shared_alchemy` |
+| 4 | Employee Self-Service IT | `msdyn_CopilotForEmployeeSelfServiceDAIT` | Active (DA bundle) | Name: `Microsoft 365 Self-Help`<br>Logical name: `msdyn_copilotforemployeeselfservicedait.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319` |
 
 ## Child packages, connection references, and flows
 
 Each row maps a packaged cloud flow to one connection reference declared in that flow's `properties.connectionReferences` block. Flows using multiple connectors therefore appear on multiple rows. Flows without declared connection references are omitted. Blank cells continue the value from the preceding row, providing a vertically grouped view.
 
-| Parent schema | Child package | Child schema | Logical name | Connector | Flow usage |
-| --- | --- | --- | --- | --- | --- |
-| `msdyn_CopilotForEmployeeSelfServiceDAHR` | `ESS DA HR ServiceNow HRSD` | `msdyn_EssDAHRServiceNowHRSD` | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS DA HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `embedded` |
-|  |  |  | `msdyn_copilotforemployeeselfservicedahr.a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03.shared_service-now` | `shared_service-now` | title: `ESS DA HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS DA HR ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `b9a7f3c8-1d5e-4e0f-96c3-7b2184d5f219`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceDAHR` | `ESS DA HR Workday` | `msdyn_EssDAHRWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `invoker` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday References`<br>workflowid: `8ed25b3a-8a7d-4007-95f5-b81fc662f3ae`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `9248c265-3050-4aeb-834a-8d90fedf9df5`<br>runtime: `invoker` |
-| `msdyn_CopilotForEmployeeSelfServiceDAIT` | `ESS DA IT ServiceNow ITSM` | `msdyn_EssDAITServiceNowITSM` | `msdyn_copilotforemployeeselfservicedait.cr.w2LCWZTZ` | `shared_service-now` | title: `ESS DA IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS DA IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS DAIT ServiceNow ITSM Get Tickets List`<br>workflowid: `4b2c3d1e-5f6a-7b8c-9d0e-1f2a3b4c5d6e`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS DA IT ServiceNow ITSM Request Body Generator`<br>workflowid: `8c7b6a5d-4e3f-2b1a-0c9d-7e6f5a4b3c2d`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceDAIT` | `ESS DA IT Workday` | `msdyn_EssDAITWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `invoker` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday References`<br>workflowid: `ac166e76-b8fd-4ae0-95cd-ea2942d2517d`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `b7f07ab6-da94-4e92-a6ef-a7193068ea48`<br>runtime: `invoker` |
-| `msdyn_CopilotForEmployeeSelfServiceHR` | `ESS HR ADP` | `msdyn_EssHRADP` | `new_sharedadpemployeeselfservi_de34b` | `shared_adpemployeeselfservi` | title: `[ADP] Flow - Unified`<br>workflowid: `5a62a319-c943-f111-88b4-7c1e528d11b6`<br>runtime: `invoker` |
-| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow HR` | `msdyn_EssHRServiceNowHRSD` | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `embedded` |
-|  |  |  | `msdyn_copilotforemployeeselfservicehr.a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03.shared_service-now` | `shared_service-now` | title: `ESS HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `b9a7f3c8-1d5e-4e0f-96c3-7b2184d5f219`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow IT` | `msdyn_EssHRServiceNowITSM` | `msdyn_copilotforemployeeselfservicehr.cr.w2LCWZTZ` | `shared_service-now` | title: `ESS HR ServiceNow ITSM Common Orchestrator`<br>workflowid: `7e2b1c3a-9f4a-4e2a-8b1e-2c3a9f4a8b1e`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow ITSM Common Orchestrator`<br>workflowid: `7e2b1c3a-9f4a-4e2a-8b1e-2c3a9f4a8b1e`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS HR ServiceNow ITSM Get Tickets List`<br>workflowid: `2a4c7e1b-3f9a-4b2e-8c1a-7e1b3f9a4b2e`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS HR ServiceNow ITSM Request Body Generator`<br>workflowid: `9f1e2c3a-7b4a-4e2c-8a1e-2c3a7b4a4e2c`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow Live Agent` | `msdyn_EssHRServiceNowLiveAgent` | `new_sharedservicenow_4ef05` | `shared_service-now` | title: `ESS HR ServiceNow Live Agent Save Summary`<br>workflowid: `4b3f7e5c-9a1d-4c8e-b6a2-5f9d8c7b6a5e`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_09a8b` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow Live Agent Save Summary`<br>workflowid: `4b3f7e5c-9a1d-4c8e-b6a2-5f9d8c7b6a5e`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceHR` | `SAP SuccessFactors` | `msdyn_EssHRSuccessFactors` | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Check User Permissions`<br>workflowid: `d86f46b5-bd1f-4e85-bb13-60b4da317d22`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `SuccessFactors Get Active UserId`<br>workflowid: `dab82937-ccdf-45b6-9406-322aa3782b18`<br>runtime: `embedded` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `SuccessFactors Get User Context`<br>workflowid: `7e728b04-1cdc-453f-966d-186258532203`<br>runtime: `embedded` |
-|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Get User Context`<br>workflowid: `7e728b04-1cdc-453f-966d-186258532203`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `SuccessFactors Role Based Permission Orchestrator`<br>workflowid: `2c6e7a1f-8b2a-4b76-9d3f-42c9e16f5b8e`<br>runtime: `embedded` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `SuccessFactors Run Common Orchestrator`<br>workflowid: `5a4c9f8d-3b77-4e12-9a3f-91f0e8d6c2ab`<br>runtime: `embedded` |
-|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Run Common Orchestrator`<br>workflowid: `5a4c9f8d-3b77-4e12-9a3f-91f0e8d6c2ab`<br>runtime: `invoker` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `SuccessFactors Run Update Orchestrator`<br>workflowid: `f8e2735a-2c41-4f79-9b14-1e4e7c3a90d6`<br>runtime: `embedded` |
-|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Run Update Orchestrator`<br>workflowid: `f8e2735a-2c41-4f79-9b14-1e4e7c3a90d6`<br>runtime: `invoker` |
-| `msdyn_CopilotForEmployeeSelfServiceHR` | `Workday` | `msdyn_EssHRWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `invoker` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday References`<br>workflowid: `6e70ebc7-0461-f111-a826-000d3a37207f`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `9248c265-3050-4aeb-834a-8d90fedf9df5`<br>runtime: `invoker` |
-| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow HR` | `msdyn_EssITServiceNowHRSD` | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS IT ServiceNow HRSD Common Orchestrator`<br>workflowid: `c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265`<br>runtime: `embedded` |
-|  |  |  | `msdyn_copilotforemployeeselfserviceit.c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265.shared_service-now` | `shared_service-now` | title: `ESS IT ServiceNow HRSD Common Orchestrator`<br>workflowid: `c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS IT ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `7d92a3f4-1b4f-42e9-9d52-6a1c3eae0b98`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow IT` | `msdyn_EssITServiceNowITSM` | `msdyn_copilotforemployeeselfserviceit.cr.w2LCWZTZ` | `shared_service-now` | title: `    ESS IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `    ESS IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS IT ServiceNow ITSM Get Tickets List`<br>workflowid: `4b2c3d1e-5f6a-7b8c-9d0e-1f2a3b4c5d6e`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS IT ServiceNow ITSM Request Body Generator`<br>workflowid: `8c7b6a5d-4e3f-2b1a-0c9d-7e6f5a4b3c2d`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow Live Agent` | `msdyn_EssITServiceNowLiveAgent` | `new_sharedservicenow_4ef05` | `shared_service-now` | title: `ESS IT ServiceNow Live Agent Save Summary`<br>workflowid: `324108e4-1f40-f011-b4cb-6045bd04a751`<br>runtime: `invoker` |
-|  |  |  | `new_sharedcommondataserviceforapps_09a8b` | `shared_commondataserviceforapps` | title: `ESS IT ServiceNow Live Agent Save Summary`<br>workflowid: `324108e4-1f40-f011-b4cb-6045bd04a751`<br>runtime: `embedded` |
-| `msdyn_CopilotForEmployeeSelfServiceIT` | `SAP SuccessFactors` | `msdyn_EssITSuccessFactors` | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Check User Permissions`<br>workflowid: `03c24504-d765-45f7-b9db-cc50e8b9439c`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS IT SuccessFactors Get Active UserId`<br>workflowid: `022a5b46-188a-455d-90c2-30d09b07f3f9`<br>runtime: `embedded` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `ESS IT SuccessFactors Get User Context`<br>workflowid: `023c7886-0d29-42bc-8a92-6962e35caf94`<br>runtime: `embedded` |
-|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Get User Context`<br>workflowid: `023c7886-0d29-42bc-8a92-6962e35caf94`<br>runtime: `embedded` |
-|  |  |  |  |  | title: `ESS IT SuccessFactors Role Based Permission Orchestrator`<br>workflowid: `3491c2a8-d0c2-4f21-9de4-a86dbcb109d0`<br>runtime: `embedded` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `ESS IT SuccessFactors Run Common Orchestrator`<br>workflowid: `3675542c-3d9c-42b7-85b7-d425ebbacdb4`<br>runtime: `embedded` |
-|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Run Common Orchestrator`<br>workflowid: `3675542c-3d9c-42b7-85b7-d425ebbacdb4`<br>runtime: `invoker` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `ESS IT SuccessFactors Run Update Orchestrator`<br>workflowid: `62a2f392-ec98-47e3-8821-754cefa60c2b`<br>runtime: `embedded` |
-|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Run Update Orchestrator`<br>workflowid: `62a2f392-ec98-47e3-8821-754cefa60c2b`<br>runtime: `invoker` |
-| `msdyn_CopilotForEmployeeSelfServiceIT` | `Workday` | `msdyn_EssITWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `invoker` |
-|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday References`<br>workflowid: `8a2bd039-81a5-4cfd-9bad-7878a216dad5`<br>runtime: `embedded` |
-|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `c5afa366-eaa3-435f-823e-3c188ebd03a2`<br>runtime: `invoker` |
+| Parent schema | Child package | Child schema | Connector | Flow usage |
+| --- | --- | --- | --- | --- |
+| `msdyn_CopilotForEmployeeSelfServiceDAHR` | `ESS DA HR ServiceNow HRSD` | `msdyn_EssDAHRServiceNowHRSD` | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS DA HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `embedded` |
+|  |  |  | Name: `ServiceNow`<br>Logical name: `msdyn_copilotforemployeeselfservicedahr.a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03.shared_service-now` | title: `ESS DA HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS DA HR ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `b9a7f3c8-1d5e-4e0f-96c3-7b2184d5f219`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceDAHR` | `ESS DA HR Workday` | `msdyn_EssDAHRWorkday` | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS HR Workday References`<br>workflowid: `8ed25b3a-8a7d-4007-95f5-b81fc662f3ae`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `WorkdayRESTExecution`<br>workflowid: `9248c265-3050-4aeb-834a-8d90fedf9df5`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceDAIT` | `ESS DA IT ServiceNow ITSM` | `msdyn_EssDAITServiceNowITSM` | Name: `ServiceNow`<br>Logical name: `msdyn_copilotforemployeeselfservicedait.cr.w2LCWZTZ` | title: `ESS DA IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS DA IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS DAIT ServiceNow ITSM Get Tickets List`<br>workflowid: `4b2c3d1e-5f6a-7b8c-9d0e-1f2a3b4c5d6e`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS DA IT ServiceNow ITSM Request Body Generator`<br>workflowid: `8c7b6a5d-4e3f-2b1a-0c9d-7e6f5a4b3c2d`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceDAIT` | `ESS DA IT Workday` | `msdyn_EssDAITWorkday` | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS IT Workday References`<br>workflowid: `ac166e76-b8fd-4ae0-95cd-ea2942d2517d`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `WorkdayRESTExecution`<br>workflowid: `b7f07ab6-da94-4e92-a6ef-a7193068ea48`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ESS HR ADP` | `msdyn_EssHRADP` | Name: `ADP Employee Self Service`<br>Logical name: `new_sharedadpemployeeselfservi_de34b` | title: `[ADP] Flow - Unified`<br>workflowid: `5a62a319-c943-f111-88b4-7c1e528d11b6`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow HR` | `msdyn_EssHRServiceNowHRSD` | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `embedded` |
+|  |  |  | Name: `ServiceNow`<br>Logical name: `msdyn_copilotforemployeeselfservicehr.a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03.shared_service-now` | title: `ESS HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS HR ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `b9a7f3c8-1d5e-4e0f-96c3-7b2184d5f219`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow IT` | `msdyn_EssHRServiceNowITSM` | Name: `ServiceNow`<br>Logical name: `msdyn_copilotforemployeeselfservicehr.cr.w2LCWZTZ` | title: `ESS HR ServiceNow ITSM Common Orchestrator`<br>workflowid: `7e2b1c3a-9f4a-4e2a-8b1e-2c3a9f4a8b1e`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS HR ServiceNow ITSM Common Orchestrator`<br>workflowid: `7e2b1c3a-9f4a-4e2a-8b1e-2c3a9f4a8b1e`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS HR ServiceNow ITSM Get Tickets List`<br>workflowid: `2a4c7e1b-3f9a-4b2e-8c1a-7e1b3f9a4b2e`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS HR ServiceNow ITSM Request Body Generator`<br>workflowid: `9f1e2c3a-7b4a-4e2c-8a1e-2c3a7b4a4e2c`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow Live Agent` | `msdyn_EssHRServiceNowLiveAgent` | Name: `ServiceNow`<br>Logical name: `new_sharedservicenow_4ef05` | title: `ESS HR ServiceNow Live Agent Save Summary`<br>workflowid: `4b3f7e5c-9a1d-4c8e-b6a2-5f9d8c7b6a5e`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_09a8b` | title: `ESS HR ServiceNow Live Agent Save Summary`<br>workflowid: `4b3f7e5c-9a1d-4c8e-b6a2-5f9d8c7b6a5e`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `SAP SuccessFactors` | `msdyn_EssHRSuccessFactors` | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `SuccessFactors Check User Permissions`<br>workflowid: `d86f46b5-bd1f-4e85-bb13-60b4da317d22`<br>runtime: `embedded` |
+|  |  |  |  | title: `SuccessFactors Get Active UserId`<br>workflowid: `dab82937-ccdf-45b6-9406-322aa3782b18`<br>runtime: `embedded` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_241f6` | title: `SuccessFactors Get User Context`<br>workflowid: `7e728b04-1cdc-453f-966d-186258532203`<br>runtime: `embedded` |
+|  |  |  | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `SuccessFactors Get User Context`<br>workflowid: `7e728b04-1cdc-453f-966d-186258532203`<br>runtime: `embedded` |
+|  |  |  |  | title: `SuccessFactors Role Based Permission Orchestrator`<br>workflowid: `2c6e7a1f-8b2a-4b76-9d3f-42c9e16f5b8e`<br>runtime: `embedded` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_241f6` | title: `SuccessFactors Run Common Orchestrator`<br>workflowid: `5a4c9f8d-3b77-4e12-9a3f-91f0e8d6c2ab`<br>runtime: `embedded` |
+|  |  |  | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `SuccessFactors Run Common Orchestrator`<br>workflowid: `5a4c9f8d-3b77-4e12-9a3f-91f0e8d6c2ab`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_241f6` | title: `SuccessFactors Run Update Orchestrator`<br>workflowid: `f8e2735a-2c41-4f79-9b14-1e4e7c3a90d6`<br>runtime: `embedded` |
+|  |  |  | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `SuccessFactors Run Update Orchestrator`<br>workflowid: `f8e2735a-2c41-4f79-9b14-1e4e7c3a90d6`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `Workday` | `msdyn_EssHRWorkday` | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS HR Workday References`<br>workflowid: `6e70ebc7-0461-f111-a826-000d3a37207f`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `WorkdayRESTExecution`<br>workflowid: `9248c265-3050-4aeb-834a-8d90fedf9df5`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow HR` | `msdyn_EssITServiceNowHRSD` | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS IT ServiceNow HRSD Common Orchestrator`<br>workflowid: `c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265`<br>runtime: `embedded` |
+|  |  |  | Name: `ServiceNow`<br>Logical name: `msdyn_copilotforemployeeselfserviceit.c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265.shared_service-now` | title: `ESS IT ServiceNow HRSD Common Orchestrator`<br>workflowid: `c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `ESS IT ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `7d92a3f4-1b4f-42e9-9d52-6a1c3eae0b98`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow IT` | `msdyn_EssITServiceNowITSM` | Name: `ServiceNow`<br>Logical name: `msdyn_copilotforemployeeselfserviceit.cr.w2LCWZTZ` | title: `    ESS IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_41c83` | title: `    ESS IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS IT ServiceNow ITSM Get Tickets List`<br>workflowid: `4b2c3d1e-5f6a-7b8c-9d0e-1f2a3b4c5d6e`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS IT ServiceNow ITSM Request Body Generator`<br>workflowid: `8c7b6a5d-4e3f-2b1a-0c9d-7e6f5a4b3c2d`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow Live Agent` | `msdyn_EssITServiceNowLiveAgent` | Name: `ServiceNow`<br>Logical name: `new_sharedservicenow_4ef05` | title: `ESS IT ServiceNow Live Agent Save Summary`<br>workflowid: `324108e4-1f40-f011-b4cb-6045bd04a751`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `new_sharedcommondataserviceforapps_09a8b` | title: `ESS IT ServiceNow Live Agent Save Summary`<br>workflowid: `324108e4-1f40-f011-b4cb-6045bd04a751`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `SAP SuccessFactors` | `msdyn_EssITSuccessFactors` | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `ESS IT SuccessFactors Check User Permissions`<br>workflowid: `03c24504-d765-45f7-b9db-cc50e8b9439c`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS IT SuccessFactors Get Active UserId`<br>workflowid: `022a5b46-188a-455d-90c2-30d09b07f3f9`<br>runtime: `embedded` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_241f6` | title: `ESS IT SuccessFactors Get User Context`<br>workflowid: `023c7886-0d29-42bc-8a92-6962e35caf94`<br>runtime: `embedded` |
+|  |  |  | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `ESS IT SuccessFactors Get User Context`<br>workflowid: `023c7886-0d29-42bc-8a92-6962e35caf94`<br>runtime: `embedded` |
+|  |  |  |  | title: `ESS IT SuccessFactors Role Based Permission Orchestrator`<br>workflowid: `3491c2a8-d0c2-4f21-9de4-a86dbcb109d0`<br>runtime: `embedded` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_241f6` | title: `ESS IT SuccessFactors Run Common Orchestrator`<br>workflowid: `3675542c-3d9c-42b7-85b7-d425ebbacdb4`<br>runtime: `embedded` |
+|  |  |  | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `ESS IT SuccessFactors Run Common Orchestrator`<br>workflowid: `3675542c-3d9c-42b7-85b7-d425ebbacdb4`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_241f6` | title: `ESS IT SuccessFactors Run Update Orchestrator`<br>workflowid: `62a2f392-ec98-47e3-8821-754cefa60c2b`<br>runtime: `embedded` |
+|  |  |  | Name: `SAP OData`<br>Logical name: `new_sharedsapodata_b7454` | title: `ESS IT SuccessFactors Run Update Orchestrator`<br>workflowid: `62a2f392-ec98-47e3-8821-754cefa60c2b`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `Workday` | `msdyn_EssITWorkday` | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `invoker` |
+|  |  |  | Name: `Microsoft Dataverse`<br>Logical name: `msdyn_sharedcommondataserviceforapps_92b66` | title: `ESS IT Workday References`<br>workflowid: `8a2bd039-81a5-4cfd-9bad-7878a216dad5`<br>runtime: `embedded` |
+|  |  |  | Name: `Workday`<br>Logical name: `new_sharedworkdaysoap_ff0df` | title: `WorkdayRESTExecution`<br>workflowid: `c5afa366-eaa3-435f-823e-3c188ebd03a2`<br>runtime: `invoker` |

--- a/solutions/ess-maker-skills/src/reference/solution-catalog.md
+++ b/solutions/ess-maker-skills/src/reference/solution-catalog.md
@@ -24,9 +24,11 @@ reference names, and runtime sources from packaged workflow definitions.
 
 > [!IMPORTANT]
 >
-> `scripts/install_ess_agent.py` resolves Marketplace applications from the
+> `src/reference/ess-agent-installation/config.json` stores the installation
+> selector and Marketplace identities. `scripts/install_ess_agent.py` validates
+> every configured application and parent solution unique name against the
 > **Parent package**, **Parent schema name**, and **Status** values below.
-> Keep those values stable when editing this catalog.
+> Update both files together.
 
 | # | Parent package | Parent schema name | Status | Parent connection reference (logical name — connector) |
 | --- | --- | --- | --- | --- |

--- a/solutions/ess-maker-skills/src/reference/solution-catalog.md
+++ b/solutions/ess-maker-skills/src/reference/solution-catalog.md
@@ -1,0 +1,97 @@
+# Solution Catalog
+
+This catalog maps each **parent package** to its **child packages**, together with the connection references each child package requires.
+
+> [!NOTE]
+>
+> This is a static source-package catalog. It describes package dependencies,
+> declared connection references, and packaged cloud-flow definitions. It does
+> **not** report which solutions are installed in a customer environment,
+> whether connection references are bound, or whether connections are active.
+
+**Provenance:** This catalog was generated from the `essvivacopilot` solution
+source tree at commit `6c9cf4b4f9a8d5b85505160019ef2d2e7e0ed102`
+(reviewed **2026-07-31**). Package relationships and schema values were read
+from package manifests, connection-reference definitions from solution
+customization XML, and flow names, workflow IDs, connector names, logical
+reference names, and runtime sources from packaged workflow definitions.
+
+- A **child** declares its parent via `applicationTargets[].targetApplicationUniqueName`. An **anchor** package declares its own schema name via `AnchorSolutionUniqueName` and has no `applicationTargets`; an anchor targeted by at least one child is listed below as a **parent**.
+- **Schema name** is the `msdyn_...` unique name (the key under `DeploymentSettings[]` for a child). It does not always equal `msdyn_` + the package name.
+- The **Connector** column shows the short connector name; every connector id has the constant prefix `/providers/Microsoft.PowerApps/apis/` (omitted for brevity).
+
+## Parents
+
+| # | Parent package | Parent schema name | Status | Parent connection reference (logical name — connector) |
+| --- | --- | --- | --- | --- |
+| 1 | Employee Self-Service HR | `msdyn_CopilotForEmployeeSelfServiceHR` | Active (CEA bundle) | _(none)_ |
+| 2 | Employee Self-Service IT | `msdyn_CopilotForEmployeeSelfServiceIT` | Active (CEA bundle) | `msdyn_copilotforemployeeselfserviceit.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319` — `shared_alchemy` |
+| 3 | Employee Self-Service HR | `msdyn_CopilotForEmployeeSelfServiceDAHR` | Active (DA bundle) | _(none)_ |
+| 4 | Employee Self-Service IT | `msdyn_CopilotForEmployeeSelfServiceDAIT` | Active (DA bundle) | `msdyn_copilotforemployeeselfservicedait.shared_alchemy.shared-alchemy-8262076a-e778-450b-8a35-5ae815712319` — `shared_alchemy` |
+
+## Child packages, connection references, and flows
+
+Each row maps a packaged cloud flow to one connection reference declared in that flow's `properties.connectionReferences` block. Flows using multiple connectors therefore appear on multiple rows. Flows without declared connection references are omitted. Blank cells continue the value from the preceding row, providing a vertically grouped view.
+
+| Parent schema | Child package | Child schema | Logical name | Connector | Flow usage |
+| --- | --- | --- | --- | --- | --- |
+| `msdyn_CopilotForEmployeeSelfServiceDAHR` | `ESS DA HR ServiceNow HRSD` | `msdyn_EssDAHRServiceNowHRSD` | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS DA HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `embedded` |
+|  |  |  | `msdyn_copilotforemployeeselfservicedahr.a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03.shared_service-now` | `shared_service-now` | title: `ESS DA HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS DA HR ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `b9a7f3c8-1d5e-4e0f-96c3-7b2184d5f219`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceDAHR` | `ESS DA HR Workday` | `msdyn_EssDAHRWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `invoker` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday References`<br>workflowid: `8ed25b3a-8a7d-4007-95f5-b81fc662f3ae`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `9248c265-3050-4aeb-834a-8d90fedf9df5`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceDAIT` | `ESS DA IT ServiceNow ITSM` | `msdyn_EssDAITServiceNowITSM` | `msdyn_copilotforemployeeselfservicedait.cr.w2LCWZTZ` | `shared_service-now` | title: `ESS DA IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS DA IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS DAIT ServiceNow ITSM Get Tickets List`<br>workflowid: `4b2c3d1e-5f6a-7b8c-9d0e-1f2a3b4c5d6e`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS DA IT ServiceNow ITSM Request Body Generator`<br>workflowid: `8c7b6a5d-4e3f-2b1a-0c9d-7e6f5a4b3c2d`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceDAIT` | `ESS DA IT Workday` | `msdyn_EssDAITWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `invoker` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday References`<br>workflowid: `ac166e76-b8fd-4ae0-95cd-ea2942d2517d`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `b7f07ab6-da94-4e92-a6ef-a7193068ea48`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ESS HR ADP` | `msdyn_EssHRADP` | `new_sharedadpemployeeselfservi_de34b` | `shared_adpemployeeselfservi` | title: `[ADP] Flow - Unified`<br>workflowid: `5a62a319-c943-f111-88b4-7c1e528d11b6`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow HR` | `msdyn_EssHRServiceNowHRSD` | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `embedded` |
+|  |  |  | `msdyn_copilotforemployeeselfservicehr.a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03.shared_service-now` | `shared_service-now` | title: `ESS HR ServiceNow HRSD Common Orchestrator`<br>workflowid: `a1f4c28d-6b7c-49b9-a32e-55d8f19c7a03`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `b9a7f3c8-1d5e-4e0f-96c3-7b2184d5f219`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow IT` | `msdyn_EssHRServiceNowITSM` | `msdyn_copilotforemployeeselfservicehr.cr.w2LCWZTZ` | `shared_service-now` | title: `ESS HR ServiceNow ITSM Common Orchestrator`<br>workflowid: `7e2b1c3a-9f4a-4e2a-8b1e-2c3a9f4a8b1e`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow ITSM Common Orchestrator`<br>workflowid: `7e2b1c3a-9f4a-4e2a-8b1e-2c3a9f4a8b1e`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS HR ServiceNow ITSM Get Tickets List`<br>workflowid: `2a4c7e1b-3f9a-4b2e-8c1a-7e1b3f9a4b2e`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS HR ServiceNow ITSM Request Body Generator`<br>workflowid: `9f1e2c3a-7b4a-4e2c-8a1e-2c3a7b4a4e2c`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `ServiceNow Live Agent` | `msdyn_EssHRServiceNowLiveAgent` | `new_sharedservicenow_4ef05` | `shared_service-now` | title: `ESS HR ServiceNow Live Agent Save Summary`<br>workflowid: `4b3f7e5c-9a1d-4c8e-b6a2-5f9d8c7b6a5e`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_09a8b` | `shared_commondataserviceforapps` | title: `ESS HR ServiceNow Live Agent Save Summary`<br>workflowid: `4b3f7e5c-9a1d-4c8e-b6a2-5f9d8c7b6a5e`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `SAP SuccessFactors` | `msdyn_EssHRSuccessFactors` | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Check User Permissions`<br>workflowid: `d86f46b5-bd1f-4e85-bb13-60b4da317d22`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `SuccessFactors Get Active UserId`<br>workflowid: `dab82937-ccdf-45b6-9406-322aa3782b18`<br>runtime: `embedded` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `SuccessFactors Get User Context`<br>workflowid: `7e728b04-1cdc-453f-966d-186258532203`<br>runtime: `embedded` |
+|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Get User Context`<br>workflowid: `7e728b04-1cdc-453f-966d-186258532203`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `SuccessFactors Role Based Permission Orchestrator`<br>workflowid: `2c6e7a1f-8b2a-4b76-9d3f-42c9e16f5b8e`<br>runtime: `embedded` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `SuccessFactors Run Common Orchestrator`<br>workflowid: `5a4c9f8d-3b77-4e12-9a3f-91f0e8d6c2ab`<br>runtime: `embedded` |
+|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Run Common Orchestrator`<br>workflowid: `5a4c9f8d-3b77-4e12-9a3f-91f0e8d6c2ab`<br>runtime: `invoker` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `SuccessFactors Run Update Orchestrator`<br>workflowid: `f8e2735a-2c41-4f79-9b14-1e4e7c3a90d6`<br>runtime: `embedded` |
+|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `SuccessFactors Run Update Orchestrator`<br>workflowid: `f8e2735a-2c41-4f79-9b14-1e4e7c3a90d6`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceHR` | `Workday` | `msdyn_EssHRWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS HR Workday`<br>workflowid: `9f1b2c3d-4e5f-6789-abcd-1234567890ab`<br>runtime: `invoker` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS HR Workday References`<br>workflowid: `6e70ebc7-0461-f111-a826-000d3a37207f`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `9248c265-3050-4aeb-834a-8d90fedf9df5`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow HR` | `msdyn_EssITServiceNowHRSD` | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS IT ServiceNow HRSD Common Orchestrator`<br>workflowid: `c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265`<br>runtime: `embedded` |
+|  |  |  | `msdyn_copilotforemployeeselfserviceit.c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265.shared_service-now` | `shared_service-now` | title: `ESS IT ServiceNow HRSD Common Orchestrator`<br>workflowid: `c3d5c4e2-5f11-4a7e-9f3b-9c57e1d78265`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `ESS IT ServiceNow HRSD Get HR Services With COEs for User`<br>workflowid: `7d92a3f4-1b4f-42e9-9d52-6a1c3eae0b98`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow IT` | `msdyn_EssITServiceNowITSM` | `msdyn_copilotforemployeeselfserviceit.cr.w2LCWZTZ` | `shared_service-now` | title: `    ESS IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_41c83` | `shared_commondataserviceforapps` | title: `    ESS IT ServiceNow ITSM Common Orchestrator`<br>workflowid: `3f7a2b1c-8d6e-4a5b-9c0d-2e3f4a5b6c7d`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS IT ServiceNow ITSM Get Tickets List`<br>workflowid: `4b2c3d1e-5f6a-7b8c-9d0e-1f2a3b4c5d6e`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS IT ServiceNow ITSM Request Body Generator`<br>workflowid: `8c7b6a5d-4e3f-2b1a-0c9d-7e6f5a4b3c2d`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `ServiceNow Live Agent` | `msdyn_EssITServiceNowLiveAgent` | `new_sharedservicenow_4ef05` | `shared_service-now` | title: `ESS IT ServiceNow Live Agent Save Summary`<br>workflowid: `324108e4-1f40-f011-b4cb-6045bd04a751`<br>runtime: `invoker` |
+|  |  |  | `new_sharedcommondataserviceforapps_09a8b` | `shared_commondataserviceforapps` | title: `ESS IT ServiceNow Live Agent Save Summary`<br>workflowid: `324108e4-1f40-f011-b4cb-6045bd04a751`<br>runtime: `embedded` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `SAP SuccessFactors` | `msdyn_EssITSuccessFactors` | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Check User Permissions`<br>workflowid: `03c24504-d765-45f7-b9db-cc50e8b9439c`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS IT SuccessFactors Get Active UserId`<br>workflowid: `022a5b46-188a-455d-90c2-30d09b07f3f9`<br>runtime: `embedded` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `ESS IT SuccessFactors Get User Context`<br>workflowid: `023c7886-0d29-42bc-8a92-6962e35caf94`<br>runtime: `embedded` |
+|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Get User Context`<br>workflowid: `023c7886-0d29-42bc-8a92-6962e35caf94`<br>runtime: `embedded` |
+|  |  |  |  |  | title: `ESS IT SuccessFactors Role Based Permission Orchestrator`<br>workflowid: `3491c2a8-d0c2-4f21-9de4-a86dbcb109d0`<br>runtime: `embedded` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `ESS IT SuccessFactors Run Common Orchestrator`<br>workflowid: `3675542c-3d9c-42b7-85b7-d425ebbacdb4`<br>runtime: `embedded` |
+|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Run Common Orchestrator`<br>workflowid: `3675542c-3d9c-42b7-85b7-d425ebbacdb4`<br>runtime: `invoker` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_241f6` | `shared_commondataserviceforapps` | title: `ESS IT SuccessFactors Run Update Orchestrator`<br>workflowid: `62a2f392-ec98-47e3-8821-754cefa60c2b`<br>runtime: `embedded` |
+|  |  |  | `new_sharedsapodata_b7454` | `shared_sapodata` | title: `ESS IT SuccessFactors Run Update Orchestrator`<br>workflowid: `62a2f392-ec98-47e3-8821-754cefa60c2b`<br>runtime: `invoker` |
+| `msdyn_CopilotForEmployeeSelfServiceIT` | `Workday` | `msdyn_EssITWorkday` | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `ESS IT Workday`<br>workflowid: `84d6a7c2-5f91-43e8-b3c7-9a21f0d4e6b5`<br>runtime: `invoker` |
+|  |  |  | `msdyn_sharedcommondataserviceforapps_92b66` | `shared_commondataserviceforapps` | title: `ESS IT Workday References`<br>workflowid: `8a2bd039-81a5-4cfd-9bad-7878a216dad5`<br>runtime: `embedded` |
+|  |  |  | `new_sharedworkdaysoap_ff0df` | `shared_workdaysoap` | title: `WorkdayRESTExecution`<br>workflowid: `c5afa366-eaa3-435f-823e-3c188ebd03a2`<br>runtime: `invoker` |

--- a/solutions/ess-maker-skills/src/skills/backup-template-configs/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/backup-template-configs/SKILL.md
@@ -18,7 +18,7 @@ are calling.
 ## Start
 
 Read `.local/config.json` to confirm setup is complete and get the
-`dataverseEndpoint`.
+`common.dataverseEndpoint`.
 
 If setup is not complete, show:
 
@@ -92,7 +92,7 @@ agent flavours are installed).
 
 **End message.**
 
-Run in the terminal, passing the `dataverseEndpoint` value from
+Run in the terminal, passing the `common.dataverseEndpoint` value from
 `.local/config.json` as `--url`:
 
 ```

--- a/solutions/ess-maker-skills/src/skills/cleanup/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/cleanup/SKILL.md
@@ -15,10 +15,10 @@ This skill scans a cloned ESS agent for compile errors and walks the user throug
 ## Step 1: Read Config
 
 Read `.local/config.json` to get the agent details:
-- `agent.folder` — the name of the cloned agent folder (e.g., `Employee Self-Service HR`)
-- `agent.slug` — the slugified name (e.g., `employee-self-service-hr`)
+- `ACTIVE_AGENT.folder` — the name of the cloned agent folder (e.g., `Employee Self-Service HR`)
+- `ACTIVE_AGENT.slug` — the slugified name (e.g., `employee-self-service-hr`)
 
-If `.local/config.json` doesn't exist or doesn't have `agent.folder`, tell the user: "I can't find your agent configuration. Run `/setup` first." Then STOP.
+If `.local/config.json` doesn't exist or doesn't have `ACTIVE_AGENT.folder`, tell the user: "I can't find your agent configuration. Run `/setup` first." Then STOP.
 
 ## Step 2: Quick Scan (before checkpoint)
 
@@ -53,8 +53,8 @@ When confirmed:
 
 Gather errors from TWO sources and combine them into a single list:
 
-1. **VS Code Problems panel** — Use the error/diagnostics tool with NO file path filter (get all errors across the workspace). Filter the results to only include errors from files inside `{agent.folder}/`.
-2. **Agent folder scan** — Use the error/diagnostics tool specifically on `{agent.folder}/`.
+1. **VS Code Problems panel** — Use the error/diagnostics tool with NO file path filter (get all errors across the workspace). Filter the results to only include errors from files inside `{ACTIVE_AGENT.folder}/`.
+2. **Agent folder scan** — Use the error/diagnostics tool specifically on `{ACTIVE_AGENT.folder}/`.
 
 Merge both lists and deduplicate (the same error may appear in both). Use the combined list for the rest of this flow.
 
@@ -75,7 +75,7 @@ After scanning, group the errors into these categories:
 ### Category 3: Missing Dialog Reference
 **Error message**: `Dialog with id '{schema}.topic.{name}' not found`
 **What it means**: The topic references another topic using a `BeginDialog` action, but the schema name in the reference is wrong. Common cause: truncated schema name (e.g., `msdyn_copilotforemployeeselfservice` instead of `msdyn_copilotforemployeeselfservicehr`).
-**Fix**: Look at the incorrect dialog reference. Read `.local/config.json` to get the correct `agent.schemaName`. Replace the wrong schema prefix with the correct one. For example, if the error says `msdyn_copilotforemployeeselfservice.topic.WorkdayManagerCheck` and the correct schemaName is `msdyn_copilotforemployeeselfservicehr`, replace `msdyn_copilotforemployeeselfservice` with `msdyn_copilotforemployeeselfservicehr` in the file.
+**Fix**: Look at the incorrect dialog reference. Read `.local/config.json` to get the correct `ACTIVE_AGENT.schemaName`. Replace the wrong schema prefix with the correct one. For example, if the error says `msdyn_copilotforemployeeselfservice.topic.WorkdayManagerCheck` and the correct schemaName is `msdyn_copilotforemployeeselfservicehr`, replace `msdyn_copilotforemployeeselfservice` with `msdyn_copilotforemployeeselfservicehr` in the file.
 
 ### Unknown Errors
 If you find errors that don't match any of the above categories, list them separately and tell the user: "I found some errors I don't have an automatic fix for. Here's what they are:" Then list them and suggest the user check the Copilot Studio documentation.
@@ -116,7 +116,7 @@ For each file with errors:
 - Show the user the proposed new description and its character count.
 
 ### Missing Dialog Reference
-- Show the incorrect reference and what it should be (using `agent.schemaName` from config).
+- Show the incorrect reference and what it should be (using `ACTIVE_AGENT.schemaName` from config).
 - If the file has multiple bad references, include all of them in the same proposal.
 
 ### Missing CloudFlow

--- a/solutions/ess-maker-skills/src/skills/connect/servicenow/step4.md
+++ b/solutions/ess-maker-skills/src/skills/connect/servicenow/step4.md
@@ -7,8 +7,8 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 display text like "ENV_URL = ..." or "BOT_ID = ..." in chat.
 
 Read `.local/connect/servicenow/config.json` for INSTANCE_NAME, SNOW_USAGE, etc.
-Read `.local/config.json` for the agent details (dataverseEndpoint, agent.botId,
-agent.name, agent.schemaName, agent.isManaged).
+Read `.local/config.json` for the agent details (common.dataverseEndpoint, ACTIVE_AGENT.botId,
+ACTIVE_AGENT.name, ACTIVE_AGENT.schemaName, ACTIVE_AGENT.isManaged).
 
 ---
 
@@ -22,11 +22,11 @@ This takes about 10–20 seconds...
 **End message.**
 
 Read `.local/config.json` to get the agent details. Set:
-- ENV_URL = `dataverseEndpoint`
-- BOT_ID = `agent.botId`
-- BOT_NAME = `agent.name`
-- SCHEMA_NAME = `agent.schemaName`
-- IS_MANAGED = `agent.isManaged`
+- ENV_URL = `common.dataverseEndpoint`
+- BOT_ID = `ACTIVE_AGENT.botId`
+- BOT_NAME = `ACTIVE_AGENT.name`
+- SCHEMA_NAME = `ACTIVE_AGENT.schemaName`
+- IS_MANAGED = `ACTIVE_AGENT.isManaged`
 
 Run this command in the terminal:
 

--- a/solutions/ess-maker-skills/src/skills/connect/step1.md
+++ b/solutions/ess-maker-skills/src/skills/connect/step1.md
@@ -111,7 +111,7 @@ value. Set `status` to `"in-progress"`. Reset all pack statuses in
 Update `.local/connect/servicenow/tasks.md` — reset steps 2, 3, and 4 from
 `- [x]` to `- [ ]`.
 
-Update `.local/config.json` — remove the `connections.ServiceNow` entry (it
+Update `.local/config.json` — remove the `common.connections.ServiceNow` entry (it
 will be re-created by step 4 with the new auth type after verification).
 
 **Message:**

--- a/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
@@ -9,7 +9,7 @@ via Dataverse. Test cases are stored as `botcomponent` records with
 
 - ALWAYS read `.local/config.json` to get the agent folder name and slug.
 - ALWAYS read all topic files in the agent folder to understand what the agent does before generating tests.
-- Write evaluation files to `{agent.folder}/evaluations/` as `.mcs.yml` YAML files.
+- Write evaluation files to `{ACTIVE_AGENT.folder}/evaluations/` as `.mcs.yml` YAML files.
 - Use the existing starter test sets in `src/examples/ess-samples/ESSEvaluationSamples/StarterTestSets/` as exemplar patterns for each test category.
 - Follow the standard mutation pipeline: **checkpoint → write files → scan → dry run → push → verify**.
 - **TRACK PROGRESS**: Use the todo list tool to track your progress through this skill's steps. Create a todo list at the start with all the steps, mark each in-progress as you start it, and mark completed when done.
@@ -18,8 +18,8 @@ via Dataverse. Test cases are stored as `botcomponent` records with
 
 ## Step 1: Read Agent Context
 
-1. Read `.local/config.json` to get `agent.folder` and `agent.slug`.
-2. Read ALL topic files in `{agent.folder}/topics/` — every `.mcs.yml` file.
+1. Read `.local/config.json` to get `ACTIVE_AGENT.folder` and `ACTIVE_AGENT.slug`.
+2. Read ALL topic files in `{ACTIVE_AGENT.folder}/topics/` — every `.mcs.yml` file.
 3. Classify each topic:
 
 | Trigger type | Classification | Use in test generation |
@@ -66,7 +66,7 @@ via Dataverse. Test cases are stored as `botcomponent` records with
 
 ### 2a. Scan for existing evaluation sets
 
-Before asking the user what to generate, scan `{agent.folder}/evaluations/` for
+Before asking the user what to generate, scan `{ACTIVE_AGENT.folder}/evaluations/` for
 existing EvaluationSet parent files. The known categories and their folder names are:
 
 | Category | Folder name |
@@ -161,7 +161,7 @@ Also ask: "Does your agent have **knowledge sources** loaded (documents, SharePo
 
 ### File format
 
-Evaluation test sets are stored as `.mcs.yml` files in `{agent.folder}/evaluations/`.
+Evaluation test sets are stored as `.mcs.yml` files in `{ACTIVE_AGENT.folder}/evaluations/`.
 There are two kinds:
 
 **EvaluationSet (parent)** — one per test category. Defines the graders.

--- a/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
@@ -28,9 +28,9 @@ children first, then the parent. Do NOT push partial deletions.
 
 ## Step 1: Identify What to Delete
 
-Read `.local/config.json` to get `agent.folder`.
+Read `.local/config.json` to get `ACTIVE_AGENT.folder`.
 
-List files in `{agent.folder}/evaluations/`. Read the `.component-map.json`
+List files in `{ACTIVE_AGENT.folder}/evaluations/`. Read the `.component-map.json`
 to understand parent→child relationships (entries with
 `parentbotcomponentid` are children).
 

--- a/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
@@ -21,9 +21,9 @@ file.**
 
 ## Step 1: Identify the Test Set / Test Cases
 
-Read `.local/config.json` to get `agent.folder`.
+Read `.local/config.json` to get `ACTIVE_AGENT.folder`.
 
-List all files in `{agent.folder}/evaluations/`. Two kinds exist:
+List all files in `{ACTIVE_AGENT.folder}/evaluations/`. Two kinds exist:
 
 - **EvaluationSet** files contain `kind: EvaluationSet` — these are parent
   records that define the test set and grader.

--- a/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
@@ -60,19 +60,26 @@ Go to Step 1.
 
 ---
 
-## Step 1 and Step 2
+## Step 1
 
 Read `src/skills/onboarding/step1.md` and follow it.
 
 (Step 1 handles connecting to Dataverse. When it finishes, it tells you to
-read step1b.md, which discovers agents. When that finishes, it tells you to
-read step2.md, which extracts the agent and starts the MCP server.)
+read step1b.md, which discovers agents.)
 
----
+## Step 2
 
-## Step 3 or Step 4
+Read `src/skills/onboarding/step1b.md` and follow it. It reloads the saved
+environment selection before discovering agents.
+
+## Step 3
 
 Read `src/skills/onboarding/step2.md` and follow it.
+
+## Step 4
+
+Read `src/skills/onboarding/step2.md` and begin at section 2.2. Do not repeat
+agent extraction.
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
@@ -85,4 +85,6 @@ agent extraction.
 
 ## Step 5
 
-Read `src/skills/onboarding/step3-flightcheck.md` and follow it.
+Read `src/skills/onboarding/step3-flightcheck.md` and begin at section 3.1.
+The opt-in question is mandatory. Wait for the user's explicit choice and
+never proceed to section 3.2 automatically.

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1.md
@@ -5,6 +5,25 @@ Do not rephrase, add commentary, or tell the user what tools you are calling.
 
 ---
 
+## 0.9 — Resume a saved environment selection
+
+Run:
+
+```
+python scripts/onboarding_state.py show
+```
+
+Find the line starting with `ONBOARDING_STATE_JSON:` and parse the JSON after
+the colon.
+
+- If it contains `environmentUrl`, save that value as ENV_URL, run
+  `python scripts/onboarding_state.py save-environment --url "{ENV_URL}"` to
+  persist any value recovered from an existing MCP config, and go directly to
+  step 1.2.
+- If it does not contain `environmentUrl`, continue to step 1.0.
+- If the command fails, show its error and stop. Do not discard unreadable
+  onboarding state.
+
 ## 1.0 — Ask how to provide the environment
 
 Use the `vscode_askQuestions` tool:
@@ -92,6 +111,12 @@ JSON after the colon to get the `instanceUrl` field. Save it as ENV_URL.
 **Strip any trailing slash** from ENV_URL before using it (e.g.,
 `https://org.crm.dynamics.com/` becomes `https://org.crm.dynamics.com`).
 
+Persist the selection:
+
+```
+python scripts/onboarding_state.py save-environment --url "{ENV_URL}"
+```
+
 Go to step 1.2.
 
 ---
@@ -112,6 +137,12 @@ Use the `vscode_askQuestions` tool:
 Save their answer as ENV_URL. **Strip any trailing
 slash** from ENV_URL before using it (e.g., `https://org.crm.dynamics.com/`
 becomes `https://org.crm.dynamics.com`).
+
+Persist the selection:
+
+```
+python scripts/onboarding_state.py save-environment --url "{ENV_URL}"
+```
 
 ## 1.2 — Check the environment's MCP configuration
 
@@ -204,6 +235,9 @@ Create `.vscode/mcp.json` with this exact content (replace the entire
   }
 }
 ```
+
+Update `workspace/onboarding/tasks.md` — change step 1 from `- [ ]` to
+`- [x]`.
 
 Continue immediately to step 1.3. Do not show admin instructions because the
 preflight check has already verified both settings.

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1.md
@@ -113,7 +113,79 @@ Save their answer as ENV_URL. **Strip any trailing
 slash** from ENV_URL before using it (e.g., `https://org.crm.dynamics.com/`
 becomes `https://org.crm.dynamics.com`).
 
-## 1.2 — Write the MCP config file
+## 1.2 — Check the environment's MCP configuration
+
+Run this command in the terminal (substitute ENV_URL):
+
+```
+python scripts/discover.py --url "{ENV_URL}" --check-mcp-config
+```
+
+A browser window may open for sign-in. Wait for the script to finish.
+
+Find the line starting with `MCP_CONFIG_JSON:` and parse the JSON after the
+colon.
+
+- If `configured` is `true` → go to step 1.2b.
+- If `configured` is `false` → save `serverEnabled` and
+  `githubCopilotEnabled`, then go to step 1.2a.
+- If the script fails → show its error and stop. Do not assume the admin
+  settings are missing and do not continue until the check succeeds.
+
+## 1.2a — Show only the missing admin configuration
+
+If `serverEnabled` is `false` and `githubCopilotEnabled` is `false`, show:
+
+**Message:**
+
+This environment needs a one-time admin setup for the Dataverse connector:
+
+1. Go to [Power Platform admin center](https://admin.powerplatform.microsoft.com/environments)
+   → your environment → **Settings** → **Product** → **Features**
+2. Turn on **"Allow MCP clients to interact with Dataverse MCP server
+   (GA version)"** and click **Save**
+3. Click **"Go to Advanced Settings"** → find **"Microsoft GitHub Copilot"**
+   → set **Is Enabled** to **Yes** → **Save & Close**
+
+Type **done** when that's set up.
+
+**End message.**
+
+If only `serverEnabled` is `false`, show:
+
+**Message:**
+
+This environment needs one Dataverse connector setting enabled:
+
+1. Go to [Power Platform admin center](https://admin.powerplatform.microsoft.com/environments)
+   → your environment → **Settings** → **Product** → **Features**
+2. Turn on **"Allow MCP clients to interact with Dataverse MCP server
+   (GA version)"** and click **Save**
+
+Type **done** when that's set up.
+
+**End message.**
+
+If only `githubCopilotEnabled` is `false`, show:
+
+**Message:**
+
+This environment needs GitHub Copilot enabled as a Dataverse MCP client:
+
+1. Go to [Power Platform admin center](https://admin.powerplatform.microsoft.com/environments)
+   → your environment → **Settings** → **Product** → **Features**
+2. Click **"Go to Advanced Settings"** → find **"Microsoft GitHub Copilot"**
+   → set **Is Enabled** to **Yes** → **Save & Close**
+
+Type **done** when that's set up.
+
+**End message.**
+
+Wait for the user. When they say `done`, return to step 1.2 and re-run the
+check. Do not accept `skip`; the programmatic check determines whether setup
+can continue.
+
+## 1.2b — Write the MCP config file
 
 Build the MCP URL by appending `/api/mcp` to ENV_URL. Double-check the
 result has exactly ONE slash between the domain and `api` — for example
@@ -133,28 +205,13 @@ Create `.vscode/mcp.json` with this exact content (replace the entire
 }
 ```
 
-Then immediately show:
-
-**Message:**
-
-Done. Now there's a one-time admin step to enable the Dataverse connector:
-
-1. Go to [Power Platform admin center](https://admin.powerplatform.microsoft.com/environments)
-   → your environment → **Settings** → **Product** → **Features**
-2. Turn on **"Allow MCP clients to interact with Dataverse MCP server
-   (GA version)"** and click **Save**
-3. Click **"Go to Advanced Settings"** → find **"Microsoft GitHub Copilot"**
-   → set **Is Enabled** to **Yes** → **Save & Close**
-
-Type **done** when that's set up, or **skip** if it's already enabled.
-
-**End message.**
-
-Wait for the user.
+Continue immediately to step 1.3. Do not show admin instructions because the
+preflight check has already verified both settings.
 
 ## 1.3 — Proceed to agent discovery
 
-The MCP config file is written and admin steps are done. The Dataverse MCP
-server will be started later — it's not needed for discovery or setup.
+The MCP config file is written and the admin configuration is verified. The
+Dataverse MCP server will be started later — it's not needed for discovery or
+setup.
 
 Read `src/skills/onboarding/step1b.md` and follow it.

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
@@ -37,7 +37,10 @@ A browser window will open for sign-in. Wait for the script to finish.
 **Check the terminal output:**
 
 - **Script printed a table of agents → go to step 1.5.**
-- **Script printed "No agents found" → go to step 1.8.**
+- **Script printed "No agents found" and no installation completed during this
+  setup run → go to step 1.8.**
+- **Script printed "No agents found" after installation completed during this
+  setup run → go to step 1.8b.**
 - **Script failed with an auth/connection error → go to step 1.9.**
 
 ---
@@ -111,16 +114,115 @@ Now read `src/skills/onboarding/step2.md` and follow it.
 
 ## 1.8 — No agents found
 
-**Message:**
+Use the `vscode_askQuestions` tool and wait for the user's response:
 
-✅ Connected to Dataverse, but no agents found in this environment. Make sure
-your ESS agent is installed in Copilot Studio before running setup.
+```json
+[
+  {
+    "header": "Select experience",
+    "question": "Which Employee Self-Service experience do you want to install?",
+    "options": [
+      {
+        "label": "ESS as DA (Recommended)",
+        "description": "Install the declarative agent experience."
+      },
+      {
+        "label": "ESS as CEA",
+        "description": "Install the custom engine agent experience."
+      }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
 
-Once installed, run `/setup` again.
+Map **ESS as DA (Recommended)** to EXPERIENCE=`da` and
+**ESS as CEA** to EXPERIENCE=`cea`.
+
+After the user answers, use the `vscode_askQuestions` tool and wait for the
+second response:
+
+```json
+[
+  {
+    "header": "Select vertical",
+    "question": "Which Employee Self-Service vertical do you want to install?",
+    "options": [
+      {
+        "label": "Employee Self-Service HR",
+        "description": "Install the Human Resources agent."
+      },
+      {
+        "label": "Employee Self-Service IT",
+        "description": "Install the Information Technology agent."
+      }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+Map **Employee Self-Service HR** to VERTICAL=`hr` and
+**Employee Self-Service IT** to VERTICAL=`it`.
+
+The installer resolves the selected application's schema name from
+`src/reference/solution-catalog.md`. Do not hard-code a schema name in the
+onboarding instructions.
+
+**Message (do NOT wait for user response — continue immediately):**
+
+Installing the selected Employee Self-Service agent in your environment.
+A browser window may open for Power Platform administrator sign-in.
+Installation can take several minutes...
 
 **End message.**
 
-**STOP. Do not continue.**
+Run this command in the terminal:
+
+```
+python scripts/install_ess_agent.py --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL}
+```
+
+- If the command prints `INSTALLED_ESS_AGENT_JSON:`, continue immediately.
+- If the command fails, go to step 1.8a.
+
+**Message (do NOT wait for user response — continue immediately):**
+
+✅ Employee Self-Service installation completed. Discovering the new agent...
+
+**End message.**
+
+Return to step 1.4 and run discovery again. Remember that installation
+completed during this setup run so a delayed agent registration does not
+trigger another installation.
+
+### 1.8a — Installation failed
+
+**Message:**
+
+The Employee Self-Service agent could not be installed automatically. Review
+the terminal error, confirm your account is a Power Platform or Dynamics 365
+administrator who can install applications in this environment, and type
+**retry** to try again.
+
+**End message.**
+
+Wait for the user. When they say retry, rerun the installation command with
+the same ENV_URL, EXPERIENCE, and VERTICAL. Do not repeat either selection
+question.
+
+### 1.8b — Installed agent is not discoverable yet
+
+**Message:**
+
+The installation completed, but the new agent is not discoverable yet.
+Provisioning can take a few minutes. Type **retry** to check again without
+reinstalling the package.
+
+**End message.**
+
+Wait for the user. When they say retry, return to step 1.4. Do not rerun the
+installation command or repeat either selection question.
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
@@ -11,19 +11,21 @@ python scripts/onboarding_state.py show
 
 Find the line starting with `ONBOARDING_STATE_JSON:` and parse the JSON after
 the colon. Save `environmentUrl` as ENV_URL and inspect the optional
-`installation` object.
+`installation` and `connection` objects.
 
 If `environmentUrl` is missing, read `src/skills/onboarding/step1.md` and
 follow it from section 0.9. Do not ask for an environment here.
 
 - If `installation.status` is `installing`, load EXPERIENCE and VERTICAL from
-  the object and go directly to section 1.8d. Do not repeat either selection
+  the object and go directly to section 1.8f. Do not repeat the agent selection
   question.
 - If `installation.status` is `manual-required`, load EXPERIENCE and VERTICAL
   from the object and go directly to section 1.8c.
-- If `installation.status` is `automatic-complete` or `verified`, remember
-  that installation completed during this setup run and continue to section
-  1.4.
+- If `installation.status` is `automatic-complete` or `verified`, load
+  EXPERIENCE and VERTICAL and go directly to section 1.8g.
+- If there is no `installation` object and `connection.status` is `missing` or
+  `selected`, load EXPERIENCE and VERTICAL from `connection` and go directly
+  to section 1.8f.
 
 ---
 
@@ -39,19 +41,75 @@ seconds...
 Run this command in the terminal (substitute ENV_URL):
 
 ```
-python scripts/discover.py --url "{ENV_URL}"
+python scripts/discover.py --url "{ENV_URL}" --sync-config
 ```
 
 A browser window will open for sign-in. Wait for the script to finish.
 
 **Check the terminal output:**
 
-- **Script printed a table of agents → go to step 1.5.**
-- **Script printed "No agents found" and no installation completed during this
+- Find `ESS_AGENT_DISCOVERY_JSON:` and parse the JSON after the colon as
+  DISCOVERY. It contains `agents`, `installedInstallationKeys`, and
+  `availableInstallations`.
+- The command also synchronizes every detected supported agent into
+  `.local/config.json`. Installed but unselected agents have
+  `installation.status` set to `installed` and `extraction.status` set to
+  `not-started`.
+- **DISCOVERY contains agents and available installations → go to step 1.4a.**
+- **DISCOVERY contains agents and no available installations → go to step
+  1.5.**
+- **Script printed "No supported ESS agents found" and no installation
+  completed during this
   setup run → go to step 1.8.**
-- **Script printed "No agents found" after installation completed during this
-  setup run → go to step 1.8b.**
+- **Script printed "No supported ESS agents found" after installation completed
+  during this setup run → go to step 1.8b.**
 - **Script failed with an auth/connection error → go to step 1.9.**
+
+---
+
+## 1.4a — Offer another supported ESS agent
+
+Build INSTALLED_AGENT_NAMES from `DISCOVERY.agents[*].name`.
+
+**Message:**
+
+This environment already has these supported ESS agents:
+
+{INSTALLED_AGENT_NAMES as a Markdown bullet list}
+
+You can install another supported agent before choosing which one to customize.
+
+**End message.**
+
+Use `vscode_askQuestions`. Build one option for every entry in
+`DISCOVERY.availableInstallations`, preserving its order and using its `label`
+and `description`. Append the continue option last:
+
+```json
+[
+  {
+    "header": "Install another agent",
+    "question": "Would you like to install another ESS agent?",
+    "options": [
+      {
+        "label": "{available installation label}",
+        "description": "{available installation description}"
+      },
+      {
+        "label": "Continue with installed agents",
+        "description": "Choose an existing agent to customize."
+      }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+- If the user selects **Continue with installed agents**, go to step 1.5.
+- Otherwise, map the selected option to its `experience` and `vertical` values,
+  save them as EXPERIENCE and VERTICAL, and go to step 1.8f. Every installation
+  route, including installing another agent, must pass connection preflight
+  before installation state is persisted or the installer is started.
 
 ---
 
@@ -124,24 +182,32 @@ Now read `src/skills/onboarding/step2.md` and follow it.
 
 ## 1.8 — No agents found
 
-Read `src/reference/ess-agent-installation/config.json`. Build the experience
-options from `experiences`, ordered by `displayOrder`; use each entry's `label`
-and `description`. Use the `vscode_askQuestions` tool and wait for the user's
-response. The resulting question should be equivalent to:
+Use `DISCOVERY.availableInstallations` from step 1.4. It contains all four
+supported agents on a fresh environment, already ordered with both DA options
+first and both CEA options last. Use `vscode_askQuestions` and wait for the
+user's response. The question should be equivalent to:
 
 ```json
 [
   {
-    "header": "Select experience",
-    "question": "Which Employee Self-Service experience do you want to install?",
+    "header": "Install ESS agent",
+    "question": "Which Employee Self-Service agent do you want to install?",
     "options": [
       {
-        "label": "ESS as DA (Recommended)",
-        "description": "Install the declarative agent experience."
+        "label": "DA : Employee Self-Service HR",
+        "description": "Install the declarative Human Resources agent."
       },
       {
-        "label": "ESS as CEA",
-        "description": "Install the custom engine agent experience."
+        "label": "DA : Employee Self-Service IT",
+        "description": "Install the declarative Information Technology agent."
+      },
+      {
+        "label": "CEA : Employee Self-Service HR",
+        "description": "Install the custom engine Human Resources agent."
+      },
+      {
+        "label": "CEA : Employee Self-Service IT",
+        "description": "Install the custom engine Information Technology agent."
       }
     ],
     "allowFreeformInput": false
@@ -149,41 +215,87 @@ response. The resulting question should be equivalent to:
 ]
 ```
 
-Map the selected label back to its key under `experiences` and save that key as
-EXPERIENCE.
-
-After the user answers, build the vertical options from `verticals`, ordered by
-`displayOrder`; use each entry's `label` and `description`. Use the
-`vscode_askQuestions` tool and wait for the second response. The resulting
-question should be equivalent to:
-
-```json
-[
-  {
-    "header": "Select vertical",
-    "question": "Which Employee Self-Service vertical do you want to install?",
-    "options": [
-      {
-        "label": "Employee Self-Service HR",
-        "description": "Install the Human Resources agent."
-      },
-      {
-        "label": "Employee Self-Service IT",
-        "description": "Install the Information Technology agent."
-      }
-    ],
-    "allowFreeformInput": false
-  }
-]
-```
-
-Map the selected label back to its key under `verticals` and save that key as
-VERTICAL.
+Map the selected option to its `experience` and `vertical` values and save them
+as EXPERIENCE and VERTICAL.
 
 The installer resolves the composite `{EXPERIENCE}.{VERTICAL}` key from
 `src/reference/ess-agent-installation/config.json` and validates its application
 and solution unique names against `src/reference/solution-catalog.md`. Do not
 hard-code a schema name in the onboarding instructions.
+
+First continue to section 1.8f. Persist the installation only after its
+connection preflight passes.
+
+### 1.8f — Validate required connections before installation
+
+**Message (do NOT wait for user response — continue immediately):**
+
+Checking required connections for the selected Employee Self-Service agent...
+
+**End message.**
+
+Run:
+
+```
+python scripts/ess_connection_binding.py inspect --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL}
+```
+
+Parse the JSON after `ESS_CONNECTION_PREFLIGHT_JSON:`.
+
+- If `status` is `not-required`, persist it and continue to section 1.8e:
+
+  ```
+  python scripts/onboarding_state.py save-connection --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status not-required
+  ```
+
+- If `status` is `ready`, save
+  `selectedConnection.name` as CONNECTION_NAME, persist it, and continue to
+  section 1.8e:
+
+  ```
+  python scripts/onboarding_state.py save-connection --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status selected --connection-name "{CONNECTION_NAME}"
+  ```
+
+  **Message (do NOT wait for user response — continue immediately):**
+
+  ✅ Found an active **{displayName}** connection. Installation can proceed.
+
+  **End message.**
+
+- If `status` is `selection-required`, use `vscode_askQuestions` to show one
+  option for every item in `connections`. Build a unique label from
+  `displayName` plus `accountName` (or `name` when no account is available),
+  and include the stable connection `name` in the description. Do not
+  auto-select among multiple connections. Save the selected item's `name` as
+  CONNECTION_NAME, persist it with the same
+  `save-connection --status selected` command, and continue to section 1.8e.
+
+- If `status` is `missing`, persist the blocked state:
+
+  ```
+  python scripts/onboarding_state.py save-connection --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status missing
+  ```
+
+  **Message:**
+
+  The selected agent requires an active **{displayName}** connection before it
+  can be installed.
+
+  {creationGuidance}
+
+  Create the connection in this environment, then choose **Check again**.
+
+  **End message.**
+
+  Ask with `vscode_askQuestions`:
+
+  - **Check again** — rerun section 1.8f.
+  - **Not yet** — stop and preserve the blocked state so `/setup` can resume.
+
+Do not run the installer unless this preflight returns `not-required`, `ready`,
+or the user explicitly selects one of multiple connected matches.
+
+### 1.8e — Persist the installation selection
 
 Persist the selection before starting the potentially long-running operation:
 
@@ -209,6 +321,17 @@ Run this command in the terminal:
 python scripts/install_ess_agent.py --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL}
 ```
 
+When connection preflight selected CONNECTION_NAME, append:
+
+```
+--connection-name "{CONNECTION_NAME}"
+```
+
+The installer independently repeats the required-connection validation and
+will refuse to start the package installation if the preflight was bypassed,
+the connection became unhealthy, or multiple matches exist without an explicit
+selection.
+
 - If the command prints `INSTALLED_ESS_AGENT_JSON:`, continue immediately.
 - If the command prints `ESS_AGENT_INSTALLATION_TIMEOUT_JSON:`, persist the
   timeout using the command below, then go to step 1.8c:
@@ -227,13 +350,51 @@ python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experie
 
 **Message (do NOT wait for user response — continue immediately):**
 
-✅ Employee Self-Service installation completed. Discovering the new agent...
+✅ Employee Self-Service installation completed. Binding its required
+connection...
 
 **End message.**
 
-Return to step 1.4 and run discovery again. Remember that installation
+Continue to section 1.8g. Do not run discovery until required connection
+binding is verified.
+
+### 1.8g — Bind and verify the required connection
+
+Reload `ONBOARDING_STATE_JSON` and read `connection.connectionName` as
+CONNECTION_NAME when present.
+
+For an agent with a selected connection, run:
+
+```
+python scripts/ess_connection_binding.py bind --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --connection-name "{CONNECTION_NAME}"
+```
+
+For an agent whose connection status is `not-required`, run the same command
+without `--connection-name`.
+
+Continue only when the command prints `ESS_CONNECTION_BINDING_JSON:` with
+`status` equal to `bound` or `not-required`. The script updates the nested
+agent state in `.local/config.json`:
+
+- `setupStatus.S1` — package installed and verified.
+- `setupStatus.S2` — required connection bound and reread from Dataverse, or
+  explicitly marked not required.
+
+Persist the resumable binding state:
+
+```
+python scripts/onboarding_state.py save-connection --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status bound --connection-name "{CONNECTION_NAME}"
+```
+
+For `not-required`, use `--status not-required` and omit `--connection-name`.
+If binding fails, show the exact error and stop. Do not mark S2 done and do not
+continue to discovery.
+
+Return to step 1.4 and run discovery again after binding succeeds. Remember
+that installation
 completed during this setup run so a delayed agent registration does not
-trigger another installation.
+trigger another installation. Once the new agent appears, step 1.4a offers
+only the other supported agents that are still missing.
 
 ### 1.8c — Automatic installation timed out
 
@@ -299,11 +460,12 @@ python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experie
 
 **Message (do NOT wait for user response — continue immediately):**
 
-✅ Employee Self-Service installation verified. Discovering the new agent...
+✅ Employee Self-Service installation verified. Binding its required
+connection...
 
 **End message.**
 
-Return to step 1.4 and run discovery again. If the checkpoint does not pass,
+Continue to section 1.8g. If the checkpoint does not pass,
 show its result and offer the same **Verify installation** and **Not yet**
 choices again. Do not rerun automatic installation.
 

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
@@ -10,10 +10,20 @@ python scripts/onboarding_state.py show
 ```
 
 Find the line starting with `ONBOARDING_STATE_JSON:` and parse the JSON after
-the colon. Save `environmentUrl` as ENV_URL.
+the colon. Save `environmentUrl` as ENV_URL and inspect the optional
+`installation` object.
 
 If `environmentUrl` is missing, read `src/skills/onboarding/step1.md` and
 follow it from section 0.9. Do not ask for an environment here.
+
+- If `installation.status` is `installing`, load EXPERIENCE and VERTICAL from
+  the object and go directly to section 1.8d. Do not repeat either selection
+  question.
+- If `installation.status` is `manual-required`, load EXPERIENCE and VERTICAL
+  from the object and go directly to section 1.8c.
+- If `installation.status` is `automatic-complete` or `verified`, remember
+  that installation completed during this setup run and continue to section
+  1.4.
 
 ---
 
@@ -114,7 +124,10 @@ Now read `src/skills/onboarding/step2.md` and follow it.
 
 ## 1.8 — No agents found
 
-Use the `vscode_askQuestions` tool and wait for the user's response:
+Read `src/reference/ess-agent-installation/config.json`. Build the experience
+options from `experiences`, ordered by `displayOrder`; use each entry's `label`
+and `description`. Use the `vscode_askQuestions` tool and wait for the user's
+response. The resulting question should be equivalent to:
 
 ```json
 [
@@ -136,11 +149,13 @@ Use the `vscode_askQuestions` tool and wait for the user's response:
 ]
 ```
 
-Map **ESS as DA (Recommended)** to EXPERIENCE=`da` and
-**ESS as CEA** to EXPERIENCE=`cea`.
+Map the selected label back to its key under `experiences` and save that key as
+EXPERIENCE.
 
-After the user answers, use the `vscode_askQuestions` tool and wait for the
-second response:
+After the user answers, build the vertical options from `verticals`, ordered by
+`displayOrder`; use each entry's `label` and `description`. Use the
+`vscode_askQuestions` tool and wait for the second response. The resulting
+question should be equivalent to:
 
 ```json
 [
@@ -162,18 +177,29 @@ second response:
 ]
 ```
 
-Map **Employee Self-Service HR** to VERTICAL=`hr` and
-**Employee Self-Service IT** to VERTICAL=`it`.
+Map the selected label back to its key under `verticals` and save that key as
+VERTICAL.
 
-The installer resolves the selected application's schema name from
-`src/reference/solution-catalog.md`. Do not hard-code a schema name in the
-onboarding instructions.
+The installer resolves the composite `{EXPERIENCE}.{VERTICAL}` key from
+`src/reference/ess-agent-installation/config.json` and validates its application
+and solution unique names against `src/reference/solution-catalog.md`. Do not
+hard-code a schema name in the onboarding instructions.
+
+Persist the selection before starting the potentially long-running operation:
+
+```
+python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status installing
+```
+
+Then continue to section 1.8d.
+
+### 1.8d — Run or resume automatic installation
 
 **Message (do NOT wait for user response — continue immediately):**
 
 Installing the selected Employee Self-Service agent in your environment.
 A browser window may open for Power Platform administrator sign-in.
-Installation can take several minutes...
+I'll check the installation status every 20 seconds for up to 10 minutes...
 
 **End message.**
 
@@ -184,7 +210,20 @@ python scripts/install_ess_agent.py --url "{ENV_URL}" --experience {EXPERIENCE} 
 ```
 
 - If the command prints `INSTALLED_ESS_AGENT_JSON:`, continue immediately.
+- If the command prints `ESS_AGENT_INSTALLATION_TIMEOUT_JSON:`, persist the
+  timeout using the command below, then go to step 1.8c:
+
+  ```
+  python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status manual-required
+  ```
+
 - If the command fails, go to step 1.8a.
+
+Persist the completed automatic installation:
+
+```
+python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status automatic-complete
+```
 
 **Message (do NOT wait for user response — continue immediately):**
 
@@ -195,6 +234,78 @@ python scripts/install_ess_agent.py --url "{ENV_URL}" --experience {EXPERIENCE} 
 Return to step 1.4 and run discovery again. Remember that installation
 completed during this setup run so a delayed agent registration does not
 trigger another installation.
+
+### 1.8c — Automatic installation timed out
+
+Read `src/reference/ess-agent-installation/config.json`. Resolve the
+`{EXPERIENCE}.{VERTICAL}` installation and use its experience label, vertical
+label, and `marketplaceApplication.uniqueName` in the message below.
+
+**Message:**
+
+Automatic installation is still not complete after 10 minutes.
+
+Please install **{EXPERIENCE_LABEL} — {VERTICAL_LABEL}** manually:
+
+1. Open Power Platform admin center and select this environment.
+2. Go to **Resources → Dynamics 365 apps**.
+3. Find and install the application with unique name
+   **{MARKETPLACE_APPLICATION_UNIQUE_NAME}**.
+
+When the installation finishes, choose **Verify installation** and I'll confirm
+it with the ESS solution FlightCheck.
+
+**End message.**
+
+Use the `vscode_askQuestions` tool and wait for the user's response:
+
+```json
+[
+  {
+    "header": "Manual installation",
+    "question": "Is the selected ESS application installed?",
+    "options": [
+      {
+        "label": "Verify installation",
+        "description": "Run the ESS solution FlightCheck now."
+      },
+      {
+        "label": "Not yet",
+        "description": "Keep this step pending so setup can resume later."
+      }
+    ],
+    "allowFreeformInput": false
+  }
+]
+```
+
+- If the user selects **Not yet**, stop. Keep `installation.status` as
+  `manual-required`.
+- If the user selects **Verify installation**, run:
+
+  ```
+  python scripts/flightcheck/cli.py --checkpoint ESS-SOLN-001 --environment-url "{ENV_URL}" --expected-solution "{MARKETPLACE_APPLICATION_UNIQUE_NAME}" --output workspace/flightcheck/installation-verification --no-open --invocation-source installer
+  ```
+
+Read `workspace/flightcheck/installation-verification/results.json`. Continue
+only when the `ESS-SOLN-001` row has status `Passed`. Do not treat the command's
+exit code alone as confirmation.
+
+When the checkpoint passes, persist the verification:
+
+```
+python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status verified
+```
+
+**Message (do NOT wait for user response — continue immediately):**
+
+✅ Employee Self-Service installation verified. Discovering the new agent...
+
+**End message.**
+
+Return to step 1.4 and run discovery again. If the checkpoint does not pass,
+show its result and offer the same **Verify installation** and **Not yet**
+choices again. Do not rerun automatic installation.
 
 ### 1.8a — Installation failed
 

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
@@ -3,7 +3,17 @@
 Every **Message** block is the exact text to show the user. Copy it verbatim.
 Do not rephrase, add commentary, or tell the user what tools you are calling.
 
-You should already have ENV_URL from Step 1.
+Reload the saved environment selection:
+
+```
+python scripts/onboarding_state.py show
+```
+
+Find the line starting with `ONBOARDING_STATE_JSON:` and parse the JSON after
+the colon. Save `environmentUrl` as ENV_URL.
+
+If `environmentUrl` is missing, read `src/skills/onboarding/step1.md` and
+follow it from section 0.9. Do not ask for an environment here.
 
 ---
 
@@ -69,6 +79,12 @@ python scripts/discover.py --url "{ENV_URL}" --select {NUMBER}
 Find the line starting with `SELECTED_AGENT_JSON:` in the output. Parse the
 JSON after the colon to get BOT_ID (`botid`), BOT_NAME (`name`),
 SCHEMA_NAME (`schemaname`), and IS_MANAGED (`ismanaged`).
+
+Persist the selected agent:
+
+```
+python scripts/onboarding_state.py save-agent --url "{ENV_URL}" --bot-id "{BOT_ID}" --name "{BOT_NAME}" --schema "{SCHEMA_NAME}" {--managed if IS_MANAGED is true}
+```
 
 Update `workspace/onboarding/tasks.md` — change both step 1 and step 2 from
 `- [ ]` to `- [x]`.

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1b.md
@@ -11,21 +11,25 @@ python scripts/onboarding_state.py show
 
 Find the line starting with `ONBOARDING_STATE_JSON:` and parse the JSON after
 the colon. Save `environmentUrl` as ENV_URL and inspect the optional
-`installation` and `connection` objects.
+`installation` object.
 
 If `environmentUrl` is missing, read `src/skills/onboarding/step1.md` and
 follow it from section 0.9. Do not ask for an environment here.
 
+- If `installation.vertical` is `it` but `installation.connectionName` is
+  missing, load EXPERIENCE and VERTICAL and go to section 1.8f regardless of
+  installation status. This reconciles durable IT installations created by
+  older setup versions before connection selection was stored. The installer
+  will detect an already-installed or in-progress package without reinstalling
+  it and then persist the selected connection.
 - If `installation.status` is `installing`, load EXPERIENCE and VERTICAL from
-  the object and go directly to section 1.8f. Do not repeat the agent selection
-  question.
+  the object, load its optional `connectionName` as CONNECTION_NAME, and go
+  directly to section 1.8d. This state exists only after Power Platform
+  accepted or reported an in-progress installation.
 - If `installation.status` is `manual-required`, load EXPERIENCE and VERTICAL
   from the object and go directly to section 1.8c.
 - If `installation.status` is `automatic-complete` or `verified`, load
   EXPERIENCE and VERTICAL and go directly to section 1.8g.
-- If there is no `installation` object and `connection.status` is `missing` or
-  `selected`, load EXPERIENCE and VERTICAL from `connection` and go directly
-  to section 1.8f.
 
 ---
 
@@ -223,8 +227,8 @@ The installer resolves the composite `{EXPERIENCE}.{VERTICAL}` key from
 and solution unique names against `src/reference/solution-catalog.md`. Do not
 hard-code a schema name in the onboarding instructions.
 
-First continue to section 1.8f. Persist the installation only after its
-connection preflight passes.
+First continue to section 1.8f. Do not persist the selected agent or preflight
+result.
 
 ### 1.8f — Validate required connections before installation
 
@@ -242,19 +246,11 @@ python scripts/ess_connection_binding.py inspect --url "{ENV_URL}" --experience 
 
 Parse the JSON after `ESS_CONNECTION_PREFLIGHT_JSON:`.
 
-- If `status` is `not-required`, persist it and continue to section 1.8e:
-
-  ```
-  python scripts/onboarding_state.py save-connection --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status not-required
-  ```
+- If `status` is `not-required`, continue directly to section 1.8d.
 
 - If `status` is `ready`, save
-  `selectedConnection.name` as CONNECTION_NAME, persist it, and continue to
-  section 1.8e:
-
-  ```
-  python scripts/onboarding_state.py save-connection --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status selected --connection-name "{CONNECTION_NAME}"
-  ```
+  `selectedConnection.name` as the in-memory CONNECTION_NAME and continue
+  directly to section 1.8d. Do not write it to onboarding state yet.
 
   **Message (do NOT wait for user response — continue immediately):**
 
@@ -267,15 +263,10 @@ Parse the JSON after `ESS_CONNECTION_PREFLIGHT_JSON:`.
   `displayName` plus `accountName` (or `name` when no account is available),
   and include the stable connection `name` in the description. Do not
   auto-select among multiple connections. Save the selected item's `name` as
-  CONNECTION_NAME, persist it with the same
-  `save-connection --status selected` command, and continue to section 1.8e.
+  the in-memory CONNECTION_NAME and continue directly to section 1.8d. Do not
+  write it to onboarding state yet.
 
-- If `status` is `missing`, persist the blocked state:
-
-  ```
-  python scripts/onboarding_state.py save-connection --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status missing
-  ```
-
+- If `status` is `missing`:
   **Message:**
 
   The selected agent requires an active **{displayName}** connection before it
@@ -290,20 +281,14 @@ Parse the JSON after `ESS_CONNECTION_PREFLIGHT_JSON:`.
   Ask with `vscode_askQuestions`:
 
   - **Check again** — rerun section 1.8f.
-  - **Not yet** — stop and preserve the blocked state so `/setup` can resume.
+  - **Not yet** — stop without saving the agent selection or connection
+    preflight. The next `/setup` run must rediscover agents and ask what to
+    install.
 
 Do not run the installer unless this preflight returns `not-required`, `ready`,
-or the user explicitly selects one of multiple connected matches.
-
-### 1.8e — Persist the installation selection
-
-Persist the selection before starting the potentially long-running operation:
-
-```
-python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status installing
-```
-
-Then continue to section 1.8d.
+or the user explicitly selects one of multiple connected matches. The installer
+owns installation-state persistence and writes it only after the Power Platform
+API confirms that installation has started or is already complete.
 
 ### 1.8d — Run or resume automatic installation
 
@@ -334,19 +319,9 @@ selection.
 
 - If the command prints `INSTALLED_ESS_AGENT_JSON:`, continue immediately.
 - If the command prints `ESS_AGENT_INSTALLATION_TIMEOUT_JSON:`, persist the
-  timeout using the command below, then go to step 1.8c:
-
-  ```
-  python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status manual-required
-  ```
+  timeout state emitted by the installer and go to step 1.8c.
 
 - If the command fails, go to step 1.8a.
-
-Persist the completed automatic installation:
-
-```
-python scripts/onboarding_state.py save-installation --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --status automatic-complete
-```
 
 **Message (do NOT wait for user response — continue immediately):**
 
@@ -360,8 +335,8 @@ binding is verified.
 
 ### 1.8g — Bind and verify the required connection
 
-Reload `ONBOARDING_STATE_JSON` and read `connection.connectionName` as
-CONNECTION_NAME when present.
+Reload `ONBOARDING_STATE_JSON` and read
+`installation.connectionName` as CONNECTION_NAME when present.
 
 For an agent with a selected connection, run:
 
@@ -369,8 +344,8 @@ For an agent with a selected connection, run:
 python scripts/ess_connection_binding.py bind --url "{ENV_URL}" --experience {EXPERIENCE} --vertical {VERTICAL} --connection-name "{CONNECTION_NAME}"
 ```
 
-For an agent whose connection status is `not-required`, run the same command
-without `--connection-name`.
+When `installation.connectionName` is absent, run the same command without
+`--connection-name`; the selected agent does not require a parent connection.
 
 Continue only when the command prints `ESS_CONNECTION_BINDING_JSON:` with
 `status` equal to `bound` or `not-required`. The script updates the nested

--- a/solutions/ess-maker-skills/src/skills/onboarding/step2.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step2.md
@@ -3,8 +3,19 @@
 Every **Message** block is the exact text to show the user. Copy it verbatim.
 Do not rephrase, add commentary, or tell the user what tools you are calling.
 
-You should already have these values from Step 1: ENV_URL, BOT_ID, BOT_NAME,
-SCHEMA_NAME, IS_MANAGED.
+Reload the saved environment and agent selection:
+
+```
+python scripts/onboarding_state.py show
+```
+
+Find the line starting with `ONBOARDING_STATE_JSON:` and parse the JSON after
+the colon. Load ENV_URL from `environmentUrl`, and BOT_ID, BOT_NAME,
+SCHEMA_NAME, and IS_MANAGED from `agent.botId`, `agent.name`,
+`agent.schemaName`, and `agent.isManaged`.
+
+If the agent object is missing, read `src/skills/onboarding/step1b.md` and
+follow it. Do not run extraction without a persisted agent selection.
 
 ---
 
@@ -74,6 +85,12 @@ Wait for the user to respond.
 ## 2.3 — Finish
 
 Update `workspace/onboarding/tasks.md` — change step 4 from `- [ ]` to `- [x]`.
+
+Clear the partial onboarding state now that the durable setup config exists:
+
+```
+python scripts/onboarding_state.py clear
+```
 
 **Message:**
 

--- a/solutions/ess-maker-skills/src/skills/onboarding/step3-flightcheck.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step3-flightcheck.md
@@ -47,7 +47,8 @@ Stop here. Do not continue.
 
 **Only if they explicitly choose "Yes — run readiness check":**
 
-Proceed to 3.2.
+Proceed to 3.2 immediately. The next visible response must be the 3.2
+**Message** block; do not remain silent after the question tool returns.
 
 Any response other than that explicit selection must not start FlightCheck.
 
@@ -57,19 +58,50 @@ Any response other than that explicit selection must not start FlightCheck.
 
 **Message:**
 
-Running readiness checks — this takes 1–3 minutes...
+Readiness check started. This usually takes 1–3 minutes. I'll show progress
+while it runs and explicitly confirm when it is complete.
 
 **End message.**
 
 Run in the terminal:
 
 ```
-python scripts/flightcheck/cli.py --scope full --invocation-source adk
+python -u scripts/flightcheck/cli.py --scope full --invocation-source adk
 ```
 
-Wait for the script to finish.
+Relay the terminal's current authentication or checking stage to the user at
+least once every 60 seconds while the command is still running. Do not leave
+the user with only the question response.
 
-Update `workspace/onboarding/tasks.md` — change step 5 from `- [ ]` to `- [x]`.
+Wait for the script to finish. A completed run prints
+`FLIGHTCHECK_COMPLETE_JSON:` and writes
+`workspace/flightcheck/results.json`. A non-zero exit code can still mean a
+completed check with failed readiness items, so use the completion marker and
+results file rather than exit code alone.
+
+If either the completion marker or results file is missing, do not mark step 5
+complete. Show:
+
+**Message:**
+
+The readiness check stopped before completion. Review the latest terminal
+error, then type **retry** to run it again.
+
+**End message.**
+
+Stop and wait for the user.
+
+When both completion signals exist, update `workspace/onboarding/tasks.md` —
+change step 5 from `- [ ]` to `- [x]`.
+
+Parse the JSON after `FLIGHTCHECK_COMPLETE_JSON:` and save `durationSeconds`
+as DURATION_SECONDS.
+
+**Message (do NOT wait for user response — continue immediately):**
+
+✅ Readiness check complete in {DURATION_SECONDS} seconds. Here are the results:
+
+**End message.**
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/onboarding/step3-flightcheck.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step3-flightcheck.md
@@ -9,6 +9,12 @@ This step runs AFTER Step 2 completes (agent extracted, MCP started).
 
 ## 3.1 — Offer the readiness check
 
+**MANDATORY MANUAL GATE:** Always ask this question, including when `/setup`
+resumes directly at Step 5. Do not infer consent from the user running
+`/setup`, from a previous answer, or from the checklist state. Invoke the
+question tool and end the turn while waiting for the user's selection. Do not
+run any FlightCheck command in the same turn as this question.
+
 Use the `vscode_askQuestions` tool:
 
 ```json
@@ -39,9 +45,11 @@ No problem — I'll keep this on your checklist. You can run
 
 Stop here. Do not continue.
 
-**If they choose "Yes":**
+**Only if they explicitly choose "Yes — run readiness check":**
 
 Proceed to 3.2.
+
+Any response other than that explicit selection must not start FlightCheck.
 
 ---
 

--- a/solutions/ess-maker-skills/src/skills/restore-template-configs/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/restore-template-configs/SKILL.md
@@ -18,7 +18,7 @@ are calling.
 ## Start
 
 Read `.local/config.json` to confirm setup is complete and get the
-`dataverseEndpoint`.
+`common.dataverseEndpoint`.
 
 If setup is not complete, show:
 
@@ -83,7 +83,7 @@ Capture the selection as `{BACKUP_PATH}`.
 
 Read the chosen backup file to inspect `metadata.envUrl`, `metadata.capturedAt`,
 `metadata.recordCount`, and `metadata.agentsDetected`. Also read the current
-`dataverseEndpoint` from `.local/config.json`.
+`common.dataverseEndpoint` from `.local/config.json`.
 
 Build the summary:
 
@@ -105,7 +105,7 @@ catalog values in `msdyn_value`, so a full overwrite is the intended
 behaviour - your customisations win.
 ```
 
-If `metadata.envUrl` (in the backup) does NOT match `dataverseEndpoint`
+If `metadata.envUrl` (in the backup) does NOT match `common.dataverseEndpoint`
 (in the current config), show one additional line in the summary:
 
 ```

--- a/solutions/ess-maker-skills/src/skills/setup/shared/config-schema.md
+++ b/solutions/ess-maker-skills/src/skills/setup/shared/config-schema.md
@@ -20,12 +20,13 @@ There are **two distinct** files. Keep them separate.
 | File | Owner | Purpose |
 |------|-------|---------|
 | `.local/connect/workday/config.json` | the connect + setup skills | Workday connection state — URLs, tenant, Entra app, OAuth client, per-skill status. **This schema.** |
-| `.local/config.json` | onboarding + flightcheck | Agent identity + `dataverseEndpoint`. `scripts/flightcheck/cli.py` reads this for the Dataverse endpoint and agent list. **Not this schema.** |
+| `.local/config.json` | onboarding + flightcheck | Shared environment state under `common` and nested agent identity under `agents.da.esshr`, `agents.da.essit`, `agents.cea.esshr`, or `agents.cea.essit`. **Not this schema.** |
 
 Never write Workday connection fields into `.local/config.json`, and never write
-agent identity / `dataverseEndpoint` into `.local/connect/workday/config.json`.
+agent identity / `common.dataverseEndpoint` into `.local/connect/workday/config.json`.
 The only crossover is read-only: a setup skill may *read* `.local/config.json`
-for `dataverseEndpoint` / `agent.botId` when it needs them (see skill-5,
+for `common.dataverseEndpoint` and the active agent's `botId` when it needs
+them (resolve `activeAgent` under `agents`; see skill-5,
 `workday/install-workday-extension-pack.md`).
 
 ---

--- a/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/create/SKILL.md
@@ -5,9 +5,9 @@ This skill guides the user through creating a new Copilot Studio topic.
 ## Rules
 
 - Do NOT run terminal commands or scripts. Use built-in file reading and writing tools only.
-- ALWAYS read existing topic files in the user's agent folder (`{agent.folder}/topics/`) as schema examples before generating any YAML.
+- ALWAYS read existing topic files in the user's agent folder (`{ACTIVE_AGENT.folder}/topics/`) as schema examples before generating any YAML.
 - ALWAYS read `.local/config.json` to get the agent folder name and schema name.
-- Write the new topic file to `{agent.folder}/topics/{TopicName}.mcs.yml`.
+- Write the new topic file to `{ACTIVE_AGENT.folder}/topics/{TopicName}.mcs.yml`.
 - After writing the file, check for errors using the diagnostics tool on the new file.
 - **PRESERVE THE AUTHORING INVARIANTS**: follow [`authoring-invariants.md`](src/reference/ess-docs/customization/authoring-invariants.md) — the generated topic MUST delegate the backend call to the shared system topic, render backend data with the standard parse → iterate → table pattern, and let failures flow through the shared error path.
 - **TEMPLATE CONFIG IS THE DEFAULT**: For any scenario that calls an ESS-orchestrated backend (ServiceNow, Workday, or SAP SuccessFactors), use the **Template Config + Shared Flow** pattern. This is the official ESS extensibility pattern. The topic calls the existing shared system topic (e.g., `ServiceNowHRSDSystemGetCommonExecution`), which invokes the shared orchestrator flow. Do NOT create standalone cloud flows for these connectors.
@@ -114,11 +114,11 @@ For any scenario that involves data collection + external system calls, think th
 
 ## Step 4: Check for Existing Patterns
 
-Read the agent snapshot at `workspace/agents/{agent.slug}/topics.md` to see if similar topics already exist. If a similar pattern exists:
+Read the agent snapshot at `workspace/agents/{ACTIVE_AGENT.slug}/topics.md` to see if similar topics already exist. If a similar pattern exists:
 - Tell the user: "I found a similar topic ({name}) that does {X}. I'll use its pattern as a reference."
 - Read the existing topic file to understand the action chain.
 
-If the topic calls a workflow, check `workspace/agents/{agent.slug}/workflows.md` to see if a suitable workflow already exists. If not, tell the user they'll also need a workflow and offer to create one after the topic.
+If the topic calls a workflow, check `workspace/agents/{ACTIVE_AGENT.slug}/workflows.md` to see if a suitable workflow already exists. If not, tell the user they'll also need a workflow and offer to create one after the topic.
 
 ## Step 5: Generate the Topic YAML
 
@@ -210,8 +210,8 @@ its steps. The user should not have to manage the dependency chain manually.
 
 ### 6.3 — Write the topic file
 
-1. Read `.local/config.json` to get `agent.folder`.
-2. Write the topic file to `{agent.folder}/topics/{filename}.mcs.yml`.
+1. Read `.local/config.json` to get `ACTIVE_AGENT.folder`.
+2. Write the topic file to `{ACTIVE_AGENT.folder}/topics/{filename}.mcs.yml`.
 
 ### 6.4 — Scan for errors
 

--- a/solutions/ess-maker-skills/src/skills/topics/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/delete/SKILL.md
@@ -23,10 +23,10 @@ file.**
 
 ## Step 1: Identify the Topic
 
-Read `.local/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `ACTIVE_AGENT.folder` and `ACTIVE_AGENT.slug`.
 
 If the user named a specific topic, find the matching file in
-`{agent.folder}/topics/`. Match by:
+`{ACTIVE_AGENT.folder}/topics/`. Match by:
 - Filename (e.g., "submit it support ticket" → `submititsupportticket.mcs.yml`)
 - Display name inside the file (`componentName` field)
 - Trigger phrases (`triggerQueries`)
@@ -70,7 +70,7 @@ non-blocking); it needs no user-facing message and never fails the step.
 
 ## Step 4: Delete the Local File
 
-Delete the topic file from `{agent.folder}/topics/{filename}.mcs.yml`.
+Delete the topic file from `{ACTIVE_AGENT.folder}/topics/{filename}.mcs.yml`.
 
 Verify the file is gone by listing the topics directory.
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -11,7 +11,7 @@ publishing.
 
 - Do NOT modify the topic. This skill only reads, reports, and writes its findings catalog/ledger under
   `.local/`; it never edits the topic.
-- Operate on the authored `.mcs.yml` in the maker's agent folder (`{agent.folder}/topics/`), i.e. the
+- Operate on the authored `.mcs.yml` in the maker's agent folder (`{ACTIVE_AGENT.folder}/topics/`), i.e. the
   topic **before publish**. Do not require the published `samples/` copy.
 - **Run the analysis silently.** Steps 3–8 are internal: run the detectors, read the reference docs, and
   persist the catalog **without narrating them**. Do not rephrase, add commentary, or tell the maker what
@@ -97,7 +97,7 @@ Decide whether the maker wants **one topic** or a **module scope** (all topics f
   ServiceNow HRSD", "review everything") → **scoped review**: resolve the module id, then jump to the
   **Scoped review** section at the end of this skill (do not run Steps 2–9 directly).
 - If it is ambiguous, read `.local/config.json` for the agent folder, list the module prefixes present in
-  `{agent.folder}/topics/` (the leading `servicenow-hrsd`, `servicenow-itsm`, `workday`, … segment), and ask
+  `{ACTIVE_AGENT.folder}/topics/` (the leading `servicenow-hrsd`, `servicenow-itsm`, `workday`, … segment), and ask
   the maker whether they want one topic or a whole module.
 
 For a single-topic review, state the full path of the file you are about to review.

--- a/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/update/SKILL.md
@@ -24,10 +24,10 @@ take effect. **NEVER stop after editing only the local file.**
 
 ## Step 1: Identify the Topic
 
-Read `.local/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `ACTIVE_AGENT.folder` and `ACTIVE_AGENT.slug`.
 
 If the user named a specific topic, find the matching file in
-`{agent.folder}/topics/`. Match by filename, `componentName`, trigger phrases,
+`{ACTIVE_AGENT.folder}/topics/`. Match by filename, `componentName`, trigger phrases,
 or `modelDescription`.
 
 If the match is ambiguous, list available topics and ask the user to pick.

--- a/solutions/ess-maker-skills/src/skills/troubleshoot/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/troubleshoot/SKILL.md
@@ -32,7 +32,7 @@ Record anonymous usage telemetry (best-effort, non-blocking — no user-facing
 message, and it never fails the step): `python scripts/emit_capability.py troubleshoot`
 
 Read `.local/config.json` to determine:
-- Which agent is active (the `agent.folder` field)
+- Which agent is active (the `ACTIVE_AGENT.folder` field)
 - Which integrations are configured
 
 Ask the user which integration is failing if it's not obvious from their

--- a/solutions/ess-maker-skills/src/skills/workflows/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/workflows/create/SKILL.md
@@ -25,10 +25,10 @@ Then read `src/skills/topics/create/SKILL.md` and follow the template config pat
 ## Rules
 
 - Do NOT run terminal commands or scripts. Use built-in file reading and writing tools only.
-- ALWAYS read existing workflow files in the user's agent folder (`{agent.folder}/workflows/`) as schema examples before generating any workflow JSON.
+- ALWAYS read existing workflow files in the user's agent folder (`{ACTIVE_AGENT.folder}/workflows/`) as schema examples before generating any workflow JSON.
 - ALWAYS read the agent's `connectionreferences.mcs.yml` to understand connector wiring.
 - ALWAYS read `.local/config.json` to get the agent folder name.
-- Create the workflow in a new folder: `{agent.folder}/workflows/{WorkflowName}-{GUID}/`
+- Create the workflow in a new folder: `{ACTIVE_AGENT.folder}/workflows/{WorkflowName}-{GUID}/`
 - Write both `metadata.yml` and `workflow.json` into that folder.
 - After writing, check for errors using the diagnostics tool.
 - **TRACK PROGRESS**: Use the todo list tool to track your progress through this skill's steps. Create a todo list at the start with all the steps, mark each in-progress as you start it, and mark completed when done.
@@ -45,14 +45,14 @@ From their response, determine:
 
 ## Step 2: Check Existing Workflows
 
-Read `workspace/agents/{agent.slug}/workflows.md` to see if a suitable workflow already exists. If the agent already has a workflow that does something similar, tell the user:
+Read `workspace/agents/{ACTIVE_AGENT.slug}/workflows.md` to see if a suitable workflow already exists. If the agent already has a workflow that does something similar, tell the user:
 - "Your agent already has a workflow called '{name}' that {does X}. Would you like to use that one, or create a new one?"
 
-Also check `workspace/agents/{agent.slug}/connections.md` to see which connectors are already configured. If the needed connector isn't available, tell the user they'll need to add it through the Copilot Studio portal first.
+Also check `workspace/agents/{ACTIVE_AGENT.slug}/connections.md` to see which connectors are already configured. If the needed connector isn't available, tell the user they'll need to add it through the Copilot Studio portal first.
 
 ## Step 3: Generate the Workflow
 
-Read the template from an existing workflow in the agent folder (e.g., `{agent.folder}/workflows/*/workflow.json`).
+Read the template from an existing workflow in the agent folder (e.g., `{ACTIVE_AGENT.folder}/workflows/*/workflow.json`).
 
 Generate a new GUID for the workflow ID. You can use any valid GUID format (8-4-4-4-12 hex characters).
 
@@ -76,7 +76,7 @@ isTransacted: true
 
 ### workflow.json
 Customize the template by:
-1. Setting the correct `connectionReferences` — match the `connectionReferenceLogicalName` to a value from `workspace/agents/{agent.slug}/connections.md`
+1. Setting the correct `connectionReferences` — match the `connectionReferenceLogicalName` to a value from `workspace/agents/{ACTIVE_AGENT.slug}/connections.md`
 2. Defining trigger inputs — what the topic will pass to the workflow
 3. Adding the correct connector action — use the right `operationId` for the task
 4. Defining the response outputs — what data goes back to the topic
@@ -94,7 +94,7 @@ Show the user the generated workflow and explain:
 ## Step 4: Write the Files
 
 After the user approves:
-1. Create the workflow folder: `{agent.folder}/workflows/{WorkflowName}-{GUID}/`
+1. Create the workflow folder: `{ACTIVE_AGENT.folder}/workflows/{WorkflowName}-{GUID}/`
 2. Write `metadata.yml`
 3. Write `workflow.json`
 4. Check for errors using the diagnostics tool
@@ -102,7 +102,7 @@ After the user approves:
 6. If clean, show the user:
    - Links to the created files so they can review them
    - The Copilot Studio web link: `https://copilotstudio.microsoft.com/`
-   - Example: "Your workflow is ready! Review it here: `{agent.folder}/workflows/{WorkflowName}-{GUID}/workflow.json` and test it in [Copilot Studio](https://copilotstudio.microsoft.com/)."
+   - Example: "Your workflow is ready! Review it here: `{ACTIVE_AGENT.folder}/workflows/{WorkflowName}-{GUID}/workflow.json` and test it in [Copilot Studio](https://copilotstudio.microsoft.com/)."
 
 After the files are written, record anonymous usage telemetry (best-effort,
 non-blocking — no user-facing message, and it never fails the step):

--- a/solutions/ess-maker-skills/src/skills/workflows/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/workflows/delete/SKILL.md
@@ -24,9 +24,9 @@ files.**
 
 ## Step 1: Identify the Workflow
 
-Read `.local/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `ACTIVE_AGENT.folder` and `ACTIVE_AGENT.slug`.
 
-List the workflow folders in `{agent.folder}/workflows/`. Each workflow is a
+List the workflow folders in `{ACTIVE_AGENT.folder}/workflows/`. Each workflow is a
 folder containing `metadata.yml` and `workflow.json`.
 
 If the user named a specific workflow, find the matching folder by:
@@ -39,7 +39,7 @@ and ask the user to pick one.
 ## Step 2: Check for Topic References
 
 Before deleting, check if any topics reference this workflow's ID. Search
-all topic files in `{agent.folder}/topics/` for the workflow's GUID (from
+all topic files in `{ACTIVE_AGENT.folder}/topics/` for the workflow's GUID (from
 `metadata.yml` → `workflowId`).
 
 If topics reference this workflow, warn the user:
@@ -82,7 +82,7 @@ non-blocking); it needs no user-facing message and never fails the step.
 
 ## Step 5: Delete the Local Files
 
-Delete the entire workflow folder: `{agent.folder}/workflows/{folder-name}/`
+Delete the entire workflow folder: `{ACTIVE_AGENT.folder}/workflows/{folder-name}/`
 
 If the user also chose to delete referencing topics (from Step 2), delete
 those topic files as well.

--- a/solutions/ess-maker-skills/src/skills/workflows/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/workflows/update/SKILL.md
@@ -22,9 +22,9 @@ to take effect. **NEVER stop after editing only the local file.**
 
 ## Step 1: Identify the Workflow
 
-Read `.local/config.json` to get `agent.folder` and `agent.slug`.
+Read `.local/config.json` to get `ACTIVE_AGENT.folder` and `ACTIVE_AGENT.slug`.
 
-List workflow folders in `{agent.folder}/workflows/`. Each contains
+List workflow folders in `{ACTIVE_AGENT.folder}/workflows/`. Each contains
 `metadata.yml` and `workflow.json`.
 
 Match the user's request to a workflow by folder name or display name in

--- a/tests/flightcheck/checks/test_solution.py
+++ b/tests/flightcheck/checks/test_solution.py
@@ -53,6 +53,7 @@ SOLUTION_ID = "11111111-1111-1111-1111-111111111111"
 class _MinimalRunner:
     env_url: str | None
     dv_token: str | None
+    expected_solution_unique_name: str | None = None
 
 
 @pytest.fixture
@@ -170,6 +171,42 @@ def test_passed_when_hr_variant_present(runner: _MinimalRunner) -> None:
     r = _check_ess_solution_installed(runner)[0]
     assert r.status == "Passed"
     assert "msdyn_copilotforemployeeselfservicehr" in r.result
+
+
+@responses.activate
+def test_failed_when_expected_variant_is_not_present(
+    runner: _MinimalRunner,
+) -> None:
+    runner.expected_solution_unique_name = (
+        "msdyn_CopilotForEmployeeSelfServiceDAIT"
+    )
+    _register_solutions(solutions=[
+        _solution_record("msdyn_copilotforemployeeselfservicehr"),
+    ])
+
+    r = _check_ess_solution_installed(runner)[0]
+
+    assert r.status == "Failed"
+    assert "msdyn_CopilotForEmployeeSelfServiceDAIT" in r.result
+
+
+@responses.activate
+def test_passed_when_expected_variant_matches_case_insensitively(
+    runner: _MinimalRunner,
+) -> None:
+    runner.expected_solution_unique_name = (
+        "msdyn_CopilotForEmployeeSelfServiceDAIT"
+    )
+    _register_solutions(solutions=[
+        _solution_record("msdyn_copilotforemployeeselfservicedait"),
+        _solution_record("msdyn_copilotforemployeeselfservicehr"),
+    ])
+
+    r = _check_ess_solution_installed(runner)[0]
+
+    assert r.status == "Passed"
+    assert "msdyn_copilotforemployeeselfservicedait" in r.result
+    assert "msdyn_copilotforemployeeselfservicehr" not in r.result
 
 
 @responses.activate

--- a/tests/flightcheck/test_cli_single_checkpoint.py
+++ b/tests/flightcheck/test_cli_single_checkpoint.py
@@ -41,6 +41,7 @@ def _args(
     return argparse.Namespace(
         checkpoint=checkpoint,
         environment_url=environment_url,
+        expected_solution=None,
         environment_id=None,
         output=str(tmp_path / "out"),
         no_telemetry=no_telemetry,
@@ -115,7 +116,11 @@ class TestHermeticRun:
 
     @staticmethod
     def _install_fake_plan(
-        monkeypatch: pytest.MonkeyPatch, rows: list[CheckResult]
+        monkeypatch: pytest.MonkeyPatch,
+        rows: list[CheckResult],
+        *,
+        requires_config: bool = False,
+        requires_dataverse_endpoint: bool = False,
     ) -> None:
         class _Spec:
             category_label = "Fake"
@@ -127,6 +132,10 @@ class TestHermeticRun:
 
             def __init__(self, fns: list) -> None:
                 self.ordered_fns = fns
+                self.requires_config = requires_config
+                self.requires_dataverse_endpoint = (
+                    requires_dataverse_endpoint
+                )
 
         def _fn(runner):  # noqa: ARG001 — runner arg is the check-fn contract
             return list(rows)
@@ -161,6 +170,30 @@ class TestHermeticRun:
         with pytest.raises(SystemExit) as exc:
             cli._run_single_checkpoint(_args("FAKE-001", tmp_path))
         assert exc.value.code == 1
+
+    def test_ess_solution_can_run_before_setup_with_explicit_environment(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _silence_output: None,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        self._install_fake_plan(
+            monkeypatch,
+            [_row("ESS-SOLN-001", Status.PASSED.value)],
+            requires_config=True,
+            requires_dataverse_endpoint=True,
+        )
+        args = _args(
+            "ESS-SOLN-001",
+            tmp_path,
+            environment_url="https://org.crm.dynamics.com",
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            cli._run_single_checkpoint(args)
+
+        assert exc.value.code == 0
 
 
 class TestCheckpointTelemetry:

--- a/tests/flightcheck/test_powerplatform_client.py
+++ b/tests/flightcheck/test_powerplatform_client.py
@@ -1,0 +1,102 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for Power Platform App Management API methods."""
+
+from __future__ import annotations
+
+import responses
+
+
+def _client():
+    from flightcheck.powerplatform_client import PowerPlatformClient
+
+    client = PowerPlatformClient("tenant")
+    client._token = "REDACTED_TOKEN"  # noqa: S105 — test fixture
+    return client
+
+
+@responses.activate
+def test_lists_environment_application_packages():
+    from flightcheck.powerplatform_client import PP_API_BASE
+
+    responses.get(
+        f"{PP_API_BASE}/appmanagement/environments/env-123/applicationPackages",
+        json={
+            "value": [{
+                "uniqueName": "msdyn_CopilotForEmployeeSelfServiceDAHR",
+                "state": "None",
+            }]
+        },
+        status=200,
+    )
+
+    packages = _client().list_environment_application_packages("env-123")
+
+    assert packages[0]["uniqueName"] == (
+        "msdyn_CopilotForEmployeeSelfServiceDAHR"
+    )
+
+
+@responses.activate
+def test_starts_application_install_and_returns_operation_id():
+    from flightcheck.powerplatform_client import PP_API_BASE
+
+    responses.post(
+        (
+            f"{PP_API_BASE}/appmanagement/environments/env-123/"
+            "applicationPackages/app-name/install"
+        ),
+        json={
+            "lastOperation": {
+                "operationId": "operation-123",
+                "state": "InstallRequested",
+            }
+        },
+        status=200,
+    )
+
+    result = _client().install_application_package("env-123", "app-name")
+
+    assert result["_operationId"] == "operation-123"
+    assert result["_async"] is False
+    assert responses.calls[0].request.body == b'{"payloadValue": ""}'
+
+
+@responses.activate
+def test_accepts_async_install_without_response_body():
+    from flightcheck.powerplatform_client import PP_API_BASE
+
+    responses.post(
+        (
+            f"{PP_API_BASE}/appmanagement/environments/env-123/"
+            "applicationPackages/app-name/install"
+        ),
+        body="",
+        status=202,
+    )
+
+    result = _client().install_application_package("env-123", "app-name")
+
+    assert result == {"_async": True, "_operationId": None}
+
+
+@responses.activate
+def test_gets_application_install_status():
+    from flightcheck.powerplatform_client import PP_API_BASE
+
+    responses.get(
+        (
+            f"{PP_API_BASE}/appmanagement/environments/env-123/"
+            "operations/operation-123"
+        ),
+        json={"operationId": "operation-123", "status": "Succeeded"},
+        status=200,
+    )
+
+    result = _client().get_application_package_install_status(
+        "env-123",
+        "operation-123",
+    )
+
+    assert result["status"] == "Succeeded"

--- a/tests/scripts/test_discover.py
+++ b/tests/scripts/test_discover.py
@@ -12,7 +12,7 @@ the function level — no external API calls are made.
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -278,3 +278,95 @@ class TestDiscoverListEnvironmentsMode:
         with pytest.raises(SystemExit) as exc_info:
             discover.main()
         assert exc_info.value.code == 2  # argparse error
+
+
+class TestMcpConfigCheck:
+    """Tests for the Dataverse MCP configuration preflight."""
+
+    @patch("discover.query_all")
+    def test_configured_when_default_server_and_client_enabled(self, query_all):
+        import discover
+
+        query_all.side_effect = [
+            [{"orgdborgsettings": "<OrgSettings />"}],
+            [{"isenabled": True, "statecode": 0}],
+        ]
+
+        state = discover.check_mcp_config("https://org.crm.dynamics.com", "token")
+
+        assert state == {
+            "configured": True,
+            "serverEnabled": True,
+            "githubCopilotEnabled": True,
+        }
+        assert query_all.call_args_list == [
+            call(
+                "https://org.crm.dynamics.com",
+                "token",
+                entity_set="organizations",
+                select="orgdborgsettings",
+            ),
+            call(
+                "https://org.crm.dynamics.com",
+                "token",
+                entity_set="allowedmcpclients",
+                select="applicationid,isenabled,statecode",
+                filter_expr=(
+                    "applicationid eq "
+                    f"'{discover.GITHUB_COPILOT_MCP_CLIENT_ID}'"
+                ),
+            ),
+        ]
+
+    @patch("discover.query_all")
+    def test_reports_each_missing_setting(self, query_all):
+        import discover
+
+        query_all.side_effect = [
+            [{
+                "orgdborgsettings": (
+                    "<OrgSettings><IsMCPEnabled>false</IsMCPEnabled>"
+                    "</OrgSettings>"
+                )
+            }],
+            [{"isenabled": False, "statecode": 0}],
+        ]
+
+        state = discover.check_mcp_config("https://org.crm.dynamics.com", "token")
+
+        assert state == {
+            "configured": False,
+            "serverEnabled": False,
+            "githubCopilotEnabled": False,
+        }
+
+    @patch("discover.query_all")
+    @patch("discover.authenticate")
+    def test_cli_outputs_machine_readable_state(
+        self, authenticate, query_all, capsys, monkeypatch
+    ):
+        import discover
+
+        authenticate.return_value = "token"
+        query_all.side_effect = [
+            [{"orgdborgsettings": "<OrgSettings />"}],
+            [{"isenabled": True, "statecode": 0}],
+        ]
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "discover.py",
+                "--url",
+                "https://org.crm.dynamics.com/",
+                "--check-mcp-config",
+            ],
+        )
+
+        discover.main()
+
+        output = capsys.readouterr().out
+        json_line = next(
+            line for line in output.splitlines()
+            if line.startswith("MCP_CONFIG_JSON:")
+        )
+        assert json.loads(json_line.split(":", 1)[1])["configured"] is True

--- a/tests/scripts/test_discover.py
+++ b/tests/scripts/test_discover.py
@@ -370,3 +370,237 @@ class TestMcpConfigCheck:
             if line.startswith("MCP_CONFIG_JSON:")
         )
         assert json.loads(json_line.split(":", 1)[1])["configured"] is True
+
+
+def test_ess_inventory_excludes_installed_agent_from_available_options():
+    import discover
+
+    config = {
+        "experiences": {
+            "da": {
+                "shortLabel": "DA",
+                "description": "DA.",
+                "displayOrder": 1,
+            },
+            "cea": {
+                "shortLabel": "CEA",
+                "description": "CEA.",
+                "displayOrder": 2,
+            },
+        },
+        "verticals": {
+            "hr": {
+                "label": "Employee Self-Service HR",
+                "description": "HR.",
+                "displayOrder": 1,
+            },
+            "it": {
+                "label": "Employee Self-Service IT",
+                "description": "IT.",
+                "displayOrder": 2,
+            },
+        },
+        "installations": {
+            "da.hr": {
+                "configKey": "da.esshr",
+                "experienceKey": "da",
+                "verticalKey": "hr",
+                "solution": {"parentUniqueName": "schema_da_hr"},
+            },
+            "da.it": {
+                "configKey": "da.essit",
+                "experienceKey": "da",
+                "verticalKey": "it",
+                "solution": {"parentUniqueName": "schema_da_it"},
+            },
+            "cea.hr": {
+                "configKey": "cea.esshr",
+                "experienceKey": "cea",
+                "verticalKey": "hr",
+                "solution": {"parentUniqueName": "schema_cea_hr"},
+            },
+            "cea.it": {
+                "configKey": "cea.essit",
+                "experienceKey": "cea",
+                "verticalKey": "it",
+                "solution": {"parentUniqueName": "schema_cea_it"},
+            },
+        },
+    }
+    agents = [
+        {
+            "botid": "ess",
+            "name": "ESS DA HR",
+            "schemaname": "SCHEMA_DA_HR",
+            "ismanaged": True,
+        },
+        {
+            "botid": "unrelated",
+            "name": "Unrelated bot",
+            "schemaname": "custom_bot",
+            "ismanaged": False,
+        },
+    ]
+
+    inventory = discover.build_ess_agent_inventory(agents, config)
+
+    assert [agent["botid"] for agent in inventory["agents"]] == ["ess"]
+    assert inventory["installedInstallationKeys"] == ["da.hr"]
+    assert [
+        option["key"] for option in inventory["availableInstallations"]
+    ] == ["da.it", "cea.hr", "cea.it"]
+
+
+@patch("discover.load_installation_config")
+@patch("discover.discover_agents")
+@patch("discover.authenticate")
+def test_agent_cli_emits_inventory_and_filters_unrelated_bots(
+    authenticate,
+    discover_agents,
+    load_config,
+    capsys,
+    monkeypatch,
+):
+    import discover
+    import install_ess_agent
+
+    authenticate.return_value = "token"
+    load_config.return_value = install_ess_agent.load_installation_config()
+    discover_agents.return_value = [
+        {
+            "botid": "ess",
+            "name": "ESS DA HR",
+            "schemaname": "msdyn_copilotforemployeeselfservicedahr",
+            "ismanaged": True,
+        },
+        {
+            "botid": "other",
+            "name": "Other bot",
+            "schemaname": "custom_other",
+            "ismanaged": False,
+        },
+    ]
+    monkeypatch.setattr(
+        "sys.argv",
+        ["discover.py", "--url", "https://org.crm.dynamics.com"],
+    )
+
+    discover.main()
+
+    output = capsys.readouterr().out
+    marker = next(
+        line for line in output.splitlines()
+        if line.startswith("ESS_AGENT_DISCOVERY_JSON:")
+    )
+    inventory = json.loads(marker.split(":", 1)[1])
+    assert [agent["botid"] for agent in inventory["agents"]] == ["ess"]
+    assert [
+        option["key"] for option in inventory["availableInstallations"]
+    ] == ["da.it", "cea.hr", "cea.it"]
+    assert "Other bot" not in output
+
+
+@patch("discover.load_installation_config")
+@patch("discover.discover_agents", return_value=[])
+@patch("discover.authenticate", return_value="token")
+def test_agent_cli_emits_all_four_options_when_no_agent_exists(
+    _authenticate,
+    _discover_agents,
+    load_config,
+    capsys,
+    monkeypatch,
+):
+    import discover
+    import install_ess_agent
+
+    load_config.return_value = install_ess_agent.load_installation_config()
+    monkeypatch.setattr(
+        "sys.argv",
+        ["discover.py", "--url", "https://org.crm.dynamics.com"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        discover.main()
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    marker = next(
+        line for line in output.splitlines()
+        if line.startswith("ESS_AGENT_DISCOVERY_JSON:")
+    )
+    inventory = json.loads(marker.split(":", 1)[1])
+    assert len(inventory["availableInstallations"]) == 4
+    assert "No supported ESS agents found" in output
+
+
+def test_sync_installed_agents_records_all_agents_and_preserves_extraction(
+    tmp_path,
+):
+    import discover
+
+    config_path = tmp_path / ".local" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text(json.dumps({
+        "configVersion": 2,
+        "setup": "complete",
+        "activeAgent": "da.esshr",
+        "common": {"environmentSku": "Sandbox"},
+        "agents": {
+            "da": {
+                "esshr": {
+                    "name": "Old HR",
+                    "folder": "workspace/agents/hr",
+                    "extraction": {
+                        "status": "complete",
+                        "workflowCount": 2,
+                    },
+                    "installation": {"status": "installed"},
+                }
+            }
+        },
+    }), encoding="utf-8")
+    inventory = {
+        "agents": [
+            {
+                "configKey": "da.esshr",
+                "name": "DA HR",
+                "botid": "bot-hr",
+                "schemaname": "schema-hr",
+                "ismanaged": True,
+            },
+            {
+                "configKey": "cea.essit",
+                "name": "CEA IT",
+                "botid": "bot-it",
+                "schemaname": "schema-it",
+                "ismanaged": True,
+            },
+        ],
+        "installedInstallationKeys": ["da.hr", "cea.it"],
+        "availableInstallations": [],
+    }
+
+    config = discover.sync_installed_agents(
+        "https://org.crm.dynamics.com/",
+        inventory,
+        config_path,
+    )
+
+    assert config["setup"] == "complete"
+    assert config["common"] == {
+        "environmentSku": "Sandbox",
+        "dataverseEndpoint": "https://org.crm.dynamics.com",
+    }
+    assert config["agents"]["da"]["esshr"]["folder"] == (
+        "workspace/agents/hr"
+    )
+    assert config["agents"]["da"]["esshr"]["extraction"] == {
+        "status": "complete",
+        "workflowCount": 2,
+    }
+    assert config["agents"]["cea"]["essit"]["installation"] == {
+        "status": "installed"
+    }
+    assert config["agents"]["cea"]["essit"]["extraction"] == {
+        "status": "not-started"
+    }

--- a/tests/scripts/test_ess_connection_binding.py
+++ b/tests/scripts/test_ess_connection_binding.py
@@ -1,0 +1,177 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import json
+
+
+def _connection(name, *, connector="shared_alchemy", status="Connected"):
+    return {
+        "name": name,
+        "properties": {
+            "apiId": f"/providers/Microsoft.PowerApps/apis/{connector}",
+            "displayName": f"Connection {name}",
+            "accountName": "maker@contoso.com",
+            "statuses": [{"status": status}],
+        },
+    }
+
+
+def test_installation_config_declares_only_it_connection_requirements():
+    import install_ess_agent
+
+    installations = install_ess_agent.load_installation_config()["installations"]
+
+    assert installations["da.hr"]["requiredConnection"] is None
+    assert installations["cea.hr"]["requiredConnection"] is None
+    assert installations["da.it"]["requiredConnection"]["connectorApiName"] == (
+        "shared_alchemy"
+    )
+    assert installations["cea.it"]["requiredConnection"]["connectorApiName"] == (
+        "shared_alchemy"
+    )
+
+
+def test_preflight_requires_manual_selection_for_multiple_connected_matches():
+    import ess_connection_binding
+    import install_ess_agent
+
+    installation = install_ess_agent.load_installation_config()["installations"][
+        "da.it"
+    ]
+    result = ess_connection_binding.build_preflight_result(
+        installation,
+        [
+            _connection("one"),
+            _connection("two"),
+            _connection("broken", status="Error"),
+            _connection("wrong", connector="shared_workdaysoap"),
+        ],
+        "environment-id",
+    )
+
+    assert result["status"] == "selection-required"
+    assert [connection["name"] for connection in result["connections"]] == [
+        "one",
+        "two",
+    ]
+    assert result["selectedConnection"] is None
+
+
+def test_preflight_auto_selects_only_connected_match():
+    import ess_connection_binding
+    import install_ess_agent
+
+    installation = install_ess_agent.load_installation_config()["installations"][
+        "cea.it"
+    ]
+    result = ess_connection_binding.build_preflight_result(
+        installation,
+        [_connection("alchemy")],
+        "environment-id",
+    )
+
+    assert result["status"] == "ready"
+    assert result["selectedConnection"]["name"] == "alchemy"
+
+
+def test_bind_updates_exact_solution_reference_and_persists_s_states(
+    tmp_path,
+    monkeypatch,
+):
+    import ess_connection_binding
+
+    class FakePPAdmin:
+        def __init__(self, tenant_id):
+            self.tenant_id = tenant_id
+
+        def authenticate(self, *, include_flow):
+            assert include_flow is False
+
+        def find_environment_id_by_dataverse_url(self, env_url):
+            return "environment-id"
+
+        def get_connections(self, environment_id):
+            assert environment_id == "environment-id"
+            return [_connection("alchemy-connection")]
+
+    reference_id = "11111111-1111-1111-1111-111111111111"
+    solution_id = "22222222-2222-2222-2222-222222222222"
+    query_results = iter([
+        [{
+            "connectionreferenceid": reference_id,
+            "connectionreferencelogicalname": (
+                "msdyn_copilotforemployeeselfservicedait.shared_alchemy."
+                "shared-alchemy-8262076a-e778-450b-8a35-5ae815712319"
+            ),
+            "connectorid": "/providers/Microsoft.PowerApps/apis/shared_alchemy",
+            "connectionid": None,
+            "statuscode": 1,
+        }],
+        [{"objectid": reference_id, "_solutionid_value": solution_id}],
+        [{
+            "solutionid": solution_id,
+            "uniquename": "msdyn_CopilotForEmployeeSelfServiceDAIT",
+        }],
+        [{
+            "connectionreferenceid": reference_id,
+            "connectionid": "alchemy-connection",
+        }],
+    ])
+    updates = []
+    monkeypatch.setattr(ess_connection_binding, "discover_tenant", lambda url: "tenant")
+    monkeypatch.setattr(ess_connection_binding, "authenticate", lambda url: "token")
+    monkeypatch.setattr(
+        ess_connection_binding,
+        "query_all",
+        lambda *args, **kwargs: next(query_results),
+    )
+    monkeypatch.setattr(
+        ess_connection_binding,
+        "update_record",
+        lambda *args: updates.append(args),
+    )
+    monkeypatch.setattr(
+        ess_connection_binding,
+        "LOCAL_CONFIG_PATH",
+        tmp_path / "config.json",
+    )
+
+    result = ess_connection_binding.bind_connection(
+        "https://org.crm.dynamics.com",
+        "da",
+        "it",
+        "alchemy-connection",
+        pp_admin_client_factory=FakePPAdmin,
+    )
+
+    assert result["status"] == "bound"
+    assert updates[0][-1] == {"connectionid": "alchemy-connection"}
+    config = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    state = config["agents"]["da"]["essit"]["setupStatus"]
+    assert state["S1"]["state"] == "done"
+    assert state["S2"]["state"] == "done"
+    assert state["S2"]["connectionName"] == "alchemy-connection"
+
+
+def test_hr_binding_marks_connection_not_required(tmp_path, monkeypatch):
+    import ess_connection_binding
+
+    monkeypatch.setattr(
+        ess_connection_binding,
+        "LOCAL_CONFIG_PATH",
+        tmp_path / "config.json",
+    )
+
+    result = ess_connection_binding.bind_connection(
+        "https://org.crm.dynamics.com",
+        "cea",
+        "hr",
+        None,
+    )
+
+    assert result["status"] == "not-required"
+    config = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    state = config["agents"]["cea"]["esshr"]["setupStatus"]
+    assert state["S2"]["notRequired"] is True

--- a/tests/scripts/test_install_ess_agent.py
+++ b/tests/scripts/test_install_ess_agent.py
@@ -63,6 +63,27 @@ def test_installation_config_has_collision_safe_composite_keys():
     }) == 4
 
 
+def test_installation_options_are_single_picker_in_da_then_cea_order():
+    import install_ess_agent
+
+    options = install_ess_agent.build_installation_options(
+        install_ess_agent.load_installation_config()
+    )
+
+    assert [option["label"] for option in options] == [
+        "DA : Employee Self-Service HR",
+        "DA : Employee Self-Service IT",
+        "CEA : Employee Self-Service HR",
+        "CEA : Employee Self-Service IT",
+    ]
+    assert [option["configKey"] for option in options] == [
+        "da.esshr",
+        "da.essit",
+        "cea.esshr",
+        "cea.essit",
+    ]
+
+
 def test_installation_config_rejects_mismatched_composite_key(tmp_path: Path):
     import install_ess_agent
 
@@ -104,9 +125,16 @@ def test_installation_config_rejects_catalog_drift(tmp_path: Path):
 
 
 class FakePPAdminClient:
-    def __init__(self, tenant_id, environment_id="env-123"):
+    def __init__(self, tenant_id, environment_id="env-123", connections=None):
         self.tenant_id = tenant_id
         self.environment_id = environment_id
+        self.connections = connections if connections is not None else [{
+            "name": "alchemy-connection",
+            "properties": {
+                "apiId": "/providers/Microsoft.PowerApps/apis/shared_alchemy",
+                "statuses": [{"status": "Connected"}],
+            },
+        }]
         self.authenticated = False
 
     def authenticate(self, *, include_flow=True):
@@ -115,6 +143,10 @@ class FakePPAdminClient:
 
     def find_environment_id_by_dataverse_url(self, _env_url):
         return self.environment_id
+
+    def get_connections(self, environment_id):
+        assert environment_id == self.environment_id
+        return self.connections
 
 
 class FakePowerPlatformClient:
@@ -197,6 +229,84 @@ def test_install_resolves_environment_and_polls_api(
     assert "Installation status (poll 1, 0s elapsed): Succeeded" in (
         capsys.readouterr().out
     )
+
+
+@patch("install_ess_agent.discover_tenant", return_value="tenant-123")
+def test_it_install_refuses_to_start_without_required_connection(
+    _mock_discover_tenant,
+):
+    import install_ess_agent
+
+    pp_admin = FakePPAdminClient("tenant-123", connections=[])
+    powerplatform = FakePowerPlatformClient(
+        "tenant-123",
+        packages=[{
+            "uniqueName": "msdyn_CopilotForEmployeeSelfServiceDAIT",
+            "state": "None",
+        }],
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="requires an active Microsoft 365 Self-Help",
+    ):
+        install_ess_agent.install_agent(
+            "https://org.crm.dynamics.com",
+            "da",
+            "it",
+            pp_admin_client_factory=lambda _tenant: pp_admin,
+            powerplatform_client_factory=lambda _tenant: powerplatform,
+        )
+
+    assert powerplatform.authenticated is False
+    assert powerplatform.install_calls == []
+
+
+def test_solution_catalog_uses_power_apps_connector_names():
+    import install_ess_agent
+
+    catalog = install_ess_agent.CATALOG_PATH.read_text(encoding="utf-8")
+
+    assert "| Logical name | Connector |" not in catalog
+    assert "| Child schema | Connector | Flow usage |" in catalog
+    for friendly_name in (
+        "Microsoft 365 Self-Help",
+        "ServiceNow",
+        "Microsoft Dataverse",
+        "SAP OData",
+        "Workday",
+    ):
+        assert f"Name: `{friendly_name}`" in catalog
+    assert "Logical name: `new_sharedworkdaysoap_ff0df`" in catalog
+
+
+def test_it_install_requires_selection_when_multiple_connections_exist():
+    import install_ess_agent
+
+    installation = install_ess_agent.load_installation_config()["installations"][
+        "cea.it"
+    ]
+    connections = [
+        {
+            "name": name,
+            "properties": {
+                "apiId": "/providers/Microsoft.PowerApps/apis/shared_alchemy",
+                "statuses": [{"status": "Connected"}],
+            },
+        }
+        for name in ("alchemy-one", "alchemy-two")
+    ]
+
+    with pytest.raises(RuntimeError, match="Multiple connected instances"):
+        install_ess_agent.validate_required_connection(
+            installation,
+            connections,
+        )
+    assert install_ess_agent.validate_required_connection(
+        installation,
+        connections,
+        "alchemy-two",
+    ) == "alchemy-two"
 
 
 @patch("install_ess_agent.discover_tenant", return_value="tenant-123")

--- a/tests/scripts/test_install_ess_agent.py
+++ b/tests/scripts/test_install_ess_agent.py
@@ -1,0 +1,235 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the Employee Self-Service Marketplace application installer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_catalog_resolves_all_parent_schema_combinations():
+    import install_ess_agent
+
+    mappings = install_ess_agent.load_parent_schemas()
+
+    assert mappings == {
+        ("cea", "hr"): "msdyn_CopilotForEmployeeSelfServiceHR",
+        ("cea", "it"): "msdyn_CopilotForEmployeeSelfServiceIT",
+        ("da", "hr"): "msdyn_CopilotForEmployeeSelfServiceDAHR",
+        ("da", "it"): "msdyn_CopilotForEmployeeSelfServiceDAIT",
+    }
+
+
+def test_catalog_requires_all_four_parent_mappings(tmp_path: Path):
+    import install_ess_agent
+
+    catalog = tmp_path / "solution-catalog.md"
+    catalog.write_text(
+        """
+## Parents
+
+| # | Parent package | Parent schema name | Status | Reference |
+| --- | --- | --- | --- | --- |
+| 1 | Employee Self-Service HR | `schema` | Active (DA bundle) | _(none)_ |
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing parent schema mappings"):
+        install_ess_agent.load_parent_schemas(catalog)
+
+
+class FakePPAdminClient:
+    def __init__(self, tenant_id, environment_id="env-123"):
+        self.tenant_id = tenant_id
+        self.environment_id = environment_id
+        self.authenticated = False
+
+    def authenticate(self, *, include_flow=True):
+        self.authenticated = True
+        self.include_flow = include_flow
+
+    def find_environment_id_by_dataverse_url(self, _env_url):
+        return self.environment_id
+
+
+class FakePowerPlatformClient:
+    def __init__(
+        self,
+        tenant_id,
+        *,
+        packages,
+        install_result=None,
+        statuses=None,
+    ):
+        self.tenant_id = tenant_id
+        self.packages = list(packages)
+        self.install_result = install_result or {}
+        self.statuses = list(statuses or [])
+        self.authenticated = False
+        self.install_calls = []
+
+    def authenticate(self):
+        self.authenticated = True
+
+    def list_environment_application_packages(self, _environment_id):
+        if self.packages and isinstance(self.packages[0], list):
+            return self.packages.pop(0)
+        return self.packages
+
+    def install_application_package(self, environment_id, unique_name):
+        self.install_calls.append((environment_id, unique_name))
+        return self.install_result
+
+    def get_application_package_install_status(
+        self,
+        _environment_id,
+        _operation_id,
+    ):
+        return self.statuses.pop(0)
+
+
+@patch("install_ess_agent.discover_tenant", return_value="tenant-123")
+def test_install_resolves_environment_and_polls_api(
+    _mock_discover_tenant,
+):
+    import install_ess_agent
+
+    pp_admin = FakePPAdminClient("tenant-123")
+    powerplatform = FakePowerPlatformClient(
+        "tenant-123",
+        packages=[{
+            "uniqueName": "msdyn_CopilotForEmployeeSelfServiceDAIT",
+            "state": "None",
+        }],
+        install_result={
+            "lastOperation": {
+                "state": "InstallRequested",
+                "operationId": "operation-123",
+            },
+            "_operationId": "operation-123",
+        },
+        statuses=[{"status": "Succeeded"}],
+    )
+
+    schema = install_ess_agent.install_agent(
+        "https://org.crm.dynamics.com/",
+        "da",
+        "it",
+        pp_admin_client_factory=lambda _tenant: pp_admin,
+        powerplatform_client_factory=lambda _tenant: powerplatform,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    assert schema == "msdyn_CopilotForEmployeeSelfServiceDAIT"
+    assert pp_admin.authenticated
+    assert pp_admin.include_flow is False
+    assert powerplatform.authenticated
+    assert powerplatform.install_calls == [
+        ("env-123", "msdyn_CopilotForEmployeeSelfServiceDAIT")
+    ]
+
+
+@patch("install_ess_agent.discover_tenant", return_value="tenant-123")
+def test_install_skips_request_when_application_is_already_installed(
+    _mock_discover_tenant,
+):
+    import install_ess_agent
+
+    powerplatform = FakePowerPlatformClient(
+        "tenant-123",
+        packages=[{
+            "uniqueName": "msdyn_CopilotForEmployeeSelfServiceHR",
+            "state": "Installed",
+        }],
+    )
+
+    schema = install_ess_agent.install_agent(
+        "https://org.crm.dynamics.com",
+        "cea",
+        "hr",
+        pp_admin_client_factory=FakePPAdminClient,
+        powerplatform_client_factory=lambda _tenant: powerplatform,
+    )
+
+    assert schema == "msdyn_CopilotForEmployeeSelfServiceHR"
+    assert powerplatform.install_calls == []
+
+
+@patch("install_ess_agent.discover_tenant", return_value="tenant-123")
+def test_install_falls_back_to_package_state_when_operation_id_is_absent(
+    _mock_discover_tenant,
+):
+    import install_ess_agent
+
+    schema_name = "msdyn_CopilotForEmployeeSelfServiceIT"
+    powerplatform = FakePowerPlatformClient(
+        "tenant-123",
+        packages=[
+            [{"uniqueName": schema_name, "state": "None"}],
+            [{"uniqueName": schema_name, "state": "Installing"}],
+            [{"uniqueName": schema_name, "state": "Installed"}],
+        ],
+        install_result={"_async": True, "_operationId": None},
+    )
+
+    schema = install_ess_agent.install_agent(
+        "https://org.crm.dynamics.com",
+        "cea",
+        "it",
+        pp_admin_client_factory=FakePPAdminClient,
+        powerplatform_client_factory=lambda _tenant: powerplatform,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    assert schema == schema_name
+
+
+@patch("install_ess_agent.discover_tenant", return_value="tenant-123")
+def test_install_reports_missing_marketplace_entitlement(
+    _mock_discover_tenant,
+):
+    import install_ess_agent
+
+    powerplatform = FakePowerPlatformClient("tenant-123", packages=[])
+
+    with pytest.raises(RuntimeError, match="not available"):
+        install_ess_agent.install_agent(
+            "https://org.crm.dynamics.com",
+            "da",
+            "hr",
+            pp_admin_client_factory=FakePPAdminClient,
+            powerplatform_client_factory=lambda _tenant: powerplatform,
+        )
+
+
+@patch("install_ess_agent.discover_tenant", return_value="tenant-123")
+def test_install_reports_application_install_permission_failure(
+    _mock_discover_tenant,
+):
+    import install_ess_agent
+
+    schema_name = "msdyn_CopilotForEmployeeSelfServiceDAHR"
+    powerplatform = FakePowerPlatformClient(
+        "tenant-123",
+        packages=[{"uniqueName": schema_name, "state": "None"}],
+        install_result={
+            "_error": "insufficient_permissions",
+            "_status": 403,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="cannot install"):
+        install_ess_agent.install_agent(
+            "https://org.crm.dynamics.com",
+            "da",
+            "hr",
+            pp_admin_client_factory=FakePPAdminClient,
+            powerplatform_client_factory=lambda _tenant: powerplatform,
+        )

--- a/tests/scripts/test_install_ess_agent.py
+++ b/tests/scripts/test_install_ess_agent.py
@@ -208,6 +208,7 @@ def test_install_resolves_environment_and_polls_api(
         },
         statuses=[{"status": "Succeeded"}],
     )
+    states = []
 
     schema = install_ess_agent.install_agent(
         "https://org.crm.dynamics.com/",
@@ -217,6 +218,7 @@ def test_install_resolves_environment_and_polls_api(
         powerplatform_client_factory=lambda _tenant: powerplatform,
         poll_interval_seconds=0,
         sleep=lambda _seconds: None,
+        installation_state_callback=states.append,
     )
 
     assert schema == "msdyn_CopilotForEmployeeSelfServiceDAIT"
@@ -226,6 +228,7 @@ def test_install_resolves_environment_and_polls_api(
     assert powerplatform.install_calls == [
         ("env-123", "msdyn_CopilotForEmployeeSelfServiceDAIT")
     ]
+    assert states == ["installing", "automatic-complete"]
     assert "Installation status (poll 1, 0s elapsed): Succeeded" in (
         capsys.readouterr().out
     )

--- a/tests/scripts/test_install_ess_agent.py
+++ b/tests/scripts/test_install_ess_agent.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -41,6 +42,65 @@ def test_catalog_requires_all_four_parent_mappings(tmp_path: Path):
 
     with pytest.raises(ValueError, match="missing parent schema mappings"):
         install_ess_agent.load_parent_schemas(catalog)
+
+
+def test_installation_config_has_collision_safe_composite_keys():
+    import install_ess_agent
+
+    config = install_ess_agent.load_installation_config()
+
+    assert set(config["installations"]) == {
+        "da.hr",
+        "da.it",
+        "cea.hr",
+        "cea.it",
+    }
+    assert config["experiences"]["da"]["recommended"] is True
+    assert config["experiences"]["cea"]["recommended"] is False
+    assert len({
+        entry["marketplaceApplication"]["uniqueName"]
+        for entry in config["installations"].values()
+    }) == 4
+
+
+def test_installation_config_rejects_mismatched_composite_key(tmp_path: Path):
+    import install_ess_agent
+
+    config = install_ess_agent.load_installation_config()
+    config["installations"]["da.hr"]["verticalKey"] = "it"
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not match"):
+        install_ess_agent.load_installation_config(config_path)
+
+
+def test_installation_config_rejects_duplicate_application_name(tmp_path: Path):
+    import install_ess_agent
+
+    config = install_ess_agent.load_installation_config()
+    config["installations"]["da.it"]["marketplaceApplication"]["uniqueName"] = (
+        config["installations"]["da.hr"]["marketplaceApplication"]["uniqueName"]
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="assigned to more than one"):
+        install_ess_agent.load_installation_config(config_path)
+
+
+def test_installation_config_rejects_catalog_drift(tmp_path: Path):
+    import install_ess_agent
+
+    config = install_ess_agent.load_installation_config()
+    config["installations"]["cea.hr"]["solution"]["parentUniqueName"] = (
+        "msdyn_WrongSolution"
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not match the parent schema"):
+        install_ess_agent.load_installation_config(config_path)
 
 
 class FakePPAdminClient:
@@ -96,6 +156,7 @@ class FakePowerPlatformClient:
 @patch("install_ess_agent.discover_tenant", return_value="tenant-123")
 def test_install_resolves_environment_and_polls_api(
     _mock_discover_tenant,
+    capsys,
 ):
     import install_ess_agent
 
@@ -133,6 +194,9 @@ def test_install_resolves_environment_and_polls_api(
     assert powerplatform.install_calls == [
         ("env-123", "msdyn_CopilotForEmployeeSelfServiceDAIT")
     ]
+    assert "Installation status (poll 1, 0s elapsed): Succeeded" in (
+        capsys.readouterr().out
+    )
 
 
 @patch("install_ess_agent.discover_tenant", return_value="tenant-123")
@@ -233,3 +297,44 @@ def test_install_reports_application_install_permission_failure(
             pp_admin_client_factory=FakePPAdminClient,
             powerplatform_client_factory=lambda _tenant: powerplatform,
         )
+
+
+@patch("install_ess_agent.discover_tenant", return_value="tenant-123")
+def test_install_times_out_after_ten_minutes_and_reports_last_status(
+    _mock_discover_tenant,
+):
+    import install_ess_agent
+
+    schema_name = "msdyn_CopilotForEmployeeSelfServiceDAHR"
+    powerplatform = FakePowerPlatformClient(
+        "tenant-123",
+        packages=[{"uniqueName": schema_name, "state": "None"}],
+        install_result={"_operationId": "operation-123"},
+        statuses=[{"status": "Running"}, {"status": "Running"}],
+    )
+    now = [0]
+    messages = []
+
+    def sleep(seconds):
+        now[0] += seconds
+
+    with pytest.raises(
+        install_ess_agent.InstallationTimeoutError,
+        match="10 minutes",
+    ):
+        install_ess_agent.install_agent(
+            "https://org.crm.dynamics.com",
+            "da",
+            "hr",
+            pp_admin_client_factory=FakePPAdminClient,
+            powerplatform_client_factory=lambda _tenant: powerplatform,
+            poll_interval_seconds=300,
+            sleep=sleep,
+            clock=lambda: now[0],
+            status_callback=messages.append,
+        )
+
+    assert messages == [
+        "Installation status (poll 1, 0s elapsed): Running",
+        "Installation status (poll 2, 300s elapsed): Running",
+    ]

--- a/tests/scripts/test_multi_agent_config.py
+++ b/tests/scripts/test_multi_agent_config.py
@@ -1,0 +1,228 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the nested multi-agent .local/config.json schema."""
+
+import json
+
+import auth
+import setup as setup_script
+
+
+def _agent_info(schema, name, bot_id):
+    return {
+        "url": "https://org.crm.dynamics.com",
+        "botId": bot_id,
+        "name": name,
+        "schema": schema,
+        "managed": True,
+    }
+
+
+def test_normalize_v2_config_exposes_active_runtime_view():
+    raw = {
+        "configVersion": 2,
+        "setup": "complete",
+        "activeAgent": "da.esshr",
+        "common": {
+            "dataverseEndpoint": "https://org.crm.dynamics.com",
+            "environmentSku": "Sandbox",
+        },
+        "agents": {
+            "da": {
+                "esshr": {
+                    "name": "ESS HR",
+                    "botId": "bot-hr",
+                    "schemaName": "schema-hr",
+                    "slug": "ess-hr",
+                    "folder": "workspace/agents/ess-hr",
+                    "extraction": {"workflowCount": 3},
+                }
+            }
+        },
+    }
+
+    normalized = auth.normalize_config(raw)
+
+    assert normalized["dataverseEndpoint"] == (
+        "https://org.crm.dynamics.com"
+    )
+    assert normalized["environmentSku"] == "Sandbox"
+    assert normalized["activeAgentKey"] == "da.esshr"
+    assert normalized["activeAgent"] == "ess-hr"
+    assert normalized["agent"]["botId"] == "bot-hr"
+    assert normalized["agents"][0]["configKey"] == "da.esshr"
+    assert normalized["workflowCount"] == 3
+
+
+def test_load_config_reads_v2_file_and_returns_runtime_aliases(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    local = tmp_path / ".local"
+    local.mkdir()
+    (local / "config.json").write_text(json.dumps({
+        "configVersion": 2,
+        "setup": "complete",
+        "activeAgent": "cea.essit",
+        "common": {
+            "dataverseEndpoint": "https://org.crm.dynamics.com",
+        },
+        "agents": {
+            "cea": {
+                "essit": {
+                    "name": "ESS IT",
+                    "botId": "bot-it",
+                    "schemaName": "schema-it",
+                    "slug": "ess-it",
+                    "folder": "workspace/agents/ess-it",
+                }
+            }
+        },
+    }), encoding="utf-8")
+
+    config = auth.load_config()
+
+    assert config["activeAgentKey"] == "cea.essit"
+    assert config["activeAgent"] == "ess-it"
+    assert config["agent"]["schemaName"] == "schema-it"
+    assert config["dataverseEndpoint"] == "https://org.crm.dynamics.com"
+
+
+def test_write_config_creates_nested_agents_and_shared_common_state(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+
+    setup_script.write_config(
+        _agent_info(
+            "msdyn_CopilotForEmployeeSelfServiceDAHR",
+            "Employee Self-Service HR",
+            "bot-hr",
+        ),
+        "employee-self-service-hr",
+        "workspace/agents/employee-self-service-hr",
+        True,
+        template_config_count=4,
+        workflow_count=5,
+        evaluation_count=6,
+    )
+
+    config = json.loads(
+        (tmp_path / ".local" / "config.json").read_text(encoding="utf-8")
+    )
+    agent = config["agents"]["da"]["esshr"]
+
+    assert config["configVersion"] == 2
+    assert config["activeAgent"] == "da.esshr"
+    assert config["common"] == {
+        "dataverseEndpoint": "https://org.crm.dynamics.com"
+    }
+    assert "agent" not in config
+    assert agent["botId"] == "bot-hr"
+    assert agent["extraction"] == {
+        "status": "complete",
+        "templateConfigsDiscovered": True,
+        "templateConfigCount": 4,
+        "workflowCount": 5,
+        "evaluationCount": 6,
+    }
+
+
+def test_write_config_adds_second_agent_without_repeating_common_state(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    local = tmp_path / ".local"
+    local.mkdir()
+    (local / "config.json").write_text(json.dumps({
+        "configVersion": 2,
+        "setup": "complete",
+        "activeAgent": "da.esshr",
+        "common": {
+            "dataverseEndpoint": "https://org.crm.dynamics.com",
+            "connections": {"ServiceNow": {"status": "connected"}},
+        },
+        "agents": {
+            "da": {
+                "esshr": {
+                    "name": "Employee Self-Service HR",
+                    "botId": "bot-hr",
+                    "schemaName": (
+                        "msdyn_CopilotForEmployeeSelfServiceDAHR"
+                    ),
+                    "slug": "employee-self-service-hr",
+                    "folder": "workspace/agents/employee-self-service-hr",
+                }
+            }
+        },
+    }), encoding="utf-8")
+
+    setup_script.write_config(
+        _agent_info(
+            "msdyn_CopilotForEmployeeSelfServiceDAIT",
+            "Employee Self-Service IT",
+            "bot-it",
+        ),
+        "employee-self-service-it",
+        "workspace/agents/employee-self-service-it",
+        False,
+    )
+
+    config = json.loads(
+        (local / "config.json").read_text(encoding="utf-8")
+    )
+
+    assert config["activeAgent"] == "da.essit"
+    assert config["agents"]["da"]["esshr"]["botId"] == "bot-hr"
+    assert config["agents"]["da"]["essit"]["botId"] == "bot-it"
+    assert config["common"]["connections"]["ServiceNow"]["status"] == (
+        "connected"
+    )
+
+
+def test_write_config_migrates_v1_agent_array(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    local = tmp_path / ".local"
+    local.mkdir()
+    (local / "config.json").write_text(json.dumps({
+        "configVersion": 1,
+        "setup": "complete",
+        "activeAgent": "employee-self-service-hr",
+        "dataverseEndpoint": "https://old.crm.dynamics.com",
+        "environmentSku": "Sandbox",
+        "agents": [{
+            "name": "Employee Self-Service HR",
+            "botId": "bot-hr",
+            "schemaName": "msdyn_CopilotForEmployeeSelfServiceDAHR",
+            "slug": "employee-self-service-hr",
+            "folder": "workspace/agents/employee-self-service-hr",
+        }],
+        "workflowCount": 2,
+    }), encoding="utf-8")
+
+    setup_script.write_config(
+        _agent_info(
+            "msdyn_CopilotForEmployeeSelfServiceDAIT",
+            "Employee Self-Service IT",
+            "bot-it",
+        ),
+        "employee-self-service-it",
+        "workspace/agents/employee-self-service-it",
+        False,
+    )
+
+    config = json.loads(
+        (local / "config.json").read_text(encoding="utf-8")
+    )
+
+    assert config["configVersion"] == 2
+    assert config["agents"]["da"]["esshr"]["extraction"] == {
+        "status": "complete",
+        "workflowCount": 2
+    }
+    assert config["agents"]["da"]["essit"]["botId"] == "bot-it"
+    assert config["common"]["environmentSku"] == "Sandbox"

--- a/tests/scripts/test_onboarding_state.py
+++ b/tests/scripts/test_onboarding_state.py
@@ -108,10 +108,80 @@ def test_new_agent_installation_clears_other_agents_connection_state(
         "cea",
         "it",
         "installing",
+        api_started=True,
     )
 
     assert "connection" not in saved
     assert "S2" not in saved["setupStatus"]
+
+
+def test_installing_state_requires_confirmed_api_start(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="installation API accepts"):
+        onboarding_state.save_installation(
+            "https://org.crm.dynamics.com",
+            "cea",
+            "it",
+            "installing",
+        )
+
+
+def test_installing_state_keeps_selected_connection_after_api_start(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+
+    saved = onboarding_state.save_installation(
+        "https://org.crm.dynamics.com",
+        "cea",
+        "it",
+        "installing",
+        "shared-alchemy-connection",
+        api_started=True,
+    )
+
+    assert saved["installation"] == {
+        "experience": "cea",
+        "vertical": "it",
+        "status": "installing",
+        "apiStarted": True,
+        "connectionName": "shared-alchemy-connection",
+    }
+
+
+def test_load_discards_legacy_preflight_and_unstarted_installation(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    state_path = tmp_path / ".local" / "onboarding.json"
+    state_path.parent.mkdir()
+    state_path.write_text(json.dumps({
+        "version": 1,
+        "environmentUrl": "https://org.crm.dynamics.com",
+        "installation": {
+            "experience": "cea",
+            "vertical": "it",
+            "status": "installing",
+        },
+        "connection": {
+            "experience": "cea",
+            "vertical": "it",
+            "status": "missing",
+        },
+        "setupStatus": {
+            "S1": {"state": "in-progress"},
+            "S2": {"state": "blocked"},
+        },
+    }), encoding="utf-8")
+
+    loaded = onboarding_state.load_state()
+
+    assert "installation" not in loaded
+    assert "connection" not in loaded
+    assert loaded["setupStatus"] == {}
 
 
 def test_recovers_environment_from_existing_mcp_config(tmp_path, monkeypatch):

--- a/tests/scripts/test_onboarding_state.py
+++ b/tests/scripts/test_onboarding_state.py
@@ -1,0 +1,93 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for scripts/onboarding_state.py."""
+
+import json
+
+import onboarding_state
+
+
+def test_environment_selection_persists(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    saved = onboarding_state.save_environment(
+        "https://org.crm.dynamics.com/"
+    )
+
+    assert saved["environmentUrl"] == "https://org.crm.dynamics.com"
+    assert onboarding_state.load_state() == saved
+
+
+def test_agent_selection_preserves_environment(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    saved = onboarding_state.save_agent(
+        "https://org.crm.dynamics.com",
+        "bot-id",
+        "ESS Agent",
+        "new_essagent",
+        True,
+    )
+
+    assert saved["environmentUrl"] == "https://org.crm.dynamics.com"
+    assert saved["agent"] == {
+        "botId": "bot-id",
+        "name": "ESS Agent",
+        "schemaName": "new_essagent",
+        "isManaged": True,
+    }
+
+
+def test_recovers_environment_from_existing_mcp_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    mcp_dir = tmp_path / ".vscode"
+    mcp_dir.mkdir()
+    (mcp_dir / "mcp.json").write_text(json.dumps({
+        "servers": {
+            "Dataverse": {
+                "type": "http",
+                "url": "https://org.crm.dynamics.com/api/mcp",
+            }
+        }
+    }), encoding="utf-8")
+
+    state = onboarding_state.load_state()
+
+    assert state == {
+        "version": 1,
+        "environmentUrl": "https://org.crm.dynamics.com",
+    }
+
+
+def test_clear_removes_partial_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    onboarding_state.save_environment("https://org.crm.dynamics.com")
+
+    onboarding_state.clear_state()
+
+    assert not (tmp_path / ".local" / "onboarding.json").exists()
+
+
+def test_explicit_environment_replaces_invalid_mcp_recovery(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    mcp_dir = tmp_path / ".vscode"
+    mcp_dir.mkdir()
+    (mcp_dir / "mcp.json").write_text(json.dumps({
+        "servers": {
+            "Dataverse": {
+                "url": "http://invalid.example/api/mcp",
+            }
+        }
+    }), encoding="utf-8")
+
+    shown = onboarding_state.load_state()
+    saved = onboarding_state.save_environment(
+        "https://valid.crm.dynamics.com"
+    )
+
+    assert "recoveryWarning" in shown
+    assert saved["environmentUrl"] == "https://valid.crm.dynamics.com"
+    assert "recoveryWarning" not in saved

--- a/tests/scripts/test_onboarding_state.py
+++ b/tests/scripts/test_onboarding_state.py
@@ -6,6 +6,7 @@
 import json
 
 import onboarding_state
+import pytest
 
 
 def test_environment_selection_persists(tmp_path, monkeypatch):
@@ -37,6 +38,36 @@ def test_agent_selection_preserves_environment(tmp_path, monkeypatch):
         "schemaName": "new_essagent",
         "isManaged": True,
     }
+
+
+def test_installation_progress_persists_for_resume(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    saved = onboarding_state.save_installation(
+        "https://org.crm.dynamics.com/",
+        "da",
+        "hr",
+        "manual-required",
+    )
+
+    assert saved["installation"] == {
+        "experience": "da",
+        "vertical": "hr",
+        "status": "manual-required",
+    }
+    assert onboarding_state.load_state() == saved
+
+
+def test_installation_progress_rejects_unknown_status(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="Unsupported installation status"):
+        onboarding_state.save_installation(
+            "https://org.crm.dynamics.com",
+            "da",
+            "hr",
+            "unknown",
+        )
 
 
 def test_recovers_environment_from_existing_mcp_config(tmp_path, monkeypatch):

--- a/tests/scripts/test_onboarding_state.py
+++ b/tests/scripts/test_onboarding_state.py
@@ -70,6 +70,50 @@ def test_installation_progress_rejects_unknown_status(tmp_path, monkeypatch):
         )
 
 
+def test_connection_binding_progress_persists_s2_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    saved = onboarding_state.save_connection(
+        "https://org.crm.dynamics.com",
+        "da",
+        "it",
+        "bound",
+        "shared-alchemy-connection",
+    )
+
+    assert saved["connection"]["status"] == "bound"
+    assert saved["setupStatus"]["S2"] == {
+        "state": "done",
+        "checkpoint": "ESS-CONN-001",
+        "verifiedBy": "programmatic",
+        "connectionName": "shared-alchemy-connection",
+        "notRequired": False,
+    }
+
+
+def test_new_agent_installation_clears_other_agents_connection_state(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    onboarding_state.save_connection(
+        "https://org.crm.dynamics.com",
+        "cea",
+        "hr",
+        "not-required",
+    )
+
+    saved = onboarding_state.save_installation(
+        "https://org.crm.dynamics.com",
+        "cea",
+        "it",
+        "installing",
+    )
+
+    assert "connection" not in saved
+    assert "S2" not in saved["setupStatus"]
+
+
 def test_recovers_environment_from_existing_mcp_config(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     mcp_dir = tmp_path / ".vscode"

--- a/tests/setup/test_onboarding_resume.py
+++ b/tests/setup/test_onboarding_resume.py
@@ -149,3 +149,26 @@ def test_existing_agents_offer_only_missing_installations_before_selection():
     ]
     assert "go to step 1.8f" in another_agent_route
     assert "go to step 1.8e" not in another_agent_route
+
+
+def test_preflight_does_not_persist_abandoned_agent_selection():
+    step1b = (_ONBOARDING / "step1b.md").read_text(encoding="utf-8")
+    normalized = " ".join(step1b.split())
+    preflight = step1b[
+        step1b.index("### 1.8f"):step1b.index("### 1.8d")
+    ]
+
+    assert "save-connection" not in preflight
+    assert "save-installation" not in preflight
+    assert "Do not persist the selected agent or preflight result" in normalized
+    assert "installer owns installation-state persistence" in normalized
+
+
+def test_legacy_it_install_without_connection_returns_to_preflight():
+    step1b = (_ONBOARDING / "step1b.md").read_text(encoding="utf-8")
+    normalized = " ".join(step1b.split())
+
+    assert "`installation.vertical` is `it`" in normalized
+    assert "`installation.connectionName` is missing" in normalized
+    assert "go to section 1.8f regardless of installation status" in normalized
+    assert "without reinstalling it" in normalized

--- a/tests/setup/test_onboarding_resume.py
+++ b/tests/setup/test_onboarding_resume.py
@@ -84,7 +84,15 @@ def test_no_agent_path_offers_installation_and_resumes_discovery():
     assert "Employee Self-Service HR" in step1b
     assert "Employee Self-Service IT" in step1b
     assert "install_ess_agent.py" in step1b
+    assert "ess-agent-installation/config.json" in step1b
     assert "src/reference/solution-catalog.md" in step1b
     assert "Return to step 1.4 and run discovery again" in normalized
     assert "without reinstalling the package" in normalized
     assert "Do not rerun the installation command" in normalized
+    assert "up to 10 minutes" in normalized
+    assert "ESS_AGENT_INSTALLATION_TIMEOUT_JSON:" in step1b
+    assert "save-installation" in step1b
+    assert "--checkpoint ESS-SOLN-001" in step1b
+    assert "--expected-solution" in step1b
+    assert "installation-verification/results.json" in step1b
+    assert "status `Passed`" in step1b

--- a/tests/setup/test_onboarding_resume.py
+++ b/tests/setup/test_onboarding_resume.py
@@ -72,3 +72,19 @@ def test_readiness_check_requires_explicit_manual_opt_in():
         in normalized_step3
     )
     assert 'Only if they explicitly choose "Yes' in step3
+
+
+def test_no_agent_path_offers_installation_and_resumes_discovery():
+    step1b = (_ONBOARDING / "step1b.md").read_text(encoding="utf-8")
+    normalized = " ".join(step1b.split())
+
+    assert "ESS as DA (Recommended)" in step1b
+    assert '"label": "ESS as CEA"' in step1b
+    assert "ESS as CEA (Recommended)" not in step1b
+    assert "Employee Self-Service HR" in step1b
+    assert "Employee Self-Service IT" in step1b
+    assert "install_ess_agent.py" in step1b
+    assert "src/reference/solution-catalog.md" in step1b
+    assert "Return to step 1.4 and run discovery again" in normalized
+    assert "without reinstalling the package" in normalized
+    assert "Do not rerun the installation command" in normalized

--- a/tests/setup/test_onboarding_resume.py
+++ b/tests/setup/test_onboarding_resume.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Structural tests for resumable onboarding instructions."""
+
+from pathlib import Path
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+_ONBOARDING = (
+    _ROOT / "solutions" / "ess-maker-skills" / "src" / "skills" / "onboarding"
+)
+_SETUP_PROMPT = (
+    _ROOT / "solutions" / "ess-maker-skills" / ".github"
+    / "prompts" / "setup.prompt.md"
+)
+
+
+def test_router_resumes_each_step_without_repeating_prior_work():
+    skill = (_ONBOARDING / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "## Step 2" in skill
+    assert "Read `src/skills/onboarding/step1b.md`" in skill
+    assert "## Step 4" in skill
+    assert "begin at section 2.2" in skill
+
+
+def test_environment_and_agent_are_persisted_during_selection():
+    step1 = (_ONBOARDING / "step1.md").read_text(encoding="utf-8")
+    step1b = (_ONBOARDING / "step1b.md").read_text(encoding="utf-8")
+
+    assert "onboarding_state.py save-environment" in step1
+    assert "onboarding_state.py save-agent" in step1b
+
+
+def test_extraction_resume_reloads_agent_and_completion_clears_state():
+    step2 = (_ONBOARDING / "step2.md").read_text(encoding="utf-8")
+
+    assert "agent.botId" in step2
+    assert "onboarding_state.py clear" in step2
+
+
+def test_complete_config_can_resume_mcp_startup_only():
+    prompt = _SETUP_PROMPT.read_text(encoding="utf-8")
+    normalized = " ".join(prompt.split())
+
+    assert "step 4 unchecked" in prompt
+    assert "mark steps 1–3 checked" in prompt
+    assert "router will continue at step 4" in normalized
+
+
+def test_complete_config_reoffers_skipped_readiness_check():
+    prompt = _SETUP_PROMPT.read_text(encoding="utf-8")
+    normalized = " ".join(prompt.split())
+
+    assert "steps 1–4 checked but step 5 unchecked" in prompt
+    assert "resume onboarding immediately at step 5" in normalized

--- a/tests/setup/test_onboarding_resume.py
+++ b/tests/setup/test_onboarding_resume.py
@@ -14,6 +14,10 @@ _SETUP_PROMPT = (
     _ROOT / "solutions" / "ess-maker-skills" / ".github"
     / "prompts" / "setup.prompt.md"
 )
+_FLIGHTCHECK_CLI = (
+    _ROOT / "solutions" / "ess-maker-skills" / "scripts"
+    / "flightcheck" / "cli.py"
+)
 
 
 def test_router_resumes_each_step_without_repeating_prior_work():
@@ -49,13 +53,25 @@ def test_complete_config_can_resume_mcp_startup_only():
     assert "router will continue at step 4" in normalized
 
 
-def test_complete_config_reoffers_skipped_readiness_check():
+def test_complete_config_rechecks_available_agents_before_readiness():
     prompt = _SETUP_PROMPT.read_text(encoding="utf-8")
     normalized = " ".join(prompt.split())
 
     assert "steps 1–4 checked but step 5 unchecked" in prompt
-    assert "beginning with its manual opt-in question" in normalized
-    assert "never start FlightCheck automatically" in normalized
+    assert "resume at agent discovery before readiness" in normalized
+    assert "onboarding_state.py save-environment" in prompt
+    assert "src/skills/onboarding/step1b.md" in prompt
+    assert "offers only missing agents before readiness" in normalized
+    assert "Do not start FlightCheck directly" in prompt
+
+
+def test_complete_config_rerun_does_not_require_reset():
+    prompt = _SETUP_PROMPT.read_text(encoding="utf-8")
+    normalized = " ".join(prompt.split())
+
+    assert "Re-running `/setup` is how the user installs another" in normalized
+    assert "Existing agent entries and workspaces are preserved" in normalized
+    assert "Type `RESET` to confirm" not in prompt
 
 
 def test_readiness_check_requires_explicit_manual_opt_in():
@@ -74,15 +90,35 @@ def test_readiness_check_requires_explicit_manual_opt_in():
     assert 'Only if they explicitly choose "Yes' in step3
 
 
+def test_readiness_check_reports_progress_and_explicit_completion():
+    step3 = (
+        _ONBOARDING / "step3-flightcheck.md"
+    ).read_text(encoding="utf-8")
+    cli = _FLIGHTCHECK_CLI.read_text(encoding="utf-8")
+    normalized = " ".join(step3.split())
+
+    assert "do not remain silent after the question tool returns" in normalized
+    assert "at least once every 60 seconds" in normalized
+    assert "python -u scripts/flightcheck/cli.py" in step3
+    assert "FLIGHTCHECK_COMPLETE_JSON:" in step3
+    assert "FLIGHTCHECK_COMPLETE_JSON:" in cli
+    assert "Readiness check complete in {DURATION_SECONDS} seconds" in step3
+    assert "do not mark step 5 complete" in normalized
+
+
 def test_no_agent_path_offers_installation_and_resumes_discovery():
     step1b = (_ONBOARDING / "step1b.md").read_text(encoding="utf-8")
     normalized = " ".join(step1b.split())
 
-    assert "ESS as DA (Recommended)" in step1b
-    assert '"label": "ESS as CEA"' in step1b
-    assert "ESS as CEA (Recommended)" not in step1b
-    assert "Employee Self-Service HR" in step1b
-    assert "Employee Self-Service IT" in step1b
+    assert "DA : Employee Self-Service HR" in step1b
+    assert "DA : Employee Self-Service IT" in step1b
+    assert "CEA : Employee Self-Service HR" in step1b
+    assert "CEA : Employee Self-Service IT" in step1b
+    assert step1b.index("DA : Employee Self-Service IT") < step1b.index(
+        "CEA : Employee Self-Service HR"
+    )
+    assert "Select experience" not in step1b
+    assert "Select vertical" not in step1b
     assert "install_ess_agent.py" in step1b
     assert "ess-agent-installation/config.json" in step1b
     assert "src/reference/solution-catalog.md" in step1b
@@ -96,3 +132,20 @@ def test_no_agent_path_offers_installation_and_resumes_discovery():
     assert "--expected-solution" in step1b
     assert "installation-verification/results.json" in step1b
     assert "status `Passed`" in step1b
+
+
+def test_existing_agents_offer_only_missing_installations_before_selection():
+    step1b = (_ONBOARDING / "step1b.md").read_text(encoding="utf-8")
+    normalized = " ".join(step1b.split())
+
+    assert "ESS_AGENT_DISCOVERY_JSON:" in step1b
+    assert "DISCOVERY.availableInstallations" in step1b
+    assert "Would you like to install another ESS agent?" in step1b
+    assert "Continue with installed agents" in step1b
+    assert "only the other supported agents that are still missing" in normalized
+
+    another_agent_route = step1b[
+        step1b.index("## 1.4a"):step1b.index("## 1.5")
+    ]
+    assert "go to step 1.8f" in another_agent_route
+    assert "go to step 1.8e" not in another_agent_route

--- a/tests/setup/test_onboarding_resume.py
+++ b/tests/setup/test_onboarding_resume.py
@@ -54,4 +54,21 @@ def test_complete_config_reoffers_skipped_readiness_check():
     normalized = " ".join(prompt.split())
 
     assert "steps 1–4 checked but step 5 unchecked" in prompt
-    assert "resume onboarding immediately at step 5" in normalized
+    assert "beginning with its manual opt-in question" in normalized
+    assert "never start FlightCheck automatically" in normalized
+
+
+def test_readiness_check_requires_explicit_manual_opt_in():
+    skill = (_ONBOARDING / "SKILL.md").read_text(encoding="utf-8")
+    step3 = (
+        _ONBOARDING / "step3-flightcheck.md"
+    ).read_text(encoding="utf-8")
+    normalized_step3 = " ".join(step3.split())
+
+    assert "The opt-in question is mandatory" in skill
+    assert "MANDATORY MANUAL GATE" in step3
+    assert (
+        "Do not run any FlightCheck command in the same turn"
+        in normalized_step3
+    )
+    assert 'Only if they explicitly choose "Yes' in step3


### PR DESCRIPTION
## Summary

- add a Dataverse MCP configuration preflight to `/setup`
- skip redundant Power Platform admin instructions when the environment is already configured
- show only the missing MCP server or GitHub Copilot client configuration
- persist partial onboarding selections across Copilot conversations
- resume at environment validation, agent discovery, extraction, MCP startup, or the optional readiness check without repeating completed work

## Notes

This draft PR will include additional setup-flow improvements in follow-up commits.

## Testing

- `python -m pytest tests\scripts\test_onboarding_state.py tests\scripts\test_discover.py tests\setup\test_onboarding_resume.py -q`