### PR TITLE
adk-telemetry: address PR #237 re-review nits (#5 + #6 + timeout comment)

### DIFF
--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -259,7 +259,10 @@ def set_identity(
     silently normalized to ``""`` (see ``_sanitize_tenant_id``).
     """
     if instance_id is not None:
-        _IDENTITY["instance_id"] = instance_id or _fc.get_instance_id()
+        # Explicit "" clears (matches docstring); auto-fetch only happens
+        # via the default-None path so an intentional clear isn't silently
+        # re-populated.
+        _IDENTITY["instance_id"] = instance_id
     elif not _IDENTITY["instance_id"]:
         _IDENTITY["instance_id"] = _fc.get_instance_id()
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/cli.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/cli.py
@@ -867,25 +867,22 @@ def _run_single_checkpoint(args):
         )
         # Best-effort tenant display name (OII; privacy-approved). Reuses the
         # already-authenticated Graph client when one was needed; never re-auths.
-        # Falls back to the persisted ``.local/.tenant_name`` cache when the
-        # live lookup is unavailable (e.g. infra-only scope where ``graph`` is
-        # None, or Graph auth failed for lack of ``Organization.Read.All``
-        # consent) so previously-resolved tenants keep their name on the event
-        # instead of emitting blank. Same-tenant guard is enforced inside the
-        # cache helper.
-        tenant_name = ""
-        try:
-            if graph is not None:
-                tenant_name = (graph.get_organization() or {}).get("displayName", "") or ""
-        except Exception:  # noqa: BLE001 — telemetry name is best-effort
-            tenant_name = ""
+        # Delegates to ``telemetry.resolve_tenant_name`` (live-then-cache
+        # fallback) so this block stays in one place. Live path degrades to
+        # cache on missing scope, missing graph, or Graph error; blank on
+        # every-source failure. Same-tenant guard enforced inside cache
+        # helpers.
         try:
             from flightcheck import telemetry
 
-            if not tenant_name and (tenant_id or ""):
-                tenant_name = telemetry.get_cached_tenant_name(tenant_id or "")
-            elif tenant_name and (tenant_id or ""):
-                telemetry.cache_tenant_name(tenant_id or "", tenant_name)
+            tenant_name = telemetry.resolve_tenant_name(
+                tenant_id or "",
+                live_resolver=(
+                    (lambda: (graph.get_organization() or {}).get("displayName", "") or "")
+                    if graph is not None
+                    else None
+                ),
+            )
 
             _tele = telemetry.emit_flightcheck_telemetry(
                 result,
@@ -1342,24 +1339,20 @@ def main():
         )
         # Best-effort tenant display name (OII; privacy-approved). Reuses the
         # already-authenticated Graph client's /organization record — no extra
-        # auth. Falls back to the persisted ``.local/.tenant_name`` cache when
-        # ``graph`` is None or the live lookup fails (e.g. Graph auth was
-        # skipped or ``Organization.Read.All`` isn't consented on this tenant)
-        # so previously-resolved tenants keep their name instead of blank.
-        # Never blocks the run.
-        tenant_name = ""
-        try:
-            if graph is not None:
-                tenant_name = (graph.get_organization() or {}).get("displayName", "") or ""
-        except Exception:  # noqa: BLE001 — telemetry name is best-effort
-            tenant_name = ""
+        # auth. Delegates to ``telemetry.resolve_tenant_name`` (live-then-cache
+        # fallback) so this block stays in one place. Same-tenant guard
+        # enforced inside cache helpers. Never blocks the run.
         try:
             from flightcheck import telemetry
 
-            if not tenant_name and tenant_id:
-                tenant_name = telemetry.get_cached_tenant_name(tenant_id)
-            elif tenant_name and tenant_id:
-                telemetry.cache_tenant_name(tenant_id, tenant_name)
+            tenant_name = telemetry.resolve_tenant_name(
+                tenant_id,
+                live_resolver=(
+                    (lambda: (graph.get_organization() or {}).get("displayName", "") or "")
+                    if graph is not None
+                    else None
+                ),
+            )
 
             _tele = telemetry.emit_flightcheck_telemetry(
                 result,

--- a/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/graph_client.py
@@ -62,8 +62,11 @@ GRAPH_SCOPES = [
 # best-effort telemetry-only label. ``tenant_class`` is driven by the ``tid``
 # claim already extracted from the token, so a timeout here only degrades
 # ``tenant_name`` to blank (recoverable on the next FlightCheck run), never
-# to a misclassification. Total worst case per authenticate() is
-# 2 × _SILENT_LOOKUP_TIMEOUT.
+# to a misclassification. ``requests`` applies this value separately to the
+# connect and read phases, so a pathological connect-then-read stall can
+# take up to ~2× this per call; the typical case (fast fail on either phase)
+# stays well under it. Total wall-clock ceiling per authenticate() therefore
+# sits between 2 × and 4 × _SILENT_LOOKUP_TIMEOUT in the worst case.
 _SILENT_LOOKUP_TIMEOUT = 3.0
 
 # Module-level requests Session with bounded retry-with-backoff for 429/5xx.

--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -463,6 +463,48 @@ def get_cached_tenant_name(tenant_id: str, local_dir: str = ".local") -> str:
     return name if isinstance(name, str) else ""
 
 
+def resolve_tenant_name(
+    tenant_id: str,
+    live_resolver: Any = None,
+    local_dir: str = ".local",
+) -> str:
+    """Return the best-available tenant display name for ``tenant_id``.
+
+    Tries ``live_resolver()`` first when supplied (any zero-arg callable
+    returning a display name string or ``""``); on empty/error it falls back
+    to the persisted ``.local/.tenant_name`` cache. A non-empty live result
+    is written to the cache so a subsequent process that can't talk to Graph
+    (e.g. the ``emit_capability.py`` shim launched from a SKILL.md step)
+    still stamps the tenant name on its events. Never raises.
+
+    Consolidates the live-then-cache fallback logic previously duplicated at
+    the two ``emit_flightcheck_telemetry`` call sites in ``flightcheck/cli.py``.
+    """
+    tid = tenant_id or ""
+    if not tid:
+        # No tenant to attach a name to: mirror ``get_cached_tenant_name``'s
+        # blank-on-blank contract so callers get a consistent story.
+        return ""
+    live = ""
+    if live_resolver is not None:
+        try:
+            live = live_resolver() or ""
+        except Exception:  # noqa: BLE001 - telemetry name is best-effort
+            live = ""
+        if not isinstance(live, str):
+            live = ""
+    if live:
+        try:
+            cache_tenant_name(tid, live, local_dir=local_dir)
+        except Exception:  # noqa: BLE001 - caching is best-effort
+            pass
+        return live
+    try:
+        return get_cached_tenant_name(tid, local_dir=local_dir) or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def get_adk_version() -> str:
     """Best-effort ADK version string (System Metadata).
 

--- a/tests/flightcheck/test_telemetry.py
+++ b/tests/flightcheck/test_telemetry.py
@@ -331,3 +331,46 @@ def test_emit_noop_when_disabled(monkeypatch, tmp_path):
     assert out["sent"] is False
     assert out["reason"] == "disabled"
     assert called["n"] == 0
+
+
+def test_resolve_tenant_name_uses_live_and_caches(tmp_path, monkeypatch):
+    """Live resolver returns a name -> we get it back and it's cached to disk."""
+    monkeypatch.chdir(tmp_path)
+    tid = "11111111-1111-1111-1111-111111111111"
+    got = telemetry.resolve_tenant_name(tid, live_resolver=lambda: "Contoso Ltd")
+    assert got == "Contoso Ltd"
+    # Written to cache so a later process without Graph still gets the name.
+    assert telemetry.get_cached_tenant_name(tid) == "Contoso Ltd"
+
+
+def test_resolve_tenant_name_falls_back_to_cache(tmp_path, monkeypatch):
+    """Live resolver blank -> cache is consulted."""
+    monkeypatch.chdir(tmp_path)
+    tid = "22222222-2222-2222-2222-222222222222"
+    telemetry.cache_tenant_name(tid, "Fabrikam Inc")
+    got = telemetry.resolve_tenant_name(tid, live_resolver=lambda: "")
+    assert got == "Fabrikam Inc"
+
+
+def test_resolve_tenant_name_swallows_live_errors(tmp_path, monkeypatch):
+    """Live resolver raising must not break the caller; cache still consulted."""
+    monkeypatch.chdir(tmp_path)
+    tid = "33333333-3333-3333-3333-333333333333"
+    telemetry.cache_tenant_name(tid, "Northwind Traders")
+
+    def boom():
+        raise RuntimeError("graph exploded")
+
+    got = telemetry.resolve_tenant_name(tid, live_resolver=boom)
+    assert got == "Northwind Traders"
+
+
+def test_resolve_tenant_name_no_tenant_id_returns_blank(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert telemetry.resolve_tenant_name("", live_resolver=lambda: "Ignored") == ""
+
+
+def test_resolve_tenant_name_no_resolver_and_no_cache(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    tid = "44444444-4444-4444-4444-444444444444"
+    assert telemetry.resolve_tenant_name(tid) == ""

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -116,6 +116,22 @@ def test_set_identity_stores_instance_and_raw_tenant(monkeypatch):
     assert ident["tenant_id"] == "00000000-0000-0000-0000-0000000000ab"
 
 
+def test_set_identity_explicit_empty_instance_id_clears(monkeypatch, tmp_path):
+    """Passing ``instance_id=""`` must clear (not silently re-populate).
+
+    The docstring guarantees an explicit ``""`` clears any field. A prior
+    version wrote ``instance_id or get_instance_id()``, which turned the
+    explicit-clear intent into an auto-fetch — regression covered here.
+    """
+    monkeypatch.chdir(tmp_path)  # isolate any .local/ writes
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-should-not-fire")
+    monkeypatch.setattr(
+        adk, "_IDENTITY", {"instance_id": "prev-guid", "tenant_id": "", "tenant_name": ""}
+    )
+    ident = adk.set_identity(instance_id="")
+    assert ident["instance_id"] == ""
+
+
 def test_set_identity_stores_tenant_name(monkeypatch):
     monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
     ident = adk.set_identity(tenant_id="00000000-0000-0000-0000-0000000000ab", tenant_name="Contoso")


### PR DESCRIPTION
Follow-up to PR #237 (merged) — addresses three optional items from `@daeunJe0ng`'s re-review of round-2 commit `0a01196`:

**Nit #5: Duplicated cache-fallback block in `flightcheck/cli.py`**
Extracted the "live Graph lookup → cache fallback → cache write-through" logic used at both `_run_single_checkpoint` and `main` emit sites into a new `flightcheck.telemetry.resolve_tenant_name(tenant_id, live_resolver=)` helper. Future policy changes now live in one place.

**Nit #6: Explicit `instance_id=""` silently re-populated**
`set_identity` used `instance_id or _fc.get_instance_id()` when `instance_id` was explicitly provided — turning intentional clears into auto-fetches, contradicting the docstring's "Passing '' for any field explicitly clears it" contract. Explicit `""` now clears; auto-fetch only runs through the default-`None` branch.

**Timeout-comment precision (non-blocking flag)**
`requests` applies `timeout` separately to the connect and read phases, so a pathological connect-then-read stall can take up to ~2× `_SILENT_LOOKUP_TIMEOUT` per lookup. Updated the module comment so the stated ceiling isn't read as a hard total in the pathological case.

**Regression tests**
- `test_set_identity_explicit_empty_instance_id_clears`
- `test_resolve_tenant_name_uses_live_and_caches`
- `test_resolve_tenant_name_falls_back_to_cache`
- `test_resolve_tenant_name_swallows_live_errors`
- `test_resolve_tenant_name_no_tenant_id_returns_blank`
- `test_resolve_tenant_name_no_resolver_and_no_cache`

**Verification**
Touched-suite (`test_adk_telemetry.py`, `tests/flightcheck/test_telemetry.py`, `test_graph_client.py`, `test_cli.py`, `test_auth.py`): **135 passed**. Broader suite has the same 14 pre-existing failures (installer + foundation-checklist) unrelated to this change.

**Still open (not in scope for this PR)**
Question #2 from the re-review — privacy sign-off that `/me?$select=companyName` is OII (org attribute), not EUPI — is a data-profile-owner action tracked in the ADO story.

ADO: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7764297