### PR TITLE
feat(work-iq): add Microsoft Work IQ MCP as an authoring-time developer tool

### DIFF
--- a/solutions/ess-maker-skills/.github/copilot-instructions.md
+++ b/solutions/ess-maker-skills/.github/copilot-instructions.md
@@ -257,6 +257,27 @@ For detailed patterns, see `src/reference/ess-docs/customization/customize.md`.
 - HTTP — for generic REST API calls to custom endpoints
 - Any Power Platform connector can be added through the Copilot Studio portal
 
+## Developer Tools (authoring-time)
+
+These are MCP tools the **maker's Copilot** uses while building. They run on the
+maker's machine under the maker's own sign-in and are **never** part of the ESS
+agent's runtime (no connection reference, extension pack, or flow) and are never
+deployed to Copilot Studio. Do not confuse them with the `/connect` integrations
+above, which configure what the deployed agent calls at runtime.
+
+### Work IQ (people & directory lookup)
+- Microsoft [Work IQ](https://github.com/microsoft/work-iq) (`@microsoft/workiq`) MCP
+  server for Microsoft 365 intelligence; enabled via a `workiq` entry in
+  `.vscode/mcp.json` (`npx -y @microsoft/workiq@latest mcp`, interactive Entra sign-in).
+- **Primary use — resolve a person to their Entra (AAD) object id.** Use the `fetch`
+  tool on a Graph-relative path: `fetch /users/{upn}` → `results[0].data.id` is the
+  Entra object id; `fetch /me/people?$search={name}` for fuzzy name lookup. In chat,
+  just ask (e.g. "what's the Entra object id for jane@contoso.com?").
+- **Boundary:** authoring-time only. Never treat Work IQ or an id it returns as a
+  runtime dependency of the ESS agent. For the *signed-in employee's* identity at
+  runtime, use the ESS user-context topics / `System.User.*`, not Work IQ.
+- See `src/reference/work-iq-mcp.md` for config, the AAD-id recipe, and consent notes.
+
 ## Agent Development Lifecycle (CRITICAL)
 
 The files in `workspace/agents/{slug}/` are a **local working copy** of the agent

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -243,6 +243,27 @@ The kit also includes a local ServiceNow MCP server (`src/mcp/servicenow/`) for 
 
 Configured automatically during `/connect servicenow`.
 
+### Work IQ MCP (developer tool — people & directory lookup)
+
+> **Authoring-time developer tool, not an agent integration.** Work IQ runs on your
+> machine under your own Microsoft Entra sign-in and helps *you* while building. It is
+> never a connection reference, extension pack, or runtime dependency of the ESS agent,
+> and it is never deployed to Copilot Studio.
+
+The kit can use Microsoft [Work IQ](https://github.com/microsoft/work-iq)
+(`@microsoft/workiq`) — Microsoft's MCP server for Microsoft 365 intelligence — so
+Copilot can resolve people and directory data on demand while you author. The common
+use is **getting a person's Entra (AAD) object id**: ask *"what's the Entra object id
+for jane@contoso.com?"* and Copilot calls Work IQ's `fetch /users/{upn}` under the
+hood. Useful for seeding test employees, wiring approvers/managers, and populating
+eval fixtures without copying object ids out of the Entra portal.
+
+Enable it: `/setup` wires the `workiq` entry into `.vscode/mcp.json` automatically
+(the entry is static — no tenant values — so it ships with the kit; needs Node.js for
+`npx` and signs in interactively on first use). See
+[`src/reference/work-iq-mcp.md`](src/reference/work-iq-mcp.md) for the config snippet,
+the AAD-id recipe, and boundaries.
+
 ---
 
 ## Getting Started
@@ -252,6 +273,7 @@ Configured automatically during `/connect servicenow`.
 - [VS Code](https://code.visualstudio.com/) (latest version)
 - [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extension (with an active subscription)
 - Access to a Power Platform environment with an ESS agent deployed
+- **Node.js** (optional) — only needed for the Work IQ developer MCP (`npx`); the rest of the kit does not require it
 - **Dataverse MCP server** enabled in your Power Platform environment with the "Microsoft GitHub Copilot" client allowed. Admin setup: Power Platform admin center → environment → Settings → Features → Dataverse Model Context Protocol → check "Allow MCP clients (GA version)" → Advanced Settings → enable "Microsoft GitHub Copilot". See [Connect Dataverse MCP with VS Code](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/data-platform-mcp-vscode).
 
 ### Recommended Models

--- a/solutions/ess-maker-skills/src/reference/work-iq-mcp.md
+++ b/solutions/ess-maker-skills/src/reference/work-iq-mcp.md
@@ -1,0 +1,108 @@
+# Work IQ MCP — people & directory lookup (developer tool)
+
+**Work IQ is an authoring-time developer tool for the maker, not a runtime part of
+the ESS agent.** It is an MCP server that runs on *your* machine and answers to
+*your* Microsoft Entra sign-in while you build. It is **never** a connection
+reference, extension pack, cloud flow, or any other runtime dependency of the ESS
+agent you are configuring, and it is never deployed to Copilot Studio.
+
+Contrast with the `/connect` family:
+
+| | `/connect servicenow \| workday` | **Work IQ MCP** |
+|---|---|---|
+| Whose capability | The **deployed ESS agent** (runtime) | The **maker's Copilot** (authoring time) |
+| Runtime footprint | Power Platform connector + extension pack + Dataverse connection reference the agent calls | **None** — lives only in `.vscode/mcp.json` |
+| Who authenticates | The **employee** at runtime (Entra SSO / ISU / OAuth) | **You, the maker**, interactively |
+| Deployed to Copilot Studio? | Yes | **No** |
+
+## What it is
+
+Work IQ ([`@microsoft/workiq`](https://github.com/microsoft/work-iq)) is Microsoft's
+MCP server for Microsoft 365 intelligence. It exposes a small, fixed set of generic
+tools that operate on **relative resource paths mapping to Microsoft Graph**, so an
+agent can read people, mail, meetings, files, and Teams data, and invoke Microsoft
+365 Copilot — all through one MCP endpoint. See the
+[Work IQ MCP overview](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq/mcp/overview)
+and the
+[tool reference](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq/mcp/tool-reference).
+
+**Tools (10 total):** `fetch`, `create_entity`, `update_entity`, `delete_entity`,
+`do_action`, `call_function`, `ask`, `list_agents`, `get_schema`, `search_paths`.
+The tool surface is fixed — new capabilities are new *paths*, not new tools.
+
+## Enable it
+
+Work IQ needs **Node.js** (for `npx`) and a Microsoft Entra sign-in. It requires no
+credentials in config — the first call opens an interactive consent/sign-in in the
+browser. First-time use also requires accepting the End User License Agreement (the
+CLI exposes `workiq accept-eula` and `workiq auth login`; run as an MCP server it
+prompts on the first tool call). Some tenants require a tenant administrator to grant
+admin consent on first use; see the
+[Tenant Administrator Enablement Guide](https://github.com/microsoft/work-iq/blob/main/ADMIN-INSTRUCTIONS.md).
+
+**New setups get this automatically.** `/setup` writes the `workiq` server into
+`.vscode/mcp.json` alongside `Dataverse`. The entry is fully static (no tenant values
+or secrets), which is why it can ship with the kit even though `.vscode/mcp.json`
+itself is machine-local and git-ignored.
+
+If you set up **before** Work IQ was added, add it manually (merge with the existing
+`servers`; keep other entries like `Dataverse` intact):
+
+```json
+{
+  "servers": {
+    "workiq": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@microsoft/workiq@latest", "mcp"]
+    }
+  }
+}
+```
+
+Reload the VS Code window (or restart the MCP servers) so Copilot picks it up.
+
+## Get a person's Entra (AAD) object id
+
+The `fetch` tool takes an `entityUrls` array of Graph-relative paths and returns
+`results[].data` (the Graph JSON) with a `statusCode`. A user's `id` **is** their
+Microsoft Entra object id (the value formerly called the AAD object id).
+
+- **By UPN / email (most reliable):**
+  ```
+  fetch /users/jane@contoso.com
+  ```
+  → `results[0].data.id` is Jane's Entra object id.
+
+- **By fuzzy name (relevance-ranked people):**
+  ```
+  fetch /me/people?$search=Jane Doe
+  ```
+  → each `value[].id` is a person's directory id; pick the intended match.
+
+- **By exact display-name filter:**
+  ```
+  fetch /users?$filter=startswith(displayName,'Jane')
+  ```
+
+In practice you just ask Copilot in natural language — for example *"what's the Entra
+object id for jane@contoso.com?"* — and it calls `fetch` under the hood.
+
+## Why it's a useful ESS addition
+
+While authoring, you frequently need a real person's Entra object id — seeding a test
+employee, wiring an approver, checking a manager relationship, or populating eval
+fixtures. Work IQ resolves people (and other M365 context) on demand from your own
+signed-in session, without hand-copying object ids out of the Entra portal. It is
+intentionally decoupled from the ESS agent's runtime: enabling or removing it changes
+nothing about the deployed agent.
+
+## Boundaries
+
+- **Authoring-time only.** Do not reference Work IQ, its tools, or any id it returns
+  as a runtime dependency of the ESS agent. If the agent needs the *signed-in
+  employee's* identity at runtime, use the ESS user-context topics / `System.User.*`,
+  not Work IQ.
+- **Acts as you.** Every call runs under the maker's delegated permissions and returns
+  data in the maker's security context — treat results as your own view of M365.
+- **Public preview.** Work IQ is in public preview; tools and permissions may change.

--- a/solutions/ess-maker-skills/src/skills/onboarding/step1.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/step1.md
@@ -133,8 +133,10 @@ Build the MCP URL by appending `/api/mcp` to ENV_URL. Double-check the
 result has exactly ONE slash between the domain and `api` — for example
 `https://org.crm.dynamics.com/api/mcp`, NOT `https://org.crm.dynamics.com//api/mcp`.
 
-Create `.vscode/mcp.json` with this exact content (replace the entire
-`url` value with the MCP URL you just built):
+Create `.vscode/mcp.json` with this exact content (replace **only** the
+Dataverse `url` value with the MCP URL you just built; leave the `workiq`
+entry exactly as-is — it is a static, no-credential developer tool
+(Microsoft Work IQ) with no tenant-specific values):
 
 ```json
 {
@@ -142,10 +144,20 @@ Create `.vscode/mcp.json` with this exact content (replace the entire
     "Dataverse": {
       "type": "http",
       "url": "https://org.crm.dynamics.com/api/mcp"
+    },
+    "workiq": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@microsoft/workiq@latest", "mcp"]
     }
   }
 }
 ```
+
+(The `workiq` server gives the maker's Copilot Microsoft 365 people/directory
+lookups during authoring — e.g. resolving a person to their Entra/AAD object
+id. It signs in interactively on first use and needs Node.js for `npx`; it is
+never part of the ESS agent's runtime. See `src/reference/work-iq-mcp.md`.)
 
 If FOUNDATION_REUSED is true, do not rerun the Allowed MCP Client prerequisite;
 it already passed in foundation `SETUP-02.2`. Continue directly to section 1.3.


### PR DESCRIPTION
## Summary

Adds **Microsoft Work IQ** (@microsoft/workiq) as an authoring-time developer MCP server, configured alongside the existing Dataverse MCP server. Work IQ lets the maker's Copilot resolve a person to their **Entra (AAD) object id** from a username/UPN while authoring.

## What's included

- **`.vscode/mcp.json` (/setup)** — a static, no-credential `workiq` stdio entry (
px -y @microsoft/workiq@latest mcp) is now written next to `Dataverse` during onboarding (`src/skills/onboarding/step1.md`).
- **`src/reference/work-iq-mcp.md`** (new) — config snippet, the AAD-id-from-username recipe (`fetch /users/{upn}` → `results[0].data.id`; `fetch /me/people?\={name}` for fuzzy lookup), consent/EULA notes, and boundaries.
- **`.github/copilot-instructions.md`** — new *Developer Tools (authoring-time)* section describing Work IQ and its primary use (resolve a person to their Entra/AAD object id).
- **`README.md`** — Work IQ MCP developer-tool section + Node.js noted as an optional prerequisite (only for `npx`).

## Boundaries

Work IQ is **authoring-time only** — it runs on the maker's machine under the maker's own Entra sign-in, is never a connection reference / extension pack / flow, and is never deployed to Copilot Studio. For the signed-in employee's identity at runtime, the ESS agent uses user-context topics / `System.User.*`, not Work IQ.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>