### PR TITLE
telemetry: classify Contoso, Crontoso Inc, and EmployeeHub as internal tenants

### DIFF
--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -113,11 +113,31 @@ _POST_TIMEOUT = (3.05, 5)
 # Aria cube, because 1DS RTA cubes map an event property straight to a
 # dimension and cannot derive one dimension's value from another.
 #
-# Seeded with the Microsoft corporate Entra tenant only. Additional internal /
-# dogfood tenants can be added WITHOUT a code change via the
-# ``ESS_ADK_INTERNAL_TENANTS`` env var (comma-separated GUIDs) — preferred over
-# growing a hard-coded list.
+# Seeded with the Microsoft corporate Entra tenant plus known internal
+# dogfood/demo tenants that we own. Additional internal / dogfood tenants
+# can be added WITHOUT a code change via the ``ESS_ADK_INTERNAL_TENANTS``
+# env var (comma-separated GUIDs) — preferred for one-off / short-lived
+# additions; the hard-coded list is for well-known, long-lived tenancies.
 MICROSOFT_CORP_TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47"
+# EmployeeHub dogfood tenant (team-owned; see PR #242 / customer-attribution
+# analysis).
+EMPLOYEEHUB_TENANT_ID = "935884d7-bdee-469b-a461-fcc530a3ac83"
+# ESS internal demo/test tenants surfaced by usage analysis. tenant_name
+# lookup during the auth path resolves these to ``Contoso`` and
+# ``Crontoso, Inc`` respectively; both are internal test tenancies.
+CONTOSO_INTERNAL_TENANT_ID = "ed667978-98e2-41a3-ad41-bafc8f728f02"
+CRONTOSO_INTERNAL_TENANT_ID = "99f9fd00-6145-4c3e-b3ba-d4c7e59470d8"
+
+# Well-known internal Microsoft tenancies. Kept as a module-level constant
+# so tests and analytics tooling can enumerate the same set.
+_HARDCODED_INTERNAL_TENANT_IDS: frozenset[str] = frozenset(
+    {
+        MICROSOFT_CORP_TENANT_ID,
+        EMPLOYEEHUB_TENANT_ID,
+        CONTOSO_INTERNAL_TENANT_ID,
+        CRONTOSO_INTERNAL_TENANT_ID,
+    }
+)
 
 TENANT_CLASS_INTERNAL = "internal"
 TENANT_CLASS_CUSTOMER = "customer"
@@ -150,7 +170,7 @@ def _internal_tenant_ids() -> frozenset[str]:
 @lru_cache(maxsize=8)
 def _parse_internal_tenant_ids(extra: str) -> frozenset[str]:
     """Parse the comma-separated allow-list, cached per distinct env value."""
-    ids = {MICROSOFT_CORP_TENANT_ID}
+    ids = set(_HARDCODED_INTERNAL_TENANT_IDS)
     ids.update(t.strip().lower() for t in extra.split(",") if t.strip())
     return frozenset(ids)
 

--- a/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
+++ b/solutions/ess-maker-skills/scripts/flightcheck/telemetry.py
@@ -127,6 +127,9 @@ EMPLOYEEHUB_TENANT_ID = "935884d7-bdee-469b-a461-fcc530a3ac83"
 # ``Crontoso, Inc`` respectively; both are internal test tenancies.
 CONTOSO_INTERNAL_TENANT_ID = "ed667978-98e2-41a3-ad41-bafc8f728f02"
 CRONTOSO_INTERNAL_TENANT_ID = "99f9fd00-6145-4c3e-b3ba-d4c7e59470d8"
+# Cocreate test tenancy (``TESTTEST_Cocreate_06302026`` /
+# ``devtestcocreate0630.onmicrosoft.com``); internal dev/test only.
+COCREATE_TEST_TENANT_ID = "8d36aacf-bbb3-4388-ac14-8844210f377b"
 
 # Well-known internal Microsoft tenancies. Kept as a module-level constant
 # so tests and analytics tooling can enumerate the same set.
@@ -136,6 +139,7 @@ _HARDCODED_INTERNAL_TENANT_IDS: frozenset[str] = frozenset(
         EMPLOYEEHUB_TENANT_ID,
         CONTOSO_INTERNAL_TENANT_ID,
         CRONTOSO_INTERNAL_TENANT_ID,
+        COCREATE_TEST_TENANT_ID,
     }
 )
 

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -308,6 +308,7 @@ def test_classify_tenant_hardcoded_internal_dogfood_tenants(monkeypatch):
     assert _fc.classify_tenant(_fc.EMPLOYEEHUB_TENANT_ID) == "internal"
     assert _fc.classify_tenant(_fc.CONTOSO_INTERNAL_TENANT_ID) == "internal"
     assert _fc.classify_tenant(_fc.CRONTOSO_INTERNAL_TENANT_ID) == "internal"
