### PR TITLE
adk-telemetry: reduce blank tenant_name via reordered bootstrap + /me fallback

### DIFF
--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -267,15 +267,15 @@ def authenticate(env_url):
         claims = result.get("id_token_claims", {}) or {}
         tenant_id = claims.get("tid", "") or tenant
         adk_telemetry.maybe_print_notice()
-        adk_telemetry.start_session(
-            tenant_id=tenant_id,
-        )
-        # Best-effort: resolve the tenant's org display name via a SILENT-ONLY
-        # Graph token (never prompts) and record it so ADK telemetry carries
-        # tenant_name even when the maker never runs FlightCheck. The Dataverse
-        # sign-in above usually leaves a first-party (FOCI) refresh token that
-        # silently satisfies the read scope; set_identity caches the name for
-        # later ADK processes. Silent failure just leaves tenant_name empty.
+        # Resolve the tenant's display name via a SILENT-ONLY Graph token
+        # BEFORE emitting adk.session.start, so the very first ADK event on a
+        # fresh install carries tenant_name (instead of blank until FlightCheck
+        # is later run). The Dataverse sign-in above usually leaves a
+        # first-party (FOCI) refresh token that silently satisfies at least
+        # one of Organization.Read.All / User.Read; the graph_client helper
+        # tries both. Silent failure is fine — set_identity is only called on
+        # success, so start_session below still emits with a blank name in the
+        # (increasingly rare) case where no Graph scope is silently redeemable.
         try:
             from flightcheck.graph_client import resolve_tenant_display_name_silent
 
@@ -284,6 +284,9 @@ def authenticate(env_url):
                 adk_telemetry.set_identity(tenant_id=tenant_id, tenant_name=_tname)
         except Exception:  # noqa: BLE001 — name resolution is best-effort
             pass
+        adk_telemetry.start_session(
+            tenant_id=tenant_id,
+        )
     except Exception:  # noqa: BLE001 — telemetry must never break auth
         pass
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
@@ -99,6 +99,16 @@ def _persist_token_cache(cache: "msal.SerializableTokenCache", cache_path: str) 
 # Dataverse login in auth.py — silently satisfies it with no prompt.
 _ORG_READ_SCOPE = ["https://graph.microsoft.com/Organization.Read.All"]
 
