### PR TITLE
flightcheck: keep GUIDs inside deep-link URLs unmasked in MANUAL reports

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/runner.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/runner.py
@@ -1510,20 +1510,42 @@ def _mask_sensitive(text: str) -> str:
     operator, so we mask the local part of addresses and the middle of
     GUIDs while keeping enough context (domain, first block) to stay
     actionable.
+
+    Text inside an ``http(s)://`` URL is left verbatim. A remediation deep
+    link (e.g. Copilot Studio ``.../environments/<env_id>/bots/<bot_id>``)
+    carries GUIDs as path segments; masking them rewrites the ``href`` and
+    the link stops resolving. Those ids already appear in every deep link
+    the report emits, so keeping them in the URL leaks nothing new while
+    keeping the link clickable. Standalone GUIDs / emails in prose are
+    still masked.
     """
     import re
-    # Email / UPN -> keep first char + full domain: j***@contoso.com
-    text = re.sub(
-        r'([A-Za-z0-9])[A-Za-z0-9._%+-]*(@[A-Za-z0-9.-]+\.[A-Za-z]{2,})',
-        r'\1***\2', text,
+    email_re = re.compile(
+        r'([A-Za-z0-9])[A-Za-z0-9._%+-]*(@[A-Za-z0-9.-]+\.[A-Za-z]{2,})'
     )
-    # GUID -> keep first block: 1a2b3c4d-****-****-****-************
-    text = re.sub(
+    guid_re = re.compile(
         r'\b([0-9a-fA-F]{8})-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
-        r'[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b',
-        r'\1-****-****-****-************', text,
+        r'[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b'
     )
-    return text
+    # A URL run: scheme + non-space chars, stopping before a ')' so a
+    # markdown target "[label](url)" ends at its wrapping paren.
+    url_re = re.compile(r'https?://[^\s)]+')
+
+    def _mask_prose(segment: str) -> str:
+        # Email / UPN -> keep first char + full domain: j***@contoso.com
+        segment = email_re.sub(r'\1***\2', segment)
+        # GUID -> keep first block: 1a2b3c4d-****-****-****-************
+        segment = guid_re.sub(r'\1-****-****-****-************', segment)
+        return segment
+
+    out: list[str] = []
+    last = 0
+    for m in url_re.finditer(text):
+        out.append(_mask_prose(text[last:m.start()]))
+        out.append(m.group(0))  # URL kept verbatim so its GUIDs survive
+        last = m.end()
+    out.append(_mask_prose(text[last:]))
+    return "".join(out)
 
 
 def _manual_checklist_items(remediation: str) -> tuple[str, list[str]]:

--- a/tests/flightcheck/test_runner_report_layout.py
+++ b/tests/flightcheck/test_runner_report_layout.py
@@ -899,3 +899,72 @@ def test_manual_checklist_masks_sensitive_data(tmp_path):
 
     assert "jdoe@contoso.com" not in html
     assert "j***@contoso.com" in html
+
+
+def test_mask_sensitive_keeps_guid_inside_url():
+    """A GUID that is a path segment of a deep link stays intact so the
+    link resolves, while a standalone GUID in prose is still masked."""
+    from flightcheck.runner import _mask_sensitive
+
+    env = "1a2b3c4d-1111-2222-3333-444455556666"
+    bot = "99998888-aaaa-bbbb-cccc-dddddddddddd"
+    text = (
+        f"Env {env} is bound. Open "
+        f"https://copilotstudio.microsoft.com/environments/{env}/bots/{bot}/overview"
+    )
+    masked = _mask_sensitive(text)
+    # URL keeps both real GUIDs.
+    assert f"/environments/{env}/bots/{bot}/overview" in masked
+    # The prose GUID before the URL is still masked.
+    assert "Env 1a2b3c4d-****-****-****-************ is bound" in masked
+
+
+def test_mask_sensitive_keeps_guid_inside_markdown_link_target():
+    """A markdown deep link "[label](url)" keeps the GUIDs in its target
+    so the rendered href resolves."""
+    from flightcheck.runner import _mask_sensitive
+
+    env = "1a2b3c4d-1111-2222-3333-444455556666"
+    text = (
+        "Open the agent in "
+        f"[Copilot Studio](https://make.powerapps.com/environments/{env}/solutions)."
+    )
+    masked = _mask_sensitive(text)
+    assert f"environments/{env}/solutions" in masked
+
+
+def test_manual_deeplink_href_keeps_guids_but_masks_prose(tmp_path):
+    """End-to-end: a MANUAL check whose remediation carries a Copilot Studio
+    deep link renders a clickable href with the real GUIDs, while a UPN in
+    the same remediation is still masked."""
+    from flightcheck.runner import FlightCheckRunner, CheckResult, save_results
+
+    env = "1a2b3c4d-1111-2222-3333-444455556666"
+    bot = "99998888-aaaa-bbbb-cccc-dddddddddddd"
+    url = (
+        f"https://copilotstudio.microsoft.com/environments/{env}/bots/{bot}/overview"
+    )
+    runner = FlightCheckRunner(scope="test")
+    runner.register("Publishing", lambda _r: [
+        CheckResult(
+            checkpoint_id="QA-001", category="Publishing",
+            priority="Medium", status="Manual",
+            description="Run evals",
+            result="Not witnessed",
+            remediation=(
+                f"Owner jdoe@contoso.com should open the agent in "
+                f"[Copilot Studio]({url}) to run evals."
+            ),
+        ),
+    ])
+    result = runner.run()
+    save_results(result, output_dir=str(tmp_path))
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    # Deep-link href keeps the real GUIDs so the link resolves.
+    assert f'href="{url}"' in html
+    # No masked GUID leaked anywhere (the only GUIDs are the URL's, kept whole).
+    assert "1a2b3c4d-****" not in html
+    # The UPN in prose is still masked.
+    assert "jdoe@contoso.com" not in html
+    assert "j***@contoso.com" in html


### PR DESCRIPTION
## Summary

`_mask_sensitive` (in `runner.py`) redacts operator-identifying values (email/UPN local parts, resource GUIDs) from `CheckResult.remediation` before a report is rendered, because readiness reports are often shared beyond the operator. It runs on the **MANUAL** render path (`_render_manual_checklist` -> `_mask_sensitive` -> `_md_links_to_html`).

Problem: it masked GUIDs that are **path segments of a deep link**. A MANUAL remediation deep link such as Copilot Studio `.../environments/<env_id>/bots/<bot_id>/overview` had both GUIDs rewritten to `1a2b3c4d-****-****-****-************`, so the resulting `href` no longer resolved. Every MANUAL check with a deep link was affected. Concretely, the publishing QA-* checks (`checks/publishing.py`) emit their Copilot Studio Analytics deep link as MANUAL, so those links were masked into broken hrefs.

## What changed

- `_mask_sensitive` now splits the text into `http(s)://` URL spans and prose, and masks **only the prose**. URL spans are kept verbatim, so a GUID that is a path segment of a deep link survives and the link resolves.
- Standalone GUIDs and emails/UPNs in prose are still masked exactly as before.
- The URL regex stops before a `)` so a markdown target `[label](url)` ends at its wrapping paren.

## Design rationale

The GUIDs that broke are `env_id` / `bot_id`, which the URL needs to be clickable. They already appear in **every** deep link the report emits (including FAILED/WARNING cards, which are never masked), so keeping them inside the URL leaks nothing the report doesn't already show. Masking them only broke the link without adding privacy. The fix is scoped to the single choke point (`_mask_sensitive`) so every MANUAL remediation inherits it, and it preserves the existing prose-masking behavior.

## Testing

- `tests/flightcheck/test_runner_report_layout.py`: added 3 tests - GUID inside a bare deep-link URL is preserved while a standalone prose GUID in the same string is still masked; GUIDs inside a markdown link target are preserved; end-to-end MANUAL check renders a deep-link `href` with real GUIDs while a UPN in the same remediation is still masked. Existing `test_mask_sensitive_redacts_upn_and_guid` and `test_manual_checklist_masks_sensitive_data` still pass.
- Full FlightCheck suite (`tests/flightcheck`): 999 passed.

## Scope

- Fix targets **URLs (links)** only. A GUID inside a non-URL context (e.g. a PowerShell `-EnvironmentName <guid>` snippet in a remediation) is still masked; that is a separate concern from clickable links and is left untouched here.
- Independent of #208 (bare-URL autolinking) and #209 (URL host hygiene gate). This bug pre-exists both on `main`: the affected publishing links are markdown links, already masked before #208.

## Risks and assumptions

- Change touches shared report rendering used by every MANUAL check. Mitigated by the full-suite run and by keeping prose masking identical.
- Assumes URL runs are delimited by whitespace or a wrapping `)`. A balanced-paren path segment after a `)` would fall outside the URL span, but GUIDs contain no parens, so masking behavior for GUIDs is unaffected.
