### PR TITLE
Split capability taxonomy so every user-facing command has its own dashboard wedge

### DIFF
--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -97,37 +97,61 @@ EVENT_FLIGHTCHECK_ERROR = "adk.flightcheck.error"
 # capability here, also add it to that Aria cube dimension value-list (see the
 # telemetry dashboards story, ADO #7532631) so the new slice renders.
 #
-# One capability per real maker-facing ADK skill / entry point:
+# One capability per real maker-facing ADK skill / entry point. The taxonomy
+# is intentionally granular: every distinct command a maker can run has its
+# own donut slice, so we can see which specific action drove a change in
+# usage. Umbrella labels (a single "evaluations" or "publishing" wedge
+# covering multiple commands) hide that signal, so we split them apart.
 #   setup                   -> first-run environment setup + discovery
 #                              (discover / list_environments are sub-steps of
 #                              this flow and do NOT emit their own capability;
 #                              the adk.agent.create event at the end of setup is
 #                              tracked separately by the "Agents Created" KPI and
 #                              is NOT a capability-donut slice)
+#   onboarding              -> workspace bootstrap after foundation setup
 #   connect                 -> ServiceNow / Workday connection setup
-#   topic_*                 -> topic authoring (create / update / delete)
-#   workflow_*              -> workflow authoring (create / update / delete)
-#   evaluations             -> eval test-set authoring + validation runs
+#   topic_create            -> author a new topic
+#   topic_update            -> modify an existing topic
+#   topic_delete            -> delete a topic
+#   topic_review            -> advisory conformance review of a topic
+#   topic_test              -> debug-and-validate loop for a topic
+#   workflow_create         -> author a new workflow
+#   workflow_update         -> modify an existing workflow
+#   workflow_delete         -> delete a workflow
+#   workflow_test           -> debug a workflow via run history
+#   evaluation_create       -> author eval test cases
+#   evaluation_update       -> modify eval test cases
+#   evaluation_delete       -> delete eval test cases
+#   evaluation_validate     -> quality-score generated eval sets
 #   cleanup                 -> error scan / fix pass
 #   troubleshoot            -> connectivity / auth diagnosis
 #   backup_template_configs -> Workday template-config backup
 #   restore_template_configs-> Workday template-config restore
-#   publishing              -> push / deploy to Copilot Studio
+#   push                    -> upload local changes to Dataverse (staging)
+#   publishing              -> publish so pushed changes go live in runtime
 #   flightcheck             -> pre-deployment readiness check
 ADK_CAPABILITIES = (
     "setup",
+    "onboarding",
     "connect",
     "topic_create",
     "topic_update",
     "topic_delete",
+    "topic_review",
+    "topic_test",
     "workflow_create",
     "workflow_update",
     "workflow_delete",
-    "evaluations",
+    "workflow_test",
+    "evaluation_create",
+    "evaluation_update",
+    "evaluation_delete",
+    "evaluation_validate",
     "cleanup",
     "troubleshoot",
     "backup_template_configs",
     "restore_template_configs",
+    "push",
     "publishing",
     "flightcheck",
 )

--- a/solutions/ess-maker-skills/scripts/evaluate_evals.py
+++ b/solutions/ess-maker-skills/scripts/evaluate_evals.py
@@ -482,7 +482,7 @@ def main():
 
         # block=True: short-lived CLI process — emit synchronously so the event
         # isn't dropped when the interpreter exits and kills a daemon thread.
-        adk_telemetry.emit_capability_use("evaluations", block=True)
+        adk_telemetry.emit_capability_use("evaluation_validate", block=True)
     except Exception:  # noqa: BLE001 — telemetry must never break evaluation
         pass
 

--- a/solutions/ess-maker-skills/scripts/push.py
+++ b/solutions/ess-maker-skills/scripts/push.py
@@ -1253,7 +1253,7 @@ def main():
     try:
         import adk_telemetry
 
-        adk_telemetry.emit_build_start(agent_id=bot_id, adk_capability="publishing")
+        adk_telemetry.emit_build_start(agent_id=bot_id, adk_capability="push")
     except Exception:  # noqa: BLE001 — telemetry must never break push
         pass
 