+# Fallback scope for the silent lookup. ``User.Read`` is user-consentable (no
+# admin consent required) and is granted as a "default" static permission for
+# most first-party Microsoft app sign-ins, so a fresh Dataverse-only sign-in
+# still tends to have a redeemable FOCI refresh token for it. When
+# Organization.Read.All silent redemption fails (admin consent required and
+# not granted — very common in enterprise), we can still learn the tenant
+# display label from ``/me?$select=companyName`` in the many tenants where
+# admins populate the user's Company Name attribute with the tenant name.
+_USER_READ_SCOPE = ["https://graph.microsoft.com/User.Read"]
+
 
 def resolve_tenant_display_name_silent(tenant_id: str) -> str:
     """Return the tenant's org displayName via a SILENT-ONLY Graph token.
@@ -109,6 +119,20 @@ def resolve_tenant_display_name_silent(tenant_id: str) -> str:
     prompting. Because the Graph CLI Tools app and the Power Platform CLI app
     (auth.py) are first-party FOCI apps sharing that cache, a prior Dataverse
     sign-in is usually enough for this to succeed with no second prompt.
+
+    Two-stage resolution to maximise coverage:
+
+    1. Try ``/organization`` with ``Organization.Read.All`` -- returns the
+       authoritative tenant display name. Requires admin consent; in tenants
+       where the admin hasn't pre-consented it (common in enterprise), this
+       silently fails and we fall through to step 2.
+    2. Try ``/me?$select=companyName`` with ``User.Read`` -- user-consent-only
+       scope typically granted as a "default" static permission at first-party
+       sign-in, so the FOCI refresh token usually redeems it without a prompt.
+       ``companyName`` is the signed-in user's Entra profile attribute;
+       enterprise admins routinely set it to the tenant display name, so this
+       recovers a useful label for the many customers that would otherwise
+       report as blank.
 
     Used by the ADK auth bootstrap so ``tenant_name`` is populated for ADK
     telemetry even when the maker never runs FlightCheck. Returns ``""`` on any
@@ -129,11 +153,22 @@ def resolve_tenant_display_name_silent(tenant_id: str) -> str:
         accounts = app.get_accounts()
         if not accounts:
             return ""
-        result = app.acquire_token_silent(_ORG_READ_SCOPE, account=accounts[0])
-        if not result or "access_token" not in result:
-            return ""
+        name = _try_organization_lookup(app, accounts[0])
+        if not name:
+            name = _try_me_company_name_lookup(app, accounts[0])
         # Persist any silently-refreshed token so later processes stay silent.
         _persist_token_cache(cache, cache_path)
+        return name or ""
+    except Exception:  # noqa: BLE001 — name resolution is strictly best-effort
+        return ""
+
+
+def _try_organization_lookup(app, account) -> str:
+    """Silent ``/organization`` via ``Organization.Read.All``; ``""`` on any error."""
+    try:
+        result = app.acquire_token_silent(_ORG_READ_SCOPE, account=account)
+        if not result or "access_token" not in result:
+            return ""
         resp = _SESSION.get(
             f"{GRAPH_BASE}/organization",
             headers={
@@ -146,7 +181,36 @@ def resolve_tenant_display_name_silent(tenant_id: str) -> str:
             return ""
         orgs = (resp.json() or {}).get("value", []) or []
         return (orgs[0].get("displayName", "") if orgs else "") or ""
-    except Exception:  # noqa: BLE001 — name resolution is strictly best-effort
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _try_me_company_name_lookup(app, account) -> str:
+    """Silent ``/me?$select=companyName`` via ``User.Read``; ``""`` on any error.
+
+    ``companyName`` is the signed-in user's Entra profile attribute, not the
+    literal tenant display name. Admins routinely populate it with the tenant
+    display name, so it is a useful fallback. Classification-wise it is OII —
+    the same classification we already have for ``tenant_name`` — and never
+    EUPI: we only read a single organizational attribute, not the user's
+    name / UPN / id.
+    """
+    try:
+        result = app.acquire_token_silent(_USER_READ_SCOPE, account=account)
+        if not result or "access_token" not in result:
+            return ""
+        resp = _SESSION.get(
+            f"{GRAPH_BASE}/me?$select=companyName",
+            headers={
+                "Authorization": f"Bearer {result['access_token']}",
+                "Accept": "application/json",
+            },
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return ""
+        return ((resp.json() or {}).get("companyName", "") or "").strip()
+    except Exception:  # noqa: BLE001
         return ""
 
 

--- a/tests/flightcheck/test_graph_client.py
+++ b/tests/flightcheck/test_graph_client.py
@@ -106,3 +106,83 @@ def test_exception_is_swallowed_returns_empty():
         graph_client.msal, "PublicClientApplication", side_effect=RuntimeError("boom")
     ):
         assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+
+
+def test_falls_back_to_me_company_name_when_organization_scope_unavailable():
+    """When Organization.Read.All is not silently redeemable (very common in
+    enterprise tenants that require admin consent), the resolver must fall
+    back to /me?$select=companyName with User.Read -- the latter is a
+    default-static permission that a fresh Dataverse sign-in usually satisfies
+    silently. This is the primary driver of blank tenant_name in prod ADK
+    telemetry, so pin the fallback path.
+    """
+    account = SimpleNamespace()
+    app = MagicMock()
+    app.get_accounts.return_value = [account]
+    app.acquire_token_interactive.side_effect = AssertionError(
+        "silent-only resolver must not prompt interactively"
+    )
+
+    # Org scope: silently unavailable. User.Read: silently redeemable.
+    def silent(scopes, account):
+        if scopes == graph_client._ORG_READ_SCOPE:
+            return None
+        if scopes == graph_client._USER_READ_SCOPE:
+            return {"access_token": "user-tok"}
+        raise AssertionError(f"unexpected scopes: {scopes}")
+
+    app.acquire_token_silent.side_effect = silent
+
+    def fake_get(url, headers, timeout):
+        assert url.endswith("/me?$select=companyName"), url
+        return _resp(200, {"companyName": "  Fabrikam Corp  "})
+
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
+         patch.object(graph_client._SESSION, "get", side_effect=fake_get):
+        # Whitespace on companyName is stripped so downstream label matches
+        # what /organization would return.
+        assert (
+            graph_client.resolve_tenant_display_name_silent("tenant-Z")
+            == "Fabrikam Corp"
+        )
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_returns_empty_when_both_scopes_silently_unavailable():
+    """When neither Organization.Read.All nor User.Read is silently redeemable,
+    the resolver must still degrade to "" without prompting. This is the
+    residual blank-tenant_name case that only goes away when the maker later
+    runs FlightCheck (which triggers an interactive Graph sign-in and caches).
+    """
+    account = SimpleNamespace()
+    app = MagicMock()
+    app.get_accounts.return_value = [account]
+    app.acquire_token_silent.return_value = None
+    app.acquire_token_interactive.side_effect = AssertionError(
+        "silent-only resolver must not prompt interactively"
+    )
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+    # Attempted BOTH scopes silently before giving up.
+    scopes_tried = [c.args[0] for c in app.acquire_token_silent.call_args_list]
+    assert graph_client._ORG_READ_SCOPE in scopes_tried
+    assert graph_client._USER_READ_SCOPE in scopes_tried
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_me_fallback_missing_company_name_returns_empty():
+    """When /me returns 200 but the user's companyName attribute is unset
+    (many tenants), the fallback returns "" rather than a bogus label.
+    """
+    account = SimpleNamespace()
+    app = MagicMock()
+    app.get_accounts.return_value = [account]
+    app.acquire_token_interactive.side_effect = AssertionError("no prompt")
+
+    def silent(scopes, account):
+        return None if scopes == graph_client._ORG_READ_SCOPE else {"access_token": "t"}
+
+    app.acquire_token_silent.side_effect = silent
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
+         patch.object(graph_client._SESSION, "get", return_value=_resp(200, {})):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -237,7 +237,163 @@ def test_authenticate_replaces_dataverse_rejected_cached_token(
     ) == "refreshed"
 
 
-class TestQueryAll:
+def test_authenticate_resolves_tenant_name_before_start_session(
+    tmp_path, monkeypatch
+) -> None:
+    """The ADK telemetry bootstrap in ``authenticate`` must resolve the
+    tenant display name via SILENT-ONLY Graph BEFORE emitting the first
+    ``adk.session.start`` event, so that first event carries ``tenant_name``.
+
+    Before this ordering fix, ``start_session`` fired first, so the very
+    first session_start on a fresh install always went out with blank
+    tenant_name (only later events -- once FlightCheck interactively
+    resolved and cached the name -- picked it up). This is a regression
+    test for that ordering: silent resolution runs first, its result is
+    fed to ``set_identity``, and only then does ``start_session`` emit.
+    """
+    import auth
+
+    class FakeCache:
+        has_state_changed = False
+
+        def deserialize(self, value: str) -> None:
+            pass
+
+        def serialize(self) -> str:
+            return ""
+
+    class FakeApp:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def get_accounts(self) -> list[dict]:
+            return []
+
+        def acquire_token_silent(self, scopes, account):
+            return None
+
+        def acquire_token_interactive(self, scopes, prompt):
+            return {
+                "access_token": "fresh-token",
+                "id_token_claims": {"tid": "tenant-id"},
+            }
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(auth, "discover_tenant", lambda _url: "tenant-id")
+    monkeypatch.setattr(auth, "_dataverse_accepts_token", lambda _url, _tok: True)
+    monkeypatch.setattr(auth.msal, "SerializableTokenCache", FakeCache)
+    monkeypatch.setattr(auth.msal, "PublicClientApplication", FakeApp)
+
+    # Instrument ADK telemetry + Graph resolver to record call order.
+    import adk_telemetry
+    from flightcheck import graph_client
+
+    calls: list[tuple[str, tuple, dict]] = []
+
+    def record(name):
+        def _rec(*args, **kwargs):
+            calls.append((name, args, kwargs))
+
+        return _rec
+
+    monkeypatch.setattr(adk_telemetry, "maybe_print_notice", record("notice"))
+    monkeypatch.setattr(adk_telemetry, "set_identity", record("set_identity"))
+    monkeypatch.setattr(adk_telemetry, "start_session", record("start_session"))
+    monkeypatch.setattr(
+        graph_client,
+        "resolve_tenant_display_name_silent",
+        lambda tid: "Contoso Ltd" if tid == "tenant-id" else "",
+    )
+
+    token = auth.authenticate("https://example.crm.dynamics.com")
+    assert token == "fresh-token"
+
+    names = [c[0] for c in calls]
+    # set_identity(tenant_name=...) must happen BEFORE start_session so the
+    # first session_start emit picks up the resolved name from _IDENTITY.
+    assert "set_identity" in names, names
+    assert "start_session" in names, names
+    assert names.index("set_identity") < names.index("start_session"), names
+
+    # The resolved name from silent Graph is what got stored.
+    si = next(c for c in calls if c[0] == "set_identity")
+    assert si[2].get("tenant_name") == "Contoso Ltd"
+    assert si[2].get("tenant_id") == "tenant-id"
+
+    # start_session receives tenant_id so common_dimensions can pair the
+    # name (already in _IDENTITY) with the raw tenant GUID.
+    ss = next(c for c in calls if c[0] == "start_session")
+    assert ss[2].get("tenant_id") == "tenant-id"
+
+
+def test_authenticate_still_emits_when_silent_graph_returns_blank(
+    tmp_path, monkeypatch
+) -> None:
+    """When silent Graph resolution yields no name (both scopes admin-only
+    or unconsented), the bootstrap must still emit ``adk.session.start`` --
+    just without ``set_identity`` overriding tenant_name. Telemetry stays
+    best-effort and non-blocking; the missing-name case degrades to blank
+    (recoverable when the maker later runs FlightCheck).
+    """
+    import auth
+
+    class FakeCache:
+        has_state_changed = False
+
+        def deserialize(self, value: str) -> None:
+            pass
+
+        def serialize(self) -> str:
+            return ""
+
+    class FakeApp:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def get_accounts(self) -> list[dict]:
+            return []
+
+        def acquire_token_silent(self, scopes, account):
+            return None
+
+        def acquire_token_interactive(self, scopes, prompt):
+            return {
+                "access_token": "fresh-token",
+                "id_token_claims": {"tid": "tenant-id"},
+            }
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(auth, "discover_tenant", lambda _url: "tenant-id")
+    monkeypatch.setattr(auth, "_dataverse_accepts_token", lambda _url, _tok: True)
+    monkeypatch.setattr(auth.msal, "SerializableTokenCache", FakeCache)
+    monkeypatch.setattr(auth.msal, "PublicClientApplication", FakeApp)
+
+    import adk_telemetry
+    from flightcheck import graph_client
+
+    calls: list[str] = []
+    monkeypatch.setattr(adk_telemetry, "maybe_print_notice", lambda: calls.append("notice"))
+    monkeypatch.setattr(
+        adk_telemetry, "set_identity", lambda **kw: calls.append("set_identity")
+    )
+    monkeypatch.setattr(
+        adk_telemetry, "start_session", lambda **kw: calls.append("start_session")
+    )
+    # Silent resolver returns "" (Organization.Read.All + User.Read both
+    # silently unavailable, as happens for a large fraction of enterprise
+    # tenants on first Dataverse sign-in).
+    monkeypatch.setattr(
+        graph_client, "resolve_tenant_display_name_silent", lambda tid: ""
+    )
+
+    token = auth.authenticate("https://example.crm.dynamics.com")
+    assert token == "fresh-token"
+
+    # start_session still fires; set_identity is NOT called (blank names
+    # would overwrite whatever the cache-fallback in common_dimensions
+    # might otherwise pick up).
+    assert "start_session" in calls
+    assert "set_identity" not in calls
     """Drives scripts/auth.py:query_all through the mock.
 
     query_all is the FlightCheck-relevant slice of auth.py — it's used by


