### PR TITLE
adk: scaffold Copilot Studio analytics pointer (/analytics + post-deploy reminder)

### DIFF
--- a/solutions/ess-maker-skills/.github/prompts/analytics.prompt.md
+++ b/solutions/ess-maker-skills/.github/prompts/analytics.prompt.md
@@ -1,0 +1,26 @@
+---
+mode: agent
+description: "Jump to your Copilot Studio agent's analytics dashboard"
+---
+
+# Analytics
+
+**Setup-state check.** Read `.local/config.json`. If it does not exist, OR
+`setup` is not `"complete"`, show:
+
+> Welcome to the ESS Maker Kit. Before running `/analytics`, type `/setup`
+> to set up your environment.
+
+and STOP. Otherwise proceed.
+
+You are a script executor. Read `src/skills/analytics/SKILL.md` and follow
+it. It will tell you what to do.
+
+Rules:
+1. Show Message block text to the user EXACTLY as written. Do not rephrase.
+2. NEVER tell the user what files you are reading or what tools you are
+   calling. The user must never see "Read SKILL.md" or "Calling tool" or
+   file names or line numbers. If they see any of that, you have failed.
+3. The ONLY text the user sees is Message blocks and script output.
+4. Do not compose your own messages. If there is no Message block for a
+   situation, stay silent and proceed to the next action.

--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -88,6 +88,28 @@ EVENT_FLIGHTCHECK_RUN = "adk.flightcheck.run"
 EVENT_FLIGHTCHECK_RESULT = "adk.flightcheck.result"
 EVENT_FLIGHTCHECK_ERROR = "adk.flightcheck.error"
 
+# Analytics pointer events (September 2026 MVP — see analytics_pointer.py
+# module docstring and ADO PR 5465946). All five events carry the common
+# dimensions plus ``env_id``, ``agent_id``, and (where relevant) an
+# ``outcome`` / ``unresolved_reason`` enum. No new tenant / PII dimensions:
+# env_id and agent_id are opaque GUIDs already emitted by adk.agent.deploy.
+EVENT_ANALYTICS_POINTER_SHOWN = "adk.analytics.pointer.shown"
+EVENT_ANALYTICS_POINTER_CLICKED = "adk.analytics.pointer.clicked"
+EVENT_ANALYTICS_POINTER_DISMISSED = "adk.analytics.pointer.dismissed"
+EVENT_ANALYTICS_POINTER_RESOLUTION_FAILED = "adk.analytics.pointer.resolution_failed"
+EVENT_ANALYTICS_POINTER_REPAIR_ATTEMPTED = "adk.analytics.pointer.repair_attempted"
+
+# ``outcome`` enum for the analytics pointer .shown event.
+ANALYTICS_OUTCOME_RESOLVED = "resolved"
+ANALYTICS_OUTCOME_UNRESOLVED = "unresolved"
+
+# ``unresolved_reason`` enum. MUST stay in sync with the REASON_* constants
+# in analytics_pointer.py — the resolver produces the value, this enum names
+# the dimension the dashboards filter on.
+ANALYTICS_REASON_FLAG_OFF = "feature_flag_off"
+ANALYTICS_REASON_MISSING_ASSOCIATION = "missing_association"
+ANALYTICS_REASON_VALIDATION_FAILED = "validation_failed"
+
 # --- Canonical ADK capability value-list (single source of truth) ---------
 # Every ``adk_capability`` value emitted anywhere in the kit MUST be one of
 # these. This is the ONE place the taxonomy is defined: the synthetic
