### PR TITLE
telemetry: classify EmployeeHub dogfood tenant as internal

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -111,11 +111,19 @@ _POST_TIMEOUT = (3.05, 5)
 # Aria cube, because 1DS RTA cubes map an event property straight to a
 # dimension and cannot derive one dimension's value from another.
 #
-# Seeded with the Microsoft corporate Entra tenant only. Additional internal /
-# dogfood tenants can be added WITHOUT a code change via the
-# ``ESS_ADK_INTERNAL_TENANTS`` env var (comma-separated GUIDs) — preferred over
-# growing a hard-coded list.
+# Seeded with the two permanent internal Microsoft tenants we know about:
+#   - Microsoft corporate Entra tenant (72f988bf...)
+#   - EmployeeHub dogfood tenant (935884d7...) -- the primary ESS-team internal
+#     dogfooding tenancy. Its events were previously classified as ``customer``
+#     and leaked to the External dashboard whenever a chart-level ``tenant_id
+#     notIn`` filter was missing; hardcoding here ensures every event is
+#     classified as internal at emit time regardless of dashboard config.
+# Additional internal / dogfood tenants can still be added WITHOUT a code
+# change via the ``ESS_ADK_INTERNAL_TENANTS`` env var (comma-separated GUIDs)
+# -- preferred over growing this hard-coded list for one-off / short-lived
+# dogfood tenancies.
 MICROSOFT_CORP_TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47"
+EMPLOYEEHUB_TENANT_ID = "935884d7-bdee-469b-a461-fcc530a3ac83"
 
 TENANT_CLASS_INTERNAL = "internal"
 TENANT_CLASS_CUSTOMER = "customer"
@@ -137,7 +145,7 @@ def _internal_tenant_ids() -> frozenset[str]:
 @lru_cache(maxsize=8)
 def _parse_internal_tenant_ids(extra: str) -> frozenset[str]:
     """Parse the comma-separated allow-list, cached per distinct env value."""
-    ids = {MICROSOFT_CORP_TENANT_ID}
+    ids = {MICROSOFT_CORP_TENANT_ID, EMPLOYEEHUB_TENANT_ID}
     ids.update(t.strip().lower() for t in extra.split(",") if t.strip())
     return frozenset(ids)
 

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -203,6 +203,19 @@ def test_classify_tenant_microsoft_corp_is_internal():
     assert _fc.classify_tenant(f"  {_fc.MICROSOFT_CORP_TENANT_ID.upper()} ") == "internal"
 
 
+def test_classify_tenant_employeehub_is_internal():
+    """EmployeeHub is the primary ESS-team dogfood tenant. Its events must
+    classify as ``internal`` at emit time without any env-var setup so they
+    never leak to the External dashboard even if a chart-level ``tenant_id
+    notIn`` filter is missing or misconfigured. Regression pin -- see prior
+    dashboard leak where EmployeeHub session_start events shipped with
+    ``tenant_class = "customer"``.
+    """
+    assert _fc.classify_tenant(_fc.EMPLOYEEHUB_TENANT_ID) == "internal"
+    # case / whitespace insensitive, matching the corp-tenant contract
+    assert _fc.classify_tenant(f"  {_fc.EMPLOYEEHUB_TENANT_ID.upper()} ") == "internal"
+
+
 def test_classify_tenant_other_tenant_is_customer():
     assert _fc.classify_tenant("11111111-1111-1111-1111-111111111111") == "customer"
 


### PR DESCRIPTION
## Problem

EmployeeHub (`935884d7-bdee-469b-a461-fcc530a3ac83`) is the primary ESS-team internal dogfood tenant, but its events are being classified as `tenant_class = customer` at emit time. That leaks EmployeeHub dogfood traffic into the External dashboard whenever a chart-level `tenant_id notIn ["935884d7-..."]` filter is missing or misconfigured.

Kusto Explorer confirms this is a live problem, not a theoretical one:

```
adk_session_start
| where EventInfo_Time > ago(2d) and tenant_class == "customer" and tenant_id == "935884d7-..."
| summarize count()
```
returns **35** — 35 EmployeeHub session_starts in the last 2 days that shipped as customer-class.

## Design context

Per the prior design (session `70ddf006`, ADO 7558661) the classifier was intentionally kept minimal: only Microsoft Corp hardcoded, dogfood tenants expected to be added via `ESS_ADK_INTERNAL_TENANTS` env var. That mechanism was never operationalized on EmployeeHub installs, so we've been relying on dashboard-level filters as the only backstop.

## Fix

Add `EMPLOYEEHUB_TENANT_ID = "935884d7-bdee-469b-a461-fcc530a3ac83"` to the hardcoded internal set in `flightcheck/telemetry.py`. Every EmployeeHub event now classifies as `internal` at emit time regardless of what env var is (or isn't) set on the install, and regardless of what dashboard filters are (or aren't) applied to each chart.

The `ESS_ADK_INTERNAL_TENANTS` env var is preserved for short-lived / one-off dogfood tenancies where a code change would be overkill.

## Impact

- **New emits**: EmployeeHub events ship as `tenant_class = internal` and are automatically excluded from External dashboard tabs (which filter `tenant_class = customer`).
- **Existing events**: not backfilled -- Aria retention is <=30 days, so historical EmployeeHub `customer`-class events will age out.
- **Dashboard-level `notIn` filter**: safe to leave in place as a redundant guard for the retention window, but no longer required.

## Tests

```
pytest tests/test_adk_telemetry.py tests/flightcheck/test_telemetry.py
65 passed in 1.46s
```

New test `test_classify_tenant_employeehub_is_internal` pins the classification (case/whitespace-insensitive, matching the corp-tenant contract).
