### PR TITLE
Classify EmployeeHub as internal telemetry

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -111,11 +111,12 @@ _POST_TIMEOUT = (3.05, 5)
 # Aria cube, because 1DS RTA cubes map an event property straight to a
 # dimension and cannot derive one dimension's value from another.
 #
-# Seeded with the Microsoft corporate Entra tenant only. Additional internal /
-# dogfood tenants can be added WITHOUT a code change via the
+# Seeded with known Microsoft corporate and dogfood Entra tenants. Additional
+# internal tenants can be added WITHOUT a code change via the
 # ``ESS_ADK_INTERNAL_TENANTS`` env var (comma-separated GUIDs) — preferred over
 # growing a hard-coded list.
 MICROSOFT_CORP_TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47"
+EMPLOYEEHUB_TENANT_ID = "935884d7-bdee-469b-a461-fcc530a3ac83"
 
 TENANT_CLASS_INTERNAL = "internal"
 TENANT_CLASS_CUSTOMER = "customer"
@@ -137,7 +138,7 @@ def _internal_tenant_ids() -> frozenset[str]:
 @lru_cache(maxsize=8)
 def _parse_internal_tenant_ids(extra: str) -> frozenset[str]:
     """Parse the comma-separated allow-list, cached per distinct env value."""
-    ids = {MICROSOFT_CORP_TENANT_ID}
+    ids = {MICROSOFT_CORP_TENANT_ID, EMPLOYEEHUB_TENANT_ID}
     ids.update(t.strip().lower() for t in extra.split(",") if t.strip())
     return frozenset(ids)
 

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -203,6 +203,10 @@ def test_classify_tenant_microsoft_corp_is_internal():
     assert _fc.classify_tenant(f"  {_fc.MICROSOFT_CORP_TENANT_ID.upper()} ") == "internal"
 
 
+def test_classify_tenant_employeehub_is_internal():
+    assert _fc.classify_tenant(_fc.EMPLOYEEHUB_TENANT_ID) == "internal"
+
+
 def test_classify_tenant_other_tenant_is_customer():
     assert _fc.classify_tenant("11111111-1111-1111-1111-111111111111") == "customer"
 


### PR DESCRIPTION
## Summary
- classify the EmployeeHub dogfood tenant (`935884d7-bdee-469b-a461-fcc530a3ac83`) as internal telemetry
- preserve the environment-variable allowlist for additional internal tenants
- add regression coverage for EmployeeHub classification

## Dashboard rollout
The dev and prod **FlightCheck (External)** and **ADK Platform (External)** tiles now also exclude this tenant ID explicitly, so retained historical EmployeeHub events are removed immediately rather than waiting for newly classified events.

No synthetic events were emitted to prod.

## Testing
- `python -m pytest tests/test_adk_telemetry.py tests/flightcheck/test_telemetry.py -q`
