### PR TITLE
chore(agentconfig-mcp): remove orphaned landing-page server descriptor

### DIFF
--- a/solutions/ess-maker-skills/src/mcp/agentconfig/mcp.server.json
+++ b/solutions/ess-maker-skills/src/mcp/agentconfig/mcp.server.json
@@ -1,9 +1,0 @@
-{
-  "id": "landing-page",
-  "serverName": "ess-landing-page-config",
-  "server": {
-    "command": "{pythonExecutable}",
-    "args": ["server.py"],
-    "cwd": "${workspaceFolder}/src/mcp/agentconfig"
-  }
-}


### PR DESCRIPTION
## What

Removes `solutions/ess-maker-skills/src/mcp/agentconfig/mcp.server.json`, an orphaned MCP server descriptor.

## Why

- `src/mcp/agentconfig/` contains **only** this descriptor. Its `cwd` (`${workspaceFolder}/src/mcp/agentconfig`) is a leftover from the pre-split MCP layout — the landing-page `server.py` now lives in `src/mcp/agentconfig_landing_page/`. So `mcp_config.py configure landing-page` would materialize a server entry that cannot launch (`server.py` not found in `cwd`).
- The landing-page server is **already** registered as a default in `.vscode/mcp.defaults.json` (`ess-landing-page-config`, `cwd → src/mcp/agentconfig_landing_page`), which is correct. The descriptor is redundant with that default.
- Nothing invokes the `landing-page` descriptor id. The contextual `configure` path is only used for on-demand connectors (servicenow, dataverse); the landing-page server — like `ess-planner` — is a default-only server with no descriptor.

## Reconciliation

Mirrors the identical removal made in planner PR #253, so `feature/planner-skill` and `feature/landing-page-config` converge cleanly in `main`.

No functional change: the landing-page server continues to run via the default in `mcp.defaults.json`.