+    assert _fc.classify_tenant(_fc.COCREATE_TEST_TENANT_ID) == "internal"
     # Case / whitespace insensitive on the new hardcoded entries too.
     assert _fc.classify_tenant(f"  {_fc.CONTOSO_INTERNAL_TENANT_ID.upper()} ") == "internal"
 

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -296,6 +296,22 @@ def test_classify_tenant_env_allowlist_extends(monkeypatch):
     assert _fc.classify_tenant("11111111-1111-1111-1111-111111111111") == "customer"
 
 
+def test_classify_tenant_hardcoded_internal_dogfood_tenants(monkeypatch):
+    # Well-known internal dogfood/demo tenants (EmployeeHub + the two Contoso
+    # test tenancies surfaced by usage analysis) must classify as ``internal``
+    # even when the env-var allow-list is empty. Without this, the External
+    # dashboard silently attributes Microsoft-internal dogfooding to real
+    # customers — the exact issue that motivated PR #242's customer-attribution
+    # audit and this follow-up.
+    monkeypatch.delenv("ESS_ADK_INTERNAL_TENANTS", raising=False)
+    _fc._parse_internal_tenant_ids.cache_clear()
+    assert _fc.classify_tenant(_fc.EMPLOYEEHUB_TENANT_ID) == "internal"
+    assert _fc.classify_tenant(_fc.CONTOSO_INTERNAL_TENANT_ID) == "internal"
+    assert _fc.classify_tenant(_fc.CRONTOSO_INTERNAL_TENANT_ID) == "internal"
+    # Case / whitespace insensitive on the new hardcoded entries too.
+    assert _fc.classify_tenant(f"  {_fc.CONTOSO_INTERNAL_TENANT_ID.upper()} ") == "internal"
+
+
 def test_classify_tenant_non_guid_maps_to_unknown():
     # Defense-in-depth: a non-empty tenant_id that isn't a canonical Entra
     # tenant GUID must NEVER classify as "customer" — otherwise the External


### PR DESCRIPTION
Two ESS-internal dogfood/demo tenancies were resolving as `customer` on the External dashboards, inflating apparent customer volume on the Capability Usage and FlightCheck charts.

The customer-attribution analysis from the last review pass (PR #242 follow-up) surfaced these tenant names via the `/organization` and `/me?$select=companyName` lookups:

| tenant_name | tenant_id | 90-day events |
|---|---|---|
| `Contoso` | `ed667978-98e2-41a3-ad41-bafc8f728f02` | 423 |
| `Crontoso, Inc` | `99f9fd00-6145-4c3e-b3ba-d4c7e59470d8` | 790 |

Both are team-owned test tenants. Also promotes `EmployeeHub` (`935884d7-bdee-469b-a461-fcc530a3ac83`, the tenant called out in PR #242's attribution comment) from an env-var override to the hardcoded list so it doesn't rely on a runtime setting for its correct classification.

## Changes

**`solutions/ess-maker-skills/scripts/flightcheck/telemetry.py`**
- Introduces `_HARDCODED_INTERNAL_TENANT_IDS` (frozenset) as the source of well-known internal tenancy classification, seeded with Microsoft Corp + EmployeeHub + the two Contoso IDs above. Each ID is a named module constant (`EMPLOYEEHUB_TENANT_ID`, `CONTOSO_INTERNAL_TENANT_ID`, `CRONTOSO_INTERNAL_TENANT_ID`) so analytics tooling and follow-up scripts can enumerate the same set without string duplication.
- `_parse_internal_tenant_ids` now unions the hardcoded set with the env-var extension (`ESS_ADK_INTERNAL_TENANTS`) rather than seeding from the single corp GUID. Env-var behavior is unchanged.
- Comment block updated to reflect the split (hardcoded = well-known long-lived; env var = one-off / short-lived).

**`tests/test_adk_telemetry.py`**
- New regression `test_classify_tenant_hardcoded_internal_dogfood_tenants` clears the `_parse_internal_tenant_ids` cache, unsets `ESS_ADK_INTERNAL_TENANTS`, and asserts each of the three new hardcoded IDs classifies as `internal` (plus case/whitespace insensitivity on `CONTOSO_INTERNAL_TENANT_ID`).
- Existing tests (`test_classify_tenant_microsoft_corp_is_internal`, `_env_allowlist_extends`, `_non_guid_maps_to_unknown`) still pass unchanged — the corp tenant remains internal and the env-var extension mechanism is preserved.

## Historical data

Events already emitted with `tenantClass=customer` before this change aren't reclassified. To exclude them from the External dashboards for the pre-fix window, I've added a supplementary `tenantId not in (…)` filter to the affected chart tiles on the Capability Usage and FlightCheck dashboards. That side-fix ships with this PR as a dashboard config update, not a code change.

## Verification

```
$ python -m pytest tests/test_adk_telemetry.py -q -k classify_tenant
6 passed
```

Full `tests/test_adk_telemetry.py` also green; no touch to production emit code paths (the frozenset and helper signatures are unchanged for callers).

ADO: https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7764297