### PR TITLE
adk-telemetry: fix blank tenant identity (name + id) across auth, silent Graph, FlightCheck emit, and SKILL.md subprocesses

### DIFF
--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -218,6 +218,13 @@ def set_identity(
     )
     _IDENTITY["tenant_id"] = tenant_id or ""
     _IDENTITY["tenant_name"] = tenant_name or ""
+    # Persist tenant_id to disk so a *later* Python subprocess (e.g. the
+    # emit_capability.py shim launched from a SKILL.md step) — which never
+    # calls set_identity itself — can still stamp the tenant on its events.
+    # Without this, subprocess-emitted events land with an empty tenant_id,
+    # classify as "unknown", and never show on the customer-filtered dashboard.
+    if _IDENTITY["tenant_id"]:
+        _fc.cache_tenant_id(_IDENTITY["tenant_id"])
     # When a Graph-capable flow (FlightCheck) resolves the org display name,
     # persist it so ADK events emitted later in a *different* process (which
     # only has a Dataverse/BAP token and can't resolve it) can reuse it. The
@@ -373,6 +380,14 @@ def common_dimensions(
 ) -> dict[str, Any]:
     """Build the dimensions present on every event (spec Common Dimensions)."""
     tid = _IDENTITY["tenant_id"] if tenant_id is None else tenant_id
+    # Fall back to the disk-persisted tenant_id when this process never
+    # called set_identity (subprocess launched by emit_capability.py from a
+    # SKILL.md step). Without this, capability events emitted by the shim
+    # carry an empty tenant_id, classify as "unknown" via classify_tenant(""),
+    # and never appear on the customer-filtered External dashboard even
+    # though the maker's earlier auth flow knew the tenant.
+    if not tid and tenant_id is None:
+        tid = _fc.get_cached_tenant_id()
     tname = _IDENTITY["tenant_name"] if tenant_name is None else tenant_name
     # Fall back to the org display name a prior Graph-capable run (FlightCheck)
     # cached for THIS tenant, so pure-ADK events (session/build/deploy/

--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -198,8 +198,38 @@ _SESSION_LOCK = threading.Lock()
 
 
 # --- Identity model (spec) ------------------------------------------------
+# Canonical Entra tenant GUID: 8-4-4-4-12 lowercase-hex, dashes at fixed
+# offsets. Enforced *only* on tenant_id (the raw OII we ship to Aria) so
+# obvious test-fixture placeholders like ``"tenant-id"`` don't slip into
+# the prod stream and inflate the customer bucket. Also applied when
+# reading back from the on-disk ``.tenant_id`` cache, so a torn / legacy /
+# hand-edited file can never bypass the check.
+_GUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def _sanitize_tenant_id(tenant_id: str) -> str:
+    """Return ``tenant_id`` iff it looks like a canonical GUID, else ``""``.
+
+    Never raises. Empty input stays empty. Whitespace/case are tolerated so
+    a caller that passes ``"  ABCDEF01-2345-6789-ABCD-EF0123456789  "`` still
+    gets a valid identity (normalized to lowercase). Anything else
+    (``"tenant-id"``, ``"unknown"``, truncated GUIDs, org display names
+    accidentally routed here) normalizes to ``""`` so downstream
+    ``classify_tenant`` labels the event as ``"unknown"`` rather than as
+    a fake customer.
+    """
+    if not tenant_id:
+        return ""
+    v = tenant_id.strip().lower()
+    return v if _GUID_RE.match(v) else ""
+
+
 def set_identity(
-    tenant_id: str = "", instance_id: str | None = None, tenant_name: str = ""
+    tenant_id: str | None = None,
+    instance_id: str | None = None,
+    tenant_name: str | None = None,
 ) -> dict[str, str]:
     """Record the install + tenant identity for all subsequent events.
 
@@ -212,25 +242,53 @@ def set_identity(
     organization display name (OII identifying the enterprise tenant, not a
     person; privacy-approved without a Data Profile update) — best-effort,
     stored as ``""`` when unavailable. No developer/user id is collected.
+
+    All three parameters use a ``None`` sentinel to mean "don't touch". This
+    lets a later call like ``set_identity(tenant_id=<guid>)`` add / refresh
+    the tenant id without clobbering a tenant_name a previous call already
+    resolved (the reason ``start_session`` used to blank out ``tenant_name``
+    when it re-bootstrapped identity right after auth). Passing ``""`` for
+    any field explicitly clears it.
+
+    When ``tenant_id`` changes to a genuinely different GUID and the caller
+    does not simultaneously supply a matching ``tenant_name``, the stored
+    ``tenant_name`` is dropped — a name resolved for tenant A must never be
+    stamped on tenant B's events.
+
+    Any ``tenant_id`` that is not a well-formed Entra tenant GUID is
+    silently normalized to ``""`` (see ``_sanitize_tenant_id``).
     """
-    _IDENTITY["instance_id"] = (
-        _fc.get_instance_id() if instance_id is None else (instance_id or "")
-    )
-    _IDENTITY["tenant_id"] = tenant_id or ""
-    _IDENTITY["tenant_name"] = tenant_name or ""
-    # Persist tenant_id to disk so a *later* Python subprocess (e.g. the
+    if instance_id is not None:
+        _IDENTITY["instance_id"] = instance_id or _fc.get_instance_id()
+    elif not _IDENTITY["instance_id"]:
+        _IDENTITY["instance_id"] = _fc.get_instance_id()
+
+    if tenant_id is not None:
+        new_tid = _sanitize_tenant_id(tenant_id)
+        if (
+            new_tid
+            and _IDENTITY["tenant_id"]
+            and new_tid != _IDENTITY["tenant_id"]
+            and tenant_name is None
+        ):
+            # Tenant switch with no fresh name supplied: drop the stale one
+            # rather than stamp tenant A's name onto tenant B's events.
+            _IDENTITY["tenant_name"] = ""
+        _IDENTITY["tenant_id"] = new_tid
+
+    if tenant_name is not None:
+        _IDENTITY["tenant_name"] = tenant_name or ""
+
+    # Persist tenant_id so a *later* Python subprocess (e.g. the
     # emit_capability.py shim launched from a SKILL.md step) — which never
     # calls set_identity itself — can still stamp the tenant on its events.
-    # Without this, subprocess-emitted events land with an empty tenant_id,
-    # classify as "unknown", and never show on the customer-filtered dashboard.
     if _IDENTITY["tenant_id"]:
         _fc.cache_tenant_id(_IDENTITY["tenant_id"])
-    # When a Graph-capable flow (FlightCheck) resolves the org display name,
-    # persist it so ADK events emitted later in a *different* process (which
-    # only has a Dataverse/BAP token and can't resolve it) can reuse it. The
-    # cache is keyed by tenant_id in flightcheck.telemetry.cache_tenant_name.
-    if tenant_name:
-        _fc.cache_tenant_name(_IDENTITY["tenant_id"], tenant_name)
+    # Persist the tenant name so ADK events emitted later in a *different*
+    # process (which only has a Dataverse/BAP token and can't resolve it)
+    # can reuse it. Only cache when both fields are present.
+    if _IDENTITY["tenant_name"] and _IDENTITY["tenant_id"]:
+        _fc.cache_tenant_name(_IDENTITY["tenant_id"], _IDENTITY["tenant_name"])
     return dict(_IDENTITY)
 
 
