### PR TITLE
flightcheck: fall back to cached tenant_name when Graph is unavailable

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -867,6 +867,12 @@ def _run_single_checkpoint(args):
         )
         # Best-effort tenant display name (OII; privacy-approved). Reuses the
         # already-authenticated Graph client when one was needed; never re-auths.
+        # Falls back to the persisted ``.local/.tenant_name`` cache when the
+        # live lookup is unavailable (e.g. infra-only scope where ``graph`` is
+        # None, or Graph auth failed for lack of ``Organization.Read.All``
+        # consent) so previously-resolved tenants keep their name on the event
+        # instead of emitting blank. Same-tenant guard is enforced inside the
+        # cache helper.
         tenant_name = ""
         try:
             if graph is not None:
@@ -875,6 +881,11 @@ def _run_single_checkpoint(args):
             tenant_name = ""
         try:
             from flightcheck import telemetry
+
+            if not tenant_name and (tenant_id or ""):
+                tenant_name = telemetry.get_cached_tenant_name(tenant_id or "")
+            elif tenant_name and (tenant_id or ""):
+                telemetry.cache_tenant_name(tenant_id or "", tenant_name)
 
             _tele = telemetry.emit_flightcheck_telemetry(
                 result,
@@ -1331,7 +1342,11 @@ def main():
         )
         # Best-effort tenant display name (OII; privacy-approved). Reuses the
         # already-authenticated Graph client's /organization record — no extra
-        # auth. Falls back to "" on any error; never blocks the run.
+        # auth. Falls back to the persisted ``.local/.tenant_name`` cache when
+        # ``graph`` is None or the live lookup fails (e.g. Graph auth was
+        # skipped or ``Organization.Read.All`` isn't consented on this tenant)
+        # so previously-resolved tenants keep their name instead of blank.
+        # Never blocks the run.
         tenant_name = ""
         try:
             if graph is not None:
@@ -1340,6 +1355,11 @@ def main():
             tenant_name = ""
         try:
             from flightcheck import telemetry
+
+            if not tenant_name and tenant_id:
+                tenant_name = telemetry.get_cached_tenant_name(tenant_id)
+            elif tenant_name and tenant_id:
+                telemetry.cache_tenant_name(tenant_id, tenant_name)
 
             _tele = telemetry.emit_flightcheck_telemetry(
                 result,

--- a/tests/flightcheck/test_cli_single_checkpoint.py
+++ b/tests/flightcheck/test_cli_single_checkpoint.py
@@ -315,3 +315,82 @@ class TestCheckpointTelemetry:
                 _args("FAKE-001", tmp_path, no_telemetry=True)
             )
         assert captured["called"] is False
