### PR TITLE
docs: fix outdated privacy/telemetry claims in CONTRIBUTING + README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,27 +42,32 @@ This toolkit:
 - **Collects pseudonymous usage telemetry** (enabled by default) to help us understand which capabilities are used and where they fail, so we can improve the product. What is emitted is a random per-install `instance_id`, the tenant GUID and organization display name (OII, not developer identity), capability names (e.g. `setup`, `connect`, `topic_create`), FlightCheck run outcomes, latency, and scrubbed error codes. **No developer/user identifier, agent content, credentials, prompts, or personal data is collected.** A one-time notice is printed the first time you run a CLI command. See [Telemetry & Privacy](solutions/ess-maker-skills/README.md#telemetry--privacy) for the full data model and event catalog.
 - **Opt out any time** via either of:
   - `python scripts/adk_telemetry.py off` (from `solutions/ess-maker-skills`), or
-  - the `ESS_ADK_TELEMETRY=off` environment variable.
-- **Stores no customer data on Microsoft systems.** All data flows for authoring / testing (topic content, evaluation prompts, sample employee records) go between your local VS Code workspace and your own Power Platform / Copilot Studio tenant under your existing license terms.
-- **Processes no personal data on Microsoft's behalf.** The telemetry above is product-improvement usage data, not customer content — no customer data (Copilot Studio topics, workflow definitions, evaluation prompts, employee records) is ever transmitted to Microsoft by this toolkit.
+    - the `ESS_ADK_TELEMETRY` environment variable set to `off` (or `0` / `false`). Set it in your shell before running any ADK command — e.g. `export ESS_ADK_TELEMETRY=off` (bash/zsh), `$env:ESS_ADK_TELEMETRY = "off"` (PowerShell), or `set ESS_ADK_TELEMETRY=off` (cmd.exe). Adding it to your shell profile (`~/.bashrc`, `~/.zshrc`, PowerShell `$PROFILE`) or to your CI environment makes it persist. The env-var overrides the config-file setting.
+- **Stores no customer data on Microsoft systems by default.** Data flows for authoring and testing (topic content, sample employee records) go between your local VS Code workspace and your own Power Platform / Copilot Studio tenant under your existing license terms.
+- **Optional eval-quality judge sends eval content to GitHub Copilot.** If you run `scripts/evaluate_evals.py`, the evaluation YAML you're grading (test-case inputs and expected outputs) is sent to `api.githubcopilot.com` for LLM scoring under your GitHub Copilot license and its data-use terms. Do not run this script on evaluation sets you are not licensed to share with GitHub Copilot. Skipping the script skips this data flow entirely.
+- **Processes no personal data on Microsoft's behalf.** The telemetry above is product-improvement usage data, not customer content — no customer data (Copilot Studio topics, workflow definitions, employee records) is ever transmitted to Microsoft by this toolkit outside of what you explicitly push to your own tenant or send to the optional judge above.
 
 For privacy questions about Copilot Studio, Power Platform, or GitHub Copilot themselves, see the [Microsoft Privacy Statement](https://privacy.microsoft.com).
 
 ## Service dependencies
 
-The toolkit's scripts call the following Microsoft services on your behalf. Every call is either against your own tenant under your existing license, or against Microsoft's Aria/1DS collector for the pseudonymous telemetry described under [Privacy](#privacy) — no other data is sent to Microsoft.
+The toolkit's scripts call the following services on your behalf. With telemetry enabled and the optional eval judge skipped, every call is either against your own tenant under your existing license or against Microsoft's Aria/1DS collector for the pseudonymous telemetry described under [Privacy](#privacy). The optional `evaluate_evals.py` judge additionally sends eval YAML content to GitHub Copilot under your Copilot license.
 
 | Service | Purpose | Auth | Tenant |
 |---|---|---|---|
 | Power Platform / Dataverse Web API | Read agent components, push template config records | MSAL (delegated, your identity) | Your Power Platform environment |
 | Copilot Studio (via Dataverse) | Read/update topics, push changes | MSAL (delegated) | Your Copilot Studio environment |
-| Microsoft Graph (optional) | Resolve tenant display name for telemetry (`Organization.Read.All` silent → `/me?$select=companyName` fallback) | MSAL (delegated) | Your Entra tenant |
+| Power Platform API (`api.powerplatform.com`) | Read licensing/billing policies and PayG environment linkage during `/flightcheck` prerequisite checks | MSAL (delegated) | Your Power Platform tenant |
+| BAP / Power Apps / Power Automate APIs (`api.bap.microsoft.com`, `api.powerapps.com`, `api.flow.microsoft.com`) | Enumerate environments, inspect flow runs, and validate connector wiring during `/flightcheck` | MSAL (delegated) | Your Power Platform tenant |
+| Azure Resource Manager (`management.azure.com`) | Read subscription state and Consumption budgets for the PayG-linked subscription during `/flightcheck` PRE-005 | MSAL (delegated) | Your Azure subscription |
+| Microsoft Graph (optional) | Resolve tenant display name for telemetry. Tries `/organization` under `Organization.Read.All` (silent); falls back to `/me?$select=companyName`, which reads the **signed-in user's Entra profile attribute** (admin-populated in many enterprise tenants) — not tenant metadata. `""` on any failure. | MSAL (delegated) | Your Entra tenant |
+| GitHub Copilot API (`api.githubcopilot.com`, optional) | Eval-set quality judging via `scripts/evaluate_evals.py`. Sends the eval YAML being graded to the Copilot chat completions endpoint under your Copilot license. Not called by any other script. | `gh auth token` | GitHub Copilot service |
 | Aria / 1DS OneCollector | Pseudonymous usage telemetry (see [Privacy](#privacy); opt out with `python scripts/adk_telemetry.py off` or `ESS_ADK_TELEMETRY=off`) | Instrumentation key, no user auth | N/A — Microsoft telemetry service |
 | ServiceNow REST API (optional) | Topic integration testing | User-provided OAuth / basic | Your ServiceNow tenant |
 | Workday SOAP / REST API (optional) | Topic integration testing | User-provided | Your Workday tenant |
 | GitHub Copilot (in VS Code) | LLM that reads prompt and instruction files and generates content | GitHub Copilot license | N/A - GitHub Copilot service |
 
-The toolkit does not call any other Microsoft services.
+Aside from the services listed above, the toolkit does not call other Microsoft or third-party services on your behalf.
 
 ## Validating your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,20 +39,25 @@ then maintainers **must file a new release request** in the [Open Source Portal]
 
 This toolkit:
 
-- **Collects no telemetry.** Microsoft does not receive any data from your use of this kit. There is no telemetry SDK, no usage reporting, no crash reporting, and no opt-in/opt-out switch because there is nothing to switch off.
-- **Stores no data on Microsoft systems.** All data flows are between your local VS Code workspace and your own Power Platform / Copilot Studio tenant.
-- **Processes no personal data on Microsoft's behalf.** Any customer data you author or test against (topic content, evaluation prompts, sample employee records) stays in your tenant under your existing Copilot Studio / Power Platform license terms.
+- **Collects pseudonymous usage telemetry** (enabled by default) to help us understand which capabilities are used and where they fail, so we can improve the product. What is emitted is a random per-install `instance_id`, the tenant GUID and organization display name (OII, not developer identity), capability names (e.g. `setup`, `connect`, `topic_create`), FlightCheck run outcomes, latency, and scrubbed error codes. **No developer/user identifier, agent content, credentials, prompts, or personal data is collected.** A one-time notice is printed the first time you run a CLI command. See [Telemetry & Privacy](solutions/ess-maker-skills/README.md#telemetry--privacy) for the full data model and event catalog.
+- **Opt out any time** via either of:
+  - `python scripts/adk_telemetry.py off` (from `solutions/ess-maker-skills`), or
+  - the `ESS_ADK_TELEMETRY=off` environment variable.
+- **Stores no customer data on Microsoft systems.** All data flows for authoring / testing (topic content, evaluation prompts, sample employee records) go between your local VS Code workspace and your own Power Platform / Copilot Studio tenant under your existing license terms.
+- **Processes no personal data on Microsoft's behalf.** The telemetry above is product-improvement usage data, not customer content — no customer data (Copilot Studio topics, workflow definitions, evaluation prompts, employee records) is ever transmitted to Microsoft by this toolkit.
 
 For privacy questions about Copilot Studio, Power Platform, or GitHub Copilot themselves, see the [Microsoft Privacy Statement](https://privacy.microsoft.com).
 
 ## Service dependencies
 
-The toolkit's scripts call the following Microsoft services on your behalf. Every call goes from your machine to your own tenant under your existing license - no data is sent to Microsoft beyond standard authentication exchanges with the services listed below.
+The toolkit's scripts call the following Microsoft services on your behalf. Every call is either against your own tenant under your existing license, or against Microsoft's Aria/1DS collector for the pseudonymous telemetry described under [Privacy](#privacy) — no other data is sent to Microsoft.
 
 | Service | Purpose | Auth | Tenant |
 |---|---|---|---|
 | Power Platform / Dataverse Web API | Read agent components, push template config records | MSAL (delegated, your identity) | Your Power Platform environment |
 | Copilot Studio (via Dataverse) | Read/update topics, push changes | MSAL (delegated) | Your Copilot Studio environment |
+| Microsoft Graph (optional) | Resolve tenant display name for telemetry (`Organization.Read.All` silent → `/me?$select=companyName` fallback) | MSAL (delegated) | Your Entra tenant |
+| Aria / 1DS OneCollector | Pseudonymous usage telemetry (see [Privacy](#privacy); opt out with `python scripts/adk_telemetry.py off` or `ESS_ADK_TELEMETRY=off`) | Instrumentation key, no user auth | N/A — Microsoft telemetry service |
 | ServiceNow REST API (optional) | Topic integration testing | User-provided OAuth / basic | Your ServiceNow tenant |
 | Workday SOAP / REST API (optional) | Topic integration testing | User-provided | Your Workday tenant |
 | GitHub Copilot (in VS Code) | LLM that reads prompt and instruction files and generates content | GitHub Copilot license | N/A - GitHub Copilot service |

--- a/README.md
+++ b/README.md
@@ -103,9 +103,22 @@ SUPPORT.md              Support model
 
 The ESS Maker Skills CLI collects pseudonymous usage telemetry (enabled by
 default) to help improve the product. No developer identity, agent content, or
-personal data is collected. See
+personal data is collected.
+
+**To opt out**, run either of the following (both are persistent and take effect immediately):
+
+```bash
+# From the solutions/ess-maker-skills directory:
+python scripts/adk_telemetry.py off
+
+# Or set the environment variable (any shell / CI):
+ESS_ADK_TELEMETRY=off
+```
+
+Re-enable later with `python scripts/adk_telemetry.py on` or by unsetting the
+env var. See
 [Telemetry & Privacy](solutions/ess-maker-skills/README.md#telemetry--privacy)
-for what's collected and how to opt out.
+for the full data model and event catalog.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -108,12 +108,35 @@ personal data is collected.
 **To opt out**, run either of the following (both are persistent and take effect immediately):
 
 ```bash
-# From the solutions/ess-maker-skills directory:
+# 1. From the solutions/ess-maker-skills directory:
 python scripts/adk_telemetry.py off
 
-# Or set the environment variable (any shell / CI):
-ESS_ADK_TELEMETRY=off
+# 2. Or set the ESS_ADK_TELEMETRY environment variable to off (any shell / CI).
+#    Syntax varies by shell — set it before running any ADK command.
 ```
+
+Setting `ESS_ADK_TELEMETRY=off` inline before a command works in bash / zsh
+(`ESS_ADK_TELEMETRY=off python scripts/...`). To persist it, add it to your
+shell profile:
+
+```bash
+# bash / zsh (~/.bashrc, ~/.zshrc):
+export ESS_ADK_TELEMETRY=off
+```
+
+```powershell
+# PowerShell ($PROFILE) — persistent:
+$env:ESS_ADK_TELEMETRY = "off"
+# ...or for the current session only, run the same line at the prompt.
+```
+
+```cmd
+:: cmd.exe — current session only:
+set ESS_ADK_TELEMETRY=off
+:: For persistence use setx ESS_ADK_TELEMETRY off (takes effect in new shells).
+```
+
+The env var overrides the config-file setting.
 
 Re-enable later with `python scripts/adk_telemetry.py on` or by unsetting the
 env var. See

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -368,10 +368,17 @@ CLI command.
   active installs and DAU/WAU/MAU. It is **not** tied to your identity.
 - Your **tenant ID** (the Entra tenant GUID) — identifies the enterprise tenant,
   not an individual user.
-- A derived **tenant class** (`internal` or `customer`) — a coarse, two-value
-  flag computed from the tenant ID so we can report Microsoft-internal dogfood
-  usage separately from external customer usage. It is non-identifying and lower
-  sensitivity than the tenant ID it is derived from.
+- The **tenant display name** (organization display name for that tenant ID) —
+  resolved best-effort via a Microsoft Graph lookup on the auth path
+  (`Organization.Read.All` silent, falling back to `/me?$select=companyName`).
+  This is org-level Organization Identifiable Information (OII), not a personal
+  identifier. Left blank when the lookup can't be completed silently. See
+  [Service dependencies](../../CONTRIBUTING.md#service-dependencies) for the
+  Graph call details.
+- A derived **tenant class** (`internal`, `customer`, or `unknown`) — a coarse,
+  three-value flag computed from the tenant ID so we can report Microsoft-internal
+  dogfood usage separately from external customer usage. It is non-identifying and
+  lower sensitivity than the tenant ID it is derived from.
 - Non-identifying context: ADK version, surface, session ID, event name, and
   per-event enums/metrics (e.g. FlightCheck verdicts, durations, check categories).
 - Scrubbed, non-sensitive **error categories** when something fails.

--- a/solutions/ess-maker-skills/README.md
+++ b/solutions/ess-maker-skills/README.md
@@ -369,10 +369,15 @@ CLI command.
 - Your **tenant ID** (the Entra tenant GUID) — identifies the enterprise tenant,
   not an individual user.
 - The **tenant display name** (organization display name for that tenant ID) —
-  resolved best-effort via a Microsoft Graph lookup on the auth path
-  (`Organization.Read.All` silent, falling back to `/me?$select=companyName`).
-  This is org-level Organization Identifiable Information (OII), not a personal
-  identifier. Left blank when the lookup can't be completed silently. See
+  resolved best-effort via a Microsoft Graph lookup on the auth path. Tries
+  `/organization` under `Organization.Read.All` (silent) first; if that isn't
+  admin-consented, falls back to `/me?$select=companyName`, which reads the
+  **signed-in user's Entra profile `companyName` attribute** (a user-profile
+  field, not tenant metadata — enterprise admins routinely populate it with the
+  tenant display name, so it is a useful label when the authoritative
+  `/organization` call is blocked). This is org-level Organization Identifiable
+  Information (OII), not a personal identifier. Left blank when neither call
+  succeeds silently. See
   [Service dependencies](../../CONTRIBUTING.md#service-dependencies) for the
   Graph call details.
 - A derived **tenant class** (`internal`, `customer`, or `unknown`) — a coarse,
@@ -406,10 +411,23 @@ python scripts/adk_telemetry.py on       # re-enable telemetry
 python scripts/adk_telemetry.py status   # show current setting
 ```
 
-You can also set an environment variable, which takes precedence:
+You can also set an environment variable, which takes precedence over the
+config file. Syntax varies by shell:
 
 ```bash
-ESS_ADK_TELEMETRY=off
+# bash / zsh — one-shot inline, current session, or persistent in ~/.bashrc:
+ESS_ADK_TELEMETRY=off python scripts/adk_telemetry.py status
+export ESS_ADK_TELEMETRY=off
+```
+
+```powershell
+# PowerShell — current session (add to $PROFILE to persist):
+$env:ESS_ADK_TELEMETRY = "off"
+```
+
+```cmd
+:: cmd.exe — current session; use `setx` to persist across new shells:
+set ESS_ADK_TELEMETRY=off
 ```
 
 **Storage, retention & deletion**


### PR DESCRIPTION
CONTRIBUTING.md's Privacy section still asserted the ADK **"collects no telemetry"** and **"has no opt-in/opt-out switch because there is nothing to switch off"**. Both false since the ADK/FlightCheck Aria telemetry and the installer telemetry shipped.

The Service Dependencies section further stated **"no data is sent to Microsoft beyond standard authentication exchanges"** and **"the toolkit does not call any other Microsoft services"** — also false: the Aria/1DS collector and the tenant-name Graph lookup are now called from the auth path.

## Changes

**`CONTRIBUTING.md` — Privacy section**
- Replaces "no telemetry" bullets with an accurate description of what's collected (random `instance_id`, tenant GUID + display name, capability names, FlightCheck outcomes, latency, scrubbed error codes).
- Adds explicit opt-out instructions (both `python scripts/adk_telemetry.py off` and the `ESS_ADK_TELEMETRY=off` env var).
- Distinguishes product-improvement telemetry from customer data (customer content is still never sent to Microsoft by the toolkit).

**`CONTRIBUTING.md` — Service dependencies section**
- Updated preamble ("either your own tenant OR Microsoft's Aria/1DS collector for pseudonymous telemetry").
- Adds two rows to the services table:
  - **Microsoft Graph** — silent `/organization` → `/me?$select=companyName` fallback for tenant display name.
  - **Aria / 1DS OneCollector** — pseudonymous usage telemetry, with the opt-out inline.

**`README.md` — Telemetry section (repo root)**
- Inlines the opt-out commands. Previously users had to click through to the sub-package README to find out how to disable telemetry. Now `python scripts/adk_telemetry.py off` and `ESS_ADK_TELEMETRY=off` appear on the top-level surface.

**`solutions/ess-maker-skills/README.md` — Telemetry & Privacy section**
- Adds tenant display name / Graph lookup disclosure (added in PR #237) that wasn't yet reflected here.
- Corrects the `tenant_class` enum from "two-value (`internal` / `customer`)" to "three-value (`internal` / `customer` / `unknown`)" to match the `classify_tenant` defense-in-depth landed in PR #242.

## Verification

No code changes; docs-only. Manually reviewed all `.md` files under the repo for other stale "no telemetry" / "no data sent" claims — none found beyond what this PR touches.

ADO: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7764297