### PR TITLE
Fix publish.py emitting adk_capability=\"publish\" (non-canonical)

### DIFF
--- a/solutions/ess-maker-skills/scripts/publish.py
+++ b/solutions/ess-maker-skills/scripts/publish.py
@@ -75,7 +75,7 @@ def main():
             [sys.executable,
              os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           "emit_capability.py"),
-             "publish"],
+             "publishing"],
             check=False, capture_output=True,
         )
     except Exception:  # noqa: BLE001

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -653,6 +653,53 @@ def test_wired_capabilities_are_in_canonical_list():
     assert not missing, f"wired capabilities not in ADK_CAPABILITIES: {missing}"
 
 
+# --- guard: any string a caller passes to the shim must be canonical --------
+def test_no_caller_passes_a_noncanonical_capability_to_the_shim():
+    """Scan the repo for ``emit_capability.py <cap>`` invocations — both
+    Python subprocess calls (from ``scripts/*.py``) and SKILL.md steps — and
+    assert every capability argument is a member of ``ADK_CAPABILITIES``.
+
+    This is the guardrail the hardcoded ``wired`` set in the test above
+    doesn't provide: a fresh caller that hardcodes a typo (as ``publish.py``
+    did with ``"publish"`` vs the canonical ``"publishing"``) silently maps
+    to ``CAPABILITY_UNKNOWN`` on the dashboards. Scanning source directly
+    catches the typo the first time it lands, no manual list update needed.
+    """
+    import re as _re
+    from pathlib import Path as _Path
+
+    repo_root = _Path(__file__).resolve().parent.parent
+    scripts_dir = repo_root / "solutions" / "ess-maker-skills" / "scripts"
+    skills_dir = repo_root / "solutions" / "ess-maker-skills" / "src" / "skills"
+
+    # Python subprocess form:
+    #   subprocess.run([..., "emit_capability.py"), "<cap>"], ...)
+    # SKILL.md form:
+    #   python scripts/emit_capability.py <cap>
+    py_pat = _re.compile(r'"emit_capability\.py"\)\s*,\s*\n?\s*"([^"]+)"')
+    md_pat = _re.compile(r'emit_capability\.py\s+([A-Za-z_][A-Za-z0-9_\-]*)')
+
+    offenders: list[tuple[str, str]] = []
+    for path in scripts_dir.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for m in py_pat.finditer(text):
+            cap = m.group(1)
+            if cap not in adk.ADK_CAPABILITIES:
+                offenders.append((str(path.relative_to(repo_root)), cap))
+    for path in skills_dir.rglob("SKILL.md"):
+        text = path.read_text(encoding="utf-8")
+        for m in md_pat.finditer(text):
+            cap = m.group(1)
+            if cap not in adk.ADK_CAPABILITIES:
+                offenders.append((str(path.relative_to(repo_root)), cap))
+
+    assert not offenders, (
+        "Non-canonical capability strings passed to emit_capability.py — these "
+        "would silently normalize to CAPABILITY_UNKNOWN on the dashboards. "
+        f"Offenders (file, capability): {offenders}"
+    )
+
+
 
 # --- emit_capability.py shim (the SKILL.md-driven hook) -------------------
 def test_shim_emits_capability_and_exits_zero(captured_post, monkeypatch):


### PR DESCRIPTION
## Summary

`publish.py` invokes the `emit_capability.py` shim with the string `"publish"`, but the canonical capability is `"publishing"` (see `ADK_CAPABILITIES` in `adk_telemetry.py`). `normalize_capability("publish")` maps to `"unknown"`, so every standalone `python scripts/publish.py` invocation on a customer install has been silently landing on the `"unknown"` slice of the *Capability Usage by Type* donut instead of `"publishing"`.

## What tipped us off

The ADK Platform (External) dashboard showed **7 unknown `capability.use` events on 2026-08-26 UTC**. Looking at the last 60 days on that cube:

| Population | `adk_capability = "unknown"` | `adk_capability = "publishing"` |
|---|---|---|
| External customers | **7** (all on Aug 26) | 0 |
| Internal | 0 | 0 |

Internal devs deploy via `push.py` — which fires `build.start` / `build.complete` events, not a `capability.use` — so publish activity never lands on the capability.use cube from internal usage. Only external customers who run the standalone `publish.py` command would put publish activity on that cube, and every such invocation currently fires `adk_capability="publish"` → normalizes to `"unknown"`.

A repo-wide grep found no other call site passing a non-canonical string to `emit_capability_use` or the shim.

## Changes

1. **`publish.py`**: `"publish"` → `"publishing"` (one-line fix).
2. **`tests/test_adk_telemetry.py`**: new `test_no_caller_passes_a_noncanonical_capability_to_the_shim` — scans `scripts/*.py` subprocess calls and SKILL.md `python scripts/emit_capability.py <cap>` steps, asserts every capability argument is in `ADK_CAPABILITIES`. The existing hardcoded `wired` set test only covered the callers I remembered to list; this guard is self-updating and catches new typos the first time they land.

## Verification

- `pytest tests/test_adk_telemetry.py` passes with the fix.
- Reverted the one-char fix locally as a sanity check: the new guard failed with offender `('publish.py', 'publish')` before I re-applied the fix.

## Follow-up (not in this PR)

Consider adding a `raw_capability` field to `emit_capability_use` that carries the pre-normalization string. Today when `"unknown"` shows up on the dashboard the source string is lost, and diagnosis is a grep + inference exercise (as this PR is). A raw field would let us drill down in Aria directly.