+
+    def test_tenant_name_falls_back_to_cache_when_graph_unavailable(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _silence_output: None,
+    ) -> None:
+        """When ``graph is None`` (infra-only scope, or Graph auth failed),
+        ``cli`` must fall back to the persisted ``.local/.tenant_name`` cache
+        so previously-resolved tenants keep their name on FlightCheck events
+        instead of emitting blank. Regression guard for the split observed in
+        prod telemetry where the same tenant emitted both blank and named
+        runs on the same ADK version.
+        """
+        monkeypatch.chdir(tmp_path)
+        from flightcheck import telemetry as _tele_mod
+        from flightcheck import registry as _reg
+
+        cached_tid = "11111111-1111-1111-1111-111111111111"
+        _tele_mod.cache_tenant_name(cached_tid, "Contoso Cached")
+
+        # Make the plan require GRAPH so the code reaches the tenant_id
+        # discovery path and then tries to build a Graph client.
+        class _Spec:
+            category_label = "Fake"
+            is_family = False
+
+        class _Plan:
+            clients = frozenset({_reg.GRAPH})
+            requires_config = False
+            requires_dataverse_endpoint = False
+
+            def __init__(self, fns: list) -> None:
+                self.ordered_fns = fns
+
+        def _fn(runner):  # noqa: ARG001
+            return [_row("FAKE-001", Status.PASSED.value)]
+
+        monkeypatch.setattr(_reg, "resolve", lambda target: _Spec())
+        monkeypatch.setattr(
+            _reg, "transitive_requirements", lambda target: _Plan([("Fake", _fn)])
+        )
+
+        # Force tenant_id to our seeded cache key and make Graph fail so the
+        # code sets ``graph = None`` — the exact scenario we're guarding.
+        import auth as _auth
+
+        monkeypatch.setattr(_auth, "discover_tenant", lambda *a, **k: cached_tid)
+
+        class _NoGraph:
+            def __init__(self, *a, **k):
+                pass
+
+            def authenticate(self):
+                raise RuntimeError("no graph in this test")
+
+            def get_organization(self):
+                raise RuntimeError("no graph in this test")
+
+        monkeypatch.setattr(cli, "GraphClient", _NoGraph, raising=False)
+        import flightcheck.graph_client as _gc
+
+        monkeypatch.setattr(_gc, "GraphClient", _NoGraph)
+
+        captured = self._capture(monkeypatch)
+        with pytest.raises(SystemExit):
+            cli._run_single_checkpoint(
+                _args(
+                    "FAKE-001",
+                    tmp_path,
+                    no_telemetry=False,
+                    environment_url="https://contoso.crm.dynamics.com",
+                )
+            )
+        assert captured["called"] is True
+        # Regression assertion: with graph unavailable, the cache must be
+        # consulted so a previously-seen tenant still gets its display name.
+        assert captured["kwargs"]["tenant_name"] == "Contoso Cached"
+        assert captured["kwargs"]["tenant_id"] == cached_tid


### PR DESCRIPTION
## Summary

FlightCheck telemetry emits the tenant display name (OII, privacy-approved) so dashboard series are human-readable. Both `cli.py` emit sites resolved `tenant_name` only via a live Microsoft Graph `/organization` call and left it as `""` whenever `graph` was `None` (infra-only scope, or Graph auth failed for want of `Organization.Read.All` consent) or the live lookup raised. The `.local/.tenant_name` cache that `adk_telemetry` already uses was never consulted.

## Evidence

Aria (prod, P30D, `essmakerkit_flightcheck_run`, `tenantClass == "customer"`):

- **483** runs across **7** tenants have `<blank>` `tenantName`.
- **197** runs across **8** tenants have a resolved `tenantName`.
- Tenant `935884d7-bdee-469b-a461-fcc530a3ac83` on ADK **0.4.24** shows **both** — 450 blank + 186 `EmployeeHub`, concurrent, latest `2026-08-12`. Same tenant, same version = code path split (not a version issue).

## Fix

At both `--scope` and single-`--checkpoint` emit sites in `flightcheck/cli.py`:

- If the live Graph lookup returned a name, proactively `cache_tenant_name(...)` (mirroring what `adk_telemetry.set_identity` already does), so any subsequent Graph-less run on this install keeps the label.
- If the live lookup returned `""` and we have a `tenant_id`, fall back to `telemetry.get_cached_tenant_name(tenant_id)`. The helper already enforces a same-tenant guard so a stale name is never leaked onto a different tenant.

Best-effort, never blocks the run.

## Test

- New regression test `test_tenant_name_falls_back_to_cache_when_graph_unavailable` seeds the cache, forces Graph auth to fail, and asserts the emit kwargs pick up the cached name.
- `pytest tests/flightcheck/test_cli.py tests/flightcheck/test_cli_single_checkpoint.py tests/flightcheck/test_telemetry.py tests/test_adk_telemetry.py` — **87 passed**.

## Non-goals / follow-ups

- Doesn't backfill blank rows already in Aria (retention <= 30 days makes them roll off).
- Doesn't add a Graph-consent-repair prompt — deliberately keeping this fully passive so telemetry never nags a maker.