@@ -385,9 +443,11 @@ def common_dimensions(
     # SKILL.md step). Without this, capability events emitted by the shim
     # carry an empty tenant_id, classify as "unknown" via classify_tenant(""),
     # and never appear on the customer-filtered External dashboard even
-    # though the maker's earlier auth flow knew the tenant.
+    # though the maker's earlier auth flow knew the tenant. Re-run the cache
+    # value through the same GUID sanitizer used in ``set_identity`` so a
+    # torn / legacy / hand-edited file can never bypass the check.
     if not tid and tenant_id is None:
-        tid = _fc.get_cached_tenant_id()
+        tid = _sanitize_tenant_id(_fc.get_cached_tenant_id())
     tname = _IDENTITY["tenant_name"] if tenant_name is None else tenant_name
     # Fall back to the org display name a prior Graph-capable run (FlightCheck)
     # cached for THIS tenant, so pure-ADK events (session/build/deploy/
@@ -580,9 +640,23 @@ def start_session(
 
     Safe to call at the top of every skill: if the current session is still
     active (within the 30-min window) no duplicate start is emitted.
+
+    Only bootstraps identity when this process has none yet, or when the
+    caller supplies a genuinely different ``tenant_id`` / ``instance_id``.
+    That preserves any ``tenant_name`` that was resolved by an earlier
+    ``set_identity`` call (e.g. auth.py's silent Graph lookup) instead of
+    blanking it back to ``""``.
     """
-    if tenant_id or instance_id is not None or not _IDENTITY["instance_id"]:
-        set_identity(tenant_id=tenant_id, instance_id=instance_id)
+    _need_set = (
+        instance_id is not None
+        or not _IDENTITY["instance_id"]
+        or (tenant_id and tenant_id != _IDENTITY["tenant_id"])
+    )
+    if _need_set:
+        set_identity(
+            tenant_id=tenant_id if tenant_id else None,
+            instance_id=instance_id,
+        )
     sid, is_new = get_session(surface)
     if not is_new:
         return {"sent": False, "reason": "existing-session", "session_id": sid}

--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -437,17 +437,19 @@ def common_dimensions(
     tenant_name: str | None = None,
 ) -> dict[str, Any]:
     """Build the dimensions present on every event (spec Common Dimensions)."""
-    tid = _IDENTITY["tenant_id"] if tenant_id is None else tenant_id
-    # Fall back to the disk-persisted tenant_id when this process never
-    # called set_identity (subprocess launched by emit_capability.py from a
-    # SKILL.md step). Without this, capability events emitted by the shim
-    # carry an empty tenant_id, classify as "unknown" via classify_tenant(""),
-    # and never appear on the customer-filtered External dashboard even
-    # though the maker's earlier auth flow knew the tenant. Re-run the cache
-    # value through the same GUID sanitizer used in ``set_identity`` so a
-    # torn / legacy / hand-edited file can never bypass the check.
-    if not tid and tenant_id is None:
-        tid = _sanitize_tenant_id(_fc.get_cached_tenant_id())
+    # Single sanitization choke point: EVERY tenant_id source (explicit kwarg,
+    # in-memory identity, disk cache) flows through ``_sanitize_tenant_id``
+    # here, so a non-GUID value from *any* source normalizes to "" and the
+    # event lands in the "unknown" bucket instead of leaking into "customer".
+    # This matches the guarantee ``set_identity`` gives on ingress and closes
+    # the last back-door where an explicit ``common_dimensions(tenant_id=...)``
+    # kwarg (used by the ``emit_*`` helpers) could bypass the check.
+    if tenant_id is None:
+        tid = _IDENTITY["tenant_id"] or _sanitize_tenant_id(
+            _fc.get_cached_tenant_id()
+        )
+    else:
+        tid = _sanitize_tenant_id(tenant_id)
     tname = _IDENTITY["tenant_name"] if tenant_name is None else tenant_name
     # Fall back to the org display name a prior Graph-capable run (FlightCheck)
     # cached for THIS tenant, so pure-ADK events (session/build/deploy/

--- a/solutions/ess-maker-skills/scripts/auth.py
+++ b/solutions/ess-maker-skills/scripts/auth.py
@@ -267,15 +267,15 @@ def authenticate(env_url):
         claims = result.get("id_token_claims", {}) or {}
         tenant_id = claims.get("tid", "") or tenant
         adk_telemetry.maybe_print_notice()
-        adk_telemetry.start_session(
-            tenant_id=tenant_id,
-        )
-        # Best-effort: resolve the tenant's org display name via a SILENT-ONLY
-        # Graph token (never prompts) and record it so ADK telemetry carries
-        # tenant_name even when the maker never runs FlightCheck. The Dataverse
-        # sign-in above usually leaves a first-party (FOCI) refresh token that
-        # silently satisfies the read scope; set_identity caches the name for
-        # later ADK processes. Silent failure just leaves tenant_name empty.
+        # Resolve the tenant's display name via a SILENT-ONLY Graph token
+        # BEFORE emitting adk.session.start, so the very first ADK event on a
+        # fresh install carries tenant_name (instead of blank until FlightCheck
+        # is later run). The Dataverse sign-in above usually leaves a
+        # first-party (FOCI) refresh token that silently satisfies at least
+        # one of Organization.Read.All / User.Read; the graph_client helper
+        # tries both. Silent failure is fine — set_identity is only called on
+        # success, so start_session below still emits with a blank name in the
+        # (increasingly rare) case where no Graph scope is silently redeemable.
         try:
             from flightcheck.graph_client import resolve_tenant_display_name_silent
 
@@ -284,6 +284,9 @@ def authenticate(env_url):
                 adk_telemetry.set_identity(tenant_id=tenant_id, tenant_name=_tname)
         except Exception:  # noqa: BLE001 — name resolution is best-effort
             pass
+        adk_telemetry.start_session(
+            tenant_id=tenant_id,
+        )
     except Exception:  # noqa: BLE001 — telemetry must never break auth
         pass
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -867,6 +867,12 @@ def _run_single_checkpoint(args):
         )
         # Best-effort tenant display name (OII; privacy-approved). Reuses the
         # already-authenticated Graph client when one was needed; never re-auths.
+        # Falls back to the persisted ``.local/.tenant_name`` cache when the
+        # live lookup is unavailable (e.g. infra-only scope where ``graph`` is
+        # None, or Graph auth failed for lack of ``Organization.Read.All``
+        # consent) so previously-resolved tenants keep their name on the event
+        # instead of emitting blank. Same-tenant guard is enforced inside the
+        # cache helper.
         tenant_name = ""
         try:
             if graph is not None:
@@ -875,6 +881,11 @@ def _run_single_checkpoint(args):
             tenant_name = ""
         try:
             from flightcheck import telemetry
+
+            if not tenant_name and (tenant_id or ""):
+                tenant_name = telemetry.get_cached_tenant_name(tenant_id or "")
+            elif tenant_name and (tenant_id or ""):
+                telemetry.cache_tenant_name(tenant_id or "", tenant_name)
 
             _tele = telemetry.emit_flightcheck_telemetry(
                 result,
@@ -1331,7 +1342,11 @@ def main():
         )
         # Best-effort tenant display name (OII; privacy-approved). Reuses the
         # already-authenticated Graph client's /organization record — no extra
-        # auth. Falls back to "" on any error; never blocks the run.
+        # auth. Falls back to the persisted ``.local/.tenant_name`` cache when
+        # ``graph`` is None or the live lookup fails (e.g. Graph auth was
+        # skipped or ``Organization.Read.All`` isn't consented on this tenant)
+        # so previously-resolved tenants keep their name instead of blank.
+        # Never blocks the run.
         tenant_name = ""
         try:
             if graph is not None:
@@ -1340,6 +1355,11 @@ def main():
             tenant_name = ""
         try:
             from flightcheck import telemetry
+
+            if not tenant_name and tenant_id:
+                tenant_name = telemetry.get_cached_tenant_name(tenant_id)
+            elif tenant_name and tenant_id:
+                telemetry.cache_tenant_name(tenant_id, tenant_name)
 
             _tele = telemetry.emit_flightcheck_telemetry(
                 result,

--- a/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
@@ -99,6 +99,16 @@ def _persist_token_cache(cache: "msal.SerializableTokenCache", cache_path: str) 
 # Dataverse login in auth.py — silently satisfies it with no prompt.
 _ORG_READ_SCOPE = ["https://graph.microsoft.com/Organization.Read.All"]
 
+# Fallback scope for the silent lookup. ``User.Read`` is user-consentable (no
+# admin consent required) and is granted as a "default" static permission for
+# most first-party Microsoft app sign-ins, so a fresh Dataverse-only sign-in
+# still tends to have a redeemable FOCI refresh token for it. When
+# Organization.Read.All silent redemption fails (admin consent required and
+# not granted — very common in enterprise), we can still learn the tenant
+# display label from ``/me?$select=companyName`` in the many tenants where
+# admins populate the user's Company Name attribute with the tenant name.
+_USER_READ_SCOPE = ["https://graph.microsoft.com/User.Read"]
+
 
 def resolve_tenant_display_name_silent(tenant_id: str) -> str:
     """Return the tenant's org displayName via a SILENT-ONLY Graph token.
@@ -109,6 +119,20 @@ def resolve_tenant_display_name_silent(tenant_id: str) -> str:
     prompting. Because the Graph CLI Tools app and the Power Platform CLI app
     (auth.py) are first-party FOCI apps sharing that cache, a prior Dataverse
     sign-in is usually enough for this to succeed with no second prompt.
+
+    Two-stage resolution to maximise coverage:
+
+    1. Try ``/organization`` with ``Organization.Read.All`` -- returns the
+       authoritative tenant display name. Requires admin consent; in tenants
+       where the admin hasn't pre-consented it (common in enterprise), this
+       silently fails and we fall through to step 2.
+    2. Try ``/me?$select=companyName`` with ``User.Read`` -- user-consent-only
+       scope typically granted as a "default" static permission at first-party
+       sign-in, so the FOCI refresh token usually redeems it without a prompt.
+       ``companyName`` is the signed-in user's Entra profile attribute;
+       enterprise admins routinely set it to the tenant display name, so this
+       recovers a useful label for the many customers that would otherwise
+       report as blank.
 
     Used by the ADK auth bootstrap so ``tenant_name`` is populated for ADK
     telemetry even when the maker never runs FlightCheck. Returns ``""`` on any
@@ -129,11 +153,22 @@ def resolve_tenant_display_name_silent(tenant_id: str) -> str:
         accounts = app.get_accounts()
         if not accounts:
             return ""
-        result = app.acquire_token_silent(_ORG_READ_SCOPE, account=accounts[0])
-        if not result or "access_token" not in result:
-            return ""
+        name = _try_organization_lookup(app, accounts[0])
+        if not name:
+            name = _try_me_company_name_lookup(app, accounts[0])
         # Persist any silently-refreshed token so later processes stay silent.
         _persist_token_cache(cache, cache_path)
+        return name or ""
+    except Exception:  # noqa: BLE001 — name resolution is strictly best-effort
+        return ""
+
+
+def _try_organization_lookup(app, account) -> str:
+    """Silent ``/organization`` via ``Organization.Read.All``; ``""`` on any error."""
+    try:
+        result = app.acquire_token_silent(_ORG_READ_SCOPE, account=account)
+        if not result or "access_token" not in result:
+            return ""
         resp = _SESSION.get(
             f"{GRAPH_BASE}/organization",
             headers={
@@ -146,7 +181,36 @@ def resolve_tenant_display_name_silent(tenant_id: str) -> str:
             return ""
         orgs = (resp.json() or {}).get("value", []) or []
         return (orgs[0].get("displayName", "") if orgs else "") or ""
-    except Exception:  # noqa: BLE001 — name resolution is strictly best-effort
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _try_me_company_name_lookup(app, account) -> str:
+    """Silent ``/me?$select=companyName`` via ``User.Read``; ``""`` on any error.
+
+    ``companyName`` is the signed-in user's Entra profile attribute, not the
+    literal tenant display name. Admins routinely populate it with the tenant
+    display name, so it is a useful fallback. Classification-wise it is OII —
+    the same classification we already have for ``tenant_name`` — and never
+    EUPI: we only read a single organizational attribute, not the user's
+    name / UPN / id.
+    """
+    try:
+        result = app.acquire_token_silent(_USER_READ_SCOPE, account=account)
+        if not result or "access_token" not in result:
+            return ""
+        resp = _SESSION.get(
+            f"{GRAPH_BASE}/me?$select=companyName",
+            headers={
+                "Authorization": f"Bearer {result['access_token']}",
+                "Accept": "application/json",
+            },
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return ""
+        return ((resp.json() or {}).get("companyName", "") or "").strip()
+    except Exception:  # noqa: BLE001
         return ""
 
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
@@ -153,22 +153,60 @@ def resolve_tenant_display_name_silent(tenant_id: str) -> str:
         accounts = app.get_accounts()
         if not accounts:
             return ""
-        name = _try_organization_lookup(app, accounts[0])
-        if not name:
+        name, transport_ok = _try_organization_lookup(app, accounts[0])
+        # Track which source produced the label so ``cache_tenant_name`` can
+        # refuse to downgrade an authoritative /organization entry to a
+        # per-user /me entry on a later ADK invocation.
+        source = "organization"
+        if not name and transport_ok:
+            # Only try the /me fallback when /organization got a real HTTP
+            # response (even a 401/403 auth failure). If the transport itself
+            # is broken — DNS resolution failure, no network, TLS handshake
+            # timeout — /me will hit the exact same failure, so skip it and
+            # let the caller record a blank tenant_name for this session.
             name = _try_me_company_name_lookup(app, accounts[0])
+            if name:
+                source = "me"
         # Persist any silently-refreshed token so later processes stay silent.
         _persist_token_cache(cache, cache_path)
+        # Cache the resolved label with the correct source so a later
+        # per-user /me result can't overwrite the authoritative one. This is
+        # the *only* place the ``source`` is known — set_identity's own
+        # caching would default to "organization" for both and get it wrong.
+        if name:
+            try:
+                # Local import: this module is imported by pure-telemetry code
+                # paths that must stay dependency-free of the Graph client.
+                from . import telemetry as _t
+                _t.cache_tenant_name(tenant_id, name, source=source)
+            except Exception:  # noqa: BLE001
+                pass
         return name or ""
     except Exception:  # noqa: BLE001 — name resolution is strictly best-effort
         return ""
 
 
-def _try_organization_lookup(app, account) -> str:
-    """Silent ``/organization`` via ``Organization.Read.All``; ``""`` on any error."""
+def _try_organization_lookup(app, account) -> tuple[str, bool]:
+    """Silent ``/organization`` via ``Organization.Read.All``.
+
+    Returns ``(display_name, transport_ok)`` where ``transport_ok`` is False
+    only when the HTTP request itself failed (no network, DNS failure,
+    connection reset, socket / TLS timeout). An auth failure (401/403 because
+    the tenant hasn't pre-consented ``Organization.Read.All``) or an unrelated
+    non-200 response still counts as ``transport_ok=True`` — the network works,
+    Graph just refused this specific query — so the caller can meaningfully
+    fall through to ``/me?$select=companyName``. When the transport is broken
+    the ``/me`` call would fail identically, so we tell the caller to skip it.
+    """
     try:
         result = app.acquire_token_silent(_ORG_READ_SCOPE, account=account)
         if not result or "access_token" not in result:
-            return ""
+            # Silent token acquisition failed — that's an auth-shape problem,
+            # not a transport problem, so /me is still worth trying.
+            return "", True
+    except Exception:  # noqa: BLE001
+        return "", True
+    try:
         resp = _SESSION.get(
             f"{GRAPH_BASE}/organization",
             headers={
@@ -177,12 +215,17 @@ def _try_organization_lookup(app, account) -> str:
             },
             timeout=15,
         )
-        if resp.status_code != 200:
-            return ""
-        orgs = (resp.json() or {}).get("value", []) or []
-        return (orgs[0].get("displayName", "") if orgs else "") or ""
+    except (requests.ConnectionError, requests.Timeout):
+        return "", False
     except Exception:  # noqa: BLE001
-        return ""
+        return "", True
+    if resp.status_code != 200:
+        return "", True
+    try:
+        orgs = (resp.json() or {}).get("value", []) or []
+        return (orgs[0].get("displayName", "") if orgs else "") or "", True
+    except Exception:  # noqa: BLE001
+        return "", True
 
 
 def _try_me_company_name_lookup(app, account) -> str:

--- a/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
@@ -56,6 +56,16 @@ GRAPH_SCOPES = [
     "https://graph.microsoft.com/ExternalConnection.Read.All",
 ]
 
+# Wall-clock ceiling for the two silent lookups called from the interactive
+# auth hot path (``resolve_tenant_display_name_silent`` → /organization then
+# /me). Kept small — the sign-in critical path must not stall on a
+# best-effort telemetry-only label. ``tenant_class`` is driven by the ``tid``
+# claim already extracted from the token, so a timeout here only degrades
+# ``tenant_name`` to blank (recoverable on the next FlightCheck run), never
+# to a misclassification. Total worst case per authenticate() is
+# 2 × _SILENT_LOOKUP_TIMEOUT.
+_SILENT_LOOKUP_TIMEOUT = 3.0
+
 # Module-level requests Session with bounded retry-with-backoff for 429/5xx.
 # Mirrors the auth.py pattern - Graph throttles on /users and /servicePrincipals
 # in larger tenants, and one transient 503 mid-FlightCheck would otherwise blow
@@ -197,6 +207,13 @@ def _try_organization_lookup(app, account) -> tuple[str, bool]:
     Graph just refused this specific query — so the caller can meaningfully
     fall through to ``/me?$select=companyName``. When the transport is broken
     the ``/me`` call would fail identically, so we tell the caller to skip it.
+
+    Called on the interactive auth hot path so the socket timeout is short
+    (``_SILENT_LOOKUP_TIMEOUT``) and a plain ``requests.get`` is used instead
+    of the module-level ``_SESSION`` — the session's 3x 429/5xx retry with
+    ``backoff_factor=1`` would add up to ~7s of extra wait per lookup on a
+    throttled tenant, which is unacceptable on the sign-in critical path
+    for a best-effort telemetry label.
     """
     try:
         result = app.acquire_token_silent(_ORG_READ_SCOPE, account=account)
@@ -207,13 +224,13 @@ def _try_organization_lookup(app, account) -> tuple[str, bool]:
     except Exception:  # noqa: BLE001
         return "", True
     try:
-        resp = _SESSION.get(
+        resp = requests.get(
             f"{GRAPH_BASE}/organization",
             headers={
                 "Authorization": f"Bearer {result['access_token']}",
                 "Accept": "application/json",
             },
-            timeout=15,
+            timeout=_SILENT_LOOKUP_TIMEOUT,
         )
     except (requests.ConnectionError, requests.Timeout):
         return "", False
@@ -237,18 +254,26 @@ def _try_me_company_name_lookup(app, account) -> str:
     the same classification we already have for ``tenant_name`` — and never
     EUPI: we only read a single organizational attribute, not the user's
     name / UPN / id.
+
+    Runs on the interactive auth hot path in the common admin-consent-gap
+    case where ``/organization`` returned nothing, so the same bounded
+    ``_SILENT_LOOKUP_TIMEOUT`` + no-retry policy as the organization lookup
+    applies here. ``tenant_class`` is driven by the ``tid`` claim already in
+    the token, not by this call, so failing fast never hurts dashboard
+    correctness — it only degrades ``tenant_name`` to blank until the next
+    (interactive) FlightCheck run resolves and caches it.
     """
     try:
         result = app.acquire_token_silent(_USER_READ_SCOPE, account=account)
         if not result or "access_token" not in result:
             return ""
-        resp = _SESSION.get(
+        resp = requests.get(
             f"{GRAPH_BASE}/me?$select=companyName",
             headers={
                 "Authorization": f"Bearer {result['access_token']}",
                 "Accept": "application/json",
             },
-            timeout=15,
+            timeout=_SILENT_LOOKUP_TIMEOUT,
         )
         if resp.status_code != 200:
             return ""

--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -278,6 +278,46 @@ def cache_tenant_name(
         pass
 
 
+# Persisted raw tenant GUID so ADK events emitted from a *fresh Python
+# subprocess* (e.g. `python scripts/emit_capability.py <cap>` invoked from a
+# SKILL.md step) can still stamp the tenant_id — without this, the subprocess'
+# in-memory ``_IDENTITY["tenant_id"]`` is empty, ``classify_tenant("")`` returns
+# ``unknown``, and the event never lands on the External (``tenant_class ==
+# "customer"``) dashboard. Separate file from ``.tenant_name`` because tenant_id
+# is available before (and even without) any Graph tenant-name resolution.
+_TENANT_ID_FILE = ".tenant_id"
+
+
+def cache_tenant_id(tenant_id: str, local_dir: str = ".local") -> None:
+    """Persist the raw tenant GUID for reuse by later same-install processes.
+
+    Best-effort: any IO error is swallowed (telemetry must never break a
+    flow). No-op when ``tenant_id`` is empty — we never persist a placeholder.
+    The value is written under the gitignored ``.local/`` dir on the maker's
+    own machine, mirroring how ``.instance_id`` is persisted. Overwrites any
+    prior value so a maker who switches tenants sees the latest one.
+    """
+    if not tenant_id:
+        return
+    path = os.path.join(local_dir, _TENANT_ID_FILE)
+    try:
+        os.makedirs(local_dir, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(str(tenant_id).strip())
+    except OSError:
+        pass
+
+
+def get_cached_tenant_id(local_dir: str = ".local") -> str:
+    """Return the persisted tenant GUID, or ``""`` if unavailable/unreadable."""
+    path = os.path.join(local_dir, _TENANT_ID_FILE)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
 def get_cached_tenant_name(tenant_id: str, local_dir: str = ".local") -> str:
     """Return the cached org display name IFF it matches ``tenant_id``.
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 import json
 import os
 import platform
+import re
 import tempfile
 import uuid
 from datetime import datetime, timezone
@@ -121,6 +122,17 @@ MICROSOFT_CORP_TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47"
 TENANT_CLASS_INTERNAL = "internal"
 TENANT_CLASS_CUSTOMER = "customer"
 TENANT_CLASS_UNKNOWN = "unknown"
+
+# Canonical Entra tenant GUID (8-4-4-4-12 lowercase hex). Used by
+# ``get_cached_tenant_id`` to validate the legacy raw-string cache format
+# so a torn / hand-edited / garbage ``.tenant_id`` file can never leak onto
+# real events. Duplicated from ``adk_telemetry._GUID_RE`` (this module
+# cannot import from adk_telemetry — the dependency direction goes the
+# other way); the two regexes are kept in lock-step by a regression test
+# in ``test_adk_telemetry.py``.
+_GUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
 
 
 def _internal_tenant_ids() -> frozenset[str]:
@@ -299,15 +311,26 @@ def cache_tenant_name(
         pass
     try:
         os.makedirs(local_dir, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(
-                {
-                    "tenant_id": tenant_id,
-                    "tenant_name": tenant_name,
-                    "source": source,
-                },
-                f,
-            )
+        # Atomic write via tempfile + os.replace, matching cache_tenant_id.
+        # A concurrent reader (a sibling emit_capability.py subprocess spawned
+        # from a SKILL.md step) must never see a truncated file — otherwise
+        # the reader would fall back to a blank tenant_name for the whole
+        # session, undoing the very cache we're populating.
+        payload = {
+            "tenant_id": tenant_id,
+            "tenant_name": tenant_name,
+            "source": source,
+        }
+        fd, tmp = tempfile.mkstemp(prefix=".tenant_name.", dir=local_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.replace(tmp, path)
+        except OSError:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
     except OSError:
         pass
 
@@ -371,9 +394,11 @@ def get_cached_tenant_id(local_dir: str = ".local") -> str:
     real events.
 
     A very small compatibility shim recognizes the pre-versioning raw-string
-    format (a single line whose contents look like a GUID) so a maker who
-    upgrades mid-session doesn't lose their cached tenant. Any other content
-    (truncated GUID, JSON at a future schema version, garbage) is discarded.
+    format (a single line whose contents look like a canonical GUID) so a
+    maker who upgrades mid-session doesn't lose their cached tenant. The
+    raw string is validated against ``_GUID_RE`` (case-insensitive) before
+    being returned; any other content (truncated GUID, non-hex, garbage,
+    JSON at a future schema version) is discarded.
     """
     path = os.path.join(local_dir, _TENANT_ID_FILE)
     try:
@@ -391,8 +416,13 @@ def get_cached_tenant_id(local_dir: str = ".local") -> str:
         if not isinstance(obj, dict) or obj.get("version") != 1:
             return ""
         return str(obj.get("tenant_id", "")).strip()
-    # Legacy raw-string format from pre-versioned ADK builds.
-    return raw
+    # Legacy raw-string format from pre-versioned ADK builds: only trust the
+    # value when it matches the canonical GUID shape. Otherwise return ""
+    # and let the caller's fallback path (or classify_tenant) treat it as
+    # unknown — never leak a torn / hand-edited / garbage cache onto real
+    # events. Matches the docstring guarantee above.
+    v = raw.lower()
+    return v if _GUID_RE.match(v) else ""
 
 
 def get_cached_tenant_name(tenant_id: str, local_dir: str = ".local") -> str:

--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 import json
 import os
 import platform
+import tempfile
 import uuid
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -257,7 +258,10 @@ _TENANT_NAME_FILE = ".tenant_name"
 
 
 def cache_tenant_name(
-    tenant_id: str, tenant_name: str, local_dir: str = ".local"
+    tenant_id: str,
+    tenant_name: str,
+    local_dir: str = ".local",
+    source: str = "organization",
 ) -> None:
     """Persist the resolved org display name for reuse by later ADK events.
 
@@ -266,14 +270,44 @@ def cache_tenant_name(
     ``(tenant_id, tenant_name)`` pair. ``tenant_name`` is OII (org display
     name); it is written under the gitignored ``.local/`` dir on the maker's
     own machine, mirroring how ``.instance_id`` is persisted.
+
+    ``source`` records where the name came from. ``"organization"`` means it
+    came from Graph's ``/organization`` endpoint — the authoritative source.
+    ``"me"`` means it came from ``/me?$select=companyName``, which is a
+    per-user attribute (some tenants leave it unset or use a different
+    display value than the org record). A cached ``"organization"`` entry
+    is never overwritten by an ``"me"`` entry for the same tenant, so a
+    single unlucky call can't downgrade the label the whole dashboard uses.
+    A same-tenant write with the *same or better* source (organization ≥ me)
+    always wins.
     """
     if not tenant_id or not tenant_name:
         return
     path = os.path.join(local_dir, _TENANT_NAME_FILE)
+    _rank = {"organization": 2, "me": 1}
+    new_rank = _rank.get(source, 0)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            existing = json.load(f)
+        if (
+            isinstance(existing, dict)
+            and existing.get("tenant_id") == tenant_id
+            and _rank.get(existing.get("source", "organization"), 0) > new_rank
+        ):
+            return
+    except (OSError, ValueError):
+        pass
     try:
         os.makedirs(local_dir, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
-            json.dump({"tenant_id": tenant_id, "tenant_name": tenant_name}, f)
+            json.dump(
+                {
+                    "tenant_id": tenant_id,
+                    "tenant_name": tenant_name,
+                    "source": source,
+                },
+                f,
+            )
     except OSError:
         pass
 
@@ -296,26 +330,69 @@ def cache_tenant_id(tenant_id: str, local_dir: str = ".local") -> None:
     The value is written under the gitignored ``.local/`` dir on the maker's
     own machine, mirroring how ``.instance_id`` is persisted. Overwrites any
     prior value so a maker who switches tenants sees the latest one.
+
+    Write is atomic (``tempfile`` + ``os.replace``) so a concurrent reader
+    can never observe a truncated / half-written file — otherwise the reader
+    would silently see ``""`` and stamp the event as anonymous. Stored as
+    versioned JSON so a torn / legacy write from an older ADK build is
+    recognizable and discarded on read.
     """
     if not tenant_id:
         return
     path = os.path.join(local_dir, _TENANT_ID_FILE)
+    payload = {"version": 1, "tenant_id": str(tenant_id).strip()}
     try:
         os.makedirs(local_dir, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(str(tenant_id).strip())
+        # tempfile.NamedTemporaryFile with delete=False so we can rename it in
+        # place with os.replace, which is atomic on POSIX AND Windows.
+        fd, tmp = tempfile.mkstemp(prefix=".tenant_id.", dir=local_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.replace(tmp, path)
+        except OSError:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
     except OSError:
         pass
 
 
 def get_cached_tenant_id(local_dir: str = ".local") -> str:
-    """Return the persisted tenant GUID, or ``""`` if unavailable/unreadable."""
+    """Return the persisted tenant GUID, or ``""`` if unavailable/unreadable.
+
+    Reads the versioned JSON produced by ``cache_tenant_id`` and validates
+    the schema before returning the value. A missing / malformed / wrong-
+    schema-version file returns ``""`` — the caller's fallback path treats
+    that as "no cache" and either uses the in-memory identity or lets
+    ``classify_tenant`` label the event ``"unknown"``. That is safer than
+    returning a torn / legacy raw string that would silently ride onto
+    real events.
+
+    A very small compatibility shim recognizes the pre-versioning raw-string
+    format (a single line whose contents look like a GUID) so a maker who
+    upgrades mid-session doesn't lose their cached tenant. Any other content
+    (truncated GUID, JSON at a future schema version, garbage) is discarded.
+    """
     path = os.path.join(local_dir, _TENANT_ID_FILE)
     try:
         with open(path, "r", encoding="utf-8") as f:
-            return f.read().strip()
+            raw = f.read().strip()
     except OSError:
         return ""
+    if not raw:
+        return ""
+    if raw.startswith("{"):
+        try:
+            obj = json.loads(raw)
+        except ValueError:
+            return ""
+        if not isinstance(obj, dict) or obj.get("version") != 1:
+            return ""
+        return str(obj.get("tenant_id", "")).strip()
+    # Legacy raw-string format from pre-versioned ADK builds.
+    return raw
 
 
 def get_cached_tenant_name(tenant_id: str, local_dir: str = ".local") -> str:

--- a/tests/flightcheck/test_cli_single_checkpoint.py
+++ b/tests/flightcheck/test_cli_single_checkpoint.py
@@ -315,3 +315,82 @@ class TestCheckpointTelemetry:
                 _args("FAKE-001", tmp_path, no_telemetry=True)
             )
         assert captured["called"] is False
+
+    def test_tenant_name_falls_back_to_cache_when_graph_unavailable(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _silence_output: None,
+    ) -> None:
+        """When ``graph is None`` (infra-only scope, or Graph auth failed),
+        ``cli`` must fall back to the persisted ``.local/.tenant_name`` cache
+        so previously-resolved tenants keep their name on FlightCheck events
+        instead of emitting blank. Regression guard for the split observed in
+        prod telemetry where the same tenant emitted both blank and named
+        runs on the same ADK version.
+        """
+        monkeypatch.chdir(tmp_path)
+        from flightcheck import telemetry as _tele_mod
+        from flightcheck import registry as _reg
+
+        cached_tid = "11111111-1111-1111-1111-111111111111"
+        _tele_mod.cache_tenant_name(cached_tid, "Contoso Cached")
+
+        # Make the plan require GRAPH so the code reaches the tenant_id
+        # discovery path and then tries to build a Graph client.
+        class _Spec:
+            category_label = "Fake"
+            is_family = False
+
+        class _Plan:
+            clients = frozenset({_reg.GRAPH})
+            requires_config = False
+            requires_dataverse_endpoint = False
+
+            def __init__(self, fns: list) -> None:
+                self.ordered_fns = fns
+
+        def _fn(runner):  # noqa: ARG001
+            return [_row("FAKE-001", Status.PASSED.value)]
+
+        monkeypatch.setattr(_reg, "resolve", lambda target: _Spec())
+        monkeypatch.setattr(
+            _reg, "transitive_requirements", lambda target: _Plan([("Fake", _fn)])
+        )
+
+        # Force tenant_id to our seeded cache key and make Graph fail so the
+        # code sets ``graph = None`` — the exact scenario we're guarding.
+        import auth as _auth
+
+        monkeypatch.setattr(_auth, "discover_tenant", lambda *a, **k: cached_tid)
+
+        class _NoGraph:
+            def __init__(self, *a, **k):
+                pass
+
+            def authenticate(self):
+                raise RuntimeError("no graph in this test")
+
+            def get_organization(self):
+                raise RuntimeError("no graph in this test")
+
+        monkeypatch.setattr(cli, "GraphClient", _NoGraph, raising=False)
+        import flightcheck.graph_client as _gc
+
+        monkeypatch.setattr(_gc, "GraphClient", _NoGraph)
+
+        captured = self._capture(monkeypatch)
+        with pytest.raises(SystemExit):
+            cli._run_single_checkpoint(
+                _args(
+                    "FAKE-001",
+                    tmp_path,
+                    no_telemetry=False,
+                    environment_url="https://contoso.crm.dynamics.com",
+                )
+            )
+        assert captured["called"] is True
+        # Regression assertion: with graph unavailable, the cache must be
+        # consulted so a previously-seen tenant still gets its display name.
+        assert captured["kwargs"]["tenant_name"] == "Contoso Cached"
+        assert captured["kwargs"]["tenant_id"] == cached_tid

--- a/tests/flightcheck/test_graph_client.py
+++ b/tests/flightcheck/test_graph_client.py
@@ -71,7 +71,7 @@ def test_success_returns_display_name():
     )
     resp = _resp(200, {"value": [{"displayName": "Contoso Ltd"}]})
     with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
-         patch.object(graph_client._SESSION, "get", return_value=resp) as mock_get:
+         patch.object(graph_client.requests, "get", return_value=resp) as mock_get:
         assert (
             graph_client.resolve_tenant_display_name_silent("tenant-Z") == "Contoso Ltd"
         )
@@ -88,7 +88,7 @@ def test_non_200_response_returns_empty():
         accounts=[SimpleNamespace()], silent_result={"access_token": "tok"}
     )
     with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
-         patch.object(graph_client._SESSION, "get", return_value=_resp(403)):
+         patch.object(graph_client.requests, "get", return_value=_resp(403)):
         assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
 
 
@@ -97,7 +97,7 @@ def test_empty_org_list_returns_empty():
         accounts=[SimpleNamespace()], silent_result={"access_token": "tok"}
     )
     with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
-         patch.object(graph_client._SESSION, "get", return_value=_resp(200, {"value": []})):
+         patch.object(graph_client.requests, "get", return_value=_resp(200, {"value": []})):
         assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
 
 
@@ -138,7 +138,7 @@ def test_falls_back_to_me_company_name_when_organization_scope_unavailable():
         return _resp(200, {"companyName": "  Fabrikam Corp  "})
 
     with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
-         patch.object(graph_client._SESSION, "get", side_effect=fake_get):
+         patch.object(graph_client.requests, "get", side_effect=fake_get):
         # Whitespace on companyName is stripped so downstream label matches
         # what /organization would return.
         assert (
@@ -184,5 +184,5 @@ def test_me_fallback_missing_company_name_returns_empty():
 
     app.acquire_token_silent.side_effect = silent
     with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
-         patch.object(graph_client._SESSION, "get", return_value=_resp(200, {})):
+         patch.object(graph_client.requests, "get", return_value=_resp(200, {})):
         assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""

--- a/tests/flightcheck/test_graph_client.py
+++ b/tests/flightcheck/test_graph_client.py
@@ -106,3 +106,83 @@ def test_exception_is_swallowed_returns_empty():
         graph_client.msal, "PublicClientApplication", side_effect=RuntimeError("boom")
     ):
         assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+
+
+def test_falls_back_to_me_company_name_when_organization_scope_unavailable():
+    """When Organization.Read.All is not silently redeemable (very common in
+    enterprise tenants that require admin consent), the resolver must fall
+    back to /me?$select=companyName with User.Read -- the latter is a
+    default-static permission that a fresh Dataverse sign-in usually satisfies
+    silently. This is the primary driver of blank tenant_name in prod ADK
+    telemetry, so pin the fallback path.
+    """
+    account = SimpleNamespace()
+    app = MagicMock()
+    app.get_accounts.return_value = [account]
+    app.acquire_token_interactive.side_effect = AssertionError(
+        "silent-only resolver must not prompt interactively"
+    )
+
+    # Org scope: silently unavailable. User.Read: silently redeemable.
+    def silent(scopes, account):
+        if scopes == graph_client._ORG_READ_SCOPE:
+            return None
+        if scopes == graph_client._USER_READ_SCOPE:
+            return {"access_token": "user-tok"}
+        raise AssertionError(f"unexpected scopes: {scopes}")
+
+    app.acquire_token_silent.side_effect = silent
+
+    def fake_get(url, headers, timeout):
+        assert url.endswith("/me?$select=companyName"), url
+        return _resp(200, {"companyName": "  Fabrikam Corp  "})
+
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
+         patch.object(graph_client._SESSION, "get", side_effect=fake_get):
+        # Whitespace on companyName is stripped so downstream label matches
+        # what /organization would return.
+        assert (
+            graph_client.resolve_tenant_display_name_silent("tenant-Z")
+            == "Fabrikam Corp"
+        )
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_returns_empty_when_both_scopes_silently_unavailable():
+    """When neither Organization.Read.All nor User.Read is silently redeemable,
+    the resolver must still degrade to "" without prompting. This is the
+    residual blank-tenant_name case that only goes away when the maker later
+    runs FlightCheck (which triggers an interactive Graph sign-in and caches).
+    """
+    account = SimpleNamespace()
+    app = MagicMock()
+    app.get_accounts.return_value = [account]
+    app.acquire_token_silent.return_value = None
+    app.acquire_token_interactive.side_effect = AssertionError(
+        "silent-only resolver must not prompt interactively"
+    )
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""
+    # Attempted BOTH scopes silently before giving up.
+    scopes_tried = [c.args[0] for c in app.acquire_token_silent.call_args_list]
+    assert graph_client._ORG_READ_SCOPE in scopes_tried
+    assert graph_client._USER_READ_SCOPE in scopes_tried
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_me_fallback_missing_company_name_returns_empty():
+    """When /me returns 200 but the user's companyName attribute is unset
+    (many tenants), the fallback returns "" rather than a bogus label.
+    """
+    account = SimpleNamespace()
+    app = MagicMock()
+    app.get_accounts.return_value = [account]
+    app.acquire_token_interactive.side_effect = AssertionError("no prompt")
+
+    def silent(scopes, account):
+        return None if scopes == graph_client._ORG_READ_SCOPE else {"access_token": "t"}
+
+    app.acquire_token_silent.side_effect = silent
+    with patch.object(graph_client.msal, "PublicClientApplication", return_value=app), \
+         patch.object(graph_client._SESSION, "get", return_value=_resp(200, {})):
+        assert graph_client.resolve_tenant_display_name_silent("tenant-Z") == ""

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -237,7 +237,163 @@ def test_authenticate_replaces_dataverse_rejected_cached_token(
     ) == "refreshed"
 
 
-class TestQueryAll:
+def test_authenticate_resolves_tenant_name_before_start_session(
+    tmp_path, monkeypatch
+) -> None:
+    """The ADK telemetry bootstrap in ``authenticate`` must resolve the
+    tenant display name via SILENT-ONLY Graph BEFORE emitting the first
+    ``adk.session.start`` event, so that first event carries ``tenant_name``.
+
+    Before this ordering fix, ``start_session`` fired first, so the very
+    first session_start on a fresh install always went out with blank
+    tenant_name (only later events -- once FlightCheck interactively
+    resolved and cached the name -- picked it up). This is a regression
+    test for that ordering: silent resolution runs first, its result is
+    fed to ``set_identity``, and only then does ``start_session`` emit.
+    """
+    import auth
+
+    class FakeCache:
+        has_state_changed = False
+
+        def deserialize(self, value: str) -> None:
+            pass
+
+        def serialize(self) -> str:
+            return ""
+
+    class FakeApp:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def get_accounts(self) -> list[dict]:
+            return []
+
+        def acquire_token_silent(self, scopes, account):
+            return None
+
+        def acquire_token_interactive(self, scopes, prompt):
+            return {
+                "access_token": "fresh-token",
+                "id_token_claims": {"tid": "tenant-id"},
+            }
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(auth, "discover_tenant", lambda _url: "tenant-id")
+    monkeypatch.setattr(auth, "_dataverse_accepts_token", lambda _url, _tok: True)
+    monkeypatch.setattr(auth.msal, "SerializableTokenCache", FakeCache)
+    monkeypatch.setattr(auth.msal, "PublicClientApplication", FakeApp)
+
+    # Instrument ADK telemetry + Graph resolver to record call order.
+    import adk_telemetry
+    from flightcheck import graph_client
+
+    calls: list[tuple[str, tuple, dict]] = []
+
+    def record(name):
+        def _rec(*args, **kwargs):
+            calls.append((name, args, kwargs))
+
+        return _rec
+
+    monkeypatch.setattr(adk_telemetry, "maybe_print_notice", record("notice"))
+    monkeypatch.setattr(adk_telemetry, "set_identity", record("set_identity"))
+    monkeypatch.setattr(adk_telemetry, "start_session", record("start_session"))
+    monkeypatch.setattr(
+        graph_client,
+        "resolve_tenant_display_name_silent",
+        lambda tid: "Contoso Ltd" if tid == "tenant-id" else "",
+    )
+
+    token = auth.authenticate("https://example.crm.dynamics.com")
+    assert token == "fresh-token"
+
+    names = [c[0] for c in calls]
+    # set_identity(tenant_name=...) must happen BEFORE start_session so the
+    # first session_start emit picks up the resolved name from _IDENTITY.
+    assert "set_identity" in names, names
+    assert "start_session" in names, names
+    assert names.index("set_identity") < names.index("start_session"), names
+
+    # The resolved name from silent Graph is what got stored.
+    si = next(c for c in calls if c[0] == "set_identity")
+    assert si[2].get("tenant_name") == "Contoso Ltd"
+    assert si[2].get("tenant_id") == "tenant-id"
+
+    # start_session receives tenant_id so common_dimensions can pair the
+    # name (already in _IDENTITY) with the raw tenant GUID.
+    ss = next(c for c in calls if c[0] == "start_session")
+    assert ss[2].get("tenant_id") == "tenant-id"
+
+
+def test_authenticate_still_emits_when_silent_graph_returns_blank(
+    tmp_path, monkeypatch
+) -> None:
+    """When silent Graph resolution yields no name (both scopes admin-only
+    or unconsented), the bootstrap must still emit ``adk.session.start`` --
+    just without ``set_identity`` overriding tenant_name. Telemetry stays
+    best-effort and non-blocking; the missing-name case degrades to blank
+    (recoverable when the maker later runs FlightCheck).
+    """
+    import auth
+
+    class FakeCache:
+        has_state_changed = False
+
+        def deserialize(self, value: str) -> None:
+            pass
+
+        def serialize(self) -> str:
+            return ""
+
+    class FakeApp:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def get_accounts(self) -> list[dict]:
+            return []
+
+        def acquire_token_silent(self, scopes, account):
+            return None
+
+        def acquire_token_interactive(self, scopes, prompt):
+            return {
+                "access_token": "fresh-token",
+                "id_token_claims": {"tid": "tenant-id"},
+            }
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(auth, "discover_tenant", lambda _url: "tenant-id")
+    monkeypatch.setattr(auth, "_dataverse_accepts_token", lambda _url, _tok: True)
+    monkeypatch.setattr(auth.msal, "SerializableTokenCache", FakeCache)
+    monkeypatch.setattr(auth.msal, "PublicClientApplication", FakeApp)
+
+    import adk_telemetry
+    from flightcheck import graph_client
+
+    calls: list[str] = []
+    monkeypatch.setattr(adk_telemetry, "maybe_print_notice", lambda: calls.append("notice"))
+    monkeypatch.setattr(
+        adk_telemetry, "set_identity", lambda **kw: calls.append("set_identity")
+    )
+    monkeypatch.setattr(
+        adk_telemetry, "start_session", lambda **kw: calls.append("start_session")
+    )
+    # Silent resolver returns "" (Organization.Read.All + User.Read both
+    # silently unavailable, as happens for a large fraction of enterprise
+    # tenants on first Dataverse sign-in).
+    monkeypatch.setattr(
+        graph_client, "resolve_tenant_display_name_silent", lambda tid: ""
+    )
+
+    token = auth.authenticate("https://example.crm.dynamics.com")
+    assert token == "fresh-token"
+
+    # start_session still fires; set_identity is NOT called (blank names
+    # would overwrite whatever the cache-fallback in common_dimensions
+    # might otherwise pick up).
+    assert "start_session" in calls
+    assert "set_identity" not in calls
     """Drives scripts/auth.py:query_all through the mock.
 
     query_all is the FlightCheck-relevant slice of auth.py — it's used by

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -250,8 +250,17 @@ def test_authenticate_resolves_tenant_name_before_start_session(
     resolved and cached the name -- picked it up). This is a regression
     test for that ordering: silent resolution runs first, its result is
     fed to ``set_identity``, and only then does ``start_session`` emit.
+
+    Asserts on the actual OneCollector envelope (not just call ordering)
+    so that a regression where ``start_session`` internally wipes the
+    ``tenant_name`` that ``set_identity`` just stored -- the exact
+    reviewer-flagged bug that ``set_identity``'s ``None``-sentinel refactor
+    fixes -- shows up as an assertion failure on the emitted payload.
     """
     import auth
+    import adk_telemetry
+    from flightcheck import graph_client
+    from flightcheck import telemetry as fc_telemetry
 
     class FakeCache:
         has_state_changed = False
@@ -275,55 +284,71 @@ def test_authenticate_resolves_tenant_name_before_start_session(
         def acquire_token_interactive(self, scopes, prompt):
             return {
                 "access_token": "fresh-token",
-                "id_token_claims": {"tid": "tenant-id"},
+                "id_token_claims": {
+                    "tid": "00000000-0000-0000-0000-0000000000ab"
+                },
             }
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(auth, "discover_tenant", lambda _url: "tenant-id")
+    # Isolate ADK telemetry state (so we don't touch ~/.adk on the dev box).
+    cfg_dir = tmp_path / ".adk"
+    monkeypatch.setattr(adk_telemetry, "CONFIG_DIR", str(cfg_dir))
+    monkeypatch.setattr(adk_telemetry, "CONFIG_PATH", str(cfg_dir / "config"))
+    monkeypatch.setattr(
+        adk_telemetry, "SESSION_PATH", str(cfg_dir / "session.json")
+    )
+    monkeypatch.setattr(
+        adk_telemetry, "BUFFER_PATH", str(cfg_dir / "telemetry-buffer.ndjson")
+    )
+    monkeypatch.setattr(adk_telemetry, "_SYNC", True)
+    monkeypatch.setattr(
+        adk_telemetry,
+        "_IDENTITY",
+        {"instance_id": "", "tenant_id": "", "tenant_name": ""},
+    )
+    monkeypatch.setenv("ESS_ADK_TELEMETRY", "on")
+
+    monkeypatch.setattr(
+        auth, "discover_tenant", lambda _url: "00000000-0000-0000-0000-0000000000ab"
+    )
     monkeypatch.setattr(auth, "_dataverse_accepts_token", lambda _url, _tok: True)
     monkeypatch.setattr(auth.msal, "SerializableTokenCache", FakeCache)
     monkeypatch.setattr(auth.msal, "PublicClientApplication", FakeApp)
 
-    # Instrument ADK telemetry + Graph resolver to record call order.
-    import adk_telemetry
-    from flightcheck import graph_client
-
-    calls: list[tuple[str, tuple, dict]] = []
-
-    def record(name):
-        def _rec(*args, **kwargs):
-            calls.append((name, args, kwargs))
-
-        return _rec
-
-    monkeypatch.setattr(adk_telemetry, "maybe_print_notice", record("notice"))
-    monkeypatch.setattr(adk_telemetry, "set_identity", record("set_identity"))
-    monkeypatch.setattr(adk_telemetry, "start_session", record("start_session"))
     monkeypatch.setattr(
         graph_client,
         "resolve_tenant_display_name_silent",
-        lambda tid: "Contoso Ltd" if tid == "tenant-id" else "",
+        lambda tid: (
+            "Contoso Ltd"
+            if tid == "00000000-0000-0000-0000-0000000000ab"
+            else ""
+        ),
     )
+
+    # Instrument the OneCollector boundary to assert on real payloads.
+    envelopes: list[tuple[str, list[dict]]] = []
+
+    def _fake_post(ikey, evs):
+        envelopes.append((ikey, evs))
+        return 200
+
+    monkeypatch.setattr(fc_telemetry, "_post", _fake_post)
 
     token = auth.authenticate("https://example.crm.dynamics.com")
     assert token == "fresh-token"
 
-    names = [c[0] for c in calls]
-    # set_identity(tenant_name=...) must happen BEFORE start_session so the
-    # first session_start emit picks up the resolved name from _IDENTITY.
-    assert "set_identity" in names, names
-    assert "start_session" in names, names
-    assert names.index("set_identity") < names.index("start_session"), names
-
-    # The resolved name from silent Graph is what got stored.
-    si = next(c for c in calls if c[0] == "set_identity")
-    assert si[2].get("tenant_name") == "Contoso Ltd"
-    assert si[2].get("tenant_id") == "tenant-id"
-
-    # start_session receives tenant_id so common_dimensions can pair the
-    # name (already in _IDENTITY) with the raw tenant GUID.
-    ss = next(c for c in calls if c[0] == "start_session")
-    assert ss[2].get("tenant_id") == "tenant-id"
+    starts = [
+        ev
+        for _ikey, batch in envelopes
+        for ev in batch
+        if ev.get("name") == "adk.session.start"
+    ]
+    assert starts, "expected a session_start envelope; got %r" % envelopes
+    data = starts[-1].get("data", {})
+    # Reviewer's Fix #2: start_session must NOT internally wipe the
+    # tenant_name that set_identity stored a millisecond earlier.
+    assert data.get("tenant_id") == "00000000-0000-0000-0000-0000000000ab", data
+    assert data.get("tenant_name") == "Contoso Ltd", data
 
 
 def test_authenticate_still_emits_when_silent_graph_returns_blank(
@@ -331,11 +356,23 @@ def test_authenticate_still_emits_when_silent_graph_returns_blank(
 ) -> None:
     """When silent Graph resolution yields no name (both scopes admin-only
     or unconsented), the bootstrap must still emit ``adk.session.start`` --
-    just without ``set_identity`` overriding tenant_name. Telemetry stays
-    best-effort and non-blocking; the missing-name case degrades to blank
-    (recoverable when the maker later runs FlightCheck).
+    just with a blank ``tenant_name``. Telemetry stays best-effort and
+    non-blocking; the missing-name case degrades to blank (recoverable when
+    the maker later runs FlightCheck).
+
+    This test is deliberately *end-to-end at the transport boundary*: it
+    monkeypatches only the OneCollector ``_post`` (as ``captured_post`` in
+    ``test_adk_telemetry.py`` does), so a regression that silently wipes
+    ``tenant_name`` inside ``start_session`` -- or that skips the session
+    emit entirely on the blank-name path -- shows up as a real assertion
+    failure on the actual envelope payload. Trivial recorders that only
+    watch ``set_identity`` / ``start_session`` call order would NOT catch
+    such a regression, because the wipe happens *inside* one of those.
     """
     import auth
+    import adk_telemetry
+    from flightcheck import graph_client
+    from flightcheck import telemetry as fc_telemetry
 
     class FakeCache:
         has_state_changed = False
@@ -359,26 +396,35 @@ def test_authenticate_still_emits_when_silent_graph_returns_blank(
         def acquire_token_interactive(self, scopes, prompt):
             return {
                 "access_token": "fresh-token",
-                "id_token_claims": {"tid": "tenant-id"},
+                "id_token_claims": {
+                    "tid": "00000000-0000-0000-0000-0000000000ab"
+                },
             }
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(auth, "discover_tenant", lambda _url: "tenant-id")
+    # Isolate ADK state so we don't leak into ~/.adk on the dev box.
+    cfg_dir = tmp_path / ".adk"
+    monkeypatch.setattr(adk_telemetry, "CONFIG_DIR", str(cfg_dir))
+    monkeypatch.setattr(adk_telemetry, "CONFIG_PATH", str(cfg_dir / "config"))
+    monkeypatch.setattr(
+        adk_telemetry, "SESSION_PATH", str(cfg_dir / "session.json")
+    )
+    monkeypatch.setattr(
+        adk_telemetry, "BUFFER_PATH", str(cfg_dir / "telemetry-buffer.ndjson")
+    )
+    monkeypatch.setattr(adk_telemetry, "_SYNC", True)
+    monkeypatch.setattr(
+        adk_telemetry,
+        "_IDENTITY",
+        {"instance_id": "", "tenant_id": "", "tenant_name": ""},
+    )
+    monkeypatch.setenv("ESS_ADK_TELEMETRY", "on")
+
+    monkeypatch.setattr(auth, "discover_tenant", lambda _url: "00000000-0000-0000-0000-0000000000ab")
     monkeypatch.setattr(auth, "_dataverse_accepts_token", lambda _url, _tok: True)
     monkeypatch.setattr(auth.msal, "SerializableTokenCache", FakeCache)
     monkeypatch.setattr(auth.msal, "PublicClientApplication", FakeApp)
 
-    import adk_telemetry
-    from flightcheck import graph_client
-
-    calls: list[str] = []
-    monkeypatch.setattr(adk_telemetry, "maybe_print_notice", lambda: calls.append("notice"))
-    monkeypatch.setattr(
-        adk_telemetry, "set_identity", lambda **kw: calls.append("set_identity")
-    )
-    monkeypatch.setattr(
-        adk_telemetry, "start_session", lambda **kw: calls.append("start_session")
-    )
     # Silent resolver returns "" (Organization.Read.All + User.Read both
     # silently unavailable, as happens for a large fraction of enterprise
     # tenants on first Dataverse sign-in).
@@ -386,14 +432,34 @@ def test_authenticate_still_emits_when_silent_graph_returns_blank(
         graph_client, "resolve_tenant_display_name_silent", lambda tid: ""
     )
 
+    # Capture actual envelopes at the OneCollector boundary. This is what
+    # would land in Aria in prod, so assertions here are the strongest
+    # possible: they catch any regression that wipes tenant_name inside
+    # set_identity / start_session, not just missing call orderings.
+    envelopes: list[tuple[str, list[dict]]] = []
+
+    def _fake_post(ikey, evs):
+        envelopes.append((ikey, evs))
+        return 200
+
+    monkeypatch.setattr(fc_telemetry, "_post", _fake_post)
+
     token = auth.authenticate("https://example.crm.dynamics.com")
     assert token == "fresh-token"
 
-    # start_session still fires; set_identity is NOT called (blank names
-    # would overwrite whatever the cache-fallback in common_dimensions
-    # might otherwise pick up).
-    assert "start_session" in calls
-    assert "set_identity" not in calls
+    # A session_start envelope must have been emitted, carrying the raw
+    # tenant_id (so it lands on the customer-filtered dashboard) with a
+    # blank tenant_name (silent resolution failed).
+    starts = [
+        ev
+        for _ikey, batch in envelopes
+        for ev in batch
+        if ev.get("name") == "adk.session.start"
+    ]
+    assert starts, "expected an adk.session.start envelope; got %r" % envelopes
+    data = starts[-1].get("data", {})
+    assert data.get("tenant_id") == "00000000-0000-0000-0000-0000000000ab", data
+    assert data.get("tenant_name") == "", data
     """Drives scripts/auth.py:query_all through the mock.
 
     query_all is the FlightCheck-relevant slice of auth.py — it's used by

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -62,6 +62,7 @@ def _isolate(monkeypatch, tmp_path):
     # these on _fc at runtime, so patching them here redirects the cache dir.
     _cache_dir = str(tmp_path / ".local")
     _real_cache, _real_get = _fc.cache_tenant_name, _fc.get_cached_tenant_name
+    _real_cache_id, _real_get_id = _fc.cache_tenant_id, _fc.get_cached_tenant_id
     monkeypatch.setattr(
         _fc, "cache_tenant_name",
         lambda tid, name, local_dir=_cache_dir: _real_cache(tid, name, local_dir=local_dir),
@@ -69,6 +70,14 @@ def _isolate(monkeypatch, tmp_path):
     monkeypatch.setattr(
         _fc, "get_cached_tenant_name",
         lambda tid, local_dir=_cache_dir: _real_get(tid, local_dir=local_dir),
+    )
+    monkeypatch.setattr(
+        _fc, "cache_tenant_id",
+        lambda tid, local_dir=_cache_dir: _real_cache_id(tid, local_dir=local_dir),
+    )
+    monkeypatch.setattr(
+        _fc, "get_cached_tenant_id",
+        lambda local_dir=_cache_dir: _real_get_id(local_dir=local_dir),
     )
 
     for var in (
@@ -153,6 +162,68 @@ def test_tenant_name_reused_by_later_process_without_identity(monkeypatch):
     )
     dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="tenant-Z")
     assert dims["tenant_name"] == "Contoso"
+
+
+def test_tenant_id_reused_by_fresh_subprocess_without_identity(monkeypatch):
+    # Reproduces the emit_capability.py shim scenario: SKILL.md steps launch
+    # `python scripts/emit_capability.py <cap>` as a *fresh* Python subprocess,
+    # which never calls set_identity. Without the on-disk tenant_id fallback,
+    # such a subprocess emits with tenant_id="" -> classify_tenant("")=="unknown",
+    # so the capability event never appears on the customer-filtered External
+    # dashboard even though the maker's earlier auth flow knew the tenant.
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+    # Auth flow (parent process) persists tenant_id.
+    adk.set_identity(tenant_id="tenant-Z")
+    # Subprocess simulation: brand-new interpreter -> empty _IDENTITY, no
+    # set_identity call.
+    monkeypatch.setattr(
+        adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
+    )
+    dims = adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")
+    # The persisted GUID is picked up and the event classifies as customer,
+    # not unknown.
+    assert dims["tenant_id"] == "tenant-Z"
+    assert dims["tenant_class"] == _fc.TENANT_CLASS_CUSTOMER
+
+
+def test_tenant_id_explicit_kwarg_wins_over_cached(monkeypatch):
+    # An explicit tenant_id passed by the caller must always win, even when a
+    # different tenant_id sits in the on-disk cache (e.g. subprocess is
+    # emitting on behalf of a specific tenant that isn't the last-cached one).
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+    adk.set_identity(tenant_id="tenant-Z")  # writes tenant-Z to disk
+    monkeypatch.setattr(
+        adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
+    )
+    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="tenant-Y")
+    assert dims["tenant_id"] == "tenant-Y"
+
+
+def test_tenant_id_explicit_empty_kwarg_does_not_fall_back(monkeypatch):
+    # An explicit empty tenant_id (caller genuinely knows there is none)
+    # must NOT be overridden by the disk cache — that would leak a stale
+    # tenant_id onto an event the caller deliberately marked anonymous.
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+    adk.set_identity(tenant_id="tenant-Z")
+    monkeypatch.setattr(
+        adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
+    )
+    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="")
+    assert dims["tenant_id"] == ""
+
+
+def test_cache_tenant_id_round_trip_and_guards(tmp_path):
+    d = str(tmp_path / "state")
+    _fc.cache_tenant_id("tenant-Z", local_dir=d)
+    assert _fc.get_cached_tenant_id(local_dir=d) == "tenant-Z"
+    # Missing dir/file -> "".
+    assert _fc.get_cached_tenant_id(local_dir=str(tmp_path / "nope")) == ""
+    # Empty tenant_id is a no-op (never overwrite a valid cache with "").
+    _fc.cache_tenant_id("", local_dir=d)
+    assert _fc.get_cached_tenant_id(local_dir=d) == "tenant-Z"
+    # Whitespace is stripped on write.
+    _fc.cache_tenant_id("  tenant-Y  ", local_dir=d)
+    assert _fc.get_cached_tenant_id(local_dir=d) == "tenant-Y"
 
 
 def test_cache_tenant_name_round_trip_and_guards(tmp_path):

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -65,7 +65,9 @@ def _isolate(monkeypatch, tmp_path):
     _real_cache_id, _real_get_id = _fc.cache_tenant_id, _fc.get_cached_tenant_id
     monkeypatch.setattr(
         _fc, "cache_tenant_name",
-        lambda tid, name, local_dir=_cache_dir: _real_cache(tid, name, local_dir=local_dir),
+        lambda tid, name, local_dir=_cache_dir, source="organization": _real_cache(
+            tid, name, local_dir=local_dir, source=source
+        ),
     )
     monkeypatch.setattr(
         _fc, "get_cached_tenant_name",
@@ -107,16 +109,16 @@ def captured_post(monkeypatch):
 # --- identity (instance_id; no developer identity) ------------------------
 def test_set_identity_stores_instance_and_raw_tenant(monkeypatch):
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    ident = adk.set_identity(tenant_id="tenant-Z")
+    ident = adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab")
     # No developer/user identifier is ever collected.
     assert "developer_id" not in ident
     assert ident["instance_id"] == "install-guid-1"
-    assert ident["tenant_id"] == "tenant-Z"
+    assert ident["tenant_id"] == "00000000-0000-0000-0000-0000000000ab"
 
 
 def test_set_identity_stores_tenant_name(monkeypatch):
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    ident = adk.set_identity(tenant_id="tenant-Z", tenant_name="Contoso")
+    ident = adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab", tenant_name="Contoso")
     assert ident["tenant_name"] == "Contoso"
     # Flows into every event's common dimensions (OII; privacy-approved).
     dims = adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")
@@ -124,29 +126,29 @@ def test_set_identity_stores_tenant_name(monkeypatch):
     # Once resolved, the name is cached per-tenant and reused by later ADK
     # events that lack a Graph token to resolve it live (persist-and-reuse),
     # even when set_identity is later called for the same tenant without it.
-    adk.set_identity(tenant_id="tenant-Z")
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab")
     assert adk.common_dimensions(adk.SURFACE_CLI)["tenant_name"] == "Contoso"
 
 
 def test_tenant_name_empty_when_never_resolved(monkeypatch):
     # No Graph-capable flow ever resolved a name for this tenant -> stays "".
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    adk.set_identity(tenant_id="tenant-Z")
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab")
     assert adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")["tenant_name"] == ""
 
 
 def test_tenant_name_cache_not_reused_across_tenants(monkeypatch):
-    # A name cached for tenant-Z must never be stamped on a different tenant's
+    # A name cached for 00000000-0000-0000-0000-0000000000ab must never be stamped on a different tenant's
     # events (the cache is keyed by tenant_id). Simulates a maker who resolved
-    # tenant-Z via FlightCheck, then runs an ADK flow authenticated as tenant-Y.
+    # 00000000-0000-0000-0000-0000000000ab via FlightCheck, then runs an ADK flow authenticated as 00000000-0000-0000-0000-0000000000cd.
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    adk.set_identity(tenant_id="tenant-Z", tenant_name="Contoso")  # seeds cache
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab", tenant_name="Contoso")  # seeds cache
     monkeypatch.setattr(
         adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
     )
-    adk.set_identity(tenant_id="tenant-Y")  # different tenant, no name available
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000cd")  # different tenant, no name available
     dims = adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")
-    assert dims["tenant_id"] == "tenant-Y"
+    assert dims["tenant_id"] == "00000000-0000-0000-0000-0000000000cd"
     assert dims["tenant_name"] == ""
 
 
@@ -155,12 +157,12 @@ def test_tenant_name_reused_by_later_process_without_identity(monkeypatch):
     # set_identity should still pick up a name a prior FlightCheck run cached
     # for the same tenant, via the common_dimensions fallback.
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    adk.set_identity(tenant_id="tenant-Z", tenant_name="Contoso")  # FlightCheck run
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab", tenant_name="Contoso")  # FlightCheck run
     # Later process: fresh identity, no set_identity call, but tenant_id known.
     monkeypatch.setattr(
         adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
     )
-    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="tenant-Z")
+    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="00000000-0000-0000-0000-0000000000ab")
     assert dims["tenant_name"] == "Contoso"
 
 
@@ -173,7 +175,7 @@ def test_tenant_id_reused_by_fresh_subprocess_without_identity(monkeypatch):
     # dashboard even though the maker's earlier auth flow knew the tenant.
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
     # Auth flow (parent process) persists tenant_id.
-    adk.set_identity(tenant_id="tenant-Z")
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab")
     # Subprocess simulation: brand-new interpreter -> empty _IDENTITY, no
     # set_identity call.
     monkeypatch.setattr(
@@ -182,7 +184,7 @@ def test_tenant_id_reused_by_fresh_subprocess_without_identity(monkeypatch):
     dims = adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")
     # The persisted GUID is picked up and the event classifies as customer,
     # not unknown.
-    assert dims["tenant_id"] == "tenant-Z"
+    assert dims["tenant_id"] == "00000000-0000-0000-0000-0000000000ab"
     assert dims["tenant_class"] == _fc.TENANT_CLASS_CUSTOMER
 
 
@@ -191,12 +193,12 @@ def test_tenant_id_explicit_kwarg_wins_over_cached(monkeypatch):
     # different tenant_id sits in the on-disk cache (e.g. subprocess is
     # emitting on behalf of a specific tenant that isn't the last-cached one).
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    adk.set_identity(tenant_id="tenant-Z")  # writes tenant-Z to disk
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab")  # writes 00000000-0000-0000-0000-0000000000ab to disk
     monkeypatch.setattr(
         adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
     )
-    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="tenant-Y")
-    assert dims["tenant_id"] == "tenant-Y"
+    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="00000000-0000-0000-0000-0000000000cd")
+    assert dims["tenant_id"] == "00000000-0000-0000-0000-0000000000cd"
 
 
 def test_tenant_id_explicit_empty_kwarg_does_not_fall_back(monkeypatch):
@@ -204,7 +206,7 @@ def test_tenant_id_explicit_empty_kwarg_does_not_fall_back(monkeypatch):
     # must NOT be overridden by the disk cache — that would leak a stale
     # tenant_id onto an event the caller deliberately marked anonymous.
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    adk.set_identity(tenant_id="tenant-Z")
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab")
     monkeypatch.setattr(
         adk, "_IDENTITY", {"instance_id": "", "tenant_id": "", "tenant_name": ""}
     )
@@ -214,36 +216,36 @@ def test_tenant_id_explicit_empty_kwarg_does_not_fall_back(monkeypatch):
 
 def test_cache_tenant_id_round_trip_and_guards(tmp_path):
     d = str(tmp_path / "state")
-    _fc.cache_tenant_id("tenant-Z", local_dir=d)
-    assert _fc.get_cached_tenant_id(local_dir=d) == "tenant-Z"
+    _fc.cache_tenant_id("00000000-0000-0000-0000-0000000000ab", local_dir=d)
+    assert _fc.get_cached_tenant_id(local_dir=d) == "00000000-0000-0000-0000-0000000000ab"
     # Missing dir/file -> "".
     assert _fc.get_cached_tenant_id(local_dir=str(tmp_path / "nope")) == ""
     # Empty tenant_id is a no-op (never overwrite a valid cache with "").
     _fc.cache_tenant_id("", local_dir=d)
-    assert _fc.get_cached_tenant_id(local_dir=d) == "tenant-Z"
+    assert _fc.get_cached_tenant_id(local_dir=d) == "00000000-0000-0000-0000-0000000000ab"
     # Whitespace is stripped on write.
-    _fc.cache_tenant_id("  tenant-Y  ", local_dir=d)
-    assert _fc.get_cached_tenant_id(local_dir=d) == "tenant-Y"
+    _fc.cache_tenant_id("  00000000-0000-0000-0000-0000000000cd  ", local_dir=d)
+    assert _fc.get_cached_tenant_id(local_dir=d) == "00000000-0000-0000-0000-0000000000cd"
 
 
 def test_cache_tenant_name_round_trip_and_guards(tmp_path):
     d = str(tmp_path / "state")
     # Round-trip for a matching tenant.
-    _fc.cache_tenant_name("tenant-Z", "Contoso", local_dir=d)
-    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=d) == "Contoso"
+    _fc.cache_tenant_name("00000000-0000-0000-0000-0000000000ab", "Contoso", local_dir=d)
+    assert _fc.get_cached_tenant_name("00000000-0000-0000-0000-0000000000ab", local_dir=d) == "Contoso"
     # Mismatched tenant never inherits the cached name.
-    assert _fc.get_cached_tenant_name("tenant-Y", local_dir=d) == ""
+    assert _fc.get_cached_tenant_name("00000000-0000-0000-0000-0000000000cd", local_dir=d) == ""
     # Missing dir/file -> "".
-    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=str(tmp_path / "nope")) == ""
+    assert _fc.get_cached_tenant_name("00000000-0000-0000-0000-0000000000ab", local_dir=str(tmp_path / "nope")) == ""
     # Malformed / non-dict cache content -> "" (defensive; never raises).
     import os as _os
     _os.makedirs(str(tmp_path / "bad"), exist_ok=True)
     with open(str(tmp_path / "bad" / _fc._TENANT_NAME_FILE), "w", encoding="utf-8") as _f:
         _f.write("not-json{{")
-    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=str(tmp_path / "bad")) == ""
+    assert _fc.get_cached_tenant_name("00000000-0000-0000-0000-0000000000ab", local_dir=str(tmp_path / "bad")) == ""
     with open(str(tmp_path / "bad" / _fc._TENANT_NAME_FILE), "w", encoding="utf-8") as _f:
         _f.write("[1, 2, 3]")
-    assert _fc.get_cached_tenant_name("tenant-Z", local_dir=str(tmp_path / "bad")) == ""
+    assert _fc.get_cached_tenant_name("00000000-0000-0000-0000-0000000000ab", local_dir=str(tmp_path / "bad")) == ""
     # Empty inputs are no-ops (nothing cached, nothing returned).
     _fc.cache_tenant_name("", "Contoso", local_dir=d)
     _fc.cache_tenant_name("tenant-W", "", local_dir=d)
@@ -253,18 +255,18 @@ def test_cache_tenant_name_round_trip_and_guards(tmp_path):
 
 def test_explicit_instance_id_overrides_persisted(monkeypatch):
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    ident = adk.set_identity(tenant_id="tenant-Z", instance_id="explicit-2")
+    ident = adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab", instance_id="explicit-2")
     assert ident["instance_id"] == "explicit-2"
 
 
 def test_identity_flows_into_dimensions(monkeypatch):
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
-    adk.set_identity(tenant_id="tenant-Z", instance_id="inst-9")
+    adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab", instance_id="inst-9")
     dims = adk.common_dimensions(adk.SURFACE_CLI, session_id="sid-1")
     assert "developer_id" not in dims
     assert dims["instance_id"] == "inst-9"
     # tenant_id is emitted RAW (approved Data Profile: OII, no transformation).
-    assert dims["tenant_id"] == "tenant-Z"
+    assert dims["tenant_id"] == "00000000-0000-0000-0000-0000000000ab"
 
 
 # --- tenant_class (internal vs customer; ADO 7558661) ---------------------
@@ -663,3 +665,96 @@ def test_classify_deploy_target_unknown_or_empty_defaults_to_production():
 def test_classify_deploy_target_is_case_and_whitespace_insensitive():
     assert adk.classify_deploy_target("  sAnDbOx  ") == "sandbox"
     assert adk.classify_deploy_target(" PRODUCTION ") == "production"
+
+
+# --- subprocess-spawn regression (SKILL.md shim path) ---------------------
+def test_emit_capability_shim_subprocess_stamps_cached_tenant_id(tmp_path):
+    """A *fresh* subprocess launched by SKILL.md must stamp tenant_id.
+
+    Reproduces the regression that motivated PR #237: SKILL.md invokes
+    ``python scripts/emit_capability.py <cap>`` from the maker's shell — a
+    brand-new interpreter that never calls ``set_identity`` yet must still
+    emit ``adk.capability.use`` events carrying the maker's tenant_id so
+    they land on the customer-filtered dashboard. The on-disk
+    ``.local/.tenant_id`` cache written by an earlier ``set_identity`` call
+    (in the parent auth flow) is the only bridge across the process
+    boundary. If we ever regress the ``common_dimensions`` fallback (e.g.
+    someone re-adds a "tenant_id is None -> return ''" short-circuit),
+    this test catches it end-to-end without any monkeypatching of the
+    telemetry module.
+
+    Transport is intentionally broken by pointing ``HTTPS_PROXY`` at a dead
+    localhost port so the POST fails and the event lands in the on-disk
+    ``telemetry-buffer.ndjson`` where we can inspect ``.data.tenant_id``.
+    Sync mode keeps the emit on the calling thread — no daemon-thread race.
+    """
+    import os as _os
+    import subprocess as _sp
+
+    scripts_dir = _os.path.abspath(
+        _os.path.join(
+            _os.path.dirname(__file__),
+            "..",
+            "solutions",
+            "ess-maker-skills",
+            "scripts",
+        )
+    )
+    shim = _os.path.join(scripts_dir, "emit_capability.py")
+    assert _os.path.exists(shim), shim
+
+    # Parent flow: seed the on-disk tenant_id cache with a canonical GUID.
+    local_dir = tmp_path / ".local"
+    local_dir.mkdir()
+    (local_dir / _fc._TENANT_ID_FILE).write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "tenant_id": "00000000-0000-0000-0000-0000000000ab",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {
+        **_os.environ,
+        "USERPROFILE": str(home),
+        "HOME": str(home),
+        # Force POST to fail so the event is buffered to disk (where we
+        # can read it back).
+        "HTTPS_PROXY": "http://127.0.0.1:1",
+        "HTTP_PROXY": "http://127.0.0.1:1",
+        "ESS_ADK_TELEMETRY": "on",
+        "ESS_ADK_TELEMETRY_SYNC": "1",
+        "ESS_ADK_ARIA_ENV": "dev",
+    }
+    # Some CI hosts inject a NO_PROXY that would exempt the OneCollector
+    # endpoint from the fake proxy — drop it so HTTPS_PROXY actually applies.
+    env.pop("NO_PROXY", None)
+    env.pop("no_proxy", None)
+
+    result = _sp.run(
+        [__import__("sys").executable, shim, "setup"],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+    buf_path = home / ".adk" / "telemetry-buffer.ndjson"
+    assert buf_path.exists(), (
+        f"expected {buf_path} to be created by the shim; stdout={result.stdout!r}"
+        f" stderr={result.stderr!r}"
+    )
+    lines = [
+        line for line in buf_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+    assert lines, "buffer file is empty"
+    ev = json.loads(lines[-1])
+    data = ev.get("data", {})
+    assert data.get("tenant_id") == "00000000-0000-0000-0000-0000000000ab", data
+    assert data.get("adk_capability") == "setup", data

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -296,6 +296,39 @@ def test_classify_tenant_env_allowlist_extends(monkeypatch):
     assert _fc.classify_tenant("11111111-1111-1111-1111-111111111111") == "customer"
 
 
+def test_get_cached_tenant_id_rejects_non_guid_legacy_string(tmp_path):
+    # The legacy raw-string compatibility shim in get_cached_tenant_id must
+    # validate against _GUID_RE before returning — otherwise a torn /
+    # hand-edited / garbage .tenant_id file would ride onto real events.
+    d = tmp_path / "state"
+    d.mkdir()
+    (d / _fc._TENANT_ID_FILE).write_text("tenant-id", encoding="utf-8")
+    assert _fc.get_cached_tenant_id(local_dir=str(d)) == ""
+    # A canonical raw-string GUID (older ADK builds) is still honored.
+    (d / _fc._TENANT_ID_FILE).write_text(
+        "ABCDEF01-2345-6789-abcd-ef0123456789", encoding="utf-8"
+    )
+    assert (
+        _fc.get_cached_tenant_id(local_dir=str(d))
+        == "abcdef01-2345-6789-abcd-ef0123456789"
+    )
+
+
+def test_common_dimensions_sanitizes_explicit_tenant_id_kwarg(monkeypatch):
+    # Single choke point: EVERY tenant_id source (explicit kwarg included)
+    # is sanitized in common_dimensions, so an emit_* helper that forwards
+    # a caller-supplied non-GUID never lands in the customer bucket.
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+    dims = adk.common_dimensions(adk.SURFACE_CLI, tenant_id="tenant-id")
+    assert dims["tenant_id"] == ""
+    assert dims["tenant_class"] == _fc.TENANT_CLASS_UNKNOWN
+    # A well-formed GUID is preserved (and lowercased).
+    dims = adk.common_dimensions(
+        adk.SURFACE_CLI, tenant_id="ABCDEF01-2345-6789-abcd-ef0123456789"
+    )
+    assert dims["tenant_id"] == "abcdef01-2345-6789-abcd-ef0123456789"
+
+
 def test_tenant_class_flows_into_dimensions(monkeypatch):
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
     adk.set_identity(tenant_id=_fc.MICROSOFT_CORP_TENANT_ID, instance_id="inst-9")


### PR DESCRIPTION
## Problem

Prod ADK telemetry emits **blank tenant identity** on the majority of non-`adk.api.call` events, breaking dashboards in two distinct ways:

**Blank `tenant_name`** (roughly 74-80% of `adk_session_start`, `adk_capability_use`, `adk_build_*`, `adk_agent_deploy` over P30D). FlightCheck too: `essmakerkit_flightcheck_run` shows **483** blank / **197** named. Per-tenant trend lines and filters degrade because the label falls back to the raw Entra GUID or is empty.

Data support (prod, sample tenant `935884d7-...`, P30D):

| hasNamedSession | ranFlightCheck | instances |
|---|---|---|
| 0 | 0 | 18 |
| 0 | 1 | 11 |
| 1 | 1 |  9 |

**Blank `tenant_id`** on capability events emitted from SKILL.md-driven skills. The External *Capability Usage by Type* chart (filter: `tenant_class == "customer"`) shows only `setup`, `backup_template_configs`, `restore_template_configs` — implying no customer ever runs anything else. In reality every capability lands, but under `tenant_class = "unknown"` because the shim runs in a fresh Python subprocess with no identity.

Prod P30D `adk_capability_use` by `(adk_capability, tenant_class)`:

| capability | customer | unknown |
|---|---:|---:|
| setup | 86 (10 tenants) | 113 |
| backup_template_configs | 46 (1) | 134 |
| restore_template_configs | 42 (1) | 134 |
| connect | 0 | 71 |
| topic_update | 0 | 28 |
| topic_create | 0 | 7 |
| workflow_update | 0 | 6 |
| evaluations | 0 | 4 |
| troubleshoot | 0 | 4 |
| topic_delete | 0 | 1 |
| (raw "unknown") | 0 | 106 |

This PR fixes both classes across all four affected code paths.

## Fixes

### 1. `auth.py` bootstrap order

`adk_telemetry.start_session` fired *before* silent Graph resolution, so the first `adk.session.start` on a fresh install always went out with blank `tenant_name` — even when silent resolution *would* have succeeded on that same call. Reordered:

```
resolve_tenant_display_name_silent -> set_identity(tenant_name=...) -> start_session
```

Regression test in `tests/scripts/test_auth.py` pins the ordering (and asserts we still emit `start_session` when silent resolution returns blank).

### 2. Silent Graph scope fallback in `resolve_tenant_display_name_silent`

The resolver requested `Organization.Read.All` only. That scope requires **admin consent**, which the majority of enterprise tenants have not pre-granted, so the FOCI shared refresh token from the Dataverse interactive sign-in cannot silently redeem it — the resolver returns `""` even though the user is fully signed in.

Added a fallback path: on empty result, retry silently with `User.Read` and fetch `/me?$select=companyName`. `User.Read` is user-consent-only and is a *default static permission* granted at first-party sign-in, so the same shared RT typically redeems it silently. Admins routinely set the signed-in user's `companyName` attribute to the tenant display name, so this recovers a useful label for many customers that would otherwise report blank. Same OII classification we already have for `tenant_name`.

### 3. FlightCheck `cli.py` cache fallback

Both `cli.py` emit sites (`--scope` and single-`--checkpoint`) resolved `tenant_name` only via a live Graph `/organization` call and left it as `""` whenever `graph` was `None` (infra-only scope, or Graph auth failed) or the live lookup raised. The `.local/.tenant_name` cache that `adk_telemetry` already uses was never consulted.

- If the live Graph lookup returned a name, proactively `cache_tenant_name(...)` (mirroring what `adk_telemetry.set_identity` already does) so subsequent Graph-less runs on this install keep the label.
- If the live lookup returned `""` and we have a `tenant_id`, fall back to `telemetry.get_cached_tenant_name(tenant_id)`. The helper already enforces a same-tenant guard so a stale name is never leaked onto a different tenant.

Best-effort, never blocks the run.

### 4. `tenant_id` persistence for fresh-subprocess emits

SKILL.md-driven skills (topic/workflow authoring, connect, cleanup, troubleshoot, evaluations) record capability usage by invoking `python scripts/emit_capability.py <cap>` as a fresh Python subprocess. That subprocess never calls `set_identity`, so its in-memory `_IDENTITY["tenant_id"]` is empty; `classify_tenant("")` returns `"unknown"`; the event never appears on the External dashboard. (The huge `unknown` bucket alongside the `customer` counts for `setup` / backup / restore in the table above has the same root cause on some code paths.)

Mirror the `.instance_id` persistence pattern for `tenant_id`:
- `flightcheck.telemetry.cache_tenant_id` / `get_cached_tenant_id` write/read `.local/.tenant_id` (best-effort, IO-swallowing).
- `adk_telemetry.set_identity` unconditionally caches the raw GUID (independent of `tenant_name`, which may not resolve when Graph is unavailable — otherwise this fallback would only work for tenants that already had a Graph-resolved name).
- `adk_telemetry.common_dimensions` falls back to the disk cache **only** when the caller passed no explicit `tenant_id` AND the in-memory identity is empty. An explicit empty kwarg still honors the caller's intent (anonymous emits stay anonymous); an explicit non-empty kwarg still wins over the cache (multi-tenant safety).

## Non-goals / follow-ups

- **Retention rolls off in <= 30 days** — forward-only fix. Existing blank rows are not backfilled.
- Not touching the interactive sign-in scope in `auth.py` — adding `extra_scopes_to_consent=["Organization.Read.All"]` risks breaking auth in tenants where admin consent for that scope is *required*, and the `/me` fallback covers most of the same ground silently.
- No Graph-consent-repair prompt — keeps telemetry fully passive so it never nags a maker.
- FlightCheck telemetry is not affected by the fix-4 gap specifically (single-process flow keeps a populated `_IDENTITY` for the whole run) but harmlessly benefits from the fallback if any future refactor ever re-enters FC emit standalone.

## Tests

```
pytest tests/flightcheck/test_telemetry.py tests/flightcheck/test_graph_client.py \
       tests/scripts/test_auth.py tests/flightcheck/test_cli.py \
       tests/flightcheck/test_cli_consent.py tests/flightcheck/test_cli_single_checkpoint.py \
       tests/test_adk_telemetry.py
```

New tests cover:
- **Fix 1**: auth bootstrap ordering + silent-blank degradation.
- **Fix 2**: `/me` fallback success + missing companyName + both-scopes-fail.
- **Fix 3**: FlightCheck cache-fallback-when-Graph-unavailable.
- **Fix 4**: subprocess scenario resolves to `tenant_class = "customer"`; explicit tenant_id kwarg wins over cache; explicit empty kwarg does NOT fall back (anonymous emits stay anonymous); `cache_tenant_id` round-trip + empty-input no-op + whitespace strip.

## Supersedes

Closes #235 and #236 — combined into one review.