### PR DESCRIPTION
## Problem

Prod ADK telemetry emits **blank `tenant_name`** on roughly 74–80% of non-`adk.api.call` events (measured on `adk_session_start`, `adk_capability_use`, `adk_build_*`, `adk_agent_deploy` over the last 30 days). Dashboard trend lines and per-tenant filters degrade for those tenants because the label falls back to the raw Entra GUID or shows blank.

Data support (prod, single sample tenant `935884d7-…`, P30D):

| `hasNamedSession` | `ranFlightCheck` | instances |
|---|---|---|
| 0 | 0 | 18 |
| 0 | 1 | 11 |
| 1 | 1 |  9 |

The 18 no-name/no-FC installs never ran FlightCheck (so no interactive Graph consent) *and* the silent Graph resolver returned empty at `adk.session.start` time. The 11 no-name/did-FC installs ran FlightCheck *after* the first `session_start` emit, so early events went out blank until the FC-cached name kicked in for later events. Only 9 installs already emit names correctly.

## Root causes and fixes

**1. Bootstrap order in `auth.py`.** `adk_telemetry.start_session` fired *before* the silent Graph resolution ran, so the very first `adk.session.start` on a fresh install always went out with blank `tenant_name` — even when silent resolution *would* have succeeded on that same call. Reordered so the flow is now:

