### PR TITLE
adk-telemetry: support Vorpal bridge schema v2

### DIFF
--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -59,6 +59,7 @@ import sys
 import threading
 import time
 import uuid
+from datetime import datetime
 from typing import Any
 
 # Reuse the OneCollector transport + helpers from the FlightCheck emitter.
@@ -773,6 +774,17 @@ def _valid_client_number(value: Any) -> bool:
     return _is_finite_number(value) and value >= 0
 
 
+def _valid_client_timestamp(value: Any) -> bool:
+    """Validate a timezone-aware ISO-8601 timestamp without rewriting it."""
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None
+
+
 def _valid_client_sequence_number(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
@@ -933,7 +945,7 @@ def _validate_client_events_envelope(envelope: Any) -> tuple[str | None, list[di
         level = event.get("level")
         if not isinstance(level, str) or level not in {"info", "error"}:
             return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
-        if not _valid_client_number(event.get("eventTimestampMs")):
+        if not _valid_client_timestamp(event.get("eventTimestamp")):
             return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
         if not _valid_client_number(event.get("timeSinceMount")):
             return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
@@ -974,7 +986,7 @@ def _validate_client_events_envelope(envelope: Any) -> tuple[str | None, list[di
                 "client_build_environment": _scrub_client_scalar(envelope["buildEnvironment"]),
                 "client_build_number": envelope["buildNumber"],
                 "client_level": event["level"],
-                "client_event_timestamp_ms": event["eventTimestampMs"],
+                "client_event_timestamp": event["eventTimestamp"],
                 "client_time_since_mount_ms": event["timeSinceMount"],
                 "client_sequence_number": event["sequenceNumber"],
             }

--- a/solutions/ess-maker-skills/scripts/adk_telemetry.py
+++ b/solutions/ess-maker-skills/scripts/adk_telemetry.py
@@ -71,10 +71,9 @@ from flightcheck import telemetry as _fc  # noqa: E402
 
 # --- Spec constants -------------------------------------------------------
 # 1.1.0: added derived ``tenant_class`` (internal vs customer) — ADO 7558661.
-# 1.2.0: adds ``adk.client.event`` and its fixed ``client_*`` field set,
-#        including ``client_level``, the ``client_properties`` JSON string,
-#        and ``client_prop_dropped_count``.
-SCHEMA_VERSION = "1.2.0"
+# 1.3.0: defines the Vorpal bridge schema-v2 ``client_*`` field projection,
+#        including batch, source chronology, host context, and operation IDs.
+SCHEMA_VERSION = "1.3.0"
 
 # Surfaces the ADK emits from (spec enum: sdk | cli | studio | docs). The
 # Python skill scripts are the CLI surface.
@@ -94,7 +93,7 @@ EVENT_FLIGHTCHECK_RESULT = "adk.flightcheck.result"
 EVENT_FLIGHTCHECK_ERROR = "adk.flightcheck.error"
 EVENT_CLIENT = "adk.client.event"
 
-CLIENT_EVENTS_SCHEMA_VERSION = 1
+CLIENT_EVENTS_SCHEMA_VERSION = 2
 # An out-of-memory guard set well above client batcher sizes, so client-side
 # batch-size changes can ship independently of ADK.
 CLIENT_EVENTS_MAX_BATCH_EVENTS = 1000
@@ -135,9 +134,9 @@ _CLIENT_EVENTS_REJECTED_REASONS = frozenset(
         CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE,
     }
 )
-# Correlation identifiers are emitted verbatim for event stitching. Apply the
-# bounded ASCII format to the whole value; field names distinguish each id's
-# purpose independently of the producer's prefix convention.
+# Batch, mount, and tool-call identifiers are emitted verbatim for event
+# stitching. Apply the bounded ASCII format to the whole value; field names
+# distinguish each id's purpose independently of the producer's prefix.
 _CLIENT_EVENTS_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 # --- Canonical ADK capability value-list (single source of truth) ---------
@@ -277,6 +276,8 @@ def set_identity(
     tenant_id: str | None = None,
     instance_id: str | None = None,
     tenant_name: str | None = None,
+    *,
+    local_dir: str | None = None,
 ) -> dict[str, str]:
     """Record the install + tenant identity for all subsequent events.
 
@@ -330,13 +331,44 @@ def set_identity(
     # emit_capability.py shim launched from a SKILL.md step) — which never
     # calls set_identity itself — can still stamp the tenant on its events.
     if _IDENTITY["tenant_id"]:
-        _fc.cache_tenant_id(_IDENTITY["tenant_id"])
+        if local_dir is None:
+            _fc.cache_tenant_id(_IDENTITY["tenant_id"])
+        else:
+            _fc.cache_tenant_id(_IDENTITY["tenant_id"], local_dir=local_dir)
     # Persist the tenant name so ADK events emitted later in a *different*
     # process (which only has a Dataverse/BAP token and can't resolve it)
     # can reuse it. Only cache when both fields are present.
     if _IDENTITY["tenant_name"] and _IDENTITY["tenant_id"]:
-        _fc.cache_tenant_name(_IDENTITY["tenant_id"], _IDENTITY["tenant_name"])
+        if local_dir is None:
+            _fc.cache_tenant_name(
+                _IDENTITY["tenant_id"],
+                _IDENTITY["tenant_name"],
+            )
+        else:
+            _fc.cache_tenant_name(
+                _IDENTITY["tenant_id"],
+                _IDENTITY["tenant_name"],
+                local_dir=local_dir,
+            )
     return dict(_IDENTITY)
+
+
+def initialize_tenant_identity(
+    tenant_id: str,
+    *,
+    local_dir: str = ".local",
+) -> dict[str, str]:
+    """Initialize telemetry from an authenticated tenant and its cached name."""
+    normalized_tenant_id = _sanitize_tenant_id(tenant_id)
+    tenant_name = _fc.get_cached_tenant_name(
+        normalized_tenant_id,
+        local_dir=local_dir,
+    )
+    return set_identity(
+        tenant_id=normalized_tenant_id,
+        tenant_name=tenant_name or None,
+        local_dir=local_dir,
+    )
 
 
 # --- Consent / opt-out ----------------------------------------------------
@@ -720,30 +752,34 @@ def _valid_client_string(value: Any, *, allow_empty: bool = False) -> bool:
     return isinstance(value, str) and (allow_empty or bool(value))
 
 
-def _valid_client_identifier(value: Any) -> bool:
-    """True when ``value`` is an identifier-shaped ephemeral correlation id.
+def _valid_bounded_client_string(value: Any, *, allow_empty: bool = False) -> bool:
+    """Validate a raw projected string without mutating its supplied value."""
+    return _valid_client_string(value, allow_empty=allow_empty) and len(value) <= CLIENT_EVENTS_MAX_STRING_LENGTH
 
-    Required correlation and mount ids must match the bounded ASCII format.
+
+def _valid_client_identifier(value: Any) -> bool:
+    """True when ``value`` is an identifier-shaped ephemeral client id.
+
+    Required batch and mount ids must match the bounded ASCII format.
     They retain their exact values for event stitching: applying ``_scrub``
-    to ``corr-<uuid>`` would collapse distinct ids to ``corr-<guid>``.
+    to an embedded UUID would collapse distinct ids to ``<guid>``.
     The envelope validator rejects invalid required ids and omits invalid
     optional tool-call ids.
     """
     return isinstance(value, str) and bool(_CLIENT_EVENTS_IDENTIFIER_RE.match(value))
 
 
-CLIENT_EVENTS_INVALID_TIME_SENTINEL = -1
+def _valid_client_number(value: Any) -> bool:
+    return _is_finite_number(value) and value >= 0
 
 
-def _client_time_since_app_start(event: dict[str, Any]) -> Any:
-    """Return a finite timing or the invalid-timing sentinel.
+def _valid_client_sequence_number(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
-    ``-1`` is unambiguous: ``performance.now()`` is non-negative, and ``0`` is a
-    valid bootloader timing. Missing or non-finite timings affect only this
-    metric; the event remains eligible for emission.
-    """
-    value = event.get("timeSinceAppStart")
-    return value if _is_finite_number(value) else CLIENT_EVENTS_INVALID_TIME_SENTINEL
+
+def _valid_client_operation_id(value: Any) -> bool:
+    """Validate Vorpal's canonical, hyphenated generated-operation UUID."""
+    return isinstance(value, str) and bool(_GUID_RE.fullmatch(value))
 
 
 def _scrub_client_scalar(value: Any) -> Any:
@@ -850,9 +886,14 @@ def _rejection(reason: str) -> dict[str, Any]:
 def _validate_client_events_envelope(envelope: Any) -> tuple[str | None, list[dict[str, Any]]]:
     if not isinstance(envelope, dict):
         return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
-    if envelope.get("schemaVersion") != CLIENT_EVENTS_SCHEMA_VERSION:
+    schema_version = envelope.get("schemaVersion")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != CLIENT_EVENTS_SCHEMA_VERSION
+    ):
         return CLIENT_EVENTS_REJECTED_UNSUPPORTED_SCHEMA_VERSION, []
-    if not _valid_client_identifier(envelope.get("correlationId")):
+    if not _valid_client_identifier(envelope.get("batchId")):
         return CLIENT_EVENTS_REJECTED_INVALID_CORRELATION_ID, []
     if not _valid_client_identifier(envelope.get("mountId")):
         return CLIENT_EVENTS_REJECTED_INVALID_MOUNT_ID, []
@@ -860,11 +901,17 @@ def _validate_client_events_envelope(envelope: Any) -> tuple[str | None, list[di
         return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
     if not _valid_client_string(envelope.get("buildEnvironment")):
         return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
-    if not _valid_client_string(envelope.get("buildNumber"), allow_empty=True):
+    if not _valid_bounded_client_string(envelope.get("buildNumber"), allow_empty=True):
+        return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+    platform = envelope.get("platform")
+    if platform is not None and not _valid_bounded_client_string(platform, allow_empty=True):
+        return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+    user_agent = envelope.get("userAgent")
+    if user_agent is not None and not _valid_bounded_client_string(user_agent, allow_empty=True):
         return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
     tool_call_id = envelope.get("toolCallId")
     # The host supplies this optional diagnostic id. Omit incompatible values;
-    # correlationId and mountId provide the identifiers required for stitching.
+    # batchId and mountId provide the identifiers required for stitching.
     if tool_call_id is not None and not _valid_client_identifier(tool_call_id):
         tool_call_id = None
 
@@ -883,8 +930,28 @@ def _validate_client_events_envelope(envelope: Any) -> tuple[str | None, list[di
         # are scrubbed and bounded during emission.
         if not _valid_client_string(event.get("eventName")):
             return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+        level = event.get("level")
+        if not isinstance(level, str) or level not in {"info", "error"}:
+            return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+        if not _valid_client_number(event.get("eventTimestampMs")):
+            return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+        if not _valid_client_number(event.get("timeSinceMount")):
+            return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+        if not _valid_client_sequence_number(event.get("sequenceNumber")):
+            return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
         locale = event.get("locale")
         if locale is not None and not _valid_client_string(locale):
+            return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+        display_mode = event.get("displayMode")
+        if display_mode is not None and not _valid_bounded_client_string(display_mode):
+            return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+        theme_name = event.get("themeName")
+        if theme_name is not None and (
+            not isinstance(theme_name, str) or theme_name not in {"light", "dark"}
+        ):
+            return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
+        operation_id = event.get("operationId")
+        if operation_id is not None and not _valid_client_operation_id(operation_id):
             return CLIENT_EVENTS_REJECTED_INVALID_EVENT_SHAPE, []
 
     # ``get_session`` mutates ~/.adk/session.json (it mints a fresh id once the
@@ -894,25 +961,38 @@ def _validate_client_events_envelope(envelope: Any) -> tuple[str | None, list[di
     sid, _ = get_session(SURFACE_CLI)
     for event in events:
         locale = event.get("locale")
+        display_mode = event.get("displayMode")
+        theme_name = event.get("themeName")
+        operation_id = event.get("operationId")
         row = common_dimensions(SURFACE_CLI, session_id=sid)
         row.update(
             {
                 "client_event_name": _scrub_client_scalar(event["eventName"]),
-                "client_correlation_id": envelope["correlationId"],
+                "client_batch_id": envelope["batchId"],
                 "client_mount_id": envelope["mountId"],
                 "client_app_name": _scrub_client_scalar(envelope["appName"]),
                 "client_build_environment": _scrub_client_scalar(envelope["buildEnvironment"]),
-                "client_build_number": _scrub_client_scalar(envelope["buildNumber"]),
-                "client_time_since_app_start_ms": _client_time_since_app_start(event),
+                "client_build_number": envelope["buildNumber"],
+                "client_level": event["level"],
+                "client_event_timestamp_ms": event["eventTimestampMs"],
+                "client_time_since_mount_ms": event["timeSinceMount"],
+                "client_sequence_number": event["sequenceNumber"],
             }
         )
         if tool_call_id is not None:
             row["client_tool_call_id"] = tool_call_id
+        if platform is not None:
+            row["client_platform"] = platform
+        if user_agent is not None:
+            row["client_user_agent"] = user_agent
         if locale is not None:
             row["client_locale"] = _scrub_client_scalar(locale)
-        level = event.get("level")
-        if isinstance(level, str):
-            row["client_level"] = _scrub_client_scalar(level)
+        if display_mode is not None:
+            row["client_display_mode"] = display_mode
+        if theme_name is not None:
+            row["client_theme_name"] = theme_name
+        if operation_id is not None:
+            row["client_operation_id"] = operation_id
         blob, dropped = _client_properties_blob(event.get("properties"))
         row["client_properties"] = blob
         row["client_prop_dropped_count"] = dropped

--- a/solutions/ess-maker-skills/scripts/telemetry_queries.kql
+++ b/solutions/ess-maker-skills/scripts/telemetry_queries.kql
@@ -30,7 +30,7 @@
 //    essmakerkit_flightcheck_check  (1 per check; category + status)
 //    essmakerkit_installer_start / _complete
 //    adk_session_start, adk_capability_use, adk_agent_create, adk_agent_deploy,
-//    adk_build_complete, adk_api_call   (ADK platform family)
+//    adk_build_complete, adk_api_call, adk_client_event   (ADK platform family)
 //  Time column on every table: EventInfo_Time (UTC).
 // =============================================================================
 
@@ -181,3 +181,62 @@ essmakerkit_flightcheck_run
 | summarize p50 = percentile(durationSecs, 50),
             p95 = percentile(durationSecs, 95),
             p99 = percentile(durationSecs, 99)
+
+
+// -----------------------------------------------------------------------------
+// 8) VORPAL CLIENT EVENTS (schemaVersion 2)
+// -----------------------------------------------------------------------------
+// Vorpal supplies the source chronology. ADK's EventInfo_Time remains the
+// collector timestamp and does not replace client_event_timestamp_ms,
+// client_time_since_mount_ms, or client_sequence_number.
+//
+// Envelope projection on every row:
+//   batchId          -> client_batch_id
+//   mountId          -> client_mount_id
+//   appName          -> client_app_name
+//   buildEnvironment -> client_build_environment
+//   buildNumber      -> client_build_number
+//   toolCallId       -> client_tool_call_id       (optional)
+//   platform         -> client_platform           (optional, supplied verbatim)
+//   userAgent        -> client_user_agent         (optional, supplied verbatim)
+//
+// Event projection:
+//   eventName        -> client_event_name
+//   level            -> client_level
+//   eventTimestampMs -> client_event_timestamp_ms
+//   timeSinceMount   -> client_time_since_mount_ms
+//   sequenceNumber   -> client_sequence_number
+//   locale           -> client_locale             (optional)
+//   displayMode      -> client_display_mode       (optional)
+//   themeName        -> client_theme_name         (optional)
+//   operationId      -> client_operation_id       (optional)
+//   properties       -> client_properties         (scrubbed JSON string)
+//
+// client_operation_id is supplied from Vorpal's generated-operation context.
+// UUID validation establishes its format; ordinary GUID-valued properties
+// continue to be scrubbed. Deduplicate retries by mount + sequence, then order
+// by the client source timestamp and sequence number.
+adk_client_event
+| where EventInfo_Time > ago(30d)
+| summarize arg_max(EventInfo_Time, *) by client_mount_id, client_sequence_number
+| order by client_event_timestamp_ms asc, client_sequence_number asc
+| project EventInfo_Time,
+          client_batch_id,
+          client_mount_id,
+          client_tool_call_id,
+          client_app_name,
+          client_build_environment,
+          client_build_number,
+          client_platform,
+          client_user_agent,
+          client_event_name,
+          client_level,
+          client_event_timestamp_ms,
+          client_time_since_mount_ms,
+          client_sequence_number,
+          client_locale,
+          client_display_mode,
+          client_theme_name,
+          client_operation_id,
+          client_properties,
+          client_prop_dropped_count

--- a/solutions/ess-maker-skills/scripts/telemetry_queries.kql
+++ b/solutions/ess-maker-skills/scripts/telemetry_queries.kql
@@ -187,7 +187,7 @@ essmakerkit_flightcheck_run
 // 8) VORPAL CLIENT EVENTS (schemaVersion 2)
 // -----------------------------------------------------------------------------
 // Vorpal supplies the source chronology. ADK's EventInfo_Time remains the
-// collector timestamp and does not replace client_event_timestamp_ms,
+// collector timestamp and does not replace client_event_timestamp,
 // client_time_since_mount_ms, or client_sequence_number.
 //
 // Envelope projection on every row:
@@ -203,7 +203,7 @@ essmakerkit_flightcheck_run
 // Event projection:
 //   eventName        -> client_event_name
 //   level            -> client_level
-//   eventTimestampMs -> client_event_timestamp_ms
+//   eventTimestamp   -> client_event_timestamp
 //   timeSinceMount   -> client_time_since_mount_ms
 //   sequenceNumber   -> client_sequence_number
 //   locale           -> client_locale             (optional)
@@ -219,7 +219,7 @@ essmakerkit_flightcheck_run
 adk_client_event
 | where EventInfo_Time > ago(30d)
 | summarize arg_max(EventInfo_Time, *) by client_mount_id, client_sequence_number
-| order by client_event_timestamp_ms asc, client_sequence_number asc
+| order by client_event_timestamp asc, client_sequence_number asc
 | project EventInfo_Time,
           client_batch_id,
           client_mount_id,
@@ -231,7 +231,7 @@ adk_client_event
           client_user_agent,
           client_event_name,
           client_level,
-          client_event_timestamp_ms,
+          client_event_timestamp,
           client_time_since_mount_ms,
           client_sequence_number,
           client_locale,

--- a/solutions/ess-maker-skills/src/mcp/agentconfig_landing_page/server.py
+++ b/solutions/ess-maker-skills/src/mcp/agentconfig_landing_page/server.py
@@ -37,6 +37,9 @@ import adk_telemetry  # type: ignore  # noqa: E402  # pylint: disable=import-err
 
 DEFAULT_WIDGET_ORIGIN = "https://workforceinsights.m365.cloud.microsoft"
 WIDGET_MIME_TYPE = "text/html;profile=mcp-app"
+SOLUTION_LOCAL_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", ".local")
+)
 
 ACCENT_COLOR_RESOURCE_URI = "ui://widget/accent-color/AccentColor.html"
 QUICK_LINKS_RESOURCE_URI = "ui://widget/quick-links/QuickLinks.html"
@@ -162,6 +165,10 @@ def get_client() -> AgentConfigClient:
     global _client
     if _client is None:
         _client = AgentConfigClient()
+        adk_telemetry.initialize_tenant_identity(
+            _client.tenant_id,
+            local_dir=SOLUTION_LOCAL_DIR,
+        )
     return _client
 
 
@@ -427,11 +434,13 @@ async def open_starter_prompts(
 )
 async def report_client_events(
     schemaVersion: Any = None,
-    correlationId: Any = None,
+    batchId: Any = None,
     mountId: Any = None,
     appName: Any = None,
     buildEnvironment: Any = None,
     buildNumber: Any = None,
+    platform: Any = None,
+    userAgent: Any = None,
     events: Any = None,
     toolCallId: Any = None,
 ) -> CallToolResult:
@@ -447,11 +456,13 @@ async def report_client_events(
     """
     envelope: dict[str, Any] = {
         "schemaVersion": schemaVersion,
-        "correlationId": correlationId,
+        "batchId": batchId,
         "mountId": mountId,
         "appName": appName,
         "buildEnvironment": buildEnvironment,
         "buildNumber": buildNumber,
+        "platform": platform,
+        "userAgent": userAgent,
         "events": events,
     }
     if toolCallId is not None:

--- a/tests/mcp/agentconfig/test_server_contract.py
+++ b/tests/mcp/agentconfig/test_server_contract.py
@@ -72,11 +72,13 @@ def test_server_exposes_the_skill_tool_contract() -> None:
         # and stays hidden from the model-visible tool list.
         "report_client_events": [
             "schemaVersion",
-            "correlationId",
+            "batchId",
             "mountId",
             "appName",
             "buildEnvironment",
             "buildNumber",
+            "platform",
+            "userAgent",
             "events",
             "toolCallId",
         ],

--- a/tests/test_adk_mcp_report_client_events.py
+++ b/tests/test_adk_mcp_report_client_events.py
@@ -81,6 +81,31 @@ def test_report_client_events_tool_is_app_only():
     assert tool.annotations.openWorldHint is False
 
 
+def test_authenticated_client_initializes_telemetry_identity(monkeypatch):
+    server = _load_adk_server()
+    captured = {}
+
+    class FakeClient:
+        tenant_id = "00000000-0000-0000-0000-0000000000ab"
+
+    monkeypatch.setattr(server, "_client", None)
+    monkeypatch.setattr(server, "AgentConfigClient", FakeClient)
+    monkeypatch.setattr(
+        server.adk_telemetry,
+        "initialize_tenant_identity",
+        lambda tenant_id, *, local_dir: captured.update(
+            tenant_id=tenant_id,
+            local_dir=local_dir,
+        ),
+    )
+
+    assert isinstance(server.get_client(), FakeClient)
+    assert captured == {
+        "tenant_id": FakeClient.tenant_id,
+        "local_dir": server.SOLUTION_LOCAL_DIR,
+    }
+
+
 def test_report_client_events_tool_returns_structured_bridge_result(monkeypatch):
     server = _load_adk_server()
     captured = {}
@@ -93,26 +118,52 @@ def test_report_client_events_tool_returns_structured_bridge_result(monkeypatch)
 
     result = asyncio.run(
         server.report_client_events(
-            schemaVersion=1,
-            correlationId="corr-test",
+            schemaVersion=2,
+            batchId="batch-test",
             mountId="mount-test",
             appName="AgentIcon",
             buildEnvironment="dev",
             buildNumber="0",
             toolCallId="tool-test",
-            events=[{"eventName": "WidgetReady", "timeSinceAppStart": 1}],
+            platform="windows",
+            userAgent="Vorpal/Test",
+            events=[
+                {
+                    "eventName": "WidgetReady",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_000,
+                    "timeSinceMount": 1,
+                    "sequenceNumber": 1,
+                    "displayMode": "inline",
+                    "themeName": "dark",
+                    "operationId": "6f7c8f9c-1234-4abc-9def-0123456789ab",
+                }
+            ],
         )
     )
 
     assert captured["envelope"] == {
-        "schemaVersion": 1,
-        "correlationId": "corr-test",
+        "schemaVersion": 2,
+        "batchId": "batch-test",
         "mountId": "mount-test",
         "appName": "AgentIcon",
         "buildEnvironment": "dev",
         "buildNumber": "0",
+        "platform": "windows",
+        "userAgent": "Vorpal/Test",
         "toolCallId": "tool-test",
-        "events": [{"eventName": "WidgetReady", "timeSinceAppStart": 1}],
+        "events": [
+            {
+                "eventName": "WidgetReady",
+                "level": "info",
+                "eventTimestampMs": 1_700_000_000_000,
+                "timeSinceMount": 1,
+                "sequenceNumber": 1,
+                "displayMode": "inline",
+                "themeName": "dark",
+                "operationId": "6f7c8f9c-1234-4abc-9def-0123456789ab",
+            }
+        ],
     }
     assert result.structuredContent == {"status": "accepted", "acceptedEventCount": 1}
     assert result.isError is False
@@ -133,8 +184,8 @@ def test_report_client_events_tool_marks_rejection_as_error(monkeypatch):
 
     result = asyncio.run(
         server.report_client_events(
-            schemaVersion=1,
-            correlationId="corr-test",
+            schemaVersion=2,
+            batchId="batch-test",
             mountId="mount-test",
             appName="AgentIcon",
             buildEnvironment="dev",
@@ -153,13 +204,21 @@ def test_report_client_events_tool_marks_rejection_as_error(monkeypatch):
 
 def _valid_tool_args():
     return {
-        "schemaVersion": 1,
-        "correlationId": "corr-test",
+        "schemaVersion": 2,
+        "batchId": "batch-test",
         "mountId": "mount-test",
         "appName": "AgentIcon",
         "buildEnvironment": "dev",
         "buildNumber": "0",
-        "events": [{"eventName": "WidgetReady", "timeSinceAppStart": 1}],
+        "events": [
+            {
+                "eventName": "WidgetReady",
+                "level": "info",
+                "eventTimestampMs": 1_700_000_000_000,
+                "timeSinceMount": 1,
+                "sequenceNumber": 1,
+            }
+        ],
     }
 
 
@@ -167,9 +226,9 @@ def _valid_tool_args():
     ("mutation", "expected_reason"),
     [
         ({"events": [1, 2]}, "invalid_event_shape"),
-        ({"correlationId": 123}, "invalid_correlation_id"),
+        ({"batchId": 123}, "invalid_correlation_id"),
         ({"mountId": 123}, "invalid_mount_id"),
-        ({"schemaVersion": "2"}, "unsupported_schema_version"),
+        ({"schemaVersion": 1}, "unsupported_schema_version"),
         ({"buildNumber": None}, "invalid_event_shape"),
         ({"events": None}, "empty_batch"),
     ],
@@ -205,31 +264,38 @@ def test_valid_envelope_is_accepted_through_the_real_call_tool_path():
     assert result.isError is False
 
 
-@pytest.mark.parametrize(
-    ("level", "expected"),
-    [
-        ("error", "error"),
-        ("", ""),
-        ("error synthetic@example.test", "error <email>"),
-        ("x" * 201, "x" * 200),
-        (None, None),
-        ({"owner": "synthetic@example.test"}, None),
-        (["synthetic@example.test"], None),
-        ({}, None),
-        ([], None),
-        (0, None),
-        (1.5, None),
-        (True, None),
-        (False, None),
-    ],
-)
-def test_client_level_is_string_only_without_losing_events(monkeypatch, level, expected):
+@pytest.mark.parametrize("level", ["", "warning", None, 0, True, {}])
+def test_invalid_required_levels_are_rejected_through_call_tool(level):
+    server = _load_adk_server()
+    args = {
+        **_valid_tool_args(),
+        "events": [
+            {
+                "eventName": "InvalidLevel",
+                "level": level,
+                "eventTimestampMs": 1_700_000_000_000,
+                "timeSinceMount": 1,
+                "sequenceNumber": 1,
+            }
+        ],
+    }
+
+    result = asyncio.run(server.mcp.call_tool("report_client_events", args))
+
+    assert result.structuredContent == {
+        "status": "rejected",
+        "acceptedEventCount": 0,
+        "rejectedReason": "invalid_event_shape",
+    }
+    assert result.isError is True
+
+
+def test_all_v2_fields_survive_the_real_call_tool_path(monkeypatch):
     server = _load_adk_server()
     emitted = []
+    operation_id = "6f7c8f9c-1234-4abc-9def-0123456789ab"
     monkeypatch.setattr(server.adk_telemetry, "get_session", lambda surface: ("test", False))
-    monkeypatch.setattr(
-        server.adk_telemetry, "common_dimensions", lambda *args, **kwargs: {}
-    )
+    monkeypatch.setattr(server.adk_telemetry, "common_dimensions", lambda *args, **kwargs: {})
     monkeypatch.setattr(
         server.adk_telemetry,
         "_emit_many",
@@ -237,22 +303,53 @@ def test_client_level_is_string_only_without_losing_events(monkeypatch, level, e
     )
     args = {
         **_valid_tool_args(),
+        "toolCallId": "call_host-generated",
+        "platform": "windows",
+        "userAgent": "Mozilla/5.0 synthetic@example.test",
         "events": [
-            {"eventName": "WithLevel", "timeSinceAppStart": 1, "level": level},
-            {"eventName": "WithoutLevel", "timeSinceAppStart": 2},
+            {
+                "eventName": "Widget.Ready",
+                "level": "error",
+                "eventTimestampMs": 1_700_000_000_123.5,
+                "timeSinceMount": 12.25,
+                "sequenceNumber": 42,
+                "locale": "en-US",
+                "displayMode": "inline",
+                "themeName": "dark",
+                "operationId": operation_id,
+                "properties": {"objectId": operation_id},
+                "someFutureField": {"nested": True},
+            }
         ],
     }
 
     result = asyncio.run(server.mcp.call_tool("report_client_events", args))
 
-    assert result.structuredContent == {"status": "accepted", "acceptedEventCount": 2}
+    assert result.structuredContent == {"status": "accepted", "acceptedEventCount": 1}
     assert result.isError is False
-    assert [row["client_event_name"] for row in emitted] == ["WithLevel", "WithoutLevel"]
-    if expected is None:
-        assert "client_level" not in emitted[0]
-    else:
-        assert emitted[0]["client_level"] == expected
-    assert "client_level" not in emitted[1]
+    assert emitted == [
+        {
+            "client_event_name": "Widget.Ready",
+            "client_batch_id": "batch-test",
+            "client_mount_id": "mount-test",
+            "client_app_name": "AgentIcon",
+            "client_build_environment": "dev",
+            "client_build_number": "0",
+            "client_level": "error",
+            "client_event_timestamp_ms": 1_700_000_000_123.5,
+            "client_time_since_mount_ms": 12.25,
+            "client_sequence_number": 42,
+            "client_tool_call_id": "call_host-generated",
+            "client_platform": "windows",
+            "client_user_agent": "Mozilla/5.0 synthetic@example.test",
+            "client_locale": "en-US",
+            "client_display_mode": "inline",
+            "client_theme_name": "dark",
+            "client_operation_id": operation_id,
+            "client_properties": '{"objectId":"<guid>"}',
+            "client_prop_dropped_count": 0,
+        }
+    ]
 
 
 def test_unknown_event_field_survives_the_real_call_tool_path():
@@ -265,7 +362,12 @@ def test_unknown_event_field_survives_the_real_call_tool_path():
     server = _load_adk_server()
     args = {
         **_valid_tool_args(),
-        "events": [{"eventName": "WidgetReady", "timeSinceAppStart": 1, "someFutureField": "x"}],
+        "events": [
+            {
+                **_valid_tool_args()["events"][0],
+                "someFutureField": "x",
+            }
+        ],
     }
 
     result = asyncio.run(server.mcp.call_tool("report_client_events", args))
@@ -289,7 +391,16 @@ def test_bridge_is_total_so_the_wrapper_needs_no_guard(monkeypatch):
 
     args = {
         **_valid_tool_args(),
-        "events": [{"eventName": "E", "timeSinceAppStart": 1} for _ in range(20)],
+        "events": [
+            {
+                "eventName": "E",
+                "level": "info",
+                "eventTimestampMs": 1_700_000_000_000 + index,
+                "timeSinceMount": index,
+                "sequenceNumber": index + 1,
+            }
+            for index in range(20)
+        ],
     }
     result = asyncio.run(server.report_client_events(**args))
 

--- a/tests/test_adk_mcp_report_client_events.py
+++ b/tests/test_adk_mcp_report_client_events.py
@@ -131,7 +131,7 @@ def test_report_client_events_tool_returns_structured_bridge_result(monkeypatch)
                 {
                     "eventName": "WidgetReady",
                     "level": "info",
-                    "eventTimestampMs": 1_700_000_000_000,
+                    "eventTimestamp": "2026-09-11T23:21:26.196Z",
                     "timeSinceMount": 1,
                     "sequenceNumber": 1,
                     "displayMode": "inline",
@@ -156,7 +156,7 @@ def test_report_client_events_tool_returns_structured_bridge_result(monkeypatch)
             {
                 "eventName": "WidgetReady",
                 "level": "info",
-                "eventTimestampMs": 1_700_000_000_000,
+                "eventTimestamp": "2026-09-11T23:21:26.196Z",
                 "timeSinceMount": 1,
                 "sequenceNumber": 1,
                 "displayMode": "inline",
@@ -214,7 +214,7 @@ def _valid_tool_args():
             {
                 "eventName": "WidgetReady",
                 "level": "info",
-                "eventTimestampMs": 1_700_000_000_000,
+                "eventTimestamp": "2026-09-11T23:21:26.196Z",
                 "timeSinceMount": 1,
                 "sequenceNumber": 1,
             }
@@ -273,7 +273,7 @@ def test_invalid_required_levels_are_rejected_through_call_tool(level):
             {
                 "eventName": "InvalidLevel",
                 "level": level,
-                "eventTimestampMs": 1_700_000_000_000,
+                "eventTimestamp": "2026-09-11T23:21:26.196Z",
                 "timeSinceMount": 1,
                 "sequenceNumber": 1,
             }
@@ -310,7 +310,7 @@ def test_all_v2_fields_survive_the_real_call_tool_path(monkeypatch):
             {
                 "eventName": "Widget.Ready",
                 "level": "error",
-                "eventTimestampMs": 1_700_000_000_123.5,
+                "eventTimestamp": "2026-09-11T23:21:26.198Z",
                 "timeSinceMount": 12.25,
                 "sequenceNumber": 42,
                 "locale": "en-US",
@@ -336,7 +336,7 @@ def test_all_v2_fields_survive_the_real_call_tool_path(monkeypatch):
             "client_build_environment": "dev",
             "client_build_number": "0",
             "client_level": "error",
-            "client_event_timestamp_ms": 1_700_000_000_123.5,
+            "client_event_timestamp": "2026-09-11T23:21:26.198Z",
             "client_time_since_mount_ms": 12.25,
             "client_sequence_number": 42,
             "client_tool_call_id": "call_host-generated",
@@ -395,7 +395,7 @@ def test_bridge_is_total_so_the_wrapper_needs_no_guard(monkeypatch):
             {
                 "eventName": "E",
                 "level": "info",
-                "eventTimestampMs": 1_700_000_000_000 + index,
+                "eventTimestamp": f"2026-09-11T23:21:{index:02d}.000Z",
                 "timeSinceMount": index,
                 "sequenceNumber": index + 1,
             }

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -109,8 +109,8 @@ def captured_post(monkeypatch):
 
 def _client_events_envelope(**overrides):
     envelope = {
-        "schemaVersion": 1,
-        "correlationId": "corr-test",
+        "schemaVersion": 2,
+        "batchId": "batch-test",
         "mountId": "mount-test",
         "appName": "AgentIcon",
         "buildEnvironment": "dev",
@@ -119,7 +119,10 @@ def _client_events_envelope(**overrides):
         "events": [
             {
                 "eventName": "WidgetReady",
-                "timeSinceAppStart": 12,
+                "level": "info",
+                "eventTimestampMs": 1_700_000_000_000,
+                "timeSinceMount": 12,
+                "sequenceNumber": 1,
                 "locale": "en-US",
                 "properties": {
                     "count": 1,
@@ -130,12 +133,29 @@ def _client_events_envelope(**overrides):
             },
             {
                 "eventName": "WidgetFunnelStage",
-                "timeSinceAppStart": 18.5,
+                "level": "info",
+                "eventTimestampMs": 1_700_000_000_010,
+                "timeSinceMount": 18.5,
+                "sequenceNumber": 2,
                 "properties": {"stage": "loaded"},
             },
         ],
     }
     envelope.update(overrides)
+    events = envelope.get("events")
+    if isinstance(events, list):
+        normalized_events = []
+        for index, event in enumerate(events):
+            if not isinstance(event, dict):
+                normalized_events.append(event)
+                continue
+            normalized = dict(event)
+            normalized.setdefault("level", "info")
+            normalized.setdefault("eventTimestampMs", 1_700_000_000_000 + index)
+            normalized.setdefault("timeSinceMount", index + 1)
+            normalized.setdefault("sequenceNumber", index + 1)
+            normalized_events.append(normalized)
+        envelope["events"] = normalized_events
     return envelope
 
 
@@ -147,6 +167,19 @@ def test_set_identity_stores_instance_and_raw_tenant(monkeypatch):
     assert "developer_id" not in ident
     assert ident["instance_id"] == "install-guid-1"
     assert ident["tenant_id"] == "00000000-0000-0000-0000-0000000000ab"
+
+
+def test_initialize_tenant_identity_uses_explicit_cache_root(tmp_path, monkeypatch):
+    local_dir = str(tmp_path / "solution-local")
+    tenant_id = "00000000-0000-0000-0000-0000000000ab"
+    _fc.cache_tenant_name(tenant_id, "Contoso", local_dir=local_dir)
+    monkeypatch.setattr(_fc, "get_instance_id", lambda: "install-guid-1")
+
+    ident = adk.initialize_tenant_identity(tenant_id, local_dir=local_dir)
+
+    assert ident["tenant_id"] == tenant_id
+    assert ident["tenant_name"] == "Contoso"
+    assert _fc.get_cached_tenant_id(local_dir=local_dir) == tenant_id
 
 
 def test_set_identity_stores_tenant_name(monkeypatch):
@@ -636,13 +669,16 @@ def test_report_client_events_accepts_and_posts_valid_batch(captured_post, monke
     ]
     first = envelopes[0]["data"]
     assert first["client_event_name"] == "WidgetReady"
-    assert first["client_correlation_id"] == "corr-test"
+    assert first["client_batch_id"] == "batch-test"
     assert first["client_mount_id"] == "mount-test"
     assert first["client_tool_call_id"] == "tool-test"
     assert first["client_app_name"] == "AgentIcon"
     assert first["client_build_environment"] == "dev"
     assert first["client_build_number"] == "0"
-    assert first["client_time_since_app_start_ms"] == 12
+    assert first["client_level"] == "info"
+    assert first["client_event_timestamp_ms"] == 1_700_000_000_000
+    assert first["client_time_since_mount_ms"] == 12
+    assert first["client_sequence_number"] == 1
     assert first["client_locale"] == "en-US"
     assert json.loads(first["client_properties"]) == {
         "count": 1,
@@ -656,6 +692,169 @@ def test_report_client_events_accepts_and_posts_valid_batch(captured_post, monke
     assert "developer_id" not in first
 
 
+def test_v2_optional_fields_are_projected_without_generic_scrubbing(captured_post, monkeypatch):
+    monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
+    operation_id = "6f7c8f9c-1234-4abc-9def-0123456789ab"
+    user_agent = "Mozilla/5.0 synthetic@example.test"
+
+    result = adk.report_client_events(
+        _client_events_envelope(
+            buildNumber="",
+            platform="Win32",
+            userAgent=user_agent,
+            events=[
+                {
+                    "eventName": "Save.Started",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_123.5,
+                    "timeSinceMount": 12.25,
+                    "sequenceNumber": 42,
+                    "locale": "en-US",
+                    "displayMode": "inline",
+                    "themeName": "dark",
+                    "operationId": operation_id,
+                    "properties": {"operationId": operation_id},
+                }
+            ],
+        ),
+        block=True,
+    )
+
+    assert result == {"status": "accepted", "acceptedEventCount": 1}
+    data = captured_post[0][1][0]["data"]
+    assert data["client_build_number"] == ""
+    assert data["client_platform"] == "Win32"
+    assert data["client_user_agent"] == user_agent
+    assert data["client_event_timestamp_ms"] == 1_700_000_000_123.5
+    assert data["client_time_since_mount_ms"] == 12.25
+    assert data["client_sequence_number"] == 42
+    assert data["client_display_mode"] == "inline"
+    assert data["client_theme_name"] == "dark"
+    assert data["client_operation_id"] == operation_id
+    assert json.loads(data["client_properties"]) == {"operationId": "<guid>"}
+
+
+def test_unavailable_v2_optional_fields_remain_absent(captured_post, monkeypatch):
+    monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
+
+    result = adk.report_client_events(
+        _client_events_envelope(
+            toolCallId=None,
+            events=[
+                {
+                    "eventName": "WidgetReady",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_000,
+                    "timeSinceMount": 0,
+                    "sequenceNumber": 1,
+                }
+            ],
+        ),
+        block=True,
+    )
+
+    assert result == {"status": "accepted", "acceptedEventCount": 1}
+    data = captured_post[0][1][0]["data"]
+    for field in (
+        "client_tool_call_id",
+        "client_platform",
+        "client_user_agent",
+        "client_locale",
+        "client_display_mode",
+        "client_theme_name",
+        "client_operation_id",
+    ):
+        assert field not in data
+
+
+def test_vorpal_owns_event_names_and_sequence_order(captured_post, monkeypatch):
+    monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
+
+    result = adk.report_client_events(
+        _client_events_envelope(
+            events=[
+                {
+                    "eventName": "WidgetReady",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_020,
+                    "timeSinceMount": 20,
+                    "sequenceNumber": 100,
+                },
+                {
+                    "eventName": "Widget.Ready",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_010,
+                    "timeSinceMount": 10,
+                    "sequenceNumber": 100,
+                },
+                {
+                    "eventName": "Future.Name.From.Vorpal",
+                    "level": "error",
+                    "eventTimestampMs": 1_700_000_000_005,
+                    "timeSinceMount": 5,
+                    "sequenceNumber": 4,
+                },
+            ],
+        ),
+        block=True,
+    )
+
+    assert result == {"status": "accepted", "acceptedEventCount": 3}
+    rows = [envelope["data"] for envelope in captured_post[0][1]]
+    assert [row["client_event_name"] for row in rows] == [
+        "WidgetReady",
+        "Widget.Ready",
+        "Future.Name.From.Vorpal",
+    ]
+    assert [row["client_sequence_number"] for row in rows] == [100, 100, 4]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("sequenceNumber", 0),
+        ("sequenceNumber", -1),
+        ("sequenceNumber", 1.5),
+        ("sequenceNumber", True),
+        ("sequenceNumber", None),
+        ("themeName", "system"),
+        ("themeName", {}),
+        ("operationId", "6F7C8F9C-1234-4ABC-9DEF-0123456789AB"),
+        ("operationId", "not-a-guid"),
+    ],
+)
+def test_invalid_v2_occurrence_metadata_rejects_the_batch(field, value, captured_post):
+    event = {
+        "eventName": "InvalidMetadata",
+        "level": "info",
+        "eventTimestampMs": 1_700_000_000_000,
+        "timeSinceMount": 1,
+        "sequenceNumber": 1,
+    }
+    event[field] = value
+
+    result = adk.report_client_events(
+        _client_events_envelope(events=[event]),
+        block=True,
+    )
+
+    assert result["rejectedReason"] == "invalid_event_shape"
+    assert captured_post == []
+
+
+@pytest.mark.parametrize("field", ["platform", "userAgent", "buildNumber"])
+def test_raw_v2_strings_are_size_bounded_without_truncation(field, captured_post):
+    result = adk.report_client_events(
+        _client_events_envelope(
+            **{field: "x" * (adk.CLIENT_EVENTS_MAX_STRING_LENGTH + 1)}
+        ),
+        block=True,
+    )
+
+    assert result["rejectedReason"] == "invalid_event_shape"
+    assert captured_post == []
+
+
 def test_report_client_events_honors_opt_out_without_retrying(captured_post, monkeypatch):
     monkeypatch.setenv("ESS_ADK_TELEMETRY", "off")
 
@@ -665,9 +864,68 @@ def test_report_client_events_honors_opt_out_without_retrying(captured_post, mon
     assert captured_post == []
 
 
-def test_report_client_events_rejects_unsupported_schema(captured_post):
+def test_client_source_chronology_survives_buffer_reemission(monkeypatch):
+    operation_id = "6f7c8f9c-1234-4abc-9def-0123456789ab"
+    calls = []
+
+    def _failing_post(_ikey, _envelopes):
+        raise OSError("offline")
+
+    monkeypatch.setattr(_fc, "_post", _failing_post)
+    first = adk.report_client_events(
+        _client_events_envelope(
+            batchId="batch-retry",
+            events=[
+                {
+                    "eventName": "Save.Started",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_123.5,
+                    "timeSinceMount": 12.25,
+                    "sequenceNumber": 42,
+                    "operationId": operation_id,
+                }
+            ],
+        ),
+        block=True,
+    )
+
+    assert first == {"status": "accepted", "acceptedEventCount": 1}
+
+    def _successful_post(_ikey, envelopes):
+        calls.append(envelopes)
+        return 200
+
+    monkeypatch.setattr(_fc, "_post", _successful_post)
+    second = adk.report_client_events(
+        _client_events_envelope(
+            batchId="batch-next",
+            events=[
+                {
+                    "eventName": "Save.Completed",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_200,
+                    "timeSinceMount": 20,
+                    "sequenceNumber": 43,
+                    "operationId": operation_id,
+                }
+            ],
+        ),
+        block=True,
+    )
+
+    assert second == {"status": "accepted", "acceptedEventCount": 1}
+    replayed = calls[0][0]["data"]
+    assert replayed["client_batch_id"] == "batch-retry"
+    assert replayed["client_event_timestamp_ms"] == 1_700_000_000_123.5
+    assert replayed["client_time_since_mount_ms"] == 12.25
+    assert replayed["client_sequence_number"] == 42
+    assert replayed["client_operation_id"] == operation_id
+
+
+@pytest.mark.parametrize("schema_version", [1, 2.0, True, "2", None])
+def test_report_client_events_rejects_unsupported_schema(schema_version, captured_post):
     result = adk.report_client_events(
-        _client_events_envelope(schemaVersion=2),
+        _client_events_envelope(schemaVersion=schema_version),
         block=True,
     )
 
@@ -684,7 +942,7 @@ def test_report_client_events_rejects_empty_and_oversized_batches(captured_post)
     oversized = adk.report_client_events(
         _client_events_envelope(
             events=[
-                {"eventName": f"Event{i}", "timeSinceAppStart": i}
+                {"eventName": f"Event{i}", "timeSinceMount": i}
                 for i in range(adk.CLIENT_EVENTS_MAX_BATCH_EVENTS + 1)
             ]
         ),
@@ -697,7 +955,7 @@ def test_report_client_events_rejects_empty_and_oversized_batches(captured_post)
 
 
 _IDENTIFIER_FIELDS = {
-    "correlationId": "invalid_correlation_id",
+    "batchId": "invalid_correlation_id",
     "mountId": "invalid_mount_id",
 }
 
@@ -706,7 +964,7 @@ _IDENTIFIER_FIELDS = {
 def test_each_identifier_field_reports_its_own_rejection_reason(field, captured_post):
     """A rejection must name the field that actually failed.
 
-    Distinct reasons let dashboards distinguish correlation-id failures from
+    The existing reason vocabulary distinguishes the batch identifier from
     mount-id failures.
     """
     expected_reason = _IDENTIFIER_FIELDS[field]
@@ -763,7 +1021,7 @@ def test_retired_reasons_are_gone_from_the_value_list():
         "x" * 65,  # one over the single length bound
     ],
 )
-def test_correlation_identifiers_are_not_a_free_text_tunnel(field, payload, captured_post):
+def test_client_identifiers_are_not_a_free_text_tunnel(field, payload, captured_post):
     """The ephemeral ids are emitted verbatim, so they must be identifier-shaped.
 
     Validate the whole value against the bounded ASCII format. Required ids
@@ -781,13 +1039,13 @@ def test_correlation_identifiers_are_not_a_free_text_tunnel(field, payload, capt
     assert captured_post == []
 
 
-def test_well_formed_correlation_identifiers_are_accepted(captured_post, monkeypatch):
+def test_well_formed_client_identifiers_are_accepted(captured_post, monkeypatch):
     # Accept generated UUID-style ids and permitted dot/underscore/dash characters.
     monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
 
     result = adk.report_client_events(
         _client_events_envelope(
-            correlationId="corr-6f7c8f9c-1234-4abc-9def-0123456789ab",
+            batchId="batch-6f7c8f9c-1234-4abc-9def-0123456789ab",
             mountId="mount-1a2b_3c.4d",
             toolCallId="tool-Call.42",
         ),
@@ -796,7 +1054,7 @@ def test_well_formed_correlation_identifiers_are_accepted(captured_post, monkeyp
 
     assert result == {"status": "accepted", "acceptedEventCount": 2}
     data = captured_post[0][1][0]["data"]
-    assert data["client_correlation_id"] == "corr-6f7c8f9c-1234-4abc-9def-0123456789ab"
+    assert data["client_batch_id"] == "batch-6f7c8f9c-1234-4abc-9def-0123456789ab"
     assert data["client_mount_id"] == "mount-1a2b_3c.4d"
     assert data["client_tool_call_id"] == "tool-Call.42"
 
@@ -811,7 +1069,7 @@ def test_identifiers_without_the_legacy_prefixes_are_accepted(captured_post, mon
 
     result = adk.report_client_events(
         _client_events_envelope(
-            correlationId="6f7c8f9c-1234-4abc-9def-0123456789ab",
+            batchId="6f7c8f9c-1234-4abc-9def-0123456789ab",
             mountId="01JQZ8XKMNP7RSTVWXYZ",  # bare ULID-style, no prefix
             toolCallId="call_abc.42",
         ),
@@ -820,7 +1078,7 @@ def test_identifiers_without_the_legacy_prefixes_are_accepted(captured_post, mon
 
     assert result == {"status": "accepted", "acceptedEventCount": 2}
     data = captured_post[0][1][0]["data"]
-    assert data["client_correlation_id"] == "6f7c8f9c-1234-4abc-9def-0123456789ab"
+    assert data["client_batch_id"] == "6f7c8f9c-1234-4abc-9def-0123456789ab"
     assert data["client_tool_call_id"] == "call_abc.42"
 
 
@@ -843,10 +1101,10 @@ def test_free_text_event_names_are_scrubbed_not_rejected(captured_post, monkeypa
     result = adk.report_client_events(
         _client_events_envelope(
             events=[
-                {"eventName": "Widget\U0001f600Ready", "timeSinceAppStart": 1},
+                {"eventName": "Widget\U0001f600Ready", "timeSinceMount": 1},
                 {
                     "eventName": "opened C:\\Users\\jdoe\\secret.docx for jdoe@contoso.com",
-                    "timeSinceAppStart": 2,
+                    "timeSinceMount": 2,
                 },
             ]
         ),
@@ -869,7 +1127,7 @@ def test_oversized_property_strings_are_truncated_not_rejected(captured_post, mo
             events=[
                 {
                     "eventName": "BigProp",
-                    "timeSinceAppStart": 1,
+                    "timeSinceMount": 1,
                     "properties": {"blob": "x" * (adk.CLIENT_EVENTS_MAX_STRING_LENGTH + 1)},
                 }
             ]
@@ -891,7 +1149,7 @@ def test_long_appname_and_locale_are_truncated_not_rejected(captured_post, monke
             events=[
                 {
                     "eventName": "E",
-                    "timeSinceAppStart": 1,
+                    "timeSinceMount": 1,
                     "locale": "L" * 500,
                 }
             ],
@@ -914,7 +1172,7 @@ def test_many_properties_and_long_arrays_are_accepted(captured_post, monkeypatch
             events=[
                 {
                     "eventName": "Wide",
-                    "timeSinceAppStart": 1,
+                    "timeSinceMount": 1,
                     "properties": {
                         **{f"k{i}": i for i in range(40)},
                         "tags": list(range(50)),
@@ -950,9 +1208,9 @@ def test_non_identifier_property_keys_are_kept_but_length_bounded():
 @pytest.mark.parametrize(
     ("event", "reason"),
     [
-        ({"eventName": "", "timeSinceAppStart": 1}, "invalid_event_shape"),
-        ({"eventName": 123, "timeSinceAppStart": 1}, "invalid_event_shape"),
-        ({"eventName": "BadLocale", "timeSinceAppStart": 1, "locale": 5}, "invalid_event_shape"),
+        ({"eventName": "", "timeSinceMount": 1}, "invalid_event_shape"),
+        ({"eventName": 123, "timeSinceMount": 1}, "invalid_event_shape"),
+        ({"eventName": "BadLocale", "timeSinceMount": 1, "locale": 5}, "invalid_event_shape"),
     ],
 )
 def test_report_client_events_rejects_out_of_contract_events(event, reason, captured_post):
@@ -965,30 +1223,59 @@ def test_report_client_events_rejects_out_of_contract_events(event, reason, capt
     assert captured_post == []
 
 
-def test_non_finite_timing_degrades_to_a_sentinel(captured_post, monkeypatch):
-    """One unusable timing costs one column on one row, not the batch.
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("eventTimestampMs", float("nan")),
+        ("eventTimestampMs", float("inf")),
+        ("eventTimestampMs", -1),
+        ("eventTimestampMs", "1700000000000"),
+        ("eventTimestampMs", True),
+        ("timeSinceMount", float("nan")),
+        ("timeSinceMount", float("inf")),
+        ("timeSinceMount", -1),
+        ("timeSinceMount", "12"),
+        ("timeSinceMount", False),
+    ],
+)
+def test_invalid_source_timing_rejects_the_batch(field, value, captured_post):
+    event = {
+        "eventName": "InvalidTiming",
+        "level": "info",
+        "eventTimestampMs": 1_700_000_000_000,
+        "timeSinceMount": 0,
+        "sequenceNumber": 1,
+    }
+    event[field] = value
 
-    ``-1`` is unambiguous because ``performance.now()`` is non-negative, and
-    ``0`` has to stay a real value — a bootloader event legitimately fires at
-    time zero, so it cannot double as the failure marker.
-    """
-    monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
+    result = adk.report_client_events(
+        _client_events_envelope(events=[event]),
+        block=True,
+    )
 
+    assert result["rejectedReason"] == "invalid_event_shape"
+    assert captured_post == []
+
+
+def test_time_since_app_start_is_not_a_v2_alias(captured_post):
     result = adk.report_client_events(
         _client_events_envelope(
             events=[
-                {"eventName": "NaNTime", "timeSinceAppStart": float("nan")},
-                {"eventName": "MissingTime"},
-                {"eventName": "StringTime", "timeSinceAppStart": "12"},
-                {"eventName": "ZeroTime", "timeSinceAppStart": 0},
+                {
+                    "eventName": "LegacyTiming",
+                    "level": "info",
+                    "eventTimestampMs": 1_700_000_000_000,
+                    "sequenceNumber": 1,
+                    "timeSinceAppStart": 12,
+                    "timeSinceMount": None,
+                }
             ]
         ),
         block=True,
     )
 
-    assert result == {"status": "accepted", "acceptedEventCount": 4}
-    times = [e["data"]["client_time_since_app_start_ms"] for e in captured_post[0][1]]
-    assert times == [-1, -1, -1, 0]
+    assert result["rejectedReason"] == "invalid_event_shape"
+    assert captured_post == []
 
 
 def test_malformed_property_bag_costs_the_bag_not_the_event(captured_post, monkeypatch):
@@ -997,10 +1284,10 @@ def test_malformed_property_bag_costs_the_bag_not_the_event(captured_post, monke
     result = adk.report_client_events(
         _client_events_envelope(
             events=[
-                {"eventName": "ListBag", "timeSinceAppStart": 1, "properties": ["not", "a", "dict"]},
+                {"eventName": "ListBag", "timeSinceMount": 1, "properties": ["not", "a", "dict"]},
                 {
                     "eventName": "MixedBag",
-                    "timeSinceAppStart": 2,
+                    "timeSinceMount": 2,
                     "properties": {"keep": "yes", "nested": {"a": 1}, "nan": float("inf")},
                 },
             ]
@@ -1020,7 +1307,7 @@ def test_malformed_property_bag_costs_the_bag_not_the_event(captured_post, monke
 def test_bad_tool_call_id_omits_the_field_and_keeps_the_batch(captured_post, monkeypatch):
     """An incompatible host-generated tool-call id is omitted.
 
-    Correlation and mount ids provide required stitching metadata, so the
+    Batch and mount ids provide required stitching metadata, so the
     batch remains useful without the optional tool-call id.
     """
     monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
@@ -1034,18 +1321,17 @@ def test_bad_tool_call_id_omits_the_field_and_keeps_the_batch(captured_post, mon
     data = captured_post[0][1][0]["data"]
     assert "client_tool_call_id" not in data
     # The fields that DO stitch a mount together are still rejected, not omitted.
-    assert data["client_correlation_id"] == "corr-test"
+    assert data["client_batch_id"] == "batch-test"
 
 
-def test_client_level_is_accepted_and_emitted(captured_post, monkeypatch):
-    # Optional client levels are emitted when present.
+def test_client_level_is_required_and_emitted(captured_post, monkeypatch):
     monkeypatch.setenv("ESS_ADK_ARIA_ENV", "dev")
 
     result = adk.report_client_events(
         _client_events_envelope(
             events=[
-                {"eventName": "E", "timeSinceAppStart": 1, "level": "error"},
-                {"eventName": "F", "timeSinceAppStart": 2},
+                {"eventName": "E", "timeSinceMount": 1, "level": "error"},
+                {"eventName": "F", "timeSinceMount": 2, "level": "info"},
             ]
         ),
         block=True,
@@ -1054,7 +1340,7 @@ def test_client_level_is_accepted_and_emitted(captured_post, monkeypatch):
     assert result == {"status": "accepted", "acceptedEventCount": 2}
     first, second = (e["data"] for e in captured_post[0][1])
     assert first["client_level"] == "error"
-    assert "client_level" not in second
+    assert second["client_level"] == "info"
 
 
 def test_unknown_envelope_fields_are_ignored_not_rejected(captured_post, monkeypatch):
@@ -1089,7 +1375,7 @@ def test_unknown_event_fields_are_ignored_not_rejected(captured_post, monkeypatc
             events=[
                 {
                     "eventName": "WidgetReady",
-                    "timeSinceAppStart": 12,
+                    "timeSinceMount": 12,
                     "someFutureField": "not yet known to ADK",
                     "properties": {"stage": "loaded"},
                 }
@@ -1118,7 +1404,7 @@ def test_report_client_events_scrubs_paths_urls_emails_and_guids(captured_post, 
             events=[
                 {
                     "eventName": "WidgetReady",
-                    "timeSinceAppStart": 1,
+                    "timeSinceMount": 1,
                     "properties": {
                         "note": "C:\\Users\\jdoe\\secret.docx see https://contoso.sharepoint.com/x",
                         "owner": "jdoe@contoso.com",
@@ -1211,7 +1497,7 @@ def test_missing_properties_still_emit_a_parseable_blob(captured_post, monkeypat
 
     result = adk.report_client_events(
         _client_events_envelope(
-            events=[{"eventName": "NoProps", "timeSinceAppStart": 1}]
+            events=[{"eventName": "NoProps", "timeSinceMount": 1}]
         ),
         block=True,
     )
@@ -1231,7 +1517,7 @@ def test_report_client_events_rejection_leaves_no_session_side_effect(captured_p
     assert not os.path.exists(adk.SESSION_PATH)
 
     result = adk.report_client_events(
-        _client_events_envelope(correlationId="not a valid id"),
+        _client_events_envelope(batchId="not a valid id"),
         block=True,
     )
 
@@ -1274,7 +1560,7 @@ def test_fail_open_echoes_the_full_sent_count(monkeypatch, captured_post):
 
     result = adk.report_client_events(
         _client_events_envelope(
-            events=[{"eventName": "E", "timeSinceAppStart": 1} for _ in range(20)]
+            events=[{"eventName": "E", "timeSinceMount": 1} for _ in range(20)]
         ),
         block=True,
     )
@@ -1287,7 +1573,7 @@ def test_oversized_batch_is_rejected_on_the_normal_path(captured_post):
     # Accept a 100-event batch and reject a batch exceeding the safety cap.
     ok = adk.report_client_events(
         _client_events_envelope(
-            events=[{"eventName": "E", "timeSinceAppStart": 1} for _ in range(100)]
+            events=[{"eventName": "E", "timeSinceMount": 1} for _ in range(100)]
         ),
         block=True,
     )
@@ -1296,7 +1582,7 @@ def test_oversized_batch_is_rejected_on_the_normal_path(captured_post):
     result = adk.report_client_events(
         _client_events_envelope(
             events=[
-                {"eventName": "E", "timeSinceAppStart": 1}
+                {"eventName": "E", "timeSinceMount": 1}
                 for _ in range(adk.CLIENT_EVENTS_MAX_BATCH_EVENTS + 1)
             ]
         ),

--- a/tests/test_adk_telemetry.py
+++ b/tests/test_adk_telemetry.py
@@ -120,7 +120,7 @@ def _client_events_envelope(**overrides):
             {
                 "eventName": "WidgetReady",
                 "level": "info",
-                "eventTimestampMs": 1_700_000_000_000,
+                "eventTimestamp": "2026-09-11T23:21:26.196Z",
                 "timeSinceMount": 12,
                 "sequenceNumber": 1,
                 "locale": "en-US",
@@ -134,7 +134,7 @@ def _client_events_envelope(**overrides):
             {
                 "eventName": "WidgetFunnelStage",
                 "level": "info",
-                "eventTimestampMs": 1_700_000_000_010,
+                "eventTimestamp": "2026-09-11T23:21:26.206Z",
                 "timeSinceMount": 18.5,
                 "sequenceNumber": 2,
                 "properties": {"stage": "loaded"},
@@ -151,7 +151,7 @@ def _client_events_envelope(**overrides):
                 continue
             normalized = dict(event)
             normalized.setdefault("level", "info")
-            normalized.setdefault("eventTimestampMs", 1_700_000_000_000 + index)
+            normalized.setdefault("eventTimestamp", "2026-09-11T23:21:26.196Z")
             normalized.setdefault("timeSinceMount", index + 1)
             normalized.setdefault("sequenceNumber", index + 1)
             normalized_events.append(normalized)
@@ -676,7 +676,7 @@ def test_report_client_events_accepts_and_posts_valid_batch(captured_post, monke
     assert first["client_build_environment"] == "dev"
     assert first["client_build_number"] == "0"
     assert first["client_level"] == "info"
-    assert first["client_event_timestamp_ms"] == 1_700_000_000_000
+    assert first["client_event_timestamp"] == "2026-09-11T23:21:26.196Z"
     assert first["client_time_since_mount_ms"] == 12
     assert first["client_sequence_number"] == 1
     assert first["client_locale"] == "en-US"
@@ -706,7 +706,7 @@ def test_v2_optional_fields_are_projected_without_generic_scrubbing(captured_pos
                 {
                     "eventName": "Save.Started",
                     "level": "info",
-                    "eventTimestampMs": 1_700_000_000_123.5,
+                    "eventTimestamp": "2026-09-11T23:21:26.198Z",
                     "timeSinceMount": 12.25,
                     "sequenceNumber": 42,
                     "locale": "en-US",
@@ -725,7 +725,7 @@ def test_v2_optional_fields_are_projected_without_generic_scrubbing(captured_pos
     assert data["client_build_number"] == ""
     assert data["client_platform"] == "Win32"
     assert data["client_user_agent"] == user_agent
-    assert data["client_event_timestamp_ms"] == 1_700_000_000_123.5
+    assert data["client_event_timestamp"] == "2026-09-11T23:21:26.198Z"
     assert data["client_time_since_mount_ms"] == 12.25
     assert data["client_sequence_number"] == 42
     assert data["client_display_mode"] == "inline"
@@ -744,7 +744,7 @@ def test_unavailable_v2_optional_fields_remain_absent(captured_post, monkeypatch
                 {
                     "eventName": "WidgetReady",
                     "level": "info",
-                    "eventTimestampMs": 1_700_000_000_000,
+                    "eventTimestamp": "2026-09-11T23:21:26.196Z",
                     "timeSinceMount": 0,
                     "sequenceNumber": 1,
                 }
@@ -776,21 +776,21 @@ def test_vorpal_owns_event_names_and_sequence_order(captured_post, monkeypatch):
                 {
                     "eventName": "WidgetReady",
                     "level": "info",
-                    "eventTimestampMs": 1_700_000_000_020,
+                    "eventTimestamp": "2026-09-11T23:21:26.216Z",
                     "timeSinceMount": 20,
                     "sequenceNumber": 100,
                 },
                 {
                     "eventName": "Widget.Ready",
                     "level": "info",
-                    "eventTimestampMs": 1_700_000_000_010,
+                    "eventTimestamp": "2026-09-11T23:21:26.206Z",
                     "timeSinceMount": 10,
                     "sequenceNumber": 100,
                 },
                 {
                     "eventName": "Future.Name.From.Vorpal",
                     "level": "error",
-                    "eventTimestampMs": 1_700_000_000_005,
+                    "eventTimestamp": "2026-09-11T23:21:26.201Z",
                     "timeSinceMount": 5,
                     "sequenceNumber": 4,
                 },
@@ -827,7 +827,7 @@ def test_invalid_v2_occurrence_metadata_rejects_the_batch(field, value, captured
     event = {
         "eventName": "InvalidMetadata",
         "level": "info",
-        "eventTimestampMs": 1_700_000_000_000,
+        "eventTimestamp": "2026-09-11T23:21:26.196Z",
         "timeSinceMount": 1,
         "sequenceNumber": 1,
     }
@@ -879,7 +879,7 @@ def test_client_source_chronology_survives_buffer_reemission(monkeypatch):
                 {
                     "eventName": "Save.Started",
                     "level": "info",
-                    "eventTimestampMs": 1_700_000_000_123.5,
+                    "eventTimestamp": "2026-09-11T23:21:26.198Z",
                     "timeSinceMount": 12.25,
                     "sequenceNumber": 42,
                     "operationId": operation_id,
@@ -903,7 +903,7 @@ def test_client_source_chronology_survives_buffer_reemission(monkeypatch):
                 {
                     "eventName": "Save.Completed",
                     "level": "info",
-                    "eventTimestampMs": 1_700_000_000_200,
+                    "eventTimestamp": "2026-09-11T23:21:26.200Z",
                     "timeSinceMount": 20,
                     "sequenceNumber": 43,
                     "operationId": operation_id,
@@ -916,7 +916,7 @@ def test_client_source_chronology_survives_buffer_reemission(monkeypatch):
     assert second == {"status": "accepted", "acceptedEventCount": 1}
     replayed = calls[0][0]["data"]
     assert replayed["client_batch_id"] == "batch-retry"
-    assert replayed["client_event_timestamp_ms"] == 1_700_000_000_123.5
+    assert replayed["client_event_timestamp"] == "2026-09-11T23:21:26.198Z"
     assert replayed["client_time_since_mount_ms"] == 12.25
     assert replayed["client_sequence_number"] == 42
     assert replayed["client_operation_id"] == operation_id
@@ -1226,11 +1226,12 @@ def test_report_client_events_rejects_out_of_contract_events(event, reason, capt
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("eventTimestampMs", float("nan")),
-        ("eventTimestampMs", float("inf")),
-        ("eventTimestampMs", -1),
-        ("eventTimestampMs", "1700000000000"),
-        ("eventTimestampMs", True),
+        ("eventTimestamp", 1_700_000_000_000),
+        ("eventTimestamp", ""),
+        ("eventTimestamp", "1700000000000"),
+        ("eventTimestamp", "2026-09-11T23:21:26.196"),
+        ("eventTimestamp", "not-a-timestamp"),
+        ("eventTimestamp", True),
         ("timeSinceMount", float("nan")),
         ("timeSinceMount", float("inf")),
         ("timeSinceMount", -1),
@@ -1242,7 +1243,7 @@ def test_invalid_source_timing_rejects_the_batch(field, value, captured_post):
     event = {
         "eventName": "InvalidTiming",
         "level": "info",
-        "eventTimestampMs": 1_700_000_000_000,
+        "eventTimestamp": "2026-09-11T23:21:26.196Z",
         "timeSinceMount": 0,
         "sequenceNumber": 1,
     }
@@ -1257,7 +1258,7 @@ def test_invalid_source_timing_rejects_the_batch(field, value, captured_post):
     assert captured_post == []
 
 
-def test_time_since_app_start_is_not_a_v2_alias(captured_post):
+def test_legacy_timing_fields_are_not_v2_aliases(captured_post):
     result = adk.report_client_events(
         _client_events_envelope(
             events=[


### PR DESCRIPTION
Establishes the schema-version 2 receiver contract for Vorpal's first telemetry shipment and initializes ADK tenant context from the authenticated AgentConfiguration client.

- validates immutable batch IDs, source timestamps, mount-relative timing, sequence numbers, levels, themes, and canonical operation UUIDs
- projects envelope, host, occurrence, and operation metadata through the existing `adk.client.event` emission and buffering path
- preserves raw build, platform, user-agent, and operation values through dedicated fields while retaining generic property scrubbing
- keeps deterministic bridge rejections structured through the real app-only FastMCP `call_tool` path
- documents the emitted Kusto field set, chronology, and retry deduplication key
- seeds tenant ID and cached tenant name from the authenticated landing-page client

## Testing

- `python -m pytest tests/test_adk_telemetry.py tests/test_adk_mcp_report_client_events.py tests/mcp/agentconfig/test_server_contract.py tests/mcp/agentconfig/test_widget_protocol.py tests/mcp/agentconfig/test_skill_orchestration.py -q`
- `python -m ruff check solutions/ess-maker-skills/scripts/adk_telemetry.py solutions/ess-maker-skills/src/mcp/agentconfig_landing_page/server.py tests/test_adk_telemetry.py tests/test_adk_mcp_report_client_events.py tests/mcp/agentconfig/test_server_contract.py`