@@ -2177,11 +2177,11 @@ def main():
                 "error_message": _error_message,
             }
         adk_telemetry.emit_build_complete(
-            agent_id=bot_id, adk_capability="publishing",
+            agent_id=bot_id, adk_capability="push",
             outcome=_outcome, duration_ms=_duration_ms, **_err_kwargs,
         )
         adk_telemetry.emit_agent_deploy(
-            agent_id=bot_id, deploy_target=_deploy_target, adk_capability="publishing",
+            agent_id=bot_id, deploy_target=_deploy_target, adk_capability="push",
             outcome=("server_error" if _failed else "success"),
             duration_ms=_duration_ms,
             **({"error_code": ("DEPLOY_PARTIAL_FAILURE" if errors
@@ -2189,6 +2189,7 @@ def main():
                 "error_category": "runtime",
                 "error_message": _error_message} if _failed else {}),
         )
+        adk_telemetry.emit_capability_use("push", block=False)
         adk_telemetry.flush(timeout=5)
     except Exception:  # noqa: BLE001 — telemetry must never break push
         pass

--- a/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/create/SKILL.md
@@ -605,7 +605,7 @@ Run `python scripts/checkpoint.py "before evaluation test set creation"` to save
 
 Then record anonymous usage telemetry (best-effort, non-blocking — no
 user-facing message, and it never fails the step):
-`python scripts/emit_capability.py evaluations`
+`python scripts/emit_capability.py evaluation_create`
 
 ### 4.2 — Write evaluation files
 

--- a/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/delete/SKILL.md
@@ -70,7 +70,7 @@ Wait for confirmation.
 
 ```
 python scripts/checkpoint.py "pre-delete-evaluation-{name}"
-python scripts/emit_capability.py evaluations
+python scripts/emit_capability.py evaluation_delete
 ```
 
 The `emit_capability.py` line records anonymous usage telemetry (best-effort,

--- a/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/evaluations/update/SKILL.md
@@ -60,7 +60,7 @@ Run in the terminal:
 
 ```
 python scripts/checkpoint.py "pre-update-evaluation"
-python scripts/emit_capability.py evaluations
+python scripts/emit_capability.py evaluation_update
 ```
 
 The `emit_capability.py` line records anonymous usage telemetry (best-effort,

--- a/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/onboarding/SKILL.md
@@ -12,6 +12,9 @@ agent, product, and connector names before displaying them.
 
 ## Start
 
+Record anonymous usage telemetry (best-effort, non-blocking — no user-facing
+message, and it never fails the step): `python scripts/emit_capability.py onboarding`
+
 Run `python scripts/setup_state.py show --view current`. When `connect_ready` is
 true, this is workspace bootstrap after foundation setup:
 

--- a/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/review/SKILL.md
@@ -89,6 +89,9 @@ roll-up's coverage line). Do not add a separate pre-analysis announcement.
 
 ## Step 1: Identify the scope
 
+Record anonymous usage telemetry (best-effort, non-blocking — no user-facing
+message, and it never fails the step): `python scripts/emit_capability.py topic_review`
+
 Decide whether the maker wants **one topic** or a **module scope** (all topics for a backend), then branch:
 
 - If the maker named a single topic (a path or one topic name) → **single-topic review**: use it and continue

--- a/solutions/ess-maker-skills/src/skills/topics/test/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/topics/test/SKILL.md
@@ -39,6 +39,9 @@ This skill **drives the topic automatically** — it launches (or attaches to) a
 
 ## Classify the topic — which fault surface?
 
+Record anonymous usage telemetry (best-effort, non-blocking — no user-facing
+message, and it never fails the step): `python scripts/emit_capability.py topic_test`
+
 Read the topic file and decide which fault surface applies — it drives which tool you reach for:
 
 - **Flow-backed** — the topic calls a shared system topic (`BeginDialog` to `...System...`) or an `InvokeFlowAction`. Faults here are usually in the flow / connector path → **Inspect the flow run**.

--- a/solutions/ess-maker-skills/src/skills/workflows/test/SKILL.md
+++ b/solutions/ess-maker-skills/src/skills/workflows/test/SKILL.md
@@ -26,6 +26,9 @@ Debugging a flow is one loop, repeated until the run is clean:
 
 ## Identify the flow
 
+Record anonymous usage telemetry (best-effort, non-blocking — no user-facing
+message, and it never fails the step): `python scripts/emit_capability.py workflow_test`
+
 Read `.local/config.json` for `agent.folder` and `agent.slug`. List the workflow folders under `{agent.folder}/workflows/` — each holds a `metadata.yml` (with `workflowId`, `name`) and a `workflow.json`. Match the user's request to a folder by name or `metadata.yml` display name; if ambiguous, list them and ask. The **flow GUID** you pass to the inspector is `workflowId` from that `metadata.yml`.
 
 ## Exercise the flow

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -512,12 +512,12 @@ def test_resolve_ikey_env_and_raw_override(monkeypatch):
 # --- emit happy path + fail-open + buffering ------------------------------
 def test_emit_happy_path_posts_envelope(captured_post, monkeypatch):
     monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
-    res = adk.emit_capability_use("evaluations", block=True)
+    res = adk.emit_capability_use("evaluation_validate", block=True)
     assert res["sent"] is True
     assert len(captured_post) == 1
     _ikey, envelopes = captured_post[0]
     assert envelopes[0]["name"] == "adk.capability.use"
-    assert envelopes[0]["data"]["adk_capability"] == "evaluations"
+    assert envelopes[0]["data"]["adk_capability"] == "evaluation_validate"
     assert envelopes[0]["iKey"] == f"o:{DEV_TOKEN}"
 
 
@@ -646,14 +646,19 @@ def test_wired_capabilities_are_in_canonical_list():
     "unknown" on the dashboards. This is the "keep in sync" contract."""
     wired = {
         # emit_capability_use(...) from the Python entry points
-        "setup", "evaluations",
+        "setup", "evaluation_validate",
         "backup_template_configs", "restore_template_configs",
+        "push",
         # emit_build_*/flightcheck_* event families
         "publishing", "flightcheck",
         # emit_capability.py shim invocations across the SKILL.md skills
         "connect",
+        "onboarding",
         "topic_create", "topic_update", "topic_delete",
+        "topic_review", "topic_test",
         "workflow_create", "workflow_update", "workflow_delete",
+        "workflow_test",
+        "evaluation_create", "evaluation_update", "evaluation_delete",
         "cleanup", "troubleshoot",
     }
     missing = wired - set(adk.ADK_CAPABILITIES)


### PR DESCRIPTION
## Summary

Split the ADK `adk_capability` taxonomy so every distinct user-facing command has its own slice on the Capability Usage donut. Umbrella labels (a single `evaluations` or `publishing` wedge covering multiple commands) hid the signal PMs need to see which specific action drove a change in usage, and left several user-facing skills with no wedge at all.

## Changes

| Before | After |
| --- | --- |
| `evaluations` (one wedge for create/update/delete/validate) | `evaluation_create`, `evaluation_update`, `evaluation_delete`, `evaluation_validate` |
| `publishing` (one wedge covering both `push.py` and `publish.py`) | `push` (push.py — upload local edits to Dataverse) + `publishing` (publish.py — make changes live) |
| _(no wedge)_ | `onboarding`, `topic_review`, `topic_test`, `workflow_test` |

### push.py rename

`push.py`'s `emit_build_start` / `emit_build_complete` / `emit_agent_deploy` events are re-stamped from `adk_capability="publishing"` to `"push"`, and `push.py` now emits a best-effort `emit_capability_use("push")` at the end of the flow so push gets its own wedge on the Capability Usage donut (mirroring `publish.py`).

> **Aria tile impact:** any tile filtering Build Outcomes / Agent Deploy on `adk_capability="publishing"` needs updating to include both `"publishing"` and `"push"` (or split into two tiles).

### Not included in this PR

- **`discover`** — owned by #238. That PR will add `discover` to `ADK_CAPABILITIES` and wire it into `discover_inventory.py`.
- **`planner`** — owned by a separate feature branch not yet merged. It will add its own taxonomy entry.
- **`flightcheck`** — stays in the taxonomy but is intentionally not part of the Capability Usage donut split; it already has dedicated FlightCheck dashboard panels.

## Tests

- `tests/test_adk_telemetry.py::test_wired_capabilities_are_in_canonical_list` updated for the new granular values.
- The happy-path emit test now uses `evaluation_validate` (was `evaluations`).
- The `test_no_caller_passes_a_noncanonical_capability_to_the_shim` guard from #254 continues to catch drift automatically — it greps `scripts/*.py` and `SKILL.md` for `emit_capability.py <cap>` invocations and asserts every value is in `ADK_CAPABILITIES`.
- `pytest tests/test_adk_telemetry.py` → 67 passed.

## ADO

https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/7830948