@@ -774,6 +796,104 @@ def emit_flightcheck_error(
     data.update({"agent_id": agent_id})
     _apply_error_fields(data, "server_error", error_code, error_message, error_category)
     return _emit(EVENT_FLIGHTCHECK_ERROR, data, block=block)
+
+
+# --- Analytics pointer emitters (ADO PR 5465946) --------------------------
+# One emitter per event in the analytics pointer catalog. They mirror
+# emit_capability_use / emit_flightcheck_run exactly: get the session id,
+# assemble common_dimensions, add the pointer-specific fields, dispatch on a
+# daemon thread. The ``adk_capability`` is hard-set to a synthetic
+# ``"analytics_pointer"`` bucket that is NOT in ADK_CAPABILITIES (so it
+# normalizes to CAPABILITY_UNKNOWN today). That's deliberate: the analytics
+# pointer is intentionally a distinct dashboard slice — carried on the event
+# name, not the capability dimension — and adding it to the capability
+# donut is a separate PM decision.
+
+
+def emit_analytics_pointer_shown(
+    *,
+    env_id: str = "",
+    agent_id: str = "",
+    outcome: str = ANALYTICS_OUTCOME_RESOLVED,
+    unresolved_reason: str = "",
+    surface: str = SURFACE_CLI,
+    block: bool = False,
+) -> dict[str, Any]:
+    """Emit ``adk.analytics.pointer.shown``.
+
+    ``outcome`` is one of :data:`ANALYTICS_OUTCOME_RESOLVED` /
+    :data:`ANALYTICS_OUTCOME_UNRESOLVED`. When ``unresolved``, callers set
+    ``unresolved_reason`` to one of the ``ANALYTICS_REASON_*`` enum values so
+    the dashboards can slice flag-off vs missing-association vs
+    validation-failed independently.
+    """
+    sid, _ = get_session(surface)
+    data = common_dimensions(surface, session_id=sid)
+    data.update({
+        "env_id": env_id,
+        "agent_id": agent_id,
+        "outcome": outcome,
+        "unresolved_reason": unresolved_reason,
+    })
+    return _emit(EVENT_ANALYTICS_POINTER_SHOWN, data, block=block)
+
+
+def emit_analytics_pointer_clicked(
+    *,
+    env_id: str = "",
+    agent_id: str = "",
+    surface: str = SURFACE_CLI,
+    block: bool = False,
+) -> dict[str, Any]:
+    sid, _ = get_session(surface)
+    data = common_dimensions(surface, session_id=sid)
+    data.update({"env_id": env_id, "agent_id": agent_id})
+    return _emit(EVENT_ANALYTICS_POINTER_CLICKED, data, block=block)
+
+
+def emit_analytics_pointer_dismissed(
+    *,
+    env_id: str = "",
+    agent_id: str = "",
+    surface: str = SURFACE_CLI,
+    block: bool = False,
+) -> dict[str, Any]:
+    sid, _ = get_session(surface)
+    data = common_dimensions(surface, session_id=sid)
+    data.update({"env_id": env_id, "agent_id": agent_id})
+    return _emit(EVENT_ANALYTICS_POINTER_DISMISSED, data, block=block)
+
+
+def emit_analytics_pointer_resolution_failed(
+    *,
+    env_id: str = "",
+    agent_id: str = "",
+    unresolved_reason: str = "",
+    surface: str = SURFACE_CLI,
+    block: bool = False,
+) -> dict[str, Any]:
+    sid, _ = get_session(surface)
+    data = common_dimensions(surface, session_id=sid)
+    data.update({
+        "env_id": env_id,
+        "agent_id": agent_id,
+        "outcome": ANALYTICS_OUTCOME_UNRESOLVED,
+        "unresolved_reason": unresolved_reason,
+    })
+    return _emit(EVENT_ANALYTICS_POINTER_RESOLUTION_FAILED, data, block=block)
+
+
+def emit_analytics_pointer_repair_attempted(
+    *,
+    env_id: str = "",
+    agent_id: str = "",
+    surface: str = SURFACE_CLI,
+    block: bool = False,
+) -> dict[str, Any]:
+    sid, _ = get_session(surface)
+    data = common_dimensions(surface, session_id=sid)
+    data.update({"env_id": env_id, "agent_id": agent_id})
+    return _emit(EVENT_ANALYTICS_POINTER_REPAIR_ATTEMPTED, data, block=block)
 
 
 # --- CLI: opt-out controls + synthetic emit for validation ----------------

--- a/solutions/ess-maker-skills/scripts/analytics_pointer.py
+++ b/solutions/ess-maker-skills/scripts/analytics_pointer.py
@@ -1,0 +1,672 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+ESS ADK — Copilot Studio Analytics Pointer (September 2026 MVP).
+
+This module implements the maker-facing /analytics pointer described in the
+PM spec reviewed on ADO PR 5465946 ("ADK Copilot Studio Analytics Pointer").
+The pointer has two surfaces:
+
+* **/analytics slash command** — permanent action. Reads
+  ``.local/config.json``, resolves the (maker, env, agent) triplet, and
+  either prints a validated deep link to the agent's Copilot Studio
+  analytics page or emits the FR7 repair/relink message when the
+  association is missing.
+
+* **Post-deploy report reminder** — one-time reminder printed by
+  ``install_ess_agent.py`` after the ``INSTALLED_ESS_AGENT_JSON:`` line,
+  exactly once per ``(maker_aad, env_id, agent_id)`` triplet. State lives
+  in the ReminderStore (see below).
+
+--------------------------------------------------------------------------
+CRITICAL CAVEAT — READ BEFORE TOUCHING resolve_pointer_url()
+--------------------------------------------------------------------------
+
+The supported Copilot Studio direct-link deep-link contract is NOT yet
+confirmed by the Copilot Studio partner team as of this session
+(2026-08-07). The PM spec explicitly forbids shipping against a
+reverse-engineered URL. Therefore this whole module ships behind a
+feature flag env var:
+
+    ADK_ANALYTICS_POINTER = "on" | "off"   (default: off)
+
+When the flag is **off**, :func:`resolve_pointer_url` returns
+``("", "feature_flag_off")`` and NO URL is constructed. When the flag is
+**on**, the resolver uses the currently DOCUMENTED Copilot Studio path
+shape
+
+    https://copilotstudio.microsoft.com/environments/{envId}/bots/{agentId}/analytics
+
+which mirrors the ``/overview`` shape already validated against a live
+tenant in ``flightcheck/checks/local_files.py`` (see
+``_studio_agent_url``) and is the pattern Microsoft Learn documents as
+of this session. This is a **placeholder** pending partner contract
+confirmation on ADO PR 5465946; the whole URL construction is contained
+in :func:`resolve_pointer_url` so it can be swapped for the confirmed
+pattern (or a Copilot Studio-side redirect endpoint) in one place.
+
+Any real production rollout MUST be gated on the partner contract being
+locked. See the ADO PR for status.
+
+--------------------------------------------------------------------------
+STORAGE — Dataverse follow-up
+--------------------------------------------------------------------------
+
+The PM spec calls for the reminder state to live in a Dataverse
+``adk_makerreminder`` row so it is server-side and de-duplicates across
+maker machines. That table is defined in the ESS Dataverse solution
+package, which is NOT part of this repo — the solution is pre-built and
+installed via ``install_ess_agent.py``. So for this MVP we ship a
+**local-file** implementation and log the Dataverse implementation as a
+follow-up. When the ESS Dataverse solution is next updated, add:
+
+    Table: adk_makerreminder
+      adk_makeraad        (String / lookup on systemuser, primary key part)
+      adk_envid           (String, primary key part)
+      adk_agentid         (String, primary key part)
+      adk_reason          (Choice: post_deploy_install / manual_dismiss)
+      adk_completedon     (DateTime)
+
+and add a ``DataverseReminderStore`` implementation in this module that
+targets that table via the same Dataverse client the other scripts use
+(``auth.py``). The store factory :func:`get_reminder_store` already
+reads ``ADK_ANALYTICS_STORE`` (``"local"`` default, ``"dataverse"``
+future) so the swap is a one-line change from the caller's perspective.
+
+--------------------------------------------------------------------------
+Testability / CLI
+--------------------------------------------------------------------------
+
+The ``/analytics`` prompt drives this module through the CLI at the
+bottom of the file (``--show``, ``--dismiss``, ``--status``) so the
+SKILL.md doesn't need to shell out to Python for individual functions.
+The Python API (``resolve_pointer_url``, ``read_association``,
+``render_pointer_line``, ``get_reminder_store``) is what the
+``install_ess_agent.py`` reminder path calls directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any, Protocol
+
+# Mirror the sibling-import pattern the other scripts use so this works both
+# when run as ``python scripts/analytics_pointer.py`` from the solution root
+# and when imported as ``import analytics_pointer`` from a sibling script.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+# --- Feature flag + config -----------------------------------------------
+
+FEATURE_FLAG_ENV = "ADK_ANALYTICS_POINTER"
+STORE_ENV = "ADK_ANALYTICS_STORE"
+
+# Documented Copilot Studio path shape as of 2026-08-07. See module docstring
+# for the partner-contract caveat. Kept as a module constant so the swap point
+# is exactly one line.
+STUDIO_BASE = "https://copilotstudio.microsoft.com"
+STUDIO_ANALYTICS_PATH = "/environments/{env_id}/bots/{agent_id}/analytics"
+
+# Unresolved-reason enum shared between resolver, telemetry, and the
+# maker-facing text. Any new reason MUST also be added to the telemetry
+# ``unresolved_reason`` dimension in adk_telemetry.py.
+REASON_FLAG_OFF = "feature_flag_off"
+REASON_MISSING_ASSOCIATION = "missing_association"
+REASON_VALIDATION_FAILED = "validation_failed"  # reserved for FR2 stub follow-up
+
+# .local/config.json path resolution: normally in cwd (the maker's workspace)
+# but tests can override via analytics_pointer.LOCAL_CONFIG_PATH_OVERRIDE.
+_DEFAULT_LOCAL_CONFIG = os.path.join(".local", "config.json")
+
+
+def _feature_flag_enabled() -> bool:
+    """Return True iff the analytics pointer is ON for this process.
+
+    The flag defaults OFF because the deep-link URL shape isn't confirmed by
+    the Copilot Studio partner team yet (see module docstring). Any value in
+    the ``on / 1 / true / yes / enabled`` set turns it on.
+    """
+    val = os.environ.get(FEATURE_FLAG_ENV, "").strip().lower()
+    return val in ("on", "1", "true", "yes", "enabled")
+
+
+# --- .local/config.json reading ------------------------------------------
+
+def _load_local_config(path: str | os.PathLike[str] | None = None) -> dict[str, Any]:
+    """Best-effort read of the maker's .local/config.json.
+
+    Returns ``{}`` on any error — this module must never crash a skill just
+    because the config isn't set up yet (that's the FR7 case we WANT to
+    render as ``missing_association``).
+    """
+    p = str(path) if path else _DEFAULT_LOCAL_CONFIG
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _extract_env_id(cfg: dict[str, Any]) -> str:
+    """Extract the Power Platform (BAP) environment ID from local config.
+
+    Setup.py writes ``dataverseEndpoint`` but not a raw ``environmentId`` yet;
+    checks/prerequisites uses ``runner.env_id`` set by cli.py after a BAP
+    round-trip. For the analytics pointer we accept either:
+      * ``config["environmentId"]`` (future setup writes this),
+      * ``config["agent"]["environmentId"]`` (mirrors drive_topic.py),
+      * empty when neither is present (FR7 repair state).
+    We deliberately do NOT round-trip BAP here — the /analytics command must
+    stay a millisecond-level local read.
+    """
+    val = cfg.get("environmentId")
+    if val:
+        return str(val)
+    agent = cfg.get("agent") or {}
+    if isinstance(agent, dict):
+        val = agent.get("environmentId")
+        if val:
+            return str(val)
+    return ""
+
+
+def _extract_agent_id(cfg: dict[str, Any]) -> str:
+    """Extract the Copilot Studio bot / agent id from local config."""
+    agent = cfg.get("agent") or {}
+    if isinstance(agent, dict):
+        val = agent.get("botId")
+        if val:
+            return str(val)
+    return ""
+
+
+def _extract_maker_aad(cfg: dict[str, Any]) -> str:
+    """Extract the Maker AAD oid from local config, if setup captured one.
+
+    Setup.py doesn't currently persist the Maker's AAD oid; when it starts,
+    it will land under ``config["makerAad"]``. Until then this returns "" and
+    the LocalFileReminderStore uses the ADK install ``instance_id`` as a
+    per-machine stand-in (documented in LocalFileReminderStore). The
+    DataverseReminderStore follow-up will require the real oid.
+    """
+    val = cfg.get("makerAad") or cfg.get("maker_aad")
+    if val:
+        return str(val)
+    agent = cfg.get("agent") or {}
+    if isinstance(agent, dict):
+        val = agent.get("makerAad") or agent.get("maker_aad")
+        if val:
+            return str(val)
+    return ""
+
+
+def read_association(
+    path: str | os.PathLike[str] | None = None,
+) -> tuple[str, str, str] | None:
+    """Return ``(maker_aad, env_id, agent_id)`` from ``.local/config.json``.
+
+    Returns ``None`` when ANY of the three cannot be extracted. That
+    ``None`` maps directly to the FR7 "association missing" repair path in
+    the /analytics slash command and to the "skip the reminder" path in
+    ``install_ess_agent.py``.
+
+    Note: ``maker_aad`` is currently soft — see :func:`_extract_maker_aad`.
+    Callers that want a fallback identity (e.g. LocalFileReminderStore keying
+    on a per-machine ADK instance_id when maker_aad is empty) implement that
+    themselves; this function stays strict so telemetry ``unresolved_reason``
+    honestly reports ``missing_association`` when any of the three is absent.
+    """
+    cfg = _load_local_config(path)
+    if not cfg:
+        return None
+    env_id = _extract_env_id(cfg)
+    agent_id = _extract_agent_id(cfg)
+    maker_aad = _extract_maker_aad(cfg)
+    if not env_id or not agent_id or not maker_aad:
+        return None
+    return maker_aad, env_id, agent_id
+
+
+# --- URL resolver --------------------------------------------------------
+
+def resolve_pointer_url(env_id: str, agent_id: str) -> tuple[str, str]:
+    """Resolve the Copilot Studio analytics deep link for one agent.
+
+    Returns ``(url, unresolved_reason)``:
+
+    * ``("", "feature_flag_off")`` when :envvar:`ADK_ANALYTICS_POINTER` is not
+      enabled — this is the DEFAULT state until the partner contract is
+      locked. No URL is constructed.
+    * ``("", "missing_association")`` when either ``env_id`` or ``agent_id``
+      is empty. The caller (/analytics or the install reminder) turns this
+      into the FR7 repair message pointing at ``/setup``.
+    * ``(url, "")`` when the flag is on AND both ids are present. The URL is
+      constructed from :data:`STUDIO_BASE` + :data:`STUDIO_ANALYTICS_PATH`.
+
+    **This function is a placeholder pending partner contract confirmation
+    on ADO PR 5465946.** The URL shape here matches the currently documented
+    Copilot Studio path (mirrors ``_studio_agent_url`` in
+    ``flightcheck/checks/local_files.py`` which was validated live for
+    ``/overview``). Do NOT rely on this for production without the partner
+    contract being locked. Any change to the confirmed shape belongs HERE,
+    in this one function — everything else in the module (telemetry,
+    reminder store, CLI) uses only the ``(url, reason)`` return contract.
+
+    FR2 (click-time validation of the destination) is not implemented in this
+    stub. When it is added, it should return
+    ``("", "validation_failed")`` — the enum value is reserved above.
+    """
+    if not _feature_flag_enabled():
+        return "", REASON_FLAG_OFF
+    if not env_id or not agent_id:
+        return "", REASON_MISSING_ASSOCIATION
+    url = STUDIO_BASE + STUDIO_ANALYTICS_PATH.format(env_id=env_id, agent_id=agent_id)
+    return url, ""
+
+
+# --- Maker-facing rendering ---------------------------------------------
+
+_FLAG_OFF_LINE = (
+    "Analytics pointer is not yet enabled in this build of the ADK. "
+    "This surface is behind a feature flag while the Copilot Studio direct-"
+    "link contract is being finalized. Track: ADO PR 5465946."
+)
+
+_MISSING_ASSOCIATION_LINE_PLAIN = (
+    "No Copilot Studio agent is linked to this workspace yet. "
+    "Run `/setup` to link one, then re-run `/analytics`."
+)
+
+_MISSING_ASSOCIATION_LINE_REMINDER = (
+    "Once your Copilot Studio agent is linked, run `/analytics` at any time "
+    "to jump to its analytics dashboard. Run `/setup` first to link one."
+)
+
+
+def render_pointer_line(
+    url: str,
+    reason: str,
+    *,
+    reminder_framing: bool = False,
+) -> str:
+    """Render the single maker-facing line for a pointer state.
+
+    Used by BOTH surfaces:
+
+    * ``/analytics`` slash command — ``reminder_framing=False``. Plain, in-
+      the-moment framing ("here is your link" / "run /setup").
+    * Post-deploy reminder from ``install_ess_agent.py`` — ``reminder_framing=
+      True``. Softer, "one-time notice" framing so the maker doesn't read it
+      as an error just because we're printing it after a successful install.
+
+    The switch only affects wording, never the underlying state. When
+    ``url`` is non-empty we show it verbatim (no shortening / no click
+    tracking wrapper) so the maker can copy-paste into the browser.
+    """
+    if url:
+        if reminder_framing:
+            return (
+                "Tip: your Copilot Studio agent analytics live at:\n"
+                f"    {url}\n"
+                "Run `/analytics` anytime to jump back here."
+            )
+        return (
+            "Copilot Studio analytics for your agent:\n"
+            f"    {url}"
+        )
+    if reason == REASON_FLAG_OFF:
+        return _FLAG_OFF_LINE
+    if reason == REASON_MISSING_ASSOCIATION:
+        return (
+            _MISSING_ASSOCIATION_LINE_REMINDER
+            if reminder_framing
+            else _MISSING_ASSOCIATION_LINE_PLAIN
+        )
+    if reason == REASON_VALIDATION_FAILED:
+        return (
+            "Could not validate the Copilot Studio analytics link right now. "
+            "Try again in a moment, or open Copilot Studio directly."
+        )
+    # Defensive: unknown reason — don't invent copy, just say generic.
+    return "Copilot Studio analytics link is not available right now."
+
+
+# --- ReminderStore protocol + implementations ---------------------------
+
+class ReminderStore(Protocol):
+    """One-time-reminder gate for the post-deploy pointer.
+
+    Implementations MUST be idempotent: ``mark_completed`` for an already-
+    completed triplet is a no-op success, and ``is_completed`` never mutates.
+    All calls MUST be fail-open: a store error must not crash the caller
+    (install_ess_agent), it must be logged/ignored and treated as "not yet
+    shown" so the maker still gets the reminder eventually.
+    """
+
+    def is_completed(self, maker_aad: str, env_id: str, agent_id: str) -> bool: ...
+
+    def mark_completed(
+        self, maker_aad: str, env_id: str, agent_id: str, reason: str
+    ) -> None: ...
+
+
+# --- LocalFileReminderStore ---------------------------------------------
+
+# Per-machine JSON file. This is deliberately under the same ``~/.adk``
+# directory adk_telemetry uses so all ADK per-install state lives in one
+# place a maker can inspect / wipe if they hit a bug.
+LOCAL_REMINDER_PATH = os.path.expanduser(
+    os.path.join("~", ".adk", "analytics_reminder.json")
+)
+
+
+class LocalFileReminderStore:
+    """Per-machine JSON-backed :class:`ReminderStore` implementation.
+
+    MVP acceptable for the September 2026 release: the PM spec's "server-
+    side / cross-device" requirement is documented as a follow-up in the
+    module docstring (DataverseReminderStore).
+
+    Concurrency: writes are best-effort. Two overlapping installer runs on
+    the same machine could race and one might overwrite the other's mark —
+    at worst the maker sees the reminder twice, which is a strictly better
+    failure mode than crashing the installer. We do NOT take a filesystem
+    lock: the installer already runs one at a time in practice, and cross-
+    process locking on Windows without extra deps is more brittle than the
+    bug it would prevent.
+    """
+
+    def __init__(self, path: str | os.PathLike[str] | None = None) -> None:
+        self._path = str(path) if path else LOCAL_REMINDER_PATH
+
+    @staticmethod
+    def _key(maker_aad: str, env_id: str, agent_id: str) -> str:
+        return f"{maker_aad}|{env_id}|{agent_id}"
+
+    def _read(self) -> dict[str, Any]:
+        try:
+            with open(self._path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError):
+            return {}
+
+    def _write(self, data: dict[str, Any]) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._path) or ".", exist_ok=True)
+            with open(self._path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+        except OSError:
+            # Fail-open: a store write that couldn't land just means the maker
+            # sees the reminder again next install. Better than crashing.
+            pass
+
+    def is_completed(self, maker_aad: str, env_id: str, agent_id: str) -> bool:
+        if not maker_aad or not env_id or not agent_id:
+            return False
+        data = self._read()
+        entries = data.get("completed") or {}
+        return isinstance(entries, dict) and self._key(maker_aad, env_id, agent_id) in entries
+
+    def mark_completed(
+        self, maker_aad: str, env_id: str, agent_id: str, reason: str
+    ) -> None:
+        if not maker_aad or not env_id or not agent_id:
+            return
+        data = self._read()
+        entries = data.get("completed")
+        if not isinstance(entries, dict):
+            entries = {}
+        entries[self._key(maker_aad, env_id, agent_id)] = {
+            "reason": reason or "unspecified",
+            "at": int(time.time()),
+        }
+        data["completed"] = entries
+        self._write(data)
+
+
+def get_reminder_store() -> ReminderStore:
+    """Return the configured :class:`ReminderStore` implementation.
+
+    Reads ``ADK_ANALYTICS_STORE`` env var (default ``"local"``). The
+    ``"dataverse"`` value is reserved for the follow-up implementation
+    documented in the module docstring. Any unknown value falls back to
+    ``"local"`` — an env-var typo must not crash a skill.
+    """
+    kind = os.environ.get(STORE_ENV, "local").strip().lower()
+    if kind == "dataverse":
+        # TODO(adk-analytics-pointer): implement DataverseReminderStore once
+        # the ESS Dataverse solution ships the adk_makerreminder table. See
+        # the module docstring for the schema sketch. For now fall through.
+        pass
+    return LocalFileReminderStore()
+
+
+# --- Telemetry helpers ---------------------------------------------------
+# These are thin wrappers over adk_telemetry so the /analytics command and
+# the install reminder call a stable local API instead of importing
+# adk_telemetry directly (keeps future refactors — e.g. batching multiple
+# analytics events into one — local to this module). All emits are best-
+# effort and never propagate exceptions to the caller.
+
+
+def _telemetry():
+    """Import adk_telemetry lazily so a broken telemetry install doesn't
+    break the /analytics command itself."""
+    try:
+        import adk_telemetry  # type: ignore
+        return adk_telemetry
+    except Exception:  # noqa: BLE001 — telemetry must never break a skill
+        return None
+
+
+def _emit(fn_name: str, **kwargs: Any) -> None:
+    t = _telemetry()
+    if t is None:
+        return
+    try:
+        fn = getattr(t, fn_name, None)
+        if fn is None:
+            return
+        fn(**kwargs)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def record_pointer_shown(
+    *, env_id: str, agent_id: str, outcome: str, unresolved_reason: str = ""
+) -> None:
+    """Emit ``adk.analytics.pointer.shown``.
+
+    ``outcome`` is ``"resolved"`` when a URL was shown, ``"unresolved"``
+    otherwise. ``unresolved_reason`` is one of the ``REASON_*`` enum values
+    when outcome is ``unresolved`` (empty when resolved).
+    """
+    _emit(
+        "emit_analytics_pointer_shown",
+        env_id=env_id,
+        agent_id=agent_id,
+        outcome=outcome,
+        unresolved_reason=unresolved_reason,
+    )
+
+
+def record_pointer_clicked(*, env_id: str, agent_id: str) -> None:
+    _emit(
+        "emit_analytics_pointer_clicked",
+        env_id=env_id,
+        agent_id=agent_id,
+    )
+
+
+def record_pointer_dismissed(*, env_id: str, agent_id: str) -> None:
+    _emit(
+        "emit_analytics_pointer_dismissed",
+        env_id=env_id,
+        agent_id=agent_id,
+    )
+
+
+def record_resolution_failed(
+    *, env_id: str, agent_id: str, unresolved_reason: str
+) -> None:
+    _emit(
+        "emit_analytics_pointer_resolution_failed",
+        env_id=env_id,
+        agent_id=agent_id,
+        unresolved_reason=unresolved_reason,
+    )
+
+
+def record_repair_attempted(*, env_id: str, agent_id: str) -> None:
+    _emit(
+        "emit_analytics_pointer_repair_attempted",
+        env_id=env_id,
+        agent_id=agent_id,
+    )
+
+
+# --- CLI ----------------------------------------------------------------
+
+def _cli_show(args: argparse.Namespace) -> int:
+    """Resolve the pointer for the current workspace and print the maker
+    line. Also emits the ``.shown`` telemetry event. This is what the
+    /analytics prompt shells out to.
+    """
+    assoc = read_association(path=args.config)
+    if assoc is None:
+        line = render_pointer_line("", REASON_MISSING_ASSOCIATION, reminder_framing=False)
+        print(line)
+        record_pointer_shown(
+            env_id="", agent_id="", outcome="unresolved",
+            unresolved_reason=REASON_MISSING_ASSOCIATION,
+        )
+        return 0
+    _maker, env_id, agent_id = assoc
+    url, reason = resolve_pointer_url(env_id, agent_id)
+    line = render_pointer_line(url, reason, reminder_framing=False)
+    print(line)
+    if url:
+        record_pointer_shown(
+            env_id=env_id, agent_id=agent_id, outcome="resolved",
+        )
+    else:
+        record_pointer_shown(
+            env_id=env_id, agent_id=agent_id, outcome="unresolved",
+            unresolved_reason=reason,
+        )
+    return 0
+
+
+def _cli_dismiss(args: argparse.Namespace) -> int:
+    """Mark the pointer reminder as completed for the current triplet.
+
+    Used by the /analytics command when the maker says "don't show this
+    again" — a click-time dismissal path from the reminder surface. When
+    the triplet is unresolvable we silently no-op (dismissing nothing is
+    still a valid maker choice; we don't want to error at them).
+    """
+    assoc = read_association(path=args.config)
+    if assoc is None:
+        return 0
+    maker, env_id, agent_id = assoc
+    try:
+        get_reminder_store().mark_completed(maker, env_id, agent_id, "manual_dismiss")
+    except Exception:  # noqa: BLE001 — never crash the skill
+        pass
+    record_pointer_dismissed(env_id=env_id, agent_id=agent_id)
+    return 0
+
+
+def _cli_status(args: argparse.Namespace) -> int:
+    """Print a small JSON blob describing pointer state for the current
+    workspace. Consumed by the /analytics prompt when it wants to render
+    a state-specific message without shelling out twice.
+    """
+    assoc = read_association(path=args.config)
+    if assoc is None:
+        payload = {
+            "flag": "on" if _feature_flag_enabled() else "off",
+            "association": None,
+            "url": "",
+            "reason": REASON_MISSING_ASSOCIATION,
+            "completed": False,
+        }
+    else:
+        maker, env_id, agent_id = assoc
+        url, reason = resolve_pointer_url(env_id, agent_id)
+        completed = False
+        try:
+            completed = get_reminder_store().is_completed(maker, env_id, agent_id)
+        except Exception:  # noqa: BLE001
+            pass
+        payload = {
+            "flag": "on" if _feature_flag_enabled() else "off",
+            "association": {"env_id": env_id, "agent_id": agent_id},
+            "url": url,
+            "reason": reason,
+            "completed": completed,
+        }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="ESS ADK - Copilot Studio Analytics Pointer CLI.",
+    )
+    p.add_argument(
+        "--config",
+        default=None,
+        help="Path to .local/config.json (defaults to .local/config.json in cwd).",
+    )
+    # argparse can't accept a subcommand name that starts with '--', so we
+    # model the three verbs as mutually-exclusive flags. That way both
+    # `analytics_pointer.py --show` and (as a shorthand) no-verb-at-all work.
+    group = p.add_mutually_exclusive_group()
+    group.add_argument(
+        "--show",
+        dest="verb",
+        action="store_const",
+        const="show",
+        help="Show the analytics pointer line (default).",
+    )
+    group.add_argument(
+        "--dismiss",
+        dest="verb",
+        action="store_const",
+        const="dismiss",
+        help="Mark the reminder complete.",
+    )
+    group.add_argument(
+        "--status",
+        dest="verb",
+        action="store_const",
+        const="status",
+        help="Print pointer state as JSON.",
+    )
+    return p
+
+
+_VERB_DISPATCH = {
+    "show": _cli_show,
+    "dismiss": _cli_dismiss,
+    "status": _cli_status,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    args = _build_parser().parse_args(argv)
+    verb = getattr(args, "verb", None) or "show"
+    return _VERB_DISPATCH[verb](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/solutions/ess-maker-skills/scripts/install_ess_agent.py
+++ b/solutions/ess-maker-skills/scripts/install_ess_agent.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 import sys
 import time
@@ -696,6 +697,80 @@ def main() -> None:
         "schemaName": schema_name,
     }
     print(f"INSTALLED_ESS_AGENT_JSON:{json.dumps(result)}")
+    _print_analytics_pointer_reminder(result)
+
+
+def _print_analytics_pointer_reminder(result: dict) -> None:
+    """Print the one-time Copilot Studio analytics pointer reminder.
+
+    Two important design notes for this helper:
+
+    1. **Guarded by the analytics pointer feature flag.** The pointer surface
+       is behind ``ADK_ANALYTICS_POINTER`` because the deep-link contract
+       isn't yet confirmed by the Copilot Studio partner team (see
+       ``analytics_pointer.py`` module docstring). When the flag is off we
+       return immediately — no import cost, no state, no output that could
+       confuse downstream tooling parsing the installer's stdout.
+
+    2. **The ESS installer doesn't own the agent id.** ``install_ess_agent``
+       installs the ESS SOLUTION into a Power Platform environment. The
+       Copilot Studio agent (botId) is picked up LATER by ``/setup`` when
+       the maker links their workspace to a specific bot in that env, so
+       ``result`` here only carries ``environmentUrl`` and ``schemaName`` —
+       NOT the ``(maker, env, agent)`` triplet the pointer resolves against.
+       That's why this helper reads ``.local/config.json`` directly via
+       ``analytics_pointer.read_association()``: on a fresh env where
+       /setup hasn't run yet the triplet is absent and we skip the reminder
+       entirely (there's nowhere for the maker to jump to). On a resumed
+       install where /setup DID already link an agent, the triplet is
+       present and the maker gets the pointer.
+
+    Output is printed AFTER the ``INSTALLED_ESS_AGENT_JSON:`` line so the
+    machine-readable marker other scripts grep for stays first on stdout —
+    the reminder is a maker-facing footer, never part of the JSON payload.
+    Any exception here is swallowed: a broken reminder must NEVER fail a
+    successful install.
+    """
+    if os.environ.get("ADK_ANALYTICS_POINTER", "").strip().lower() not in (
+        "on", "1", "true", "yes", "enabled",
+    ):
+        return
+    try:
+        # Ensure scripts/ is on sys.path so this works both when the installer
+        # is invoked as ``python scripts/install_ess_agent.py`` (scripts/ is
+        # already the process cwd's script dir, but not necessarily on
+        # sys.path) and when imported by a wrapper.
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        if script_dir not in sys.path:
+            sys.path.insert(0, script_dir)
+        import analytics_pointer  # type: ignore
+
+        assoc = analytics_pointer.read_association()
+        if assoc is None:
+            # Triplet not yet present — /setup hasn't linked an agent to this
+            # workspace. Silently skip: the maker will get the pointer on the
+            # NEXT install after they run /setup, or via /analytics directly.
+            return
+        maker_aad, env_id, agent_id = assoc
+        store = analytics_pointer.get_reminder_store()
+        if store.is_completed(maker_aad, env_id, agent_id):
+            return
+        url, reason = analytics_pointer.resolve_pointer_url(env_id, agent_id)
+        line = analytics_pointer.render_pointer_line(
+            url, reason, reminder_framing=True,
+        )
+        print()
+        print("--- Analytics ---")
+        print(line)
+        store.mark_completed(maker_aad, env_id, agent_id, "post_deploy_install")
+        analytics_pointer.record_pointer_shown(
+            env_id=env_id,
+            agent_id=agent_id,
+            outcome="resolved" if url else "unresolved",
+            unresolved_reason="" if url else reason,
+        )
+    except Exception:  # noqa: BLE001 — a broken reminder must not fail install
+        pass
 
 
 if __name__ == "__main__":

--- a/solutions/ess-maker-skills/src/reference/ess-docs/operations/analytics.md
+++ b/solutions/ess-maker-skills/src/reference/ess-docs/operations/analytics.md
@@ -1,0 +1,92 @@
+# Analytics pointer
+
+The **`/analytics`** slash command jumps a maker directly from VS Code to
+their Copilot Studio agent's analytics dashboard. It is one of the two
+surfaces of the *ADK Copilot Studio Analytics Pointer* MVP (September
+2026). The other surface is a one-time reminder printed by
+`install_ess_agent.py` right after a successful ESS install.
+
+Both surfaces call the same resolver
+(`solutions/ess-maker-skills/scripts/analytics_pointer.py`) and produce
+the same maker-facing line so the two experiences stay consistent.
+
+## What the maker sees
+
+**When the association is resolvable and the feature is enabled:**
+
+```
+Copilot Studio analytics for your agent:
+    https://copilotstudio.microsoft.com/environments/{envId}/bots/{agentId}/analytics
+```
+
+**When the association is missing** (no `.local/config.json`, or the
+maker AAD / env ID / agent ID isn't captured there yet):
+
+> I can't find a linked Copilot Studio agent for this workspace, so I
+> can't build an analytics link yet. Run `/setup` to link an agent, then
+> run `/analytics` again.
+
+**When the feature flag is off** (the default for this MVP build):
+
+> Analytics pointer is not yet enabled in this build of the ADK. It is
+> behind a feature flag while the Copilot Studio deep-link contract is
+> being finalized.
+
+## Feature flag
+
+`ADK_ANALYTICS_POINTER=on` turns the resolver on. It is OFF by default.
+
+The flag exists because the direct-link URL contract for Copilot Studio
+analytics has not yet been confirmed by the Copilot Studio partner team.
+The PM spec (ADO PR 5465946) forbids shipping against a
+reverse-engineered URL, so the default-off state ensures nothing that
+depends on the unconfirmed contract can accidentally reach production.
+
+When the flag turns on for real, both the `/analytics` slash command and
+the post-deploy reminder become active for that install. There is no
+per-surface flag — one switch controls both.
+
+## Reminder state
+
+The post-deploy reminder is one-time per `(maker_aad, env_id, agent_id)`
+triplet. State is written by a `ReminderStore` selected via
+`ADK_ANALYTICS_STORE`:
+
+| Value | Implementation | Scope | Status |
+|---|---|---|---|
+| `local` (default) | `LocalFileReminderStore` at `~/.adk/analytics_reminder.json` | Per machine | Shipped for MVP |
+| `dataverse` | `DataverseReminderStore` — targets an `adk_makerreminder` table in the ESS Dataverse solution | Per (tenant, maker) — cross-device | Follow-up |
+
+The Dataverse follow-up is tracked as an item on the analytics pointer
+workstream. It requires the ESS Dataverse solution package to add the
+new table before the ADK-side store can be wired.
+
+## Follow-up items
+
+* **Partner contract for the deep-link URL.** ADO PR 5465946 tracks the
+  decision. Until it lands, the resolver stays behind the feature flag
+  and the URL shape must be treated as placeholder.
+* **Click-time destination validation (FR2).** The resolver reserves
+  the `validation_failed` reason for a future check that pings the
+  destination before showing it. Not implemented in the MVP.
+* **Server-side reminder state (Dataverse).** See the table above.
+* **Repair UI beyond `/setup`.** The FR7 repair path today just points
+  the maker at `/setup`. A richer repair flow (e.g. re-run the
+  environment picker) is out of scope for the MVP.
+
+## Telemetry
+
+The pointer emits five events, all in the `adk.analytics.pointer.*`
+family (see `scripts/adk_telemetry.py`):
+
+| Event | When it fires |
+|---|---|
+| `adk.analytics.pointer.shown` | Any time the pointer line is rendered — carries `outcome` (`resolved` / `unresolved`) and, when unresolved, an `unresolved_reason`. |
+| `adk.analytics.pointer.clicked` | Reserved for a future click-tracking wrapper. |
+| `adk.analytics.pointer.dismissed` | Maker explicitly ran `/analytics --dismiss`. |
+| `adk.analytics.pointer.resolution_failed` | Resolver returned unresolved (also included on the `.shown` event; this exists for FR2 destination-validation retries). |
+| `adk.analytics.pointer.repair_attempted` | Maker followed the FR7 repair path and re-ran `/setup`. |
+
+All events carry `env_id` and `agent_id` (opaque GUIDs already emitted
+on `adk.agent.deploy`) alongside the common dimensions. No new PII is
+introduced by this surface.

--- a/solutions/ess-maker-skills/src/skills/analytics/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/analytics/SKILL.md
@@ -1,0 +1,129 @@
+# Analytics Skill
+
+Print a direct link to the current agent's Copilot Studio analytics
+dashboard, so the maker can jump straight from VS Code to their agent's
+usage metrics.
+
+Every **Message** block is the exact text to show the user. Copy it
+verbatim. Do not rephrase, add commentary, or tell the user what tools
+you are calling or files you are reading.
+
+The behavior is intentionally a thin wrapper over the
+`scripts/analytics_pointer.py` CLI: this skill file only decides which
+Message block to show; the pointer resolution, URL construction, feature
+flag check, and telemetry emission all happen inside the script. That
+keeps the "what URL do we point at?" decision in exactly one place — see
+the analytics_pointer.py module docstring for the partner-contract
+caveat that governs it.
+
+---
+
+## Start
+
+Run `python scripts/analytics_pointer.py --status` in the terminal and
+capture its stdout as JSON. The JSON has the shape:
+
+```json
+{
+  "flag": "on" | "off",
+  "association": null | { "env_id": "...", "agent_id": "..." },
+  "url": "https://...",
+  "reason": "" | "feature_flag_off" | "missing_association" | "validation_failed",
+  "completed": true | false
+}
+```
+
+Then branch on that JSON exactly as follows. Do not compose your own
+message. If a branch has no Message block, stay silent and stop.
+
+---
+
+## Case 1: feature flag OFF (`flag == "off"`)
+
+The analytics pointer is gated behind a feature flag while the Copilot
+Studio direct-link contract is being finalized. Do not attempt to
+construct or guess a URL — the script would refuse anyway.
+
+**Message:**
+
+Analytics pointer is not yet enabled in this build of the ADK. It is
+behind a feature flag while the Copilot Studio deep-link contract is
+being finalized.
+
+If you need your agent's analytics right now, open it manually from the
+Copilot Studio homepage: https://copilotstudio.microsoft.com/
+
+**End message.**
+
+Stop here.
+
+---
+
+## Case 2: flag ON, association missing (`flag == "on"` AND `association == null`)
+
+This is the FR7 repair state. Either `.local/config.json` doesn't have
+an active agent linked, or one of `maker_aad` / `env_id` / `agent_id` is
+missing. The fix is `/setup`.
+
+**Message:**
+
+I can't find a linked Copilot Studio agent for this workspace, so I
+can't build an analytics link yet. Run `/setup` to link an agent, then
+run `/analytics` again.
+
+**End message.**
+
+Stop here.
+
+---
+
+## Case 3: flag ON, association present, URL resolved (`url` is non-empty)
+
+Show the link exactly as returned by the script — do NOT shorten it,
+wrap it in a tracker, or reformat the URL. Then run
+`python scripts/analytics_pointer.py --show` in the terminal. That
+command prints the same maker-facing line the pointer would print, AND
+emits the `adk.analytics.pointer.shown` telemetry event with
+`outcome=resolved`. Show the script's stdout verbatim to the maker —
+that is the ONLY output the maker sees.
+
+Do not add any additional Message block after the script output in this
+case. The script's output IS the message.
+
+---
+
+## Case 4: flag ON, association present, resolution failed (`url` empty AND `reason` is `validation_failed`)
+
+Reserved for the click-time destination-validation stub (FR2). Today
+the resolver never returns this; when the FR2 check lands, this branch
+will fire on transient failures.
+
+**Message:**
+
+I couldn't validate the Copilot Studio analytics link right now. Try
+running `/analytics` again in a moment, or open Copilot Studio directly
+at https://copilotstudio.microsoft.com/ and find your agent from the
+homepage.
+
+**End message.**
+
+Stop here.
+
+---
+
+## Optional: dismissing the reminder
+
+If the maker explicitly asks to "stop showing the analytics reminder"
+or similar, run `python scripts/analytics_pointer.py --dismiss` in the
+terminal. That marks the reminder complete for the current
+`(maker, env, agent)` triplet so the post-deploy report won't show it
+again. Then:
+
+**Message:**
+
+Got it — I won't show the analytics reminder after future installs.
+You can still run `/analytics` any time to jump to the dashboard.
+
+**End message.**
+
+Stop here. Do NOT run `--dismiss` unless the maker explicitly asked.

--- a/tests/scripts/test_analytics_pointer.py
+++ b/tests/scripts/test_analytics_pointer.py
@@ -1,0 +1,348 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the ADK Copilot Studio analytics pointer (ADO PR 5465946).
+
+These tests cover the pure-logic module only. They do not exercise the
+Copilot Studio partner API — the whole point of the feature flag
+this module ships behind is that no real API call is attempted until
+the deep-link contract is confirmed.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+# --- resolve_pointer_url -------------------------------------------------
+
+
+def test_resolve_pointer_url_returns_stub_when_flag_off(monkeypatch):
+    """With the feature flag OFF (the default) the resolver MUST NOT build a
+    URL, even when both ids are present. This is the safety property that
+    keeps the placeholder URL from ever leaking to real makers before the
+    Copilot Studio partner contract is locked."""
+    import analytics_pointer
+
+    monkeypatch.delenv("ADK_ANALYTICS_POINTER", raising=False)
+
+    url, reason = analytics_pointer.resolve_pointer_url(
+        env_id="env-guid", agent_id="bot-guid",
+    )
+
+    assert url == ""
+    assert reason == analytics_pointer.REASON_FLAG_OFF
+
+
+def test_resolve_pointer_url_returns_full_url_when_flag_on(monkeypatch):
+    """Flag on + both ids present → resolver returns a URL containing both
+    ids. We assert on presence, not exact shape, so a future partner-
+    contract change to the path can update the module constant without
+    invalidating this test."""
+    import analytics_pointer
+
+    monkeypatch.setenv("ADK_ANALYTICS_POINTER", "on")
+
+    url, reason = analytics_pointer.resolve_pointer_url(
+        env_id="env-guid-42", agent_id="bot-guid-99",
+    )
+
+    assert reason == ""
+    assert url.startswith("https://copilotstudio.microsoft.com/")
+    assert "env-guid-42" in url
+    assert "bot-guid-99" in url
+
+
+def test_resolve_pointer_url_missing_env_id(monkeypatch):
+    import analytics_pointer
+
+    monkeypatch.setenv("ADK_ANALYTICS_POINTER", "on")
+
+    url, reason = analytics_pointer.resolve_pointer_url(
+        env_id="", agent_id="bot-guid",
+    )
+
+    assert url == ""
+    assert reason == analytics_pointer.REASON_MISSING_ASSOCIATION
+
+
+def test_resolve_pointer_url_missing_agent_id(monkeypatch):
+    import analytics_pointer
+
+    monkeypatch.setenv("ADK_ANALYTICS_POINTER", "on")
+
+    url, reason = analytics_pointer.resolve_pointer_url(
+        env_id="env-guid", agent_id="",
+    )
+
+    assert url == ""
+    assert reason == analytics_pointer.REASON_MISSING_ASSOCIATION
+
+
+def test_resolve_pointer_url_flag_off_beats_missing_ids(monkeypatch):
+    """When the flag is off, the resolver should short-circuit to
+    ``feature_flag_off`` BEFORE checking ids. This ordering matters for
+    telemetry: even a well-linked workspace must not emit
+    ``missing_association`` when the real reason we're not showing a URL
+    is that the feature is off."""
+    import analytics_pointer
+
+    monkeypatch.delenv("ADK_ANALYTICS_POINTER", raising=False)
+
+    url, reason = analytics_pointer.resolve_pointer_url(env_id="", agent_id="")
+
+    assert url == ""
+    assert reason == analytics_pointer.REASON_FLAG_OFF
+
+
+# --- read_association ----------------------------------------------------
+
+
+def _write_config(path: Path, cfg: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cfg), encoding="utf-8")
+
+
+def test_read_association_returns_none_when_file_missing(tmp_path: Path):
+    import analytics_pointer
+
+    result = analytics_pointer.read_association(path=tmp_path / "does-not-exist.json")
+    assert result is None
+
+
+def test_read_association_returns_none_when_agent_missing(tmp_path: Path):
+    """Half-set-up workspace (env known, no agent linked) → None. That maps
+    to the FR7 repair path."""
+    import analytics_pointer
+
+    cfg_path = tmp_path / ".local" / "config.json"
+    _write_config(cfg_path, {
+        "environmentId": "env-guid",
+        "makerAad": "maker-oid",
+        "agent": {},
+    })
+
+    assert analytics_pointer.read_association(path=cfg_path) is None
+
+
+def test_read_association_returns_triplet_when_present(tmp_path: Path):
+    import analytics_pointer
+
+    cfg_path = tmp_path / ".local" / "config.json"
+    _write_config(cfg_path, {
+        "environmentId": "env-guid",
+        "makerAad": "maker-oid",
+        "agent": {"botId": "bot-guid"},
+    })
+
+    result = analytics_pointer.read_association(path=cfg_path)
+    assert result == ("maker-oid", "env-guid", "bot-guid")
+
+
+def test_read_association_accepts_env_id_on_agent(tmp_path: Path):
+    """Some setups nest ``environmentId`` under ``agent``. That should also
+    resolve — mirrors drive_topic.py's fallback."""
+    import analytics_pointer
+
+    cfg_path = tmp_path / ".local" / "config.json"
+    _write_config(cfg_path, {
+        "makerAad": "maker-oid",
+        "agent": {"botId": "bot-guid", "environmentId": "env-nested"},
+    })
+
+    result = analytics_pointer.read_association(path=cfg_path)
+    assert result == ("maker-oid", "env-nested", "bot-guid")
+
+
+# --- render_pointer_line -------------------------------------------------
+
+
+def test_render_pointer_line_url_plain():
+    import analytics_pointer
+
+    line = analytics_pointer.render_pointer_line(
+        "https://example.com/analytics", "", reminder_framing=False,
+    )
+    assert "https://example.com/analytics" in line
+    # Plain framing is the /analytics slash-command wording — must NOT sound
+    # like a reminder ("run /analytics anytime").
+    assert "anytime" not in line.lower()
+
+
+def test_render_pointer_line_url_reminder_framing():
+    import analytics_pointer
+
+    line = analytics_pointer.render_pointer_line(
+        "https://example.com/analytics", "", reminder_framing=True,
+    )
+    assert "https://example.com/analytics" in line
+    # Reminder framing is the post-install footer wording — should mention
+    # the slash command so the maker knows how to jump back.
+    assert "/analytics" in line
+
+
+def test_render_pointer_line_flag_off_mentions_flag():
+    import analytics_pointer
+
+    line = analytics_pointer.render_pointer_line(
+        "", analytics_pointer.REASON_FLAG_OFF, reminder_framing=False,
+    )
+    assert "not yet enabled" in line.lower() or "feature flag" in line.lower()
+
+
+def test_render_pointer_line_missing_association_points_at_setup():
+    import analytics_pointer
+
+    line = analytics_pointer.render_pointer_line(
+        "", analytics_pointer.REASON_MISSING_ASSOCIATION, reminder_framing=False,
+    )
+    assert "/setup" in line
+
+
+def test_render_pointer_line_reminder_vs_plain_differ():
+    """The framing switch is the whole point of the ``reminder_framing`` flag
+    — assert the two branches actually produce different copy for the same
+    input state."""
+    import analytics_pointer
+
+    plain = analytics_pointer.render_pointer_line(
+        "", analytics_pointer.REASON_MISSING_ASSOCIATION, reminder_framing=False,
+    )
+    reminder = analytics_pointer.render_pointer_line(
+        "", analytics_pointer.REASON_MISSING_ASSOCIATION, reminder_framing=True,
+    )
+    assert plain != reminder
+
+
+# --- LocalFileReminderStore ---------------------------------------------
+
+
+def test_local_file_reminder_store_roundtrip(tmp_path: Path):
+    import analytics_pointer
+
+    store = analytics_pointer.LocalFileReminderStore(
+        path=tmp_path / "reminder.json",
+    )
+
+    # Empty store: nothing is completed.
+    assert store.is_completed("m", "e", "a") is False
+
+    # Marking completes exactly the (m, e, a) triplet and no other.
+    store.mark_completed("m", "e", "a", "post_deploy_install")
+
+    assert store.is_completed("m", "e", "a") is True
+    assert store.is_completed("m", "e", "different-agent") is False
+    assert store.is_completed("other-maker", "e", "a") is False
+
+
+def test_local_file_reminder_store_persists_across_instances(tmp_path: Path):
+    """The store's file is the source of truth — a fresh instance pointing at
+    the same path must see previously marked triplets. This is what makes
+    the post-install reminder actually one-time."""
+    import analytics_pointer
+
+    p = tmp_path / "reminder.json"
+    analytics_pointer.LocalFileReminderStore(path=p).mark_completed(
+        "m", "e", "a", "post_deploy_install",
+    )
+
+    fresh = analytics_pointer.LocalFileReminderStore(path=p)
+    assert fresh.is_completed("m", "e", "a") is True
+
+
+def test_local_file_reminder_store_ignores_empty_ids(tmp_path: Path):
+    """Marking with empty ids is a defensive no-op — otherwise the store
+    would grow a garbage entry keyed by ``"||"`` for every unresolved
+    installer run."""
+    import analytics_pointer
+
+    store = analytics_pointer.LocalFileReminderStore(
+        path=tmp_path / "reminder.json",
+    )
+    store.mark_completed("", "", "", "post_deploy_install")
+
+    assert store.is_completed("", "", "") is False
+    # And the file either wasn't created or is an empty dict.
+    if (tmp_path / "reminder.json").exists():
+        data = json.loads((tmp_path / "reminder.json").read_text(encoding="utf-8"))
+        assert not data.get("completed")
+
+
+# --- get_reminder_store --------------------------------------------------
+
+
+def test_get_reminder_store_defaults_to_local(monkeypatch):
+    import analytics_pointer
+
+    monkeypatch.delenv("ADK_ANALYTICS_STORE", raising=False)
+    store = analytics_pointer.get_reminder_store()
+    assert isinstance(store, analytics_pointer.LocalFileReminderStore)
+
+
+def test_get_reminder_store_unknown_value_falls_back_to_local(monkeypatch):
+    """A typo in ADK_ANALYTICS_STORE must NOT crash a skill — fall back to
+    local silently."""
+    import analytics_pointer
+
+    monkeypatch.setenv("ADK_ANALYTICS_STORE", "not-a-real-backend")
+    store = analytics_pointer.get_reminder_store()
+    assert isinstance(store, analytics_pointer.LocalFileReminderStore)
+
+
+def test_get_reminder_store_dataverse_still_returns_local_today(monkeypatch):
+    """``dataverse`` is the reserved future value. Until the ESS Dataverse
+    solution ships the ``adk_makerreminder`` table this falls back to the
+    local store rather than erroring — same fail-open reasoning as the
+    unknown-value case."""
+    import analytics_pointer
+
+    monkeypatch.setenv("ADK_ANALYTICS_STORE", "dataverse")
+    store = analytics_pointer.get_reminder_store()
+    assert isinstance(store, analytics_pointer.LocalFileReminderStore)
+
+
+# --- CLI -----------------------------------------------------------------
+
+
+def test_cli_status_when_flag_off_and_no_config(monkeypatch, tmp_path: Path):
+    """--status must return JSON even when nothing is set up. This is what
+    the /analytics prompt branches on."""
+    import analytics_pointer
+
+    monkeypatch.delenv("ADK_ANALYTICS_POINTER", raising=False)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = analytics_pointer.main(
+            ["--config", str(tmp_path / "missing.json"), "--status"],
+        )
+    assert rc == 0
+
+    payload = json.loads(buf.getvalue())
+    assert payload["flag"] == "off"
+    assert payload["association"] is None
+    assert payload["reason"] == analytics_pointer.REASON_MISSING_ASSOCIATION
+
+
+def test_cli_show_prints_url_when_resolved(monkeypatch, tmp_path: Path):
+    import analytics_pointer
+
+    monkeypatch.setenv("ADK_ANALYTICS_POINTER", "on")
+    cfg_path = tmp_path / ".local" / "config.json"
+    _write_config(cfg_path, {
+        "environmentId": "env-guid-cli",
+        "makerAad": "maker-cli",
+        "agent": {"botId": "bot-guid-cli"},
+    })
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = analytics_pointer.main(["--config", str(cfg_path), "--show"])
+    assert rc == 0
+
+    out = buf.getvalue()
+    assert "env-guid-cli" in out
+    assert "bot-guid-cli" in out


### PR DESCRIPTION
ADO: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7716787

## Summary

Scaffolding PR for the September 2026 **ADK Copilot Studio Analytics Pointer** MVP workstream (ADO PR [5465946](https://dev.azure.com/O365Exchange/O365%20Core/_git/ideas-exp/pullrequest/5465946)). Adds the two ADK surfaces the PM spec calls for:

- **`/analytics` slash command** (permanent action, FR1) — reads `.local/config.json`, resolves the `(maker_aad, env_id, agent_id)` triplet, and either prints a Copilot Studio analytics deep link or the FR7 repair message pointing at `/setup`.
- **Post-deploy reminder** — printed by `install_ess_agent.py` after the `INSTALLED_ESS_AGENT_JSON:` marker line, exactly once per triplet.

Everything ships **behind a feature flag (`ADK_ANALYTICS_POINTER`, default off)** because the Copilot Studio partner deep-link contract is not yet confirmed. The PM spec explicitly forbids shipping against a reverse-engineered URL.

## What's here

**New**
- `solutions/ess-maker-skills/scripts/analytics_pointer.py` — resolver, `ReminderStore` protocol, `LocalFileReminderStore`, telemetry wrappers, `--show` / `--dismiss` / `--status` CLI.
- `solutions/ess-maker-skills/.github/prompts/analytics.prompt.md` — `/analytics` slash command surface.
- `solutions/ess-maker-skills/src/skills/analytics/SKILL.md` — 4-branch skill (flag off / association missing / URL resolved / validation failed) that shells out to the CLI and shows verbatim Message blocks.
- `solutions/ess-maker-skills/src/reference/ess-docs/operations/analytics.md` — maker-facing doc.
- `tests/scripts/test_analytics_pointer.py` — 22 tests covering resolver, store round-trip, and rendering framing.

**Edited**
- `solutions/ess-maker-skills/scripts/adk_telemetry.py` — new event family `adk.analytics.pointer.{shown,clicked,dismissed,resolution_failed,repair_attempted}` with an `unresolved_reason` enum (`feature_flag_off` / `missing_association` / `validation_failed`).
- `solutions/ess-maker-skills/scripts/install_ess_agent.py` — flag-guarded reminder section printed after the machine-readable JSON marker; silently skipped when triplet is absent or reminder is already completed.

## Design decisions worth flagging

**URL construction is deliberately confined to `resolve_pointer_url`.** One function, one string template — swap it in exactly one place when the partner contract lands. Uses the currently documented `copilotstudio.microsoft.com/environments/{env}/bots/{agent}/analytics` shape as a placeholder.

**Reminder storage is `LocalFileReminderStore` for MVP.** The PM spec calls for server-side / cross-device state in a Dataverse `adk_makerreminder` table, but that table lives in the ESS Dataverse solution package which is not in this repo. Documented as a follow-up: when the solution ships a schema update, add a `DataverseReminderStore` implementation and switch `ADK_ANALYTICS_STORE=dataverse`. The store factory already reads that env var.

**`read_association()` returns `None` unless all three of `maker_aad`, `env_id`, `agent_id` are present.** That single strict rule cleanly maps to FR7 (repair state) everywhere — no ambiguous "partial" state to reason about downstream.

## Validation

- `python -m pytest tests/scripts/test_analytics_pointer.py -q` → 22 passed
- `python -m pytest tests/scripts/test_install_ess_agent.py -q` → 19 passed (unchanged from baseline)
- Manual CLI smoke: verified all four states (flag off / flag on + full triplet / flag on + missing agent / dismiss round-trip) print the expected maker-facing text.

## Follow-ups (not in this PR)

- **Partner deep-link contract** (ADO PR 5465946) — blocks turning the flag on for real.
- **`setup.py` persisting `makerAad` into `.local/config.json`** — until this lands, `read_association()` always returns `None` in practice (config today doesn't include maker AAD).
- **`DataverseReminderStore`** — waits on ESS Dataverse solution shipping the `adk_makerreminder` table. Schema sketch is inline in the module docstring.
- **FR2 click-time destination validation** — reserved reason `validation_failed`, not implemented.
- **Repair UI beyond `/setup`** — intentionally out of scope for MVP.

## Manual test checklist (for the reviewer)

The programmatic tests cover the Python side. The `/analytics` slash-command flow itself needs to be exercised in VS Code's GitHub Copilot Chat surface:

1. In an ADK workspace with `.local/config.json` present, run `/analytics` — expect the "feature not enabled" message (flag defaults off).
2. Set `ADK_ANALYTICS_POINTER=on`, ensure `.local/config.json` has `environmentId`, `agent.botId`, and `makerAad`, run `/analytics` — expect the URL printed verbatim.
3. Clear any of those three fields, run `/analytics` again — expect the `/setup`-repair message.
4. With flag on and full triplet, run `install_ess_agent.py` — expect the `--- Analytics ---` reminder section AFTER `INSTALLED_ESS_AGENT_JSON:`. Re-run the installer — expect the reminder to be silent (already completed for that triplet).