`\\\
resolve_tenant_display_name_silent -> set_identity(tenant_name=...) -> start_session
\\\`

Regression test in `tests/scripts/test_auth.py` pins the ordering (and asserts we still emit `start_session` when silent resolution returns blank).

**2. Silent Graph scope in `resolve_tenant_display_name_silent`.** The resolver requested `Organization.Read.All` only. That scope requires **admin consent**, which the majority of enterprise tenants have not pre-granted, so the FOCI shared refresh token from the Dataverse interactive sign-in cannot silently redeem it — the resolver returns `""` even though the user is fully signed in. Added a fallback path: on empty result, retry silently with `User.Read` and fetch `/me?$select=companyName`. `User.Read` is user-consent-only and is a *default static permission* granted at first-party sign-in, so the same shared RT typically redeems it silently. Admins routinely set the signed-in user's `companyName` attribute to the tenant display name, so this recovers a useful label for the many customers that would otherwise report as blank. Same OII classification we already have for `tenant_name`.

## Non-goals / follow-ups

- **Retention rolls off in ≤30 days** — this fix is forward-only. Existing blank rows are not backfilled.
- Not touching the `Organization.Read.All` scope requested at Dataverse sign-in itself — adding `extra_scopes_to_consent` risks breaking auth in tenants where admin consent for that scope is *required*, and the fallback covers most of the same ground silently.

## Tests

`\\\
pytest tests/flightcheck/test_telemetry.py tests/flightcheck/test_graph_client.py tests/scripts/test_auth.py tests/flightcheck/test_cli.py tests/flightcheck/test_cli_consent.py
83 passed in 4.11s
\\\`

New tests: ordering + fallback-scope + missing-companyName + both-silent-fail cases